### PR TITLE
Add Evaluation Governance reviewer demo quickstart v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ VERITAS includes a reviewer-facing Evaluation Governance artifact chain for insp
 These artifacts are non-enforcing in v1. They do not change `/v1/decide`, do not automatically establish legitimacy, and do not certify regulatory compliance. They are intended to make architecture-hardening evidence explicit, versioned, challengeable, and auditable.
 
 - Evaluation Governance overview: [docs/en/architecture/evaluation-governance-overview-v1.md](docs/en/architecture/evaluation-governance-overview-v1.md)
+- Evaluation Governance reviewer demo quickstart: [docs/en/demo/evaluation-governance-reviewer-demo-quickstart-v1.md](docs/en/demo/evaluation-governance-reviewer-demo-quickstart-v1.md)
 - [Evaluation Function Governance v1](docs/en/architecture/evaluation-function-governance-v1.md)
 - [Evaluation Receipt v1](docs/en/architecture/evaluation-receipt-v1.md)
 - [Outcome Delta Attribution v1](docs/en/architecture/outcome-delta-attribution-v1.md)

--- a/README_JP.md
+++ b/README_JP.md
@@ -71,6 +71,7 @@ VERITASには、authority、評価関数の定義、Evaluation Receipt、outcome
 これらは v1 では非強制のレビュアー向け成果物です。`/v1/decide` の挙動を変更せず、legitimacyを自動的に保証せず、規制適合を認証するものでもありません。目的は、architecture hardening のための証跡を明示的・version管理可能・異議申し立て可能・監査可能にすることです。
 
 - Evaluation Governance overview: [docs/en/architecture/evaluation-governance-overview-v1.md](docs/en/architecture/evaluation-governance-overview-v1.md)
+- Evaluation Governance reviewer demo quickstart: [docs/en/demo/evaluation-governance-reviewer-demo-quickstart-v1.md](docs/en/demo/evaluation-governance-reviewer-demo-quickstart-v1.md)
 - [Evaluation Function Governance v1](docs/en/architecture/evaluation-function-governance-v1.md)
 - [Evaluation Receipt v1](docs/en/architecture/evaluation-receipt-v1.md)
 - [Outcome Delta Attribution v1](docs/en/architecture/outcome-delta-attribution-v1.md)

--- a/docs/en/architecture/evaluation-governance-overview-v1.md
+++ b/docs/en/architecture/evaluation-governance-overview-v1.md
@@ -84,6 +84,8 @@ See:
 
 The synthetic sample bundle can be validated locally with `scripts/demo/validate_evaluation_governance_sample_bundle.py`.
 
+For a one-command synthetic reviewer demo, see [Evaluation Governance Reviewer Demo Quickstart v1](../demo/evaluation-governance-reviewer-demo-quickstart-v1.md).
+
 In v1, this packet integration is optional, non-enforcing, and reference-only.
 It does not require live runtime generation yet and does not change `/v1/decide`
 behavior.

