### PR TITLE
Add Evaluation Governance end-to-end reviewer demo runner v1

### DIFF
--- a/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/README.md
+++ b/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/README.md
@@ -1,0 +1,47 @@
+# Evaluation Governance Reviewer Demo v1
+
+This directory contains a synthetic end-to-end offline reviewer demo for the
+Evaluation Governance helper chain. It generates the Evaluation Governance
+offline chain and then generates a Reviewer Evidence Packet from that chain.
+
+The demo is intentionally narrow in v1:
+
+- It is non-runtime and non-enforcing.
+- It does not call `/v1/decide`.
+- It does not change runtime admissibility behavior.
+- It does not prove legitimacy.
+- It does not certify regulatory compliance.
+- It does not dereference external artifact references.
+- It does not require network access.
+- It does not include secrets or PII.
+
+## Generate to a temporary output directory
+
+```bash
+python scripts/demo/run_evaluation_governance_reviewer_demo.py \
+  --input-dir docs/en/demo/examples/evaluation-governance-offline-chain-v1 \
+  --output-dir /tmp/evaluation-governance-reviewer-demo
+```
+
+## Regenerate checked-in example outputs intentionally
+
+```bash
+python scripts/demo/run_evaluation_governance_reviewer_demo.py \
+  --input-dir docs/en/demo/examples/evaluation-governance-offline-chain-v1 \
+  --write-example-output
+```
+
+## Checked-in generated examples
+
+The files under [`generated/`](generated/) are checked in for reviewer
+readability. They show the full reviewer-facing output directory produced from
+synthetic local inputs:
+
+- Evaluation Governance offline chain artifacts
+- `chain-manifest.generated.example.json`
+- `reviewer-evidence-packet.generated.example.json`
+- `demo-summary.generated.example.json`
+
+The helper validates schema shape through the underlying helper chain where
+validation is available. The helper does not establish present legitimacy and
+does not enforce runtime decisions.

--- a/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated/chain-manifest.generated.example.json
+++ b/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated/chain-manifest.generated.example.json
@@ -1,0 +1,67 @@
+{
+  "artifacts": [
+    {
+      "artifact_hash": "5cae168299c60becc997dde84fc143fa059edc2b5fca81dde1997f5916f4500f",
+      "artifact_ref": "evaluation-receipt-1.example.json",
+      "artifact_type": "evaluation_receipt"
+    },
+    {
+      "artifact_hash": "81c64573c36975ccf755f53718d1b759d00f612832aee47c35081117824a9cfa",
+      "artifact_ref": "evaluation-receipt-2.example.json",
+      "artifact_type": "evaluation_receipt"
+    },
+    {
+      "artifact_hash": "9e029c8f3a1df6f1b368def1d6cc7a665ffd6efe1b5c05c1d198d18f5105efb4",
+      "artifact_ref": "evaluation-receipt-3.example.json",
+      "artifact_type": "evaluation_receipt"
+    },
+    {
+      "artifact_hash": "4ce275c69363b76007a280e2ffcfb384efa2bc795532745f88dfc4da10ae6421",
+      "artifact_ref": "manifest-change-receipt.example.json",
+      "artifact_type": "manifest_change_receipt"
+    },
+    {
+      "artifact_hash": "17029f187996728b120db5bbf7bb92f26d6a16f833bdc3b7c66bd05077d62d33",
+      "artifact_ref": "outcome-delta-attribution-1.generated.example.json",
+      "artifact_type": "outcome_delta_attribution"
+    },
+    {
+      "artifact_hash": "59fac37138155946793fd958cdf2e8c96a842671fa1f64829e6c1f99b3dd531e",
+      "artifact_ref": "outcome-delta-attribution-2.generated.example.json",
+      "artifact_type": "outcome_delta_attribution"
+    },
+    {
+      "artifact_hash": "9e6390164ff4d51dcc66d19b58dc9ca08f915ad07637ef580228aca4a39d3c6e",
+      "artifact_ref": "evaluation-drift-detection-1.generated.example.json",
+      "artifact_type": "evaluation_drift_detection"
+    },
+    {
+      "artifact_hash": "16b7d149551c7a415ee931a10d83c5e4d486fab59b0adda649d65b1e81d08b40",
+      "artifact_ref": "evaluation-drift-detection-2.generated.example.json",
+      "artifact_type": "evaluation_drift_detection"
+    },
+    {
+      "artifact_hash": "900ca433a0128a9f4e9308f9da783c6ae11dc7ae68af5fdd61add67d30f67c89",
+      "artifact_ref": "trajectory-admissibility-monitor.generated.example.json",
+      "artifact_type": "trajectory_admissibility_monitor"
+    },
+    {
+      "artifact_hash": "2af7ec64add0c6e1919216fb79c47d56ad3f60653a009503646cc108d61efda0",
+      "artifact_ref": "legitimacy-impact-review.generated.example.json",
+      "artifact_type": "legitimacy_impact_review"
+    }
+  ],
+  "chain_id": "evaluation-governance-offline-chain-example-001",
+  "chain_summary": "Synthetic offline Evaluation Governance chain generated for reviewer-facing architecture review.",
+  "issued_at": "2026-01-01T00:00:00Z",
+  "non_enforcing": true,
+  "non_goals": [
+    "does_not_change_runtime_behavior",
+    "does_not_establish_legitimacy",
+    "does_not_certify_compliance",
+    "does_not_call_v1_decide",
+    "does_not_dereference_artifact_refs"
+  ],
+  "non_runtime": true,
+  "schema_version": "evaluation-governance-offline-chain-manifest-v1"
+}

--- a/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated/demo-summary.generated.example.json
+++ b/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated/demo-summary.generated.example.json
@@ -1,0 +1,59 @@
+{
+  "demo_id": "evaluation-governance-reviewer-demo-example-001",
+  "demo_summary": "Synthetic offline Evaluation Governance reviewer demo generated for architecture review.",
+  "generated_artifacts": [
+    {
+      "artifact_hash": "17029f187996728b120db5bbf7bb92f26d6a16f833bdc3b7c66bd05077d62d33",
+      "artifact_ref": "outcome-delta-attribution-1.generated.example.json",
+      "artifact_type": "outcome_delta_attribution"
+    },
+    {
+      "artifact_hash": "59fac37138155946793fd958cdf2e8c96a842671fa1f64829e6c1f99b3dd531e",
+      "artifact_ref": "outcome-delta-attribution-2.generated.example.json",
+      "artifact_type": "outcome_delta_attribution"
+    },
+    {
+      "artifact_hash": "9e6390164ff4d51dcc66d19b58dc9ca08f915ad07637ef580228aca4a39d3c6e",
+      "artifact_ref": "evaluation-drift-detection-1.generated.example.json",
+      "artifact_type": "evaluation_drift_detection"
+    },
+    {
+      "artifact_hash": "16b7d149551c7a415ee931a10d83c5e4d486fab59b0adda649d65b1e81d08b40",
+      "artifact_ref": "evaluation-drift-detection-2.generated.example.json",
+      "artifact_type": "evaluation_drift_detection"
+    },
+    {
+      "artifact_hash": "900ca433a0128a9f4e9308f9da783c6ae11dc7ae68af5fdd61add67d30f67c89",
+      "artifact_ref": "trajectory-admissibility-monitor.generated.example.json",
+      "artifact_type": "trajectory_admissibility_monitor"
+    },
+    {
+      "artifact_hash": "2af7ec64add0c6e1919216fb79c47d56ad3f60653a009503646cc108d61efda0",
+      "artifact_ref": "legitimacy-impact-review.generated.example.json",
+      "artifact_type": "legitimacy_impact_review"
+    },
+    {
+      "artifact_hash": "d93640952799e89965054eba89be984fcdbd7bb5101f90c1599b7e22a15e4d25",
+      "artifact_ref": "chain-manifest.generated.example.json",
+      "artifact_type": "chain_manifest"
+    },
+    {
+      "artifact_hash": "ff980465d217b085cb77421daee6c29b67026a0bac3193b93a0cb75e7641893f",
+      "artifact_ref": "reviewer-evidence-packet.generated.example.json",
+      "artifact_type": "reviewer_evidence_packet"
+    }
+  ],
+  "input_dir": "docs/en/demo/examples/evaluation-governance-offline-chain-v1",
+  "issued_at": "2026-01-01T00:00:00Z",
+  "non_enforcing": true,
+  "non_goals": [
+    "does_not_change_runtime_behavior",
+    "does_not_call_v1_decide",
+    "does_not_establish_legitimacy",
+    "does_not_certify_compliance",
+    "does_not_dereference_external_artifact_refs",
+    "does_not_require_network_access"
+  ],
+  "non_runtime": true,
+  "schema_version": "evaluation-governance-reviewer-demo-summary-v1"
+}

