### PR TITLE
Add Evaluation Governance reviewer demo report generator v1

### DIFF
--- a/docs/en/demo/evaluation-governance-reviewer-demo-quickstart-v1.md
+++ b/docs/en/demo/evaluation-governance-reviewer-demo-quickstart-v1.md
@@ -78,7 +78,20 @@ non-runtime / non-enforcing boundaries, and Reviewer Evidence Packet
 attachments. It does not establish legitimacy, does not certify compliance, and
 does not call `/v1/decide`.
 
-## 6. Expected outputs
+## 6. Generate a reviewer report
+
+```bash
+python scripts/demo/generate_evaluation_governance_reviewer_demo_report.py \
+  --demo-dir /tmp/evaluation-governance-reviewer-demo \
+  --output /tmp/evaluation-governance-reviewer-demo/reviewer-demo-report.md
+```
+
+This creates a human-readable Markdown summary of the chain manifest,
+Reviewer Evidence Packet, trajectory monitor, and legitimacy impact review.
+It does not establish legitimacy, does not certify compliance, and does not
+call `/v1/decide`.
+
+## 7. Expected outputs
 
 The output directory should contain:
 
@@ -94,7 +107,7 @@ reviewer-evidence-packet.generated.example.json
 demo-summary.generated.example.json
 ```
 
-## 7. What reviewers should inspect first
+## 8. What reviewers should inspect first
 
 Recommended inspection order:
 
@@ -109,7 +122,7 @@ Recommended inspection order:
 5. `legitimacy-impact-review.generated.example.json`
    - shows legitimacy-impacting change signals
 
-## 8. Regenerate checked-in examples intentionally
+## 9. Regenerate checked-in examples intentionally
 
 Maintainers can intentionally regenerate checked-in example outputs with:
 
@@ -123,7 +136,7 @@ This intentionally updates checked-in example outputs.
 Normal reviewers should prefer `--output-dir`.
 This mode exists for maintainers.
 
-## 9. Relationship to Reviewer Evidence Packet
+## 10. Relationship to Reviewer Evidence Packet
 
 The Reviewer Evidence Packet can include optional `evaluation_governance_artifacts`.
 The generated packet attaches the Evaluation Governance chain artifacts for review.
@@ -135,7 +148,7 @@ See:
 - [Reviewer Evidence Packet v1](reviewer-evidence-packet.md)
 - [Evaluation Governance offline-chain Reviewer Evidence Packet example](examples/evaluation-governance-chain-reviewer-packet-v1/README.md)
 
-## 10. Relationship to Evaluation Governance overview
+## 11. Relationship to Evaluation Governance overview
 
 The Evaluation Governance overview explains the artifact chain.
 This quickstart explains how to run the synthetic reviewer demo.
@@ -144,14 +157,14 @@ See:
 
 - [Evaluation Governance Overview v1](../architecture/evaluation-governance-overview-v1.md)
 
-## 11. Troubleshooting
+## 12. Troubleshooting
 
 - If Python cannot import dependencies, run the repository's normal development setup first.
 - If output files are not created, confirm `--output-dir` is provided.
 - If trying to write checked-in examples, use `--write-example-output`.
 - The demo should not require network access.
 
-## 12. Non-goals
+## 13. Non-goals
 
 - This quickstart does not claim regulatory compliance.
 - This quickstart does not claim automatic legitimacy determination.

--- a/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/README.md
+++ b/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/README.md
@@ -43,6 +43,17 @@ non-runtime / non-enforcing boundaries, and Reviewer Evidence Packet
 attachments. It does not establish legitimacy, certify compliance, or call
 `/v1/decide`.
 
+## Generate the checked-in reviewer report example
+
+```bash
+python scripts/demo/generate_evaluation_governance_reviewer_demo_report.py \
+  --demo-dir docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated \
+  --output docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated/reviewer-demo-report.generated.example.md
+```
+
+This report is a human-readable Markdown summary for reviewers. It does not
+establish legitimacy, certify compliance, or call `/v1/decide`.
+
 ## Checked-in generated examples
 
 The files under [`generated/`](generated/) are checked in for reviewer

--- a/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated/reviewer-demo-report.generated.example.md
+++ b/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated/reviewer-demo-report.generated.example.md
@@ -1,0 +1,139 @@
+# Evaluation Governance Reviewer Demo Report
+
+## 1. Report purpose
+
+This report summarizes a synthetic, offline Evaluation Governance reviewer demo output.
+
+Boundary statements:
+
+- This report is non-runtime.
+- This report is non-enforcing in v1.
+- This report does not call /v1/decide.
+- This report does not establish legitimacy.
+- This report does not certify regulatory compliance.
+- This report does not dereference external artifact refs.
+- This report does not require network access.
+
+## 2. Demo boundary
+
+- demo_id: `evaluation-governance-reviewer-demo-example-001`
+- issued_at: `2026-01-01T00:00:00Z`
+- non_runtime: `true`
+- non_enforcing: `true`
+- non_goals:
+  - `does_not_change_runtime_behavior`
+  - `does_not_call_v1_decide`
+  - `does_not_establish_legitimacy`
+  - `does_not_certify_compliance`
+  - `does_not_dereference_external_artifact_refs`
+  - `does_not_require_network_access`
+
+## 3. Generated artifact chain
+
+- chain_id: `evaluation-governance-offline-chain-example-001`
+- issued_at: `2026-01-01T00:00:00Z`
+- artifact count: `10`
+- artifact types:
+  - `evaluation_receipt`
+  - `manifest_change_receipt`
+  - `outcome_delta_attribution`
+  - `evaluation_drift_detection`
+  - `trajectory_admissibility_monitor`
+  - `legitimacy_impact_review`
+
+| Artifact type | Artifact ref |
+| --- | --- |
+| evaluation_receipt | evaluation-receipt-1.example.json |
+| evaluation_receipt | evaluation-receipt-2.example.json |
+| evaluation_receipt | evaluation-receipt-3.example.json |
+| manifest_change_receipt | manifest-change-receipt.example.json |
+| outcome_delta_attribution | outcome-delta-attribution-1.generated.example.json |
+| outcome_delta_attribution | outcome-delta-attribution-2.generated.example.json |
+| evaluation_drift_detection | evaluation-drift-detection-1.generated.example.json |
+| evaluation_drift_detection | evaluation-drift-detection-2.generated.example.json |
+| trajectory_admissibility_monitor | trajectory-admissibility-monitor.generated.example.json |
+| legitimacy_impact_review | legitimacy-impact-review.generated.example.json |
+
+## 4. Reviewer Evidence Packet attachments
+
+- packet schema version: `v1`
+- evaluation_governance_artifacts exists: `true`
+- Evaluation Governance attachment count: `10`
+- attachment types:
+  - `evaluation_receipt`
+  - `manifest_change_receipt`
+  - `outcome_delta_attribution`
+  - `evaluation_drift_detection`
+  - `trajectory_admissibility_monitor`
+  - `legitimacy_impact_review`
+
+| Attachment type | Required for review | Schema ref |
+| --- | --- | --- |
+| evaluation_receipt | false | docs/en/demo/schemas/evaluation-receipt-v1.schema.json |
+| evaluation_receipt | false | docs/en/demo/schemas/evaluation-receipt-v1.schema.json |
+| evaluation_receipt | false | docs/en/demo/schemas/evaluation-receipt-v1.schema.json |
+| manifest_change_receipt | false | docs/en/demo/schemas/manifest-change-receipt-v1.schema.json |
+| outcome_delta_attribution | false | docs/en/demo/schemas/outcome-delta-attribution-v1.schema.json |
+| outcome_delta_attribution | false | docs/en/demo/schemas/outcome-delta-attribution-v1.schema.json |
+| evaluation_drift_detection | false | docs/en/demo/schemas/evaluation-drift-detection-v1.schema.json |
+| evaluation_drift_detection | false | docs/en/demo/schemas/evaluation-drift-detection-v1.schema.json |
+| trajectory_admissibility_monitor | false | docs/en/demo/schemas/trajectory-admissibility-monitor-v1.schema.json |
+| legitimacy_impact_review | false | docs/en/demo/schemas/legitimacy-impact-review-v1.schema.json |
+
+These are optional reviewer evidence attachments in v1, not mandatory runtime outputs.
+
+## 5. Trajectory-level admissibility signals
+
+- trajectory_status: `strategically_shaped`
+- recommended_governance_action: `mark_strategic_admissibility_drift`
+- admissibility_scope_change.scope_expanded: `true`
+- expansion_type: `delegated_authority_expansion`
+- trajectory_risk_signals:
+  - `admissibility_envelope_expansion` (high): The v1 helper observed trajectory-level scope expansion.
+  - `delegated_scope_widening` (high): Authority evidence or authority state changed over time.
+  - `continuity_as_authorization_risk` (medium): Repeated continuity events lacked explicit reauthorization evidence.
+  - `strategic_admissibility_drift` (high): Scope expansion appeared across repeated attribution or drift artifacts.
+  - `governance_exhaustion_signal` (medium): Repeated escalation or requalification events were observed.
+
+These signals are reviewer-facing indicators, not runtime enforcement outcomes.
+
+## 6. Legitimacy impact review signals
+
+- legitimacy_impact_detected: `true`
+- review_status: `pending`
+- recommended_governance_action: `multi_party_review`
+- impact_categories:
+  - `authority_scope_expansion`
+  - `human_oversight_weakened`
+  - `escalation_requirement_reduced`
+  - `high_risk_admissibility_expanded`
+  - `evaluation_behavior_changed`
+
+VERITAS does not automatically create or guarantee legitimacy. This artifact surfaces legitimacy-impacting signals for review.
+
+## 7. Validation status
+
+Validation status: PASS
+
+The reviewer demo validator confirmed:
+
+- expected files present
+- schema shape validated where schemas exist
+- safety boundaries checked
+- reviewer packet attachments checked
+
+## 8. Reviewer inspection order
+
+1. `demo-summary.generated.example.json`
+2. `chain-manifest.generated.example.json`
+3. `reviewer-evidence-packet.generated.example.json`
+4. `trajectory-admissibility-monitor.generated.example.json`
+5. `legitimacy-impact-review.generated.example.json`
+
+## 9. Non-goals
+
+- This report does not claim regulatory compliance.
+- This report does not claim automatic legitimacy determination.
+- This report does not change runtime behavior.
+- This report does not certify governance correctness.
+- This report does not replace human, legal, compliance, or audit review.

--- a/scripts/demo/generate_evaluation_governance_reviewer_demo_report.py
+++ b/scripts/demo/generate_evaluation_governance_reviewer_demo_report.py
@@ -1,0 +1,584 @@
+#!/usr/bin/env python3
+"""Generate a Markdown report for Evaluation Governance reviewer demos.
+
+This helper is intentionally local/offline, non-runtime, and non-enforcing. It
+summarizes an already generated Evaluation Governance reviewer demo directory
+without calling ``/v1/decide``, dereferencing artifact references, accessing the
+network, requiring secrets, or modifying input artifacts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.demo.validate_evaluation_governance_reviewer_demo import (  # noqa: E402
+    ReviewerDemoValidationError,
+    ReviewerDemoValidationResult,
+    validate_reviewer_demo,
+)
+
+DEMO_SUMMARY_FILE_NAME = "demo-summary.generated.example.json"
+CHAIN_MANIFEST_FILE_NAME = "chain-manifest.generated.example.json"
+REVIEWER_PACKET_FILE_NAME = "reviewer-evidence-packet.generated.example.json"
+TRAJECTORY_MONITOR_FILE_NAME = (
+    "trajectory-admissibility-monitor.generated.example.json"
+)
+LEGITIMACY_REVIEW_FILE_NAME = "legitimacy-impact-review.generated.example.json"
+
+
+@dataclass(frozen=True)
+class ChainManifestSummary:
+    """Reviewer-relevant chain manifest fields for report rendering."""
+
+    chain_id: str
+    issued_at: str
+    artifact_count: int
+    artifact_types: list[str]
+    artifacts: list[dict[str, str]]
+
+
+@dataclass(frozen=True)
+class ReviewerPacketSummary:
+    """Reviewer Evidence Packet attachment fields for report rendering."""
+
+    packet_schema_version: str
+    has_evaluation_governance_artifacts: bool
+    attachment_count: int
+    attachment_types: list[str]
+    attachments: list[dict[str, str]]
+
+
+@dataclass(frozen=True)
+class TrajectoryMonitorSummary:
+    """Trajectory-level admissibility monitor fields for report rendering."""
+
+    trajectory_status: str
+    recommended_governance_action: str
+    scope_expanded: bool
+    expansion_type: str
+    risk_signals: list[dict[str, str]]
+
+
+@dataclass(frozen=True)
+class LegitimacyReviewSummary:
+    """Legitimacy impact review fields for report rendering."""
+
+    legitimacy_impact_detected: bool
+    impact_categories: list[str]
+    review_status: str
+    recommended_governance_action: str
+
+
+@dataclass(frozen=True)
+class ReportInputs:
+    """Loaded and summarized reviewer demo inputs for Markdown rendering."""
+
+    demo_summary: dict[str, Any]
+    chain_manifest: ChainManifestSummary
+    reviewer_packet: ReviewerPacketSummary
+    trajectory_monitor: TrajectoryMonitorSummary
+    legitimacy_review: LegitimacyReviewSummary
+    validation_result: ReviewerDemoValidationResult | None
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    """Load a local JSON object without dereferencing artifact references."""
+    if not path.is_file():
+        raise FileNotFoundError(f"missing JSON file: {path}")
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid JSON in {path}: {exc}") from exc
+
+    if not isinstance(payload, dict):
+        raise TypeError(f"expected JSON object in {path}")
+    return payload
+
+
+def _string(value: Any, default: str = "not provided") -> str:
+    """Return ``value`` as a report-safe string for simple Markdown fields."""
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, str):
+        return value
+    return str(value)
+
+
+def _bool(value: Any) -> bool:
+    """Return a strict boolean only when the JSON value is a boolean."""
+    return value if isinstance(value, bool) else False
+
+
+def _table_cell(value: Any) -> str:
+    """Render a compact Markdown table cell without changing references."""
+    return _string(value).replace("|", "\\|").replace("\n", " ")
+
+
+def _unique_preserving_order(values: list[str]) -> list[str]:
+    """Return unique strings in their first-seen order."""
+    seen: set[str] = set()
+    unique_values = []
+    for value in values:
+        if value not in seen:
+            unique_values.append(value)
+            seen.add(value)
+    return unique_values
+
+
+def _require_demo_boundaries(demo_summary: dict[str, Any]) -> None:
+    """Require non-runtime and non-enforcing demo boundaries."""
+    if demo_summary.get("non_runtime") is not True:
+        raise ValueError("demo-summary non_runtime must be true")
+    if demo_summary.get("non_enforcing") is not True:
+        raise ValueError("demo-summary non_enforcing must be true")
+
+
+def summarize_chain_manifest(
+    chain_manifest: dict[str, Any],
+) -> ChainManifestSummary:
+    """Summarize chain manifest artifacts without dereferencing refs."""
+    artifacts_payload = chain_manifest.get("artifacts", [])
+    artifacts = []
+    artifact_types = []
+    if isinstance(artifacts_payload, list):
+        for artifact in artifacts_payload:
+            if not isinstance(artifact, dict):
+                continue
+            artifact_type = _string(artifact.get("artifact_type"))
+            artifact_ref = _string(artifact.get("artifact_ref"))
+            artifacts.append(
+                {
+                    "artifact_type": artifact_type,
+                    "artifact_ref": artifact_ref,
+                }
+            )
+            artifact_types.append(artifact_type)
+
+    return ChainManifestSummary(
+        chain_id=_string(chain_manifest.get("chain_id")),
+        issued_at=_string(chain_manifest.get("issued_at")),
+        artifact_count=len(artifacts),
+        artifact_types=_unique_preserving_order(artifact_types),
+        artifacts=artifacts,
+    )
+
+
+def summarize_reviewer_packet(
+    reviewer_packet: dict[str, Any],
+) -> ReviewerPacketSummary:
+    """Summarize Reviewer Evidence Packet attachments for review."""
+    attachments_payload = reviewer_packet.get("evaluation_governance_artifacts")
+    has_attachments = isinstance(attachments_payload, list)
+    attachments = []
+    attachment_types = []
+    if isinstance(attachments_payload, list):
+        for attachment in attachments_payload:
+            if not isinstance(attachment, dict):
+                continue
+            attachment_type = _string(attachment.get("artifact_type"))
+            attachments.append(
+                {
+                    "artifact_type": attachment_type,
+                    "required_for_review": _string(
+                        attachment.get("required_for_review")
+                    ),
+                    "schema_ref": _string(attachment.get("schema_ref")),
+                }
+            )
+            attachment_types.append(attachment_type)
+
+    return ReviewerPacketSummary(
+        packet_schema_version=_string(
+            reviewer_packet.get("schema_version")
+            or reviewer_packet.get("packet_version")
+        ),
+        has_evaluation_governance_artifacts=has_attachments,
+        attachment_count=len(attachments),
+        attachment_types=_unique_preserving_order(attachment_types),
+        attachments=attachments,
+    )
+
+
+def summarize_trajectory_monitor(
+    trajectory_monitor: dict[str, Any],
+) -> TrajectoryMonitorSummary:
+    """Summarize trajectory-level admissibility monitor signals."""
+    scope_change = trajectory_monitor.get("admissibility_scope_change", {})
+    if not isinstance(scope_change, dict):
+        scope_change = {}
+
+    risk_signals_payload = trajectory_monitor.get("trajectory_risk_signals", [])
+    risk_signals = []
+    if isinstance(risk_signals_payload, list):
+        for signal in risk_signals_payload:
+            if not isinstance(signal, dict):
+                continue
+            risk_signals.append(
+                {
+                    "signal_type": _string(signal.get("signal_type")),
+                    "severity": _string(signal.get("severity")),
+                    "explanation": _string(signal.get("explanation")),
+                }
+            )
+
+    return TrajectoryMonitorSummary(
+        trajectory_status=_string(trajectory_monitor.get("trajectory_status")),
+        recommended_governance_action=_string(
+            trajectory_monitor.get("recommended_governance_action")
+        ),
+        scope_expanded=_bool(scope_change.get("scope_expanded")),
+        expansion_type=_string(scope_change.get("expansion_type")),
+        risk_signals=risk_signals,
+    )
+
+
+def summarize_legitimacy_review(
+    legitimacy_review: dict[str, Any],
+) -> LegitimacyReviewSummary:
+    """Summarize legitimacy-impacting signals without determining legitimacy."""
+    categories_payload = legitimacy_review.get("impact_categories", [])
+    impact_categories = []
+    if isinstance(categories_payload, list):
+        impact_categories = [
+            category for category in categories_payload if isinstance(category, str)
+        ]
+
+    return LegitimacyReviewSummary(
+        legitimacy_impact_detected=_bool(
+            legitimacy_review.get("legitimacy_impact_detected")
+        ),
+        impact_categories=impact_categories,
+        review_status=_string(legitimacy_review.get("review_status")),
+        recommended_governance_action=_string(
+            legitimacy_review.get("recommended_governance_action")
+        ),
+    )
+
+
+def _render_list(items: list[str], indent: str = "") -> list[str]:
+    """Render a Markdown bullet list, using an explicit empty marker."""
+    if not items:
+        return [f"{indent}- none"]
+    return [f"{indent}- `{item}`" for item in items]
+
+
+def render_markdown_report(report_inputs: ReportInputs) -> str:
+    """Render the reviewer-facing Markdown report."""
+    demo_summary = report_inputs.demo_summary
+    chain = report_inputs.chain_manifest
+    packet = report_inputs.reviewer_packet
+    monitor = report_inputs.trajectory_monitor
+    review = report_inputs.legitimacy_review
+
+    lines = [
+        "# Evaluation Governance Reviewer Demo Report",
+        "",
+        "## 1. Report purpose",
+        "",
+        (
+            "This report summarizes a synthetic, offline Evaluation Governance "
+            "reviewer demo output."
+        ),
+        "",
+        "Boundary statements:",
+        "",
+        "- This report is non-runtime.",
+        "- This report is non-enforcing in v1.",
+        "- This report does not call /v1/decide.",
+        "- This report does not establish legitimacy.",
+        "- This report does not certify regulatory compliance.",
+        "- This report does not dereference external artifact refs.",
+        "- This report does not require network access.",
+        "",
+        "## 2. Demo boundary",
+        "",
+        f"- demo_id: `{_string(demo_summary.get('demo_id'))}`",
+        f"- issued_at: `{_string(demo_summary.get('issued_at'))}`",
+        f"- non_runtime: `{_string(demo_summary.get('non_runtime'))}`",
+        f"- non_enforcing: `{_string(demo_summary.get('non_enforcing'))}`",
+        "- non_goals:",
+    ]
+    lines.extend(_render_list(demo_summary.get("non_goals", []), "  "))
+    lines.extend(
+        [
+            "",
+            "## 3. Generated artifact chain",
+            "",
+            f"- chain_id: `{chain.chain_id}`",
+            f"- issued_at: `{chain.issued_at}`",
+            f"- artifact count: `{chain.artifact_count}`",
+            "- artifact types:",
+        ]
+    )
+    lines.extend(_render_list(chain.artifact_types, "  "))
+    lines.extend(
+        [
+            "",
+            "| Artifact type | Artifact ref |",
+            "| --- | --- |",
+        ]
+    )
+    for artifact in chain.artifacts:
+        lines.append(
+            "| "
+            f"{_table_cell(artifact['artifact_type'])} | "
+            f"{_table_cell(artifact['artifact_ref'])} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## 4. Reviewer Evidence Packet attachments",
+            "",
+            f"- packet schema version: `{packet.packet_schema_version}`",
+            "- evaluation_governance_artifacts exists: "
+            f"`{_string(packet.has_evaluation_governance_artifacts)}`",
+            "- Evaluation Governance attachment count: "
+            f"`{packet.attachment_count}`",
+            "- attachment types:",
+        ]
+    )
+    lines.extend(_render_list(packet.attachment_types, "  "))
+    lines.extend(
+        [
+            "",
+            "| Attachment type | Required for review | Schema ref |",
+            "| --- | --- | --- |",
+        ]
+    )
+    for attachment in packet.attachments:
+        lines.append(
+            "| "
+            f"{_table_cell(attachment['artifact_type'])} | "
+            f"{_table_cell(attachment['required_for_review'])} | "
+            f"{_table_cell(attachment['schema_ref'])} |"
+        )
+    lines.extend(
+        [
+            "",
+            (
+                "These are optional reviewer evidence attachments in v1, not "
+                "mandatory runtime outputs."
+            ),
+            "",
+            "## 5. Trajectory-level admissibility signals",
+            "",
+            f"- trajectory_status: `{monitor.trajectory_status}`",
+            "- recommended_governance_action: "
+            f"`{monitor.recommended_governance_action}`",
+            "- admissibility_scope_change.scope_expanded: "
+            f"`{_string(monitor.scope_expanded)}`",
+            f"- expansion_type: `{monitor.expansion_type}`",
+            "- trajectory_risk_signals:",
+        ]
+    )
+    if monitor.risk_signals:
+        for signal in monitor.risk_signals:
+            lines.append(
+                "  - "
+                f"`{signal['signal_type']}` "
+                f"({signal['severity']}): {signal['explanation']}"
+            )
+        lines.extend(
+            [
+                "",
+                (
+                    "These signals are reviewer-facing indicators, not runtime "
+                    "enforcement outcomes."
+                ),
+            ]
+        )
+    else:
+        lines.append("  - none")
+
+    lines.extend(
+        [
+            "",
+            "## 6. Legitimacy impact review signals",
+            "",
+            "- legitimacy_impact_detected: "
+            f"`{_string(review.legitimacy_impact_detected)}`",
+            f"- review_status: `{review.review_status}`",
+            "- recommended_governance_action: "
+            f"`{review.recommended_governance_action}`",
+            "- impact_categories:",
+        ]
+    )
+    lines.extend(_render_list(review.impact_categories, "  "))
+    lines.extend(
+        [
+            "",
+            (
+                "VERITAS does not automatically create or guarantee legitimacy. "
+                "This artifact surfaces legitimacy-impacting signals for review."
+            ),
+            "",
+            "## 7. Validation status",
+            "",
+        ]
+    )
+    if report_inputs.validation_result is None:
+        lines.extend(
+            [
+                "Validation status: NOT RUN",
+                "",
+                "Validation was not run for this report generation request.",
+            ]
+        )
+    else:
+        lines.extend(
+            [
+                "Validation status: PASS",
+                "",
+                "The reviewer demo validator confirmed:",
+                "",
+                "- expected files present",
+                "- schema shape validated where schemas exist",
+                "- safety boundaries checked",
+                "- reviewer packet attachments checked",
+            ]
+        )
+
+    lines.extend(
+        [
+            "",
+            "## 8. Reviewer inspection order",
+            "",
+            "1. `demo-summary.generated.example.json`",
+            "2. `chain-manifest.generated.example.json`",
+            "3. `reviewer-evidence-packet.generated.example.json`",
+            "4. `trajectory-admissibility-monitor.generated.example.json`",
+            "5. `legitimacy-impact-review.generated.example.json`",
+            "",
+            "## 9. Non-goals",
+            "",
+            "- This report does not claim regulatory compliance.",
+            "- This report does not claim automatic legitimacy determination.",
+            "- This report does not change runtime behavior.",
+            "- This report does not certify governance correctness.",
+            (
+                "- This report does not replace human, legal, compliance, or "
+                "audit review."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def generate_reviewer_demo_report(
+    demo_dir: Path | str,
+    validate: bool = True,
+) -> str:
+    """Generate a Markdown report from a local reviewer demo output directory.
+
+    Args:
+        demo_dir: Directory containing generated reviewer demo artifacts.
+        validate: Whether to run the local reviewer demo validator first.
+
+    Returns:
+        Human-readable Markdown report content.
+
+    Raises:
+        ReviewerDemoValidationError: If validation is enabled and fails.
+        ValueError: If required non-runtime/non-enforcing boundaries are absent.
+        FileNotFoundError: If required report input files are missing.
+    """
+    resolved_demo_dir = Path(demo_dir).resolve()
+    validation_result = validate_reviewer_demo(resolved_demo_dir) if validate else None
+
+    demo_summary = load_json(resolved_demo_dir / DEMO_SUMMARY_FILE_NAME)
+    _require_demo_boundaries(demo_summary)
+    chain_manifest = load_json(resolved_demo_dir / CHAIN_MANIFEST_FILE_NAME)
+    reviewer_packet = load_json(resolved_demo_dir / REVIEWER_PACKET_FILE_NAME)
+    trajectory_monitor = load_json(resolved_demo_dir / TRAJECTORY_MONITOR_FILE_NAME)
+    legitimacy_review = load_json(resolved_demo_dir / LEGITIMACY_REVIEW_FILE_NAME)
+
+    report_inputs = ReportInputs(
+        demo_summary=demo_summary,
+        chain_manifest=summarize_chain_manifest(chain_manifest),
+        reviewer_packet=summarize_reviewer_packet(reviewer_packet),
+        trajectory_monitor=summarize_trajectory_monitor(trajectory_monitor),
+        legitimacy_review=summarize_legitimacy_review(legitimacy_review),
+        validation_result=validation_result,
+    )
+    return render_markdown_report(report_inputs)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments for report generation."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate a local, non-runtime Evaluation Governance reviewer "
+            "demo Markdown report."
+        )
+    )
+    parser.add_argument(
+        "--demo-dir",
+        required=True,
+        type=Path,
+        help="Directory containing generated reviewer demo artifacts.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional Markdown output path. Prints to stdout when omitted.",
+    )
+    parser.add_argument(
+        "--validate",
+        action="store_true",
+        default=True,
+        help="Validate the demo directory before generating the report.",
+    )
+    parser.add_argument(
+        "--no-validate",
+        action="store_false",
+        dest="validate",
+        help="Skip validation and render only from local JSON inputs.",
+    )
+    return parser.parse_args(argv)
+
+
+def _print_failure(error: Exception) -> None:
+    """Print a concise report generation failure to stderr."""
+    print("FAIL generated reviewer demo report", file=sys.stderr)
+    if isinstance(error, ReviewerDemoValidationError):
+        print(f"Check: {error.check}", file=sys.stderr)
+        print(f"File: {error.path}", file=sys.stderr)
+        print(f"Error: {error.message}", file=sys.stderr)
+        return
+    print(f"Error: {error}", file=sys.stderr)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the reviewer demo report generator CLI."""
+    args = _parse_args(argv)
+    try:
+        report = generate_reviewer_demo_report(args.demo_dir, args.validate)
+        if args.output is not None:
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            args.output.write_text(report, encoding="utf-8")
+            print("PASS generated reviewer demo report")
+            print(f"Output: {args.output}")
+        else:
+            print(report, end="")
+    except Exception as exc:  # noqa: BLE001
+        _print_failure(exc)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/demo/test_evaluation_governance_reviewer_demo_report.py
+++ b/tests/demo/test_evaluation_governance_reviewer_demo_report.py
@@ -1,0 +1,121 @@
+"""Tests for the Evaluation Governance reviewer demo report generator."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.demo import run_evaluation_governance_reviewer_demo as runner
+from scripts.demo import validate_evaluation_governance_reviewer_demo as validator
+from scripts.demo import (
+    generate_evaluation_governance_reviewer_demo_report as report_generator,
+)
+
+EXAMPLE_INPUT_DIR = Path(
+    "docs/en/demo/examples/evaluation-governance-offline-chain-v1"
+)
+SCRIPT_PATH = Path(
+    "scripts/demo/generate_evaluation_governance_reviewer_demo_report.py"
+)
+
+
+def _generate_demo(tmp_path: Path) -> Path:
+    runner.run_reviewer_demo(EXAMPLE_INPUT_DIR, tmp_path)
+    return tmp_path
+
+
+def test_report_generator_imports_cleanly() -> None:
+    assert callable(report_generator.load_json)
+    assert callable(report_generator.render_markdown_report)
+    assert callable(report_generator.summarize_chain_manifest)
+    assert callable(report_generator.summarize_reviewer_packet)
+    assert callable(report_generator.summarize_trajectory_monitor)
+    assert callable(report_generator.summarize_legitimacy_review)
+    assert callable(report_generator.generate_reviewer_demo_report)
+    assert callable(report_generator.main)
+
+
+def test_generate_reviewer_demo_report_contains_reviewer_sections(
+    tmp_path: Path,
+) -> None:
+    demo_dir = _generate_demo(tmp_path)
+    validator.validate_reviewer_demo(demo_dir)
+
+    report = report_generator.generate_reviewer_demo_report(demo_dir)
+
+    assert "Evaluation Governance Reviewer Demo Report" in report
+    assert "non-runtime" in report
+    assert "non-enforcing" in report
+    assert "does not call /v1/decide" in report
+    assert "does not establish legitimacy" in report
+    assert "Reviewer Evidence Packet attachments" in report
+    assert "Trajectory-level admissibility signals" in report
+    assert "Legitimacy impact review signals" in report
+    assert "Validation status: PASS" in report
+
+
+def test_report_generator_cli_writes_output(tmp_path: Path) -> None:
+    demo_dir = _generate_demo(tmp_path)
+    output_path = tmp_path / "report.md"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--demo-dir",
+            str(demo_dir),
+            "--output",
+            str(output_path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "PASS generated reviewer demo report" in completed.stdout
+    assert output_path.is_file()
+    assert "Validation status: PASS" in output_path.read_text(encoding="utf-8")
+
+
+def test_report_generator_cli_stdout_mode(tmp_path: Path) -> None:
+    demo_dir = _generate_demo(tmp_path)
+
+    completed = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "--demo-dir", str(demo_dir)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "Evaluation Governance Reviewer Demo Report" in completed.stdout
+
+
+def test_report_generator_cli_fails_validation_before_writing(
+    tmp_path: Path,
+) -> None:
+    demo_dir = _generate_demo(tmp_path)
+    missing_path = demo_dir / "demo-summary.generated.example.json"
+    missing_path.unlink()
+    output_path = tmp_path / "report.md"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--demo-dir",
+            str(demo_dir),
+            "--output",
+            str(output_path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode != 0
+    assert "FAIL generated reviewer demo report" in completed.stderr
+    assert "demo-summary.generated.example.json" in completed.stderr
+    assert not output_path.exists()


### PR DESCRIPTION
### Motivation

- Provide a local/offline reviewer-facing Markdown report that summarizes a validated Evaluation Governance reviewer demo output so human reviewers can quickly inspect chain manifest, reviewer evidence packet attachments, trajectory admissibility signals, and legitimacy-impacting signals.
- Keep the feature strictly helper/docs/tests-only and preserve existing runtime, schema, admissibility, and governance behavior by avoiding any /v1/decide calls, network access, dereferencing of external artifact refs, secrets, or production configuration changes.
- Make report generation validation-first to avoid producing misleading PASS reports and surface missing or malformed example artifacts early.
- Maintain security boundaries and reviewer-facing warnings (no PII, no automatic legitimacy or compliance claims) and follow repo coding/test conventions (PEP8, docstrings, unit tests).

### Description

- Added `scripts/demo/generate_evaluation_governance_reviewer_demo_report.py` implementing `load_json`, `render_markdown_report`, `summarize_chain_manifest`, `summarize_reviewer_packet`, `summarize_trajectory_monitor`, `summarize_legitimacy_review`, `generate_reviewer_demo_report(demo_dir, validate=True)`, and a CLI `main()` that supports `--demo-dir`, `--output`, and `--no-validate`, and reuses `validate_reviewer_demo` from the existing validator. The script uses `pathlib`, `json`, `argparse`, and `dataclasses`, never touches network or dereferences artifact refs, and enforces `demo_summary.non_runtime` and `demo_summary.non_enforcing`.
- Added unit tests in `tests/demo/test_evaluation_governance_reviewer_demo_report.py` covering importability, content assertions for the generated report, CLI file output mode, stdout mode, and validation-failure behavior where the generator must fail before writing output.
- Checked-in a generated example report at `docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated/reviewer-demo-report.generated.example.md` produced from the existing checked-in demo artifacts and updated minimal docs: `docs/en/demo/evaluation-governance-reviewer-demo-quickstart-v1.md` and `docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/README.md` to show the new report-generation commands.
- Implementation notes: report structure follows the requested sectioning, includes compact artifact and attachment tables, clearly states non-runtime/non-enforcing boundaries and non-goals, and prints a concise success message when `--output` is used; the generator raises on validation failures and does not write output in that case.

### Testing

- Ran static checks: `PYENV_VERSION=3.12.13 python -m ruff check scripts/demo/generate_evaluation_governance_reviewer_demo_report.py tests/demo/test_evaluation_governance_reviewer_demo_report.py` and all ruff checks passed.
- Ran the demo-related test suite: `PYENV_VERSION=3.12.13 python -m pytest tests/demo/test_evaluation_governance_reviewer_demo_report.py tests/demo/test_evaluation_governance_reviewer_demo_validator.py tests/demo/test_evaluation_governance_reviewer_demo_runner.py tests/demo/test_evaluation_governance_chain_reviewer_packet.py` and the tests passed (20 passed, 1 warning) for the exercised targets.
- Exercised the CLI against checked-in examples to generate `reviewer-demo-report.generated.example.md` and confirmed the CLI printed `PASS generated reviewer demo report` and wrote the expected file; validation-failure CLI behavior was also tested and correctly exited non-zero without writing output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a261751f2e483269f599620af3c1d9c)