--- a/docs/en/demo/evaluation-governance-reviewer-demo-quickstart-v1.md
+++ b/docs/en/demo/evaluation-governance-reviewer-demo-quickstart-v1.md
@@ -1,0 +1,148 @@
+# Evaluation Governance Reviewer Demo Quickstart v1
+
+## 1. Purpose
+
+This quickstart shows how to run the synthetic, offline Evaluation Governance reviewer demo.
+
+The demo generates reviewer-facing artifacts for:
+
+- Outcome Delta Attribution
+- Evaluation Drift Detection
+- Trajectory-Level Admissibility Monitor
+- Legitimacy Impact Review
+- Chain Manifest
+- Reviewer Evidence Packet
+- Demo Summary
+
+## 2. What this demo demonstrates
+
+The demo follows this end-to-end reviewer path:
+
+```text
+Evaluation Receipt
+-> Outcome Delta Attribution
+-> Evaluation Drift Detection
+-> Trajectory-Level Admissibility Monitor
+-> Legitimacy Impact Review
+-> Reviewer Evidence Packet
+```
+
+This helps reviewers inspect how VERITAS represents:
+
+- authority and evaluator evidence
+- outcome changes
+- drift signals
+- trajectory-level admissibility movement
+- legitimacy-impacting changes
+- reviewer evidence attachments
+
+## 3. Important boundary
+
+This demo is synthetic.
+This demo is offline.
+This demo is non-runtime.
+This demo is non-enforcing in v1.
+It does not call `/v1/decide`.
+It does not change runtime admissibility.
+It does not establish legitimacy.
+It does not certify regulatory compliance.
+It does not dereference external artifact refs.
+It does not require network access.
+It does not contain secrets or PII.
+
+## 4. Run the demo
+
+Run the reviewer demo with a temporary output directory:
+
+```bash
+python scripts/demo/run_evaluation_governance_reviewer_demo.py \
+  --input-dir docs/en/demo/examples/evaluation-governance-offline-chain-v1 \
+  --output-dir /tmp/evaluation-governance-reviewer-demo
+```
+
+This writes generated reviewer-facing artifacts to:
+
+```text
+/tmp/evaluation-governance-reviewer-demo
+```
+
+## 5. Expected outputs
+
+The output directory should contain:
+
+```text
+outcome-delta-attribution-1.generated.example.json
+outcome-delta-attribution-2.generated.example.json
+evaluation-drift-detection-1.generated.example.json
+evaluation-drift-detection-2.generated.example.json
+trajectory-admissibility-monitor.generated.example.json
+legitimacy-impact-review.generated.example.json
+chain-manifest.generated.example.json
+reviewer-evidence-packet.generated.example.json
+demo-summary.generated.example.json
+```
+
+## 6. What reviewers should inspect first
+
+Recommended inspection order:
+
+1. `demo-summary.generated.example.json`
+   - confirms non-runtime and non-enforcing demo boundaries
+2. `chain-manifest.generated.example.json`
+   - lists generated chain artifacts
+3. `reviewer-evidence-packet.generated.example.json`
+   - shows Evaluation Governance artifacts attached as reviewer evidence
+4. `trajectory-admissibility-monitor.generated.example.json`
+   - shows trajectory-level admissibility movement
+5. `legitimacy-impact-review.generated.example.json`
+   - shows legitimacy-impacting change signals
+
+## 7. Regenerate checked-in examples intentionally
+
+Maintainers can intentionally regenerate checked-in example outputs with:
+
+```bash
+python scripts/demo/run_evaluation_governance_reviewer_demo.py \
+  --input-dir docs/en/demo/examples/evaluation-governance-offline-chain-v1 \
+  --write-example-output
+```
+
+This intentionally updates checked-in example outputs.
+Normal reviewers should prefer `--output-dir`.
+This mode exists for maintainers.
+
+## 8. Relationship to Reviewer Evidence Packet
+
+The Reviewer Evidence Packet can include optional `evaluation_governance_artifacts`.
+The generated packet attaches the Evaluation Governance chain artifacts for review.
+These attachments are optional reviewer evidence in v1.
+They are not mandatory runtime outputs.
+
+See:
+
+- [Reviewer Evidence Packet v1](reviewer-evidence-packet.md)
+- [Evaluation Governance offline-chain Reviewer Evidence Packet example](examples/evaluation-governance-chain-reviewer-packet-v1/README.md)
+
+## 9. Relationship to Evaluation Governance overview
+
+The Evaluation Governance overview explains the artifact chain.
+This quickstart explains how to run the synthetic reviewer demo.
+
+See:
+
+- [Evaluation Governance Overview v1](../architecture/evaluation-governance-overview-v1.md)
+
+## 10. Troubleshooting
+
+- If Python cannot import dependencies, run the repository's normal development setup first.
+- If output files are not created, confirm `--output-dir` is provided.
+- If trying to write checked-in examples, use `--write-example-output`.
+- The demo should not require network access.
+
+## 11. Non-goals
+
+- This quickstart does not claim regulatory compliance.
+- This quickstart does not claim automatic legitimacy determination.
+- This quickstart does not change runtime behavior.
+- This quickstart does not certify governance correctness.
+- This quickstart does not replace human, legal, compliance, or audit review.