--- a/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated/evaluation-drift-detection-1.generated.example.json
+++ b/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated/evaluation-drift-detection-1.generated.example.json
@@ -1,0 +1,34 @@
+{
+  "current_evaluation_receipt_ref": "evaluation-governance-offline-chain-receipt-002",
+  "detection_hash": "f53cab1310a7fccd8efa8815d50685be5a4fff42f14ac575cbbdc9e490c82c66",
+  "detection_id": "evaluation-governance-offline-chain-drift-detection-001",
+  "detection_summary": "Draft detection marked suspected drift from allow to escalate.",
+  "drift_causes": [
+    {
+      "cause_type": "evaluator_version_changed",
+      "evidence_refs": [
+        "evaluation-governance-offline-chain-receipt-002"
+      ],
+      "explanation": "The evaluator version changed between receipts.",
+      "severity": "medium"
+    },
+    {
+      "cause_type": "rule_version_changed",
+      "evidence_refs": [
+        "evaluation-governance-offline-chain-receipt-002"
+      ],
+      "explanation": "The rule set version changed between receipts.",
+      "severity": "medium"
+    }
+  ],
+  "drift_detected": true,
+  "drift_status": "suspected",
+  "evaluator_consistency_status": "unknown",
+  "explanation_status": "partially_explained",
+  "issued_at": "2026-01-01T00:00:00Z",
+  "outcome_delta_attribution_hash": "17029f187996728b120db5bbf7bb92f26d6a16f833bdc3b7c66bd05077d62d33",
+  "outcome_delta_attribution_ref": "evaluation-governance-offline-chain-attribution-001",
+  "prior_evaluation_receipt_ref": "evaluation-governance-offline-chain-receipt-001",
+  "recommended_governance_action": "requalify_evaluator",
+  "schema_version": "evaluation-drift-detection-v1"
+}

--- a/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated/evaluation-drift-detection-2.generated.example.json
+++ b/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated/evaluation-drift-detection-2.generated.example.json
@@ -1,0 +1,26 @@
+{
+  "current_evaluation_receipt_ref": "evaluation-governance-offline-chain-receipt-003",
+  "detection_hash": "8f41b1da1892d642e7aef809ee3ec8e36694bf03fb5396595d0e0805e29812bd",
+  "detection_id": "evaluation-governance-offline-chain-drift-detection-002",
+  "detection_summary": "Draft detection did not detect evaluator drift from escalate to escalate.",
+  "drift_causes": [
+    {
+      "cause_type": "material_context_ambiguous",
+      "evidence_refs": [
+        "evaluation-governance-offline-chain-receipt-003"
+      ],
+      "explanation": "The material context state changed between receipts.",
+      "severity": "medium"
+    }
+  ],
+  "drift_detected": false,
+  "drift_status": "not_detected",
+  "evaluator_consistency_status": "not_comparable",
+  "explanation_status": "fully_explained",
+  "issued_at": "2026-01-01T00:00:00Z",
+  "outcome_delta_attribution_hash": "59fac37138155946793fd958cdf2e8c96a842671fa1f64829e6c1f99b3dd531e",
+  "outcome_delta_attribution_ref": "evaluation-governance-offline-chain-attribution-002",
+  "prior_evaluation_receipt_ref": "evaluation-governance-offline-chain-receipt-002",
+  "recommended_governance_action": "none",
+  "schema_version": "evaluation-drift-detection-v1"
+}

--- a/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated/legitimacy-impact-review.generated.example.json
+++ b/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated/legitimacy-impact-review.generated.example.json
@@ -1,0 +1,83 @@
+{
+  "auditability_impact": {
+    "auditability_reduced": false,
+    "evidence_chain_weakened": false,
+    "evidence_refs": [
+      "legitimacy-helper-manifest-change-001"
+    ],
+    "explanation": "No auditability reduction was detected.",
+    "receipt_requirements_reduced": false,
+    "replayability_reduced": false
+  },
+  "authority_impact": {
+    "authority_scope_expanded": true,
+    "evidence_refs": [
+      "sample://authority/synthetic-board-charter-v1",
+      "legitimacy-helper-manifest-change-001",
+      "trajectory-admissibility-monitor-example-001"
+    ],
+    "explanation": "Authority-impacting signals were detected for reviewer assessment.",
+    "root_authority_changed": false,
+    "trusted_authority_source_changed": false
+  },
+  "escalation_impact": {
+    "escalation_authority_changed": true,
+    "escalation_path_changed": true,
+    "escalation_requirement_reduced": true,
+    "evidence_refs": [
+      "legitimacy-helper-manifest-change-001",
+      "approval-evidence-example-001"
+    ],
+    "explanation": "Escalation requirements or authority may have changed."
+  },
+  "high_risk_admissibility_impact": {
+    "evidence_refs": [
+      "legitimacy-helper-manifest-change-001",
+      "trajectory-admissibility-monitor-example-001"
+    ],
+    "explanation": "High-risk admissibility scope expansion signals require review.",
+    "high_risk_controls_weakened": true,
+    "high_risk_review_requirement_reduced": true,
+    "high_risk_scope_expanded": true
+  },
+  "impact_categories": [
+    "authority_scope_expansion",
+    "human_oversight_weakened",
+    "escalation_requirement_reduced",
+    "high_risk_admissibility_expanded",
+    "evaluation_behavior_changed"
+  ],
+  "issued_at": "2026-01-01T00:00:00Z",
+  "legitimacy_impact_detected": true,
+  "oversight_impact": {
+    "approval_requirement_reduced": true,
+    "evidence_refs": [
+      "approval-evidence-example-001",
+      "legitimacy-helper-manifest-change-001"
+    ],
+    "explanation": "Human oversight or approval requirements may be weakened.",
+    "human_oversight_weakened": true,
+    "reviewer_authority_changed": false
+  },
+  "recommended_governance_action": "multi_party_review",
+  "refusal_boundary_impact": {
+    "evidence_refs": [
+      "legitimacy-helper-manifest-change-001",
+      "trajectory-admissibility-monitor-example-001"
+    ],
+    "explanation": "No refusal boundary relaxation was detected.",
+    "refusal_boundary_relaxed": false,
+    "refusal_condition_changed": false,
+    "refusal_condition_removed": false
+  },
+  "review_hash": "795e3d6d9d5968f9c058dfb99dd77d7b545bd6c5fbd10b9a3f793a54d24b4619",
+  "review_id": "legitimacy-impact-review-example-001",
+  "review_status": "pending",
+  "review_summary": "Draft offline review surfaced legitimacy-impacting signals (authority_scope_expansion, human_oversight_weakened, escalation_requirement_reduced, high_risk_admissibility_expanded, evaluation_behavior_changed); status=pending, recommended_action=multi_party_review. This is reviewable evidence only, not an automatic legitimacy or compliance determination.",
+  "reviewed_artifact_hash": "2222222222222222222222222222222222222222222222222222222222222222",
+  "reviewed_artifact_ref": "evaluation-function-manifest-example-001",
+  "reviewed_artifact_type": "evaluation_function_manifest",
+  "schema_version": "legitimacy-impact-review-v1",
+  "triggering_change_hash": "4ce275c69363b76007a280e2ffcfb384efa2bc795532745f88dfc4da10ae6421",
+  "triggering_change_ref": "legitimacy-helper-manifest-change-001"
+}

--- a/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated/outcome-delta-attribution-1.generated.example.json
+++ b/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated/outcome-delta-attribution-1.generated.example.json
@@ -1,0 +1,63 @@
+{
+  "attribution_confidence": "high",
+  "attribution_hash": "41f28700eaaa596b60e5d775d2d014827a4200f3595c90b3d689bf684584165d",
+  "attribution_id": "evaluation-governance-offline-chain-attribution-001",
+  "attribution_summary": "Outcome changed from allow to escalate; detected causes: evaluator_version_changed, rule_version_changed, authority_state_changed, consequence_class_changed.",
+  "current_evaluation_receipt_hash": "81c64573c36975ccf755f53718d1b759d00f612832aee47c35081117824a9cfa",
+  "current_evaluation_receipt_ref": "evaluation-governance-offline-chain-receipt-002",
+  "current_outcome": "escalate",
+  "delta_causes": [
+    {
+      "cause_type": "evaluator_version_changed",
+      "current_value_ref": "eval-v1.1.0",
+      "evidence_refs": [
+        "evaluation-governance-offline-chain-receipt-002"
+      ],
+      "explanation": "The evaluator version changed between receipts.",
+      "prior_value_ref": "eval-v1.0.0",
+      "severity": "medium"
+    },
+    {
+      "cause_type": "rule_version_changed",
+      "current_value_ref": "rules-v2",
+      "evidence_refs": [
+        "evaluation-governance-offline-chain-receipt-002"
+      ],
+      "explanation": "The rule set version changed between receipts.",
+      "prior_value_ref": "rules-v1",
+      "severity": "medium"
+    },
+    {
+      "cause_type": "authority_state_changed",
+      "current_value_ref": "[\"authority-evidence-example-v2\"]",
+      "evidence_refs": [
+        "evaluation-governance-offline-chain-receipt-002"
+      ],
+      "explanation": "The authority evidence references changed between receipts.",
+      "prior_value_ref": "[\"authority-evidence-example-v1\"]",
+      "severity": "high"
+    },
+    {
+      "cause_type": "consequence_class_changed",
+      "current_value_ref": "{\"class_id\": \"synthetic-high-evaluation-governance-event\", \"class_label\": \"high\", \"classifier_id\": \"synthetic-trajectory-classifier\", \"classifier_version\": \"1.0.0-demo\"}",
+      "evidence_refs": [
+        "evaluation-governance-offline-chain-receipt-002"
+      ],
+      "explanation": "The consequence classification changed between receipts.",
+      "prior_value_ref": "{\"class_id\": \"synthetic-medium-evaluation-governance-event\", \"class_label\": \"medium\", \"classifier_id\": \"synthetic-trajectory-classifier\", \"classifier_version\": \"1.0.0-demo\"}",
+      "severity": "high"
+    }
+  ],
+  "issued_at": "2026-01-01T00:00:00Z",
+  "outcome_changed": true,
+  "prior_evaluation_receipt_hash": "5cae168299c60becc997dde84fc143fa059edc2b5fca81dde1997f5916f4500f",
+  "prior_evaluation_receipt_ref": "evaluation-governance-offline-chain-receipt-001",
+  "prior_outcome": "allow",
+  "recommended_governance_action": "review",
+  "schema_version": "outcome-delta-attribution-v1",
+  "unresolved_delta": {
+    "present": false,
+    "reason": "No unexplained evaluation drift was detected.",
+    "requires_review": false
+  }
+}