--- a/docs/en/demo/external-reviewer-quickstart.md
+++ b/docs/en/demo/external-reviewer-quickstart.md
@@ -52,6 +52,10 @@ Use this 10–15 minute path for a reviewer-facing inspection:
 7. Optionally review Evaluation Governance artifacts, if present. These attachments are optional in v1, non-enforcing, and useful for architecture-hardening review without changing runtime admissibility.
    A synthetic example packet is available at `docs/en/demo/examples/reviewer-evidence-packet-with-evaluation-governance-v1.json`; schema validation does not require the referenced artifact files to exist.
 
+## Evaluation Governance offline reviewer demo
+
+For a one-command synthetic offline demo, see [Evaluation Governance Reviewer Demo Quickstart v1](evaluation-governance-reviewer-demo-quickstart-v1.md). The demo is reviewer-facing, non-runtime, and non-enforcing in v1, and it produces a Reviewer Evidence Packet with optional Evaluation Governance attachments.
+
 ## Local bundle generation
 
 Reviewers can reproduce the GitHub Actions reviewer evidence artifact locally by running:

--- a/docs/en/demo/reviewer-evidence-packet.md
+++ b/docs/en/demo/reviewer-evidence-packet.md
@@ -38,6 +38,8 @@ These attachments are optional reviewer evidence attachments in v1. Reviewer pac
 
 A non-enforcing example packet with optional Evaluation Governance attachment references is checked in at `docs/en/demo/examples/reviewer-evidence-packet-with-evaluation-governance-v1.json`. A synthetic end-to-end Evaluation Governance sample bundle is also available at `docs/en/demo/examples/evaluation-governance-sample-bundle-v1/`. A synthetic packet generated from the Evaluation Governance offline chain manifest is checked in at `docs/en/demo/examples/evaluation-governance-chain-reviewer-packet-v1/`.
 
+Evaluation Governance reviewer packet examples can be generated from the offline demo chain. See [Evaluation Governance Reviewer Demo Quickstart v1](evaluation-governance-reviewer-demo-quickstart-v1.md).
+
 Evaluation Governance artifacts are non-enforcing in v1 unless future runtime integration is added. Their presence supports external review, but does not automatically establish legitimacy, does not change runtime admissibility, does not introduce fail-closed behavior, and does not require live receipt generation.
 
 ## Local/offline boundary


### PR DESCRIPTION
### Motivation

- Provide a concise, reviewer-facing quickstart that makes the Evaluation Governance offline end-to-end demo easy to find, run, and inspect. 
- Surface safe, reviewer-oriented boundaries (synthetic, offline, non-runtime, non-enforcing in v1) and avoid implying runtime enforcement, legitimacy, or regulatory certification.

### Description

- Add `docs/en/demo/evaluation-governance-reviewer-demo-quickstart-v1.md` describing purpose, end-to-end artifact path, safe `--output-dir` run command, expected outputs, recommended inspection order, maintainer `--write-example-output` mode, troubleshooting, and non-goals. 
- Insert compact cross-links to the new quickstart from `docs/en/demo/external-reviewer-quickstart.md`, `docs/en/architecture/evaluation-governance-overview-v1.md`, and `docs/en/demo/reviewer-evidence-packet.md`.
- Add very small, compact links in `README.md` and `README_JP.md` under the Evaluation Governance reviewer artifacts section. 
- All changes are documentation-only and do not modify runtime code, schemas, `/v1/decide` behavior, production governance configuration, admissibility logic, fail-closed behavior, or add live receipt generation.

### Testing

- Ran the reviewer demo: `python3 scripts/demo/run_evaluation_governance_reviewer_demo.py --input-dir docs/en/demo/examples/evaluation-governance-offline-chain-v1 --output-dir /tmp/evaluation-governance-reviewer-demo`, which completed successfully and produced the expected artifacts in `/tmp/evaluation-governance-reviewer-demo`.
- Ran repository checks with `git diff --check`, which reported no whitespace or diff-check issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2605f16ff88326bc93ce80cd6a9c07)