--- a/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated/outcome-delta-attribution-2.generated.example.json
+++ b/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated/outcome-delta-attribution-2.generated.example.json
@@ -1,0 +1,33 @@
+{
+  "attribution_confidence": "medium",
+  "attribution_hash": "f2ecc5814675be88bed77cca104a904d2af2e262b4e2afd8d42b9033c37d63dc",
+  "attribution_id": "evaluation-governance-offline-chain-attribution-002",
+  "attribution_summary": "Outcome changed from escalate to escalate; detected causes: material_context_changed.",
+  "current_evaluation_receipt_hash": "9e029c8f3a1df6f1b368def1d6cc7a665ffd6efe1b5c05c1d198d18f5105efb4",
+  "current_evaluation_receipt_ref": "evaluation-governance-offline-chain-receipt-003",
+  "current_outcome": "escalate",
+  "delta_causes": [
+    {
+      "cause_type": "material_context_changed",
+      "current_value_ref": "{\"context_freshness_state\": \"fresh\", \"context_hash\": \"eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\", \"stale_context_allowed\": false}",
+      "evidence_refs": [
+        "evaluation-governance-offline-chain-receipt-003"
+      ],
+      "explanation": "The material context state changed between receipts.",
+      "prior_value_ref": "{\"context_freshness_state\": \"fresh\", \"context_hash\": \"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\", \"stale_context_allowed\": false}",
+      "severity": "medium"
+    }
+  ],
+  "issued_at": "2026-01-01T00:00:00Z",
+  "outcome_changed": false,
+  "prior_evaluation_receipt_hash": "81c64573c36975ccf755f53718d1b759d00f612832aee47c35081117824a9cfa",
+  "prior_evaluation_receipt_ref": "evaluation-governance-offline-chain-receipt-002",
+  "prior_outcome": "escalate",
+  "recommended_governance_action": "review",
+  "schema_version": "outcome-delta-attribution-v1",
+  "unresolved_delta": {
+    "present": false,
+    "reason": "No unexplained evaluation drift was detected.",
+    "requires_review": false
+  }
+}

--- a/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated/reviewer-evidence-packet.generated.example.json
+++ b/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated/reviewer-evidence-packet.generated.example.json
@@ -1,0 +1,752 @@
+{
+  "aggregate_summary": {
+    "blocked_cases": 4,
+    "committed_cases": 1,
+    "failed_chains": 0,
+    "incomplete_chains": 0,
+    "indeterminate_chains": 0,
+    "local_offline_only": true,
+    "passed_cases": 5,
+    "total_cases": 5,
+    "verified_chains": 5
+  },
+  "boundary_note": "local/offline synthetic reviewer evidence only; no /v1/decide call, runtime admissibility change, live service integration, legitimacy determination, or compliance certification",
+  "cases": [
+    {
+      "actual_outcome": "block",
+      "authority_validation_status": "fail",
+      "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+      "case_id": "missing_authority",
+      "evidence_chain_manifest_summary": {
+        "action_class": "permission_change",
+        "authority_evidence_hash": null,
+        "authority_evidence_id": null,
+        "bind_coverage_operation_id": "saas_permission_change_demo",
+        "bind_receipt_hash": null,
+        "bind_receipt_id": null,
+        "chain_status": "blocked",
+        "decision_id": "decision-saas-001",
+        "execution_intent_id": "intent-saas-001",
+        "final_outcome": "block",
+        "generated_at": "2026-04-26T00:00:00+00:00",
+        "human_approval_receipt_hash": "22c26614740e5a495beea2a46f1e8a498303e8c50d96a2f25a2a8e788d1c4547",
+        "human_approval_receipt_id": "har-saas-001",
+        "manifest_hash": "66e0d0a277ca167b9021191e721a87c19edffa954f70d671e35bfe434613db8e",
+        "manifest_id": "ecm-saas-permission-change-missing_authority",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "missing_links": [
+          "authority_evidence_hash"
+        ],
+        "observed_effects_summary": [],
+        "operation_id": "saas-permission-change-missing_authority",
+        "outcome_receipt_hash": "8f28c45ec0f7efd2f8f4cd25b02fe46450c012b10a06ed715d9ed25f899ea71f",
+        "outcome_receipt_id": "outcome-saas-permission-change-missing_authority",
+        "refusal_basis": [
+          "authority_expired_or_missing",
+          "authority_invalid",
+          "authority_missing"
+        ],
+        "requested_scope": [
+          "saas:grant_admin"
+        ],
+        "target_resource": "synthetic_offline_resource",
+        "target_system": "mock_saas_directory"
+      },
+      "evidence_chain_verification_summary": {
+        "decision_id": "decision-saas-001",
+        "execution_intent_id": "intent-saas-001",
+        "failure_reasons": [],
+        "is_valid": true,
+        "manifest_hash_matches": true,
+        "manifest_id": "ecm-saas-permission-change-missing_authority",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "mismatched_links": [],
+        "missing_links": [
+          "authority_evidence_hash"
+        ],
+        "operation_id": "saas-permission-change-missing_authority",
+        "recomputed_manifest_hash": "66e0d0a277ca167b9021191e721a87c19edffa954f70d671e35bfe434613db8e",
+        "verification_status": "verified",
+        "verified_at": "2026-04-26T00:00:00+00:00",
+        "verified_links": [
+          "bind_coverage_operation_id",
+          "human_approval_receipt_hash",
+          "manifest_hash",
+          "outcome_receipt_hash"
+        ]
+      },
+      "expected_outcome": "block",
+      "failure_reasons": [
+        "authority_expired_or_missing",
+        "authority_invalid",
+        "authority_missing"
+      ],
+      "human_approval_summary": {
+        "approval_receipt_id": "har-saas-001",
+        "approved": true,
+        "approved_scope": [
+          "saas:grant_admin"
+        ],
+        "approver_identity": "human:synthetic_reviewer",
+        "approver_role": "synthetic_reviewer",
+        "failure_reasons": [],
+        "receipt_hash_present": true
+      },
+      "outcome_receipt_summary": {
+        "action_class": "permission_change",
+        "bind_receipt_id": null,
+        "blocked": true,
+        "committed": false,
+        "decision_id": "decision-saas-001",
+        "escalated": false,
+        "evaluated_at": "2026-04-26T00:00:00+00:00",
+        "execution_intent_id": "intent-saas-001",
+        "failure_reasons": [
+          "authority_expired_or_missing",
+          "authority_invalid",
+          "authority_missing"
+        ],
+        "final_outcome": "block",
+        "intended_action": "grant_admin_permission",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "observed_effects": [],
+        "operation_id": "saas-permission-change-missing_authority",
+        "outcome_hash": "8f28c45ec0f7efd2f8f4cd25b02fe46450c012b10a06ed715d9ed25f899ea71f",
+        "outcome_receipt_id": "outcome-saas-permission-change-missing_authority",
+        "post_state_fingerprint": null,
+        "postcondition_status": "skipped",
+        "pre_state_fingerprint": null,
+        "requested_scope": [
+          "saas:grant_admin"
+        ],
+        "rollback_status": null,
+        "rolled_back": false,
+        "target_resource": "synthetic_offline_resource",
+        "target_system": "mock_saas_directory"
+      },
+      "passed": true,
+      "refusal_basis": [
+        "authority_expired_or_missing",
+        "authority_invalid",
+        "authority_missing"
+      ],
+      "requested_scope": [
+        "saas:grant_admin"
+      ],
+      "reviewer_interpretation": "The local/offline fixture blocked because AuthorityEvidence was missing.",
+      "runtime_recommended_outcome": "block",
+      "target_resource": "synthetic_offline_resource",
+      "target_system": "mock_saas_directory"
+    },
+    {
+      "actual_outcome": "block",
+      "authority_validation_status": "fail",
+      "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+      "case_id": "missing_human_approval",
+      "evidence_chain_manifest_summary": {
+        "action_class": "permission_change",
+        "authority_evidence_hash": "86bd3a69cb781db382f94e0a87e6a36aaa203d934403a23ac36e8856a9d5e940",
+        "authority_evidence_id": "aev-saas-001",
+        "bind_coverage_operation_id": "saas_permission_change_demo",
+        "bind_receipt_hash": null,
+        "bind_receipt_id": null,
+        "chain_status": "blocked",
+        "decision_id": "decision-saas-001",
+        "execution_intent_id": "intent-saas-001",
+        "final_outcome": "block",
+        "generated_at": "2026-04-26T00:00:00+00:00",
+        "human_approval_receipt_hash": null,
+        "human_approval_receipt_id": null,
+        "manifest_hash": "de5f807be0e901dc94a3968a831a30485aa059dc04722e479771199d1226477b",
+        "manifest_id": "ecm-saas-permission-change-missing_human_approval",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "missing_links": [
+          "human_approval_receipt_hash"
+        ],
+        "observed_effects_summary": [],
+        "operation_id": "saas-permission-change-missing_human_approval",
+        "outcome_receipt_hash": "9675064eed76fafddc5aae73292bba314f31a3e106f81451c4a0f3d472bf6ebd",
+        "outcome_receipt_id": "outcome-saas-permission-change-missing_human_approval",
+        "refusal_basis": [
+          "human_approval_missing"
+        ],
+        "requested_scope": [
+          "saas:grant_admin"
+        ],
+        "target_resource": "synthetic_offline_resource",
+        "target_system": "mock_saas_directory"
+      },
+      "evidence_chain_verification_summary": {
+        "decision_id": "decision-saas-001",
+        "execution_intent_id": "intent-saas-001",
+        "failure_reasons": [],
+        "is_valid": true,
+        "manifest_hash_matches": true,
+        "manifest_id": "ecm-saas-permission-change-missing_human_approval",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "mismatched_links": [],
+        "missing_links": [
+          "human_approval_receipt_hash"
+        ],
+        "operation_id": "saas-permission-change-missing_human_approval",
+        "recomputed_manifest_hash": "de5f807be0e901dc94a3968a831a30485aa059dc04722e479771199d1226477b",
+        "verification_status": "verified",
+        "verified_at": "2026-04-26T00:00:00+00:00",
+        "verified_links": [
+          "authority_evidence_hash",
+          "bind_coverage_operation_id",
+          "manifest_hash",
+          "outcome_receipt_hash"
+        ]
+      },
+      "expected_outcome": "block",
+      "failure_reasons": [
+        "human_approval_missing"
+      ],
+      "human_approval_summary": {
+        "approval_receipt_id": null,
+        "approved": false,
+        "approved_scope": [],
+        "approver_identity": null,
+        "approver_role": null,
+        "failure_reasons": [
+          "human_approval_missing"
+        ],
+        "receipt_hash_present": false
+      },
+      "outcome_receipt_summary": {
+        "action_class": "permission_change",
+        "bind_receipt_id": null,
+        "blocked": true,
+        "committed": false,
+        "decision_id": "decision-saas-001",
+        "escalated": false,
+        "evaluated_at": "2026-04-26T00:00:00+00:00",
+        "execution_intent_id": "intent-saas-001",
+        "failure_reasons": [
+          "human_approval_missing"
+        ],
+        "final_outcome": "block",
+        "intended_action": "grant_admin_permission",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "observed_effects": [],
+        "operation_id": "saas-permission-change-missing_human_approval",
+        "outcome_hash": "9675064eed76fafddc5aae73292bba314f31a3e106f81451c4a0f3d472bf6ebd",
+        "outcome_receipt_id": "outcome-saas-permission-change-missing_human_approval",
+        "post_state_fingerprint": null,
+        "postcondition_status": "skipped",
+        "pre_state_fingerprint": null,
+        "requested_scope": [
+          "saas:grant_admin"
+        ],
+        "rollback_status": null,
+        "rolled_back": false,
+        "target_resource": "synthetic_offline_resource",
+        "target_system": "mock_saas_directory"
+      },
+      "passed": true,
+      "refusal_basis": [
+        "human_approval_missing"
+      ],
+      "requested_scope": [
+        "saas:grant_admin"
+      ],
+      "reviewer_interpretation": "The local/offline fixture blocked because HumanApprovalReceipt was missing.",
+      "runtime_recommended_outcome": "block",
+      "target_resource": "synthetic_offline_resource",
+      "target_system": "mock_saas_directory"
+    },
+    {
+      "actual_outcome": "block",
+      "authority_validation_status": "fail",
+      "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+      "case_id": "expired_human_approval",
+      "evidence_chain_manifest_summary": {
+        "action_class": "permission_change",
+        "authority_evidence_hash": "86bd3a69cb781db382f94e0a87e6a36aaa203d934403a23ac36e8856a9d5e940",
+        "authority_evidence_id": "aev-saas-001",
+        "bind_coverage_operation_id": "saas_permission_change_demo",
+        "bind_receipt_hash": null,
+        "bind_receipt_id": null,
+        "chain_status": "blocked",
+        "decision_id": "decision-saas-001",
+        "execution_intent_id": "intent-saas-001",
+        "final_outcome": "block",
+        "generated_at": "2026-04-26T00:00:00+00:00",
+        "human_approval_receipt_hash": null,
+        "human_approval_receipt_id": null,
+        "manifest_hash": "a01e60928b028538839d9d0709424d92d7bf164efd209adcc7cfcc768982f20a",
+        "manifest_id": "ecm-saas-permission-change-expired_human_approval",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "missing_links": [
+          "human_approval_receipt_hash"
+        ],
+        "observed_effects_summary": [],
+        "operation_id": "saas-permission-change-expired_human_approval",
+        "outcome_receipt_hash": "04f7b00e736648ed570282482a90bf453e4e8d871e26f4ca4d173467f0be92af",
+        "outcome_receipt_id": "outcome-saas-permission-change-expired_human_approval",
+        "refusal_basis": [
+          "human_approval_missing"
+        ],
+        "requested_scope": [
+          "saas:grant_admin"
+        ],
+        "target_resource": "synthetic_offline_resource",
+        "target_system": "mock_saas_directory"
+      },
+      "evidence_chain_verification_summary": {
+        "decision_id": "decision-saas-001",
+        "execution_intent_id": "intent-saas-001",
+        "failure_reasons": [],
+        "is_valid": true,
+        "manifest_hash_matches": true,
+        "manifest_id": "ecm-saas-permission-change-expired_human_approval",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "mismatched_links": [],
+        "missing_links": [
+          "human_approval_receipt_hash"
+        ],
+        "operation_id": "saas-permission-change-expired_human_approval",
+        "recomputed_manifest_hash": "a01e60928b028538839d9d0709424d92d7bf164efd209adcc7cfcc768982f20a",
+        "verification_status": "verified",
+        "verified_at": "2026-04-26T00:00:00+00:00",
+        "verified_links": [
+          "authority_evidence_hash",
+          "bind_coverage_operation_id",
+          "manifest_hash",
+          "outcome_receipt_hash"
+        ]
+      },
+      "expected_outcome": "block",
+      "failure_reasons": [
+        "human_approval_missing"
+      ],
+      "human_approval_summary": {
+        "approval_receipt_id": null,
+        "approved": false,
+        "approved_scope": [],
+        "approver_identity": null,
+        "approver_role": null,
+        "failure_reasons": [
+          "human_approval_expired"
+        ],
+        "receipt_hash_present": false
+      },
+      "outcome_receipt_summary": {
+        "action_class": "permission_change",
+        "bind_receipt_id": null,
+        "blocked": true,
+        "committed": false,
+        "decision_id": "decision-saas-001",
+        "escalated": false,
+        "evaluated_at": "2026-04-26T00:00:00+00:00",
+        "execution_intent_id": "intent-saas-001",
+        "failure_reasons": [
+          "human_approval_missing"
+        ],
+        "final_outcome": "block",
+        "intended_action": "grant_admin_permission",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "observed_effects": [],
+        "operation_id": "saas-permission-change-expired_human_approval",
+        "outcome_hash": "04f7b00e736648ed570282482a90bf453e4e8d871e26f4ca4d173467f0be92af",
+        "outcome_receipt_id": "outcome-saas-permission-change-expired_human_approval",
+        "post_state_fingerprint": null,
+        "postcondition_status": "skipped",
+        "pre_state_fingerprint": null,
+        "requested_scope": [
+          "saas:grant_admin"
+        ],
+        "rollback_status": null,
+        "rolled_back": false,
+        "target_resource": "synthetic_offline_resource",
+        "target_system": "mock_saas_directory"
+      },
+      "passed": true,
+      "refusal_basis": [
+        "human_approval_missing"
+      ],
+      "requested_scope": [
+        "saas:grant_admin"
+      ],
+      "reviewer_interpretation": "The local/offline fixture blocked because HumanApprovalReceipt was expired.",
+      "runtime_recommended_outcome": "block",
+      "target_resource": "synthetic_offline_resource",
+      "target_system": "mock_saas_directory"
+    },
+    {
+      "actual_outcome": "block",
+      "authority_validation_status": "fail",
+      "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+      "case_id": "scope_mismatch",
+      "evidence_chain_manifest_summary": {
+        "action_class": "permission_change",
+        "authority_evidence_hash": "f3ef007f0aa8236117004edd91c0abd105762b8f4d02f8b2572a5988c6c0647a",
+        "authority_evidence_id": "aev-saas-001",
+        "bind_coverage_operation_id": "saas_permission_change_demo",
+        "bind_receipt_hash": null,
+        "bind_receipt_id": null,
+        "chain_status": "blocked",
+        "decision_id": "decision-saas-001",
+        "execution_intent_id": "intent-saas-001",
+        "final_outcome": "block",
+        "generated_at": "2026-04-26T00:00:00+00:00",
+        "human_approval_receipt_hash": null,
+        "human_approval_receipt_id": null,
+        "manifest_hash": "4e3785488ebac6a6e58abf0f23303ff0f7737f1899ec1618ac809432934d7484",
+        "manifest_id": "ecm-saas-permission-change-scope_mismatch",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "missing_links": [
+          "human_approval_receipt_hash"
+        ],
+        "observed_effects_summary": [],
+        "operation_id": "saas-permission-change-scope_mismatch",
+        "outcome_receipt_hash": "3fff28c56dd93ff5d7e11c71a9ed6ba134c31dc8a057810e72d24b93f2c8a54f",
+        "outcome_receipt_id": "outcome-saas-permission-change-scope_mismatch",
+        "refusal_basis": [
+          "authority_invalid",
+          "human_approval_missing"
+        ],
+        "requested_scope": [
+          "saas:grant_admin"
+        ],
+        "target_resource": "synthetic_offline_resource",
+        "target_system": "mock_saas_directory"
+      },
+      "evidence_chain_verification_summary": {
+        "decision_id": "decision-saas-001",
+        "execution_intent_id": "intent-saas-001",
+        "failure_reasons": [],
+        "is_valid": true,
+        "manifest_hash_matches": true,
+        "manifest_id": "ecm-saas-permission-change-scope_mismatch",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "mismatched_links": [],
+        "missing_links": [
+          "human_approval_receipt_hash"
+        ],
+        "operation_id": "saas-permission-change-scope_mismatch",
+        "recomputed_manifest_hash": "4e3785488ebac6a6e58abf0f23303ff0f7737f1899ec1618ac809432934d7484",
+        "verification_status": "verified",
+        "verified_at": "2026-04-26T00:00:00+00:00",
+        "verified_links": [
+          "authority_evidence_hash",
+          "bind_coverage_operation_id",
+          "manifest_hash",
+          "outcome_receipt_hash"
+        ]
+      },
+      "expected_outcome": "block",
+      "failure_reasons": [
+        "authority_invalid",
+        "human_approval_missing"
+      ],
+      "human_approval_summary": {
+        "approval_receipt_id": null,
+        "approved": false,
+        "approved_scope": [],
+        "approver_identity": null,
+        "approver_role": null,
+        "failure_reasons": [
+          "human_approval_scope_not_granted"
+        ],
+        "receipt_hash_present": false
+      },
+      "outcome_receipt_summary": {
+        "action_class": "permission_change",
+        "bind_receipt_id": null,
+        "blocked": true,
+        "committed": false,
+        "decision_id": "decision-saas-001",
+        "escalated": false,
+        "evaluated_at": "2026-04-26T00:00:00+00:00",
+        "execution_intent_id": "intent-saas-001",
+        "failure_reasons": [
+          "authority_invalid",
+          "human_approval_missing"
+        ],
+        "final_outcome": "block",
+        "intended_action": "grant_admin_permission",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "observed_effects": [],
+        "operation_id": "saas-permission-change-scope_mismatch",
+        "outcome_hash": "3fff28c56dd93ff5d7e11c71a9ed6ba134c31dc8a057810e72d24b93f2c8a54f",
+        "outcome_receipt_id": "outcome-saas-permission-change-scope_mismatch",
+        "post_state_fingerprint": null,
+        "postcondition_status": "skipped",
+        "pre_state_fingerprint": null,
+        "requested_scope": [
+          "saas:grant_admin"
+        ],
+        "rollback_status": null,
+        "rolled_back": false,
+        "target_resource": "synthetic_offline_resource",
+        "target_system": "mock_saas_directory"
+      },
+      "passed": true,
+      "refusal_basis": [
+        "authority_invalid",
+        "human_approval_missing"
+      ],
+      "requested_scope": [
+        "saas:grant_admin"
+      ],
+      "reviewer_interpretation": "The local/offline fixture blocked because approved authority or approval scope was insufficient.",
+      "runtime_recommended_outcome": "block",
+      "target_resource": "synthetic_offline_resource",
+      "target_system": "mock_saas_directory"
+    },
+    {
+      "actual_outcome": "commit",
+      "authority_validation_status": "pass",
+      "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+      "case_id": "valid_authority_and_approval",
+      "evidence_chain_manifest_summary": {
+        "action_class": "permission_change",
+        "authority_evidence_hash": "6879ecdcdeded375a2e81832fe8819a698c9c5df151d7819224420f21a7a53a0",
+        "authority_evidence_id": "aev-saas-001",
+        "bind_coverage_operation_id": "saas_permission_change_demo",
+        "bind_receipt_hash": null,
+        "bind_receipt_id": null,
+        "chain_status": "complete",
+        "decision_id": "decision-saas-001",
+        "execution_intent_id": "intent-saas-001",
+        "final_outcome": "commit",
+        "generated_at": "2026-04-26T00:00:00+00:00",
+        "human_approval_receipt_hash": "22c26614740e5a495beea2a46f1e8a498303e8c50d96a2f25a2a8e788d1c4547",
+        "human_approval_receipt_id": "har-saas-001",
+        "manifest_hash": "264d650ff037717002e56642e702db0853792e256bf0b624cd5d6df2f5bc1bcb",
+        "manifest_id": "ecm-saas-permission-change-valid_authority_and_approval",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "missing_links": [],
+        "observed_effects_summary": [
+          {
+            "effect_type": "permission_grant",
+            "fixture_only": true,
+            "permission": "saas:grant_admin",
+            "target_resource": "synthetic_offline_resource"
+          }
+        ],
+        "operation_id": "saas-permission-change-valid_authority_and_approval",
+        "outcome_receipt_hash": "e8eb969be01b97993b20283a6f0314f5e83be4d6377e879f7b3719562e5a036a",
+        "outcome_receipt_id": "outcome-saas-permission-change-valid_authority_and_approval",
+        "refusal_basis": [],
+        "requested_scope": [
+          "saas:grant_admin"
+        ],
+        "target_resource": "synthetic_offline_resource",
+        "target_system": "mock_saas_directory"
+      },
+      "evidence_chain_verification_summary": {
+        "decision_id": "decision-saas-001",
+        "execution_intent_id": "intent-saas-001",
+        "failure_reasons": [],
+        "is_valid": true,
+        "manifest_hash_matches": true,
+        "manifest_id": "ecm-saas-permission-change-valid_authority_and_approval",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "mismatched_links": [],
+        "missing_links": [],
+        "operation_id": "saas-permission-change-valid_authority_and_approval",
+        "recomputed_manifest_hash": "264d650ff037717002e56642e702db0853792e256bf0b624cd5d6df2f5bc1bcb",
+        "verification_status": "verified",
+        "verified_at": "2026-04-26T00:00:00+00:00",
+        "verified_links": [
+          "authority_evidence_hash",
+          "bind_coverage_operation_id",
+          "human_approval_receipt_hash",
+          "manifest_hash",
+          "outcome_receipt_hash"
+        ]
+      },
+      "expected_outcome": "commit",
+      "failure_reasons": [],
+      "human_approval_summary": {
+        "approval_receipt_id": "har-saas-001",
+        "approved": true,
+        "approved_scope": [
+          "saas:grant_admin"
+        ],
+        "approver_identity": "human:synthetic_reviewer",
+        "approver_role": "synthetic_reviewer",
+        "failure_reasons": [],
+        "receipt_hash_present": true
+      },
+      "outcome_receipt_summary": {
+        "action_class": "permission_change",
+        "bind_receipt_id": null,
+        "blocked": false,
+        "committed": true,
+        "decision_id": "decision-saas-001",
+        "escalated": false,
+        "evaluated_at": "2026-04-26T00:00:00+00:00",
+        "execution_intent_id": "intent-saas-001",
+        "failure_reasons": [],
+        "final_outcome": "commit",
+        "intended_action": "grant_admin_permission",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "observed_effects": [
+          {
+            "effect_type": "permission_grant",
+            "fixture_only": true,
+            "permission": "saas:grant_admin",
+            "target_resource": "synthetic_offline_resource"
+          }
+        ],
+        "operation_id": "saas-permission-change-valid_authority_and_approval",
+        "outcome_hash": "e8eb969be01b97993b20283a6f0314f5e83be4d6377e879f7b3719562e5a036a",
+        "outcome_receipt_id": "outcome-saas-permission-change-valid_authority_and_approval",
+        "post_state_fingerprint": null,
+        "postcondition_status": "passed",
+        "pre_state_fingerprint": null,
+        "requested_scope": [
+          "saas:grant_admin"
+        ],
+        "rollback_status": null,
+        "rolled_back": false,
+        "target_resource": "synthetic_offline_resource",
+        "target_system": "mock_saas_directory"
+      },
+      "passed": true,
+      "refusal_basis": [],
+      "requested_scope": [
+        "saas:grant_admin"
+      ],
+      "reviewer_interpretation": "AuthorityEvidence and HumanApprovalReceipt were sufficient for the local/offline fixture to reach a commit outcome.",
+      "runtime_recommended_outcome": "commit",
+      "target_resource": "synthetic_offline_resource",
+      "target_system": "mock_saas_directory"
+    }
+  ],
+  "demo_id": "evaluation_governance_offline_chain_reviewer_packet_v1",
+  "evaluation_governance_artifacts": [
+    {
+      "artifact_hash": "5cae168299c60becc997dde84fc143fa059edc2b5fca81dde1997f5916f4500f",
+      "artifact_ref": "evaluation-receipt-1.example.json",
+      "artifact_type": "evaluation_receipt",
+      "required_for_review": false,
+      "schema_ref": "docs/en/demo/schemas/evaluation-receipt-v1.schema.json"
+    },
+    {
+      "artifact_hash": "81c64573c36975ccf755f53718d1b759d00f612832aee47c35081117824a9cfa",
+      "artifact_ref": "evaluation-receipt-2.example.json",
+      "artifact_type": "evaluation_receipt",
+      "required_for_review": false,
+      "schema_ref": "docs/en/demo/schemas/evaluation-receipt-v1.schema.json"
+    },
+    {
+      "artifact_hash": "9e029c8f3a1df6f1b368def1d6cc7a665ffd6efe1b5c05c1d198d18f5105efb4",
+      "artifact_ref": "evaluation-receipt-3.example.json",
+      "artifact_type": "evaluation_receipt",
+      "required_for_review": false,
+      "schema_ref": "docs/en/demo/schemas/evaluation-receipt-v1.schema.json"
+    },
+    {
+      "artifact_hash": "4ce275c69363b76007a280e2ffcfb384efa2bc795532745f88dfc4da10ae6421",
+      "artifact_ref": "manifest-change-receipt.example.json",
+      "artifact_type": "manifest_change_receipt",
+      "required_for_review": false,
+      "schema_ref": "docs/en/demo/schemas/manifest-change-receipt-v1.schema.json"
+    },
+    {
+      "artifact_hash": "17029f187996728b120db5bbf7bb92f26d6a16f833bdc3b7c66bd05077d62d33",
+      "artifact_ref": "outcome-delta-attribution-1.generated.example.json",
+      "artifact_type": "outcome_delta_attribution",
+      "required_for_review": false,
+      "schema_ref": "docs/en/demo/schemas/outcome-delta-attribution-v1.schema.json"
+    },
+    {
+      "artifact_hash": "59fac37138155946793fd958cdf2e8c96a842671fa1f64829e6c1f99b3dd531e",
+      "artifact_ref": "outcome-delta-attribution-2.generated.example.json",
+      "artifact_type": "outcome_delta_attribution",
+      "required_for_review": false,
+      "schema_ref": "docs/en/demo/schemas/outcome-delta-attribution-v1.schema.json"
+    },
+    {
+      "artifact_hash": "9e6390164ff4d51dcc66d19b58dc9ca08f915ad07637ef580228aca4a39d3c6e",
+      "artifact_ref": "evaluation-drift-detection-1.generated.example.json",
+      "artifact_type": "evaluation_drift_detection",
+      "required_for_review": false,
+      "schema_ref": "docs/en/demo/schemas/evaluation-drift-detection-v1.schema.json"
+    },
+    {
+      "artifact_hash": "16b7d149551c7a415ee931a10d83c5e4d486fab59b0adda649d65b1e81d08b40",
+      "artifact_ref": "evaluation-drift-detection-2.generated.example.json",
+      "artifact_type": "evaluation_drift_detection",
+      "required_for_review": false,
+      "schema_ref": "docs/en/demo/schemas/evaluation-drift-detection-v1.schema.json"
+    },
+    {
+      "artifact_hash": "900ca433a0128a9f4e9308f9da783c6ae11dc7ae68af5fdd61add67d30f67c89",
+      "artifact_ref": "trajectory-admissibility-monitor.generated.example.json",
+      "artifact_type": "trajectory_admissibility_monitor",
+      "required_for_review": false,
+      "schema_ref": "docs/en/demo/schemas/trajectory-admissibility-monitor-v1.schema.json"
+    },
+    {
+      "artifact_hash": "2af7ec64add0c6e1919216fb79c47d56ad3f60653a009503646cc108d61efda0",
+      "artifact_ref": "legitimacy-impact-review.generated.example.json",
+      "artifact_type": "legitimacy_impact_review",
+      "required_for_review": false,
+      "schema_ref": "docs/en/demo/schemas/legitimacy-impact-review-v1.schema.json"
+    }
+  ],
+  "generated_at": "2026-01-01T00:00:00Z",
+  "local_offline_only": true,
+  "packet_hash": "425af2062d031478088d0194daaf18462ce6c982e9db9d59598b28f9da0a852b",
+  "packet_id": "reviewer-evidence-packet-saas-permission-change-v1",
+  "packet_version": "v1",
+  "reviewer_notes": [
+    "This packet is a synthetic offline reviewer evidence packet generated from an Evaluation Governance offline chain manifest.",
+    "Evaluation Governance artifacts are attached as optional reviewer evidence and are not runtime enforcement inputs.",
+    "This helper does not call /v1/decide, change runtime admissibility, or introduce fail-closed behavior.",
+    "This packet does not prove legitimacy, certify compliance, or include secrets, PII, customer data, or live external service data."
+  ],
+  "summary": "Synthetic local/offline reviewer packet generated from Evaluation Governance offline chain manifest 'evaluation-governance-offline-chain-example-001'. It attaches chain artifacts as optional reviewer evidence and does not establish legitimacy or certify compliance.",
+  "title": "Evaluation Governance Offline Chain Reviewer Evidence Packet"
+}

--- a/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated/trajectory-admissibility-monitor.generated.example.json
+++ b/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated/trajectory-admissibility-monitor.generated.example.json
@@ -1,0 +1,112 @@
+{
+  "admissibility_scope_change": {
+    "expansion_type": "delegated_authority_expansion",
+    "explicit_reauthorization_present": false,
+    "reauthorization_evidence_refs": [],
+    "scope_expanded": true
+  },
+  "baseline_authority_scope": {
+    "authority_evidence_ref": "authority-evidence-example-v1",
+    "scope_hash": "cd394c49479686f78fafa76d3c430017143b0cf186d705744d5c792d0c6f1a21",
+    "scope_id": "baseline-authority-scope"
+  },
+  "continuity_event_summary": {
+    "continuity_events_observed": 3,
+    "escalation_events_count": 2,
+    "low_risk_events_count": 1,
+    "material_change_events_count": 2,
+    "requalification_events_count": 1
+  },
+  "current_authority_scope": {
+    "authority_evidence_ref": "authority-evidence-example-v2",
+    "scope_hash": "a1d920789a49e251e52fe44e6a90e0f473eff97d69964e40b5ff9e5f1d501176",
+    "scope_id": "current-authority-scope"
+  },
+  "evaluation_drift_detection_refs": [
+    "evaluation-governance-offline-chain-drift-detection-001",
+    "evaluation-governance-offline-chain-drift-detection-002"
+  ],
+  "evaluation_receipt_refs": [
+    "evaluation-governance-offline-chain-receipt-001",
+    "evaluation-governance-offline-chain-receipt-002",
+    "evaluation-governance-offline-chain-receipt-003"
+  ],
+  "issued_at": "2026-01-01T00:00:00Z",
+  "monitor_hash": "3c1ca1fd304f9dc5d6a55916487cb427dea2fe3d8027aadf70d804ba81b8dede",
+  "monitor_id": "trajectory-admissibility-monitor-example-001",
+  "monitor_summary": "Trajectory monitor observed 3 evaluation receipts, 2 outcome delta attributions, and 2 drift detections. Authority scope changed across the trajectory and repeated continuity events may indicate admissibility envelope expansion.",
+  "outcome_delta_attribution_refs": [
+    "evaluation-governance-offline-chain-attribution-001",
+    "evaluation-governance-offline-chain-attribution-002"
+  ],
+  "recommended_governance_action": "mark_strategic_admissibility_drift",
+  "schema_version": "trajectory-admissibility-monitor-v1",
+  "trajectory_id": "trajectory-admissibility-monitor-example-001",
+  "trajectory_risk_signals": [
+    {
+      "evidence_refs": [
+        "evaluation-governance-offline-chain-receipt-001",
+        "evaluation-governance-offline-chain-receipt-002",
+        "evaluation-governance-offline-chain-receipt-003",
+        "evaluation-governance-offline-chain-attribution-001",
+        "evaluation-governance-offline-chain-attribution-002",
+        "evaluation-governance-offline-chain-drift-detection-001",
+        "evaluation-governance-offline-chain-drift-detection-002"
+      ],
+      "explanation": "The v1 helper observed trajectory-level scope expansion.",
+      "severity": "high",
+      "signal_type": "admissibility_envelope_expansion"
+    },
+    {
+      "evidence_refs": [
+        "evaluation-governance-offline-chain-receipt-001",
+        "evaluation-governance-offline-chain-receipt-002",
+        "evaluation-governance-offline-chain-receipt-003",
+        "evaluation-governance-offline-chain-attribution-001",
+        "evaluation-governance-offline-chain-attribution-002"
+      ],
+      "explanation": "Authority evidence or authority state changed over time.",
+      "severity": "high",
+      "signal_type": "delegated_scope_widening"
+    },
+    {
+      "evidence_refs": [
+        "evaluation-governance-offline-chain-receipt-001",
+        "evaluation-governance-offline-chain-receipt-002",
+        "evaluation-governance-offline-chain-receipt-003"
+      ],
+      "explanation": "Repeated continuity events lacked explicit reauthorization evidence.",
+      "severity": "medium",
+      "signal_type": "continuity_as_authorization_risk"
+    },
+    {
+      "evidence_refs": [
+        "evaluation-governance-offline-chain-attribution-001",
+        "evaluation-governance-offline-chain-attribution-002",
+        "evaluation-governance-offline-chain-drift-detection-001",
+        "evaluation-governance-offline-chain-drift-detection-002"
+      ],
+      "explanation": "Scope expansion appeared across repeated attribution or drift artifacts.",
+      "severity": "high",
+      "signal_type": "strategic_admissibility_drift"
+    },
+    {
+      "evidence_refs": [
+        "evaluation-governance-offline-chain-receipt-001",
+        "evaluation-governance-offline-chain-receipt-002",
+        "evaluation-governance-offline-chain-receipt-003",
+        "evaluation-governance-offline-chain-drift-detection-001",
+        "evaluation-governance-offline-chain-drift-detection-002"
+      ],
+      "explanation": "Repeated escalation or requalification events were observed.",
+      "severity": "medium",
+      "signal_type": "governance_exhaustion_signal"
+    }
+  ],
+  "trajectory_status": "strategically_shaped",
+  "trajectory_window": {
+    "ended_at": "2026-01-03T00:00:00Z",
+    "evaluation_count": 3,
+    "started_at": "2026-01-01T00:00:00Z"
+  }
+}

--- a/scripts/demo/run_evaluation_governance_reviewer_demo.py
+++ b/scripts/demo/run_evaluation_governance_reviewer_demo.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Run the synthetic Evaluation Governance reviewer demo end to end.
+
+This helper composes the offline Evaluation Governance chain runner with the
+Reviewer Evidence Packet generator. It is intentionally local/offline,
+non-runtime, and non-enforcing: it does not call ``/v1/decide``, does not alter
+runtime admissibility, does not dereference external artifact references, and
+does not establish legitimacy or certify compliance.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.demo.generate_reviewer_evidence_packet_from_evaluation_governance_chain import (  # noqa: E501
+    generate_reviewer_evidence_packet_from_chain,
+)
+from scripts.demo.run_evaluation_governance_offline_chain import (
+    DEFAULT_GENERATED_DIR_NAME,
+    GENERATED_FILE_NAMES,
+    run_offline_chain,
+)
+
+ISSUED_AT = "2026-01-01T00:00:00Z"
+DEMO_ID = "evaluation-governance-reviewer-demo-example-001"
+DEMO_SUMMARY_SCHEMA_VERSION = "evaluation-governance-reviewer-demo-summary-v1"
+DEMO_SUMMARY_FILE_NAME = "demo-summary.generated.example.json"
+REVIEWER_PACKET_FILE_NAME = "reviewer-evidence-packet.generated.example.json"
+DEFAULT_INPUT_DIR = (
+    REPO_ROOT / "docs/en/demo/examples/evaluation-governance-offline-chain-v1"
+)
+EXAMPLE_OUTPUT_DIR = (
+    REPO_ROOT
+    / "docs/en/demo/examples/evaluation-governance-reviewer-demo-v1"
+    / DEFAULT_GENERATED_DIR_NAME
+)
+SUMMARY_ARTIFACT_TYPES = {
+    "attribution_1": "outcome_delta_attribution",
+    "attribution_2": "outcome_delta_attribution",
+    "drift_1": "evaluation_drift_detection",
+    "drift_2": "evaluation_drift_detection",
+    "monitor": "trajectory_admissibility_monitor",
+    "review": "legitimacy_impact_review",
+    "manifest": "chain_manifest",
+}
+NON_GOALS = [
+    "does_not_change_runtime_behavior",
+    "does_not_call_v1_decide",
+    "does_not_establish_legitimacy",
+    "does_not_certify_compliance",
+    "does_not_dereference_external_artifact_refs",
+    "does_not_require_network_access",
+]
+
+
+@dataclass(frozen=True)
+class ReviewerDemoRunResult:
+    """Result metadata returned by ``run_reviewer_demo`` for tests and CLIs."""
+
+    output_dir: Path
+    chain_manifest: dict[str, Any]
+    reviewer_packet: dict[str, Any]
+    demo_summary: dict[str, Any]
+    artifact_paths: dict[str, Path]
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    """Load a local JSON object from ``path`` with clear demo-runner errors."""
+    if not path.is_file():
+        raise FileNotFoundError(f"missing JSON file: {path}")
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid JSON in {path}: {exc}") from exc
+
+    if not isinstance(payload, dict):
+        raise TypeError(f"expected JSON object in {path}")
+    return payload
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Write ``payload`` as stable, reviewer-readable JSON."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"{json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True)}\n",
+        encoding="utf-8",
+    )
+
+
+def canonical_json_hash(payload: Any) -> str:
+    """Return the SHA-256 digest of canonical JSON for local artifacts."""
+    canonical = json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def _artifact_entry(
+    artifact_type: str,
+    artifact_ref: str,
+    artifact_payload: dict[str, Any],
+) -> dict[str, str]:
+    """Build a demo summary artifact entry with a canonical JSON hash."""
+    return {
+        "artifact_type": artifact_type,
+        "artifact_ref": artifact_ref,
+        "artifact_hash": canonical_json_hash(artifact_payload),
+    }
+
+
+def build_demo_summary(
+    input_dir: Path,
+    chain_artifacts: dict[str, dict[str, Any]],
+    reviewer_packet: dict[str, Any],
+) -> dict[str, Any]:
+    """Build the reviewer-facing summary for the synthetic end-to-end demo."""
+    generated_artifacts = []
+    for key, file_name in GENERATED_FILE_NAMES.items():
+        generated_artifacts.append(
+            _artifact_entry(
+                SUMMARY_ARTIFACT_TYPES[key],
+                file_name,
+                chain_artifacts[key],
+            )
+        )
+    generated_artifacts.append(
+        _artifact_entry(
+            "reviewer_evidence_packet",
+            REVIEWER_PACKET_FILE_NAME,
+            reviewer_packet,
+        )
+    )
+
+    return {
+        "schema_version": DEMO_SUMMARY_SCHEMA_VERSION,
+        "demo_id": DEMO_ID,
+        "issued_at": ISSUED_AT,
+        "non_runtime": True,
+        "non_enforcing": True,
+        "input_dir": input_dir.as_posix(),
+        "generated_artifacts": generated_artifacts,
+        "demo_summary": (
+            "Synthetic offline Evaluation Governance reviewer demo generated "
+            "for architecture review."
+        ),
+        "non_goals": NON_GOALS,
+    }
+
+
+def run_reviewer_demo(input_dir: Path, output_dir: Path) -> ReviewerDemoRunResult:
+    """Generate the complete synthetic reviewer demo output directory.
+
+    Args:
+        input_dir: Directory containing local synthetic Evaluation Governance
+            example inputs for the offline chain runner.
+        output_dir: Directory where reviewer-facing generated artifacts are
+            written.
+
+    Returns:
+        Metadata for generated chain artifacts, the reviewer packet, and the
+        demo summary.
+
+    Raises:
+        FileNotFoundError: If required local input files are missing.
+        ValueError: If JSON is invalid or helper validation fails.
+    """
+    summary_input_dir = input_dir
+    input_dir = input_dir.resolve()
+    output_dir = output_dir.resolve()
+
+    chain_result = run_offline_chain(input_dir, output_dir)
+    reviewer_packet = generate_reviewer_evidence_packet_from_chain(
+        chain_result.manifest,
+        output_dir,
+    )
+    reviewer_packet_path = output_dir / REVIEWER_PACKET_FILE_NAME
+    write_json(reviewer_packet_path, reviewer_packet)
+
+    demo_summary = build_demo_summary(
+        summary_input_dir,
+        chain_result.artifacts,
+        reviewer_packet,
+    )
+    demo_summary_path = output_dir / DEMO_SUMMARY_FILE_NAME
+    write_json(demo_summary_path, demo_summary)
+
+    artifact_paths = dict(chain_result.artifact_paths)
+    artifact_paths["reviewer_packet"] = reviewer_packet_path
+    artifact_paths["demo_summary"] = demo_summary_path
+
+    return ReviewerDemoRunResult(
+        output_dir=output_dir,
+        chain_manifest=chain_result.manifest,
+        reviewer_packet=reviewer_packet,
+        demo_summary=demo_summary,
+        artifact_paths=artifact_paths,
+    )
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments for the reviewer demo runner."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate a non-runtime, non-enforcing end-to-end Evaluation "
+            "Governance reviewer demo from local synthetic inputs."
+        )
+    )
+    parser.add_argument(
+        "--input-dir",
+        default=DEFAULT_INPUT_DIR,
+        type=Path,
+        help=(
+            "Directory containing synthetic offline-chain input JSON files "
+            f"(default: {DEFAULT_INPUT_DIR.relative_to(REPO_ROOT)})"
+        ),
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        help="Safe output directory for generated reviewer-facing artifacts.",
+    )
+    parser.add_argument(
+        "--write-example-output",
+        action="store_true",
+        help=(
+            "Intentionally overwrite checked-in reviewer demo example outputs. "
+            "Required when --output-dir is omitted."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def _resolve_output_dir(args: argparse.Namespace) -> Path:
+    """Resolve output directory while preventing accidental repo mutations."""
+    if args.output_dir is not None:
+        return args.output_dir
+    if args.write_example_output:
+        return EXAMPLE_OUTPUT_DIR
+    raise ValueError(
+        "refusing to write checked-in generated examples without "
+        "--write-example-output; pass --output-dir for safe temporary output"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the Evaluation Governance reviewer demo CLI."""
+    args = _parse_args(argv)
+    try:
+        output_dir = _resolve_output_dir(args)
+        result = run_reviewer_demo(args.input_dir, output_dir)
+    except Exception as exc:  # noqa: BLE001 - CLI presents concise errors.
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    print("Evaluation Governance Reviewer Demo")
+    print("")
+    print("PASS generated offline chain artifacts")
+    print("PASS generated reviewer evidence packet")
+    print("PASS generated demo summary")
+    print("")
+    print(f"Output directory: {result.output_dir}")
+    print("")
+    print(f"Generated {len(result.artifact_paths)} reviewer-facing artifacts.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/demo/test_evaluation_governance_reviewer_demo_runner.py
+++ b/tests/demo/test_evaluation_governance_reviewer_demo_runner.py
@@ -1,0 +1,116 @@
+"""Tests for the Evaluation Governance end-to-end reviewer demo runner."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from scripts.demo import run_evaluation_governance_reviewer_demo as runner
+
+EXAMPLE_DIR = Path(
+    "docs/en/demo/examples/evaluation-governance-offline-chain-v1"
+)
+SCRIPT_PATH = Path("scripts/demo/run_evaluation_governance_reviewer_demo.py")
+GENERATED_FILE_NAMES = [
+    "outcome-delta-attribution-1.generated.example.json",
+    "outcome-delta-attribution-2.generated.example.json",
+    "evaluation-drift-detection-1.generated.example.json",
+    "evaluation-drift-detection-2.generated.example.json",
+    "trajectory-admissibility-monitor.generated.example.json",
+    "legitimacy-impact-review.generated.example.json",
+    "chain-manifest.generated.example.json",
+    "reviewer-evidence-packet.generated.example.json",
+    "demo-summary.generated.example.json",
+]
+REQUIRED_ARTIFACT_TYPES = {
+    "evaluation_receipt",
+    "manifest_change_receipt",
+    "outcome_delta_attribution",
+    "evaluation_drift_detection",
+    "trajectory_admissibility_monitor",
+    "legitimacy_impact_review",
+}
+REQUIRED_NON_GOALS = {
+    "does_not_call_v1_decide",
+    "does_not_establish_legitimacy",
+    "does_not_certify_compliance",
+}
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_runner_imports_cleanly() -> None:
+    assert callable(runner.run_reviewer_demo)
+    assert callable(runner.canonical_json_hash)
+    assert callable(runner.build_demo_summary)
+    assert callable(runner.write_json)
+    assert callable(runner.load_json)
+    assert callable(runner.main)
+
+
+def test_run_reviewer_demo_generates_expected_artifacts(tmp_path: Path) -> None:
+    result = runner.run_reviewer_demo(EXAMPLE_DIR, tmp_path)
+
+    for file_name in GENERATED_FILE_NAMES:
+        assert (tmp_path / file_name).is_file()
+
+    packet = _load_json(tmp_path / "reviewer-evidence-packet.generated.example.json")
+    artifacts = packet.get("evaluation_governance_artifacts")
+    assert isinstance(artifacts, list)
+    artifact_types = {artifact["artifact_type"] for artifact in artifacts}
+    assert REQUIRED_ARTIFACT_TYPES <= artifact_types
+
+    summary = _load_json(tmp_path / "demo-summary.generated.example.json")
+    assert summary["schema_version"] == runner.DEMO_SUMMARY_SCHEMA_VERSION
+    assert summary["non_runtime"] is True
+    assert summary["non_enforcing"] is True
+    assert REQUIRED_NON_GOALS <= set(summary["non_goals"])
+    assert result.reviewer_packet == packet
+    assert result.demo_summary == summary
+
+
+def test_runner_cli_writes_to_output_dir(tmp_path: Path) -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--input-dir",
+            str(EXAMPLE_DIR),
+            "--output-dir",
+            str(tmp_path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "Evaluation Governance Reviewer Demo" in completed.stdout
+    assert "PASS generated offline chain artifacts" in completed.stdout
+    assert "PASS generated reviewer evidence packet" in completed.stdout
+    assert "PASS generated demo summary" in completed.stdout
+    assert "Generated 9 reviewer-facing artifacts." in completed.stdout
+    for file_name in GENERATED_FILE_NAMES:
+        assert (tmp_path / file_name).is_file()
+
+
+def test_runner_cli_refuses_implicit_example_mutation() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--input-dir",
+            str(EXAMPLE_DIR),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode != 0
+    assert "refusing to write checked-in generated examples" in completed.stderr


### PR DESCRIPTION
### Motivation
- Provide a thin, non-runtime end-to-end reviewer demo that composes the existing Evaluation Governance offline chain runner with the Reviewer Evidence Packet generator to produce a reviewer-facing output directory from synthetic local inputs.
- Keep the change strictly docs/tests/helpers-only and explicitly avoid any runtime enforcement, `/v1/decide` invocation, schema or admissibility logic changes, network access, secrets, or production policy mutation.  

### Description
- Add a new CLI/script `scripts/demo/run_evaluation_governance_reviewer_demo.py` that reuses `run_offline_chain` and `generate_reviewer_evidence_packet_from_chain` and exposes `run_reviewer_demo(input_dir, output_dir)`, `canonical_json_hash`, `build_demo_summary`, `write_json`, and `load_json` helpers with clear docstrings.  
- Implement safe CLI semantics with `--input-dir`, `--output-dir`, and `--write-example-output`, refusing to overwrite checked-in examples unless `--write-example-output` is provided.  
- Add checked-in example outputs and a short README under `docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/` (including `generated/chain-manifest.generated.example.json`, `generated/reviewer-evidence-packet.generated.example.json`, and `generated/demo-summary.generated.example.json`) to serve as reviewer-readable artifacts.  
- Add tests `tests/demo/test_evaluation_governance_reviewer_demo_runner.py` that cover import safety, direct `run_reviewer_demo(...)` execution, expected artifact generation and contents, CLI success, and refusal to mutate checked-in examples; all new code contains docstrings and avoids side effects at import time.

### Testing
- Ran the new demo CLI to regenerate checked-in examples with `PYENV_VERSION=3.11.15 python scripts/demo/run_evaluation_governance_reviewer_demo.py --input-dir docs/en/demo/examples/evaluation-governance-offline-chain-v1 --write-example-output`, which completed successfully and wrote the expected `generated/` files. (succeeded)
- Executed unit tests: `PYENV_VERSION=3.11.15 python -m pytest tests/demo/test_evaluation_governance_reviewer_demo_runner.py tests/demo/test_evaluation_governance_offline_chain_runner.py tests/demo/test_evaluation_governance_chain_reviewer_packet.py` and additional helper tests listed in the demo suite; all ran and passed locally. (succeeded)
- Verified CLI behavior via subprocess in tests that assert exit codes and stdout/stderr messages (the CLI success and the refusal-to-mutate behavior both pass). (succeeded)
- Ran `ruff` checks on the new script and test file (`python -m ruff check scripts/demo/run_evaluation_governance_reviewer_demo.py tests/demo/test_evaluation_governance_reviewer_demo_runner.py`) to validate style; checks passed. (succeeded)

Security note: this change is intentionally offline/read-only for reviewer artifacts and does not introduce network calls, secrets, PII handling, runtime enforcement, schema changes, or changes to admissibility or governance logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26003fa8c083269c1d458b98d626a6)