### PR TITLE
Add Evaluation Governance reviewer demo suite runner v1

### DIFF
--- a/docs/en/demo/evaluation-governance-reviewer-demo-quickstart-v1.md
+++ b/docs/en/demo/evaluation-governance-reviewer-demo-quickstart-v1.md
@@ -91,7 +91,32 @@ Reviewer Evidence Packet, trajectory monitor, and legitimacy impact review.
 It does not establish legitimacy, does not certify compliance, and does not
 call `/v1/decide`.
 
-## 7. Expected outputs
+## 7. Run the full demo suite
+
+Recommended reviewer command:
+
+```bash
+python scripts/demo/run_evaluation_governance_reviewer_demo_suite.py \
+  --input-dir docs/en/demo/examples/evaluation-governance-offline-chain-v1 \
+  --output-dir /tmp/evaluation-governance-reviewer-demo
+```
+
+This runs generation, validation, and Markdown report generation in one
+synthetic offline workflow. It is non-runtime and non-enforcing, does not call
+`/v1/decide`, does not establish legitimacy, and does not certify compliance.
+
+Maintainers can intentionally refresh checked-in generated examples with:
+
+```bash
+python scripts/demo/run_evaluation_governance_reviewer_demo_suite.py \
+  --input-dir docs/en/demo/examples/evaluation-governance-offline-chain-v1 \
+  --write-example-output
+```
+
+`--write-example-output` intentionally updates checked-in generated examples.
+Normal reviewers should prefer `--output-dir`.
+
+## 8. Expected outputs
 
 The output directory should contain:
 
@@ -107,7 +132,7 @@ reviewer-evidence-packet.generated.example.json
 demo-summary.generated.example.json
 ```
 
-## 8. What reviewers should inspect first
+## 9. What reviewers should inspect first
 
 Recommended inspection order:
 
@@ -122,7 +147,7 @@ Recommended inspection order:
 5. `legitimacy-impact-review.generated.example.json`
    - shows legitimacy-impacting change signals
 
-## 9. Regenerate checked-in examples intentionally
+## 10. Regenerate checked-in examples intentionally
 
 Maintainers can intentionally regenerate checked-in example outputs with:
 
@@ -136,7 +161,7 @@ This intentionally updates checked-in example outputs.
 Normal reviewers should prefer `--output-dir`.
 This mode exists for maintainers.
 
-## 10. Relationship to Reviewer Evidence Packet
+## 11. Relationship to Reviewer Evidence Packet
 
 The Reviewer Evidence Packet can include optional `evaluation_governance_artifacts`.
 The generated packet attaches the Evaluation Governance chain artifacts for review.
@@ -148,7 +173,7 @@ See:
 - [Reviewer Evidence Packet v1](reviewer-evidence-packet.md)
 - [Evaluation Governance offline-chain Reviewer Evidence Packet example](examples/evaluation-governance-chain-reviewer-packet-v1/README.md)
 
-## 11. Relationship to Evaluation Governance overview
+## 12. Relationship to Evaluation Governance overview
 
 The Evaluation Governance overview explains the artifact chain.
 This quickstart explains how to run the synthetic reviewer demo.
@@ -157,14 +182,14 @@ See:
 
 - [Evaluation Governance Overview v1](../architecture/evaluation-governance-overview-v1.md)
 
-## 12. Troubleshooting
+## 13. Troubleshooting
 
 - If Python cannot import dependencies, run the repository's normal development setup first.
 - If output files are not created, confirm `--output-dir` is provided.
 - If trying to write checked-in examples, use `--write-example-output`.
 - The demo should not require network access.
 
-## 13. Non-goals
+## 14. Non-goals
 
 - This quickstart does not claim regulatory compliance.
 - This quickstart does not claim automatic legitimacy determination.

--- a/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/README.md
+++ b/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/README.md
@@ -31,6 +31,17 @@ python scripts/demo/run_evaluation_governance_reviewer_demo.py \
   --write-example-output
 ```
 
+## Run the full demo suite
+
+```bash
+python scripts/demo/run_evaluation_governance_reviewer_demo_suite.py \
+  --input-dir docs/en/demo/examples/evaluation-governance-offline-chain-v1 \
+  --write-example-output
+```
+
+This regenerates the checked-in generated examples, validates them, and writes
+`generated/reviewer-demo-report.generated.example.md`.
+
 ## Validate checked-in generated examples
 
 ```bash

--- a/docs/en/demo/external-reviewer-quickstart.md
+++ b/docs/en/demo/external-reviewer-quickstart.md
@@ -54,7 +54,7 @@ Use this 10–15 minute path for a reviewer-facing inspection:
 
 ## Evaluation Governance offline reviewer demo
 
-For a one-command synthetic offline demo, see [Evaluation Governance Reviewer Demo Quickstart v1](evaluation-governance-reviewer-demo-quickstart-v1.md). The demo is reviewer-facing, non-runtime, and non-enforcing in v1, and it produces a Reviewer Evidence Packet with optional Evaluation Governance attachments.
+For a one-command synthetic offline demo, see [Evaluation Governance Reviewer Demo Quickstart v1](evaluation-governance-reviewer-demo-quickstart-v1.md). The demo is reviewer-facing, non-runtime, and non-enforcing in v1, and it produces a Reviewer Evidence Packet with optional Evaluation Governance attachments. For the full Evaluation Governance offline reviewer demo, run the suite command documented in `docs/en/demo/evaluation-governance-reviewer-demo-quickstart-v1.md`.
 
 ## Local bundle generation
 

--- a/scripts/demo/run_evaluation_governance_reviewer_demo_suite.py
+++ b/scripts/demo/run_evaluation_governance_reviewer_demo_suite.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Run the full synthetic Evaluation Governance reviewer demo suite.
+
+This thin orchestration helper composes existing local/offline demo helpers:
+
+1. Generate reviewer demo outputs.
+2. Validate the generated outputs.
+3. Generate the Markdown reviewer report.
+
+It is intentionally non-runtime and non-enforcing. It does not call
+``/v1/decide``, mutate production governance configuration, dereference
+external artifact references, access the network, establish legitimacy, or
+certify regulatory compliance.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.demo.generate_evaluation_governance_reviewer_demo_report import (  # noqa: E501
+    generate_reviewer_demo_report,
+)
+from scripts.demo.run_evaluation_governance_reviewer_demo import (
+    DEFAULT_INPUT_DIR,
+    EXAMPLE_OUTPUT_DIR,
+    run_reviewer_demo,
+)
+from scripts.demo.validate_evaluation_governance_reviewer_demo import (
+    ReviewerDemoValidationResult,
+    validate_reviewer_demo,
+)
+
+REPORT_FILE_NAME = "reviewer-demo-report.md"
+EXAMPLE_REPORT_FILE_NAME = "reviewer-demo-report.generated.example.md"
+
+
+@dataclass(frozen=True)
+class ReviewerDemoSuiteResult:
+    """Result metadata returned by ``run_reviewer_demo_suite``."""
+
+    output_dir: Path
+    report_path: Path
+    validation_result: ReviewerDemoValidationResult
+
+
+def resolve_output_dir(
+    output_dir: Path | None = None,
+    write_example_output: bool = False,
+) -> Path:
+    """Resolve the suite output directory while avoiding unsafe repo writes.
+
+    Args:
+        output_dir: Safe caller-provided output directory for generated files.
+        write_example_output: Whether to intentionally update checked-in
+            generated example outputs.
+
+    Returns:
+        The directory the suite should write.
+
+    Raises:
+        ValueError: If neither output mode is selected.
+    """
+    if output_dir is not None and write_example_output:
+        raise ValueError(
+            "--output-dir and --write-example-output are mutually exclusive"
+        )
+    if output_dir is not None:
+        return output_dir
+    if write_example_output:
+        return EXAMPLE_OUTPUT_DIR
+    raise ValueError(
+        "--output-dir or --write-example-output is required; pass "
+        "--output-dir for safe temporary output, or --write-example-output "
+        "to intentionally update checked-in generated examples"
+    )
+
+
+def select_report_output_path(
+    output_dir: Path,
+    write_example_output: bool = False,
+) -> Path:
+    """Return the report path for temporary or checked-in example output."""
+    file_name = EXAMPLE_REPORT_FILE_NAME if write_example_output else REPORT_FILE_NAME
+    return output_dir / file_name
+
+
+def run_reviewer_demo_suite(
+    input_dir: Path,
+    output_dir: Path | None = None,
+    write_example_output: bool = False,
+) -> ReviewerDemoSuiteResult:
+    """Run generation, validation, and report creation for the reviewer demo.
+
+    Args:
+        input_dir: Directory containing synthetic offline-chain input files.
+        output_dir: Optional safe output directory. Required unless
+            ``write_example_output`` is true.
+        write_example_output: Intentionally write the checked-in generated
+            example output directory and generated example report.
+
+    Returns:
+        Paths and validation metadata for the completed suite run.
+
+    Raises:
+        ValueError: If no output mode is selected.
+        FileNotFoundError: If required local inputs are missing.
+        ReviewerDemoValidationError: If generated outputs fail validation.
+    """
+    resolved_output_dir = resolve_output_dir(output_dir, write_example_output)
+    run_result = run_reviewer_demo(input_dir, resolved_output_dir)
+    validation_result = validate_reviewer_demo(run_result.output_dir)
+    report = generate_reviewer_demo_report(run_result.output_dir, validate=True)
+    report_path = select_report_output_path(
+        run_result.output_dir,
+        write_example_output,
+    )
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(report, encoding="utf-8")
+    return ReviewerDemoSuiteResult(
+        output_dir=run_result.output_dir,
+        report_path=report_path,
+        validation_result=validation_result,
+    )
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments for the reviewer demo suite."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run the non-runtime Evaluation Governance reviewer demo suite: "
+            "generate outputs, validate them, and write a Markdown report."
+        )
+    )
+    parser.add_argument(
+        "--input-dir",
+        default=DEFAULT_INPUT_DIR,
+        type=Path,
+        help=(
+            "Directory containing synthetic offline-chain input JSON files "
+            f"(default: {DEFAULT_INPUT_DIR.relative_to(REPO_ROOT)})"
+        ),
+    )
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument(
+        "--output-dir",
+        type=Path,
+        help="Safe output directory for generated reviewer demo artifacts.",
+    )
+    output_group.add_argument(
+        "--write-example-output",
+        action="store_true",
+        help=(
+            "Intentionally overwrite checked-in reviewer demo generated "
+            "examples and the generated example report."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the Evaluation Governance reviewer demo suite CLI."""
+    args = _parse_args(argv)
+    try:
+        result = run_reviewer_demo_suite(
+            input_dir=args.input_dir,
+            output_dir=args.output_dir,
+            write_example_output=args.write_example_output,
+        )
+    except Exception as exc:  # noqa: BLE001 - CLI presents concise errors.
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    print("Evaluation Governance Reviewer Demo Suite")
+    print("")
+    print("PASS generated reviewer demo outputs")
+    print("PASS validated reviewer demo outputs")
+    print("PASS generated reviewer demo report")
+    print("")
+    print(f"Output directory: {result.output_dir}")
+    print(f"Report: {result.report_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/demo/test_evaluation_governance_reviewer_demo_suite.py
+++ b/tests/demo/test_evaluation_governance_reviewer_demo_suite.py
@@ -1,0 +1,114 @@
+"""Tests for the Evaluation Governance reviewer demo suite runner."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.demo import run_evaluation_governance_reviewer_demo_suite as suite
+from scripts.demo.validate_evaluation_governance_reviewer_demo import (
+    validate_reviewer_demo,
+)
+
+EXAMPLE_INPUT_DIR = Path(
+    "docs/en/demo/examples/evaluation-governance-offline-chain-v1"
+)
+SCRIPT_PATH = Path(
+    "scripts/demo/run_evaluation_governance_reviewer_demo_suite.py"
+)
+EXPECTED_OUTPUT_FILES = [
+    "outcome-delta-attribution-1.generated.example.json",
+    "outcome-delta-attribution-2.generated.example.json",
+    "evaluation-drift-detection-1.generated.example.json",
+    "evaluation-drift-detection-2.generated.example.json",
+    "trajectory-admissibility-monitor.generated.example.json",
+    "legitimacy-impact-review.generated.example.json",
+    "chain-manifest.generated.example.json",
+    "reviewer-evidence-packet.generated.example.json",
+    "demo-summary.generated.example.json",
+]
+
+
+def test_suite_imports_cleanly() -> None:
+    assert callable(suite.resolve_output_dir)
+    assert callable(suite.select_report_output_path)
+    assert callable(suite.run_reviewer_demo_suite)
+    assert callable(suite.main)
+
+
+def test_run_reviewer_demo_suite_generates_validated_report(
+    tmp_path: Path,
+) -> None:
+    result = suite.run_reviewer_demo_suite(EXAMPLE_INPUT_DIR, output_dir=tmp_path)
+
+    for file_name in EXPECTED_OUTPUT_FILES:
+        assert (tmp_path / file_name).is_file()
+
+    report_path = tmp_path / "reviewer-demo-report.md"
+    assert result.output_dir == tmp_path.resolve()
+    assert result.report_path == report_path
+    assert report_path.is_file()
+
+    report = report_path.read_text(encoding="utf-8")
+    assert "Evaluation Governance Reviewer Demo Report" in report
+    assert "Validation status: PASS" in report
+    assert "does not establish legitimacy" in report
+    assert "does not certify regulatory compliance" in report
+
+    validation_result = validate_reviewer_demo(tmp_path)
+    assert validation_result.expected_files_count == len(EXPECTED_OUTPUT_FILES)
+
+
+def test_suite_cli_writes_to_output_dir(tmp_path: Path) -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--input-dir",
+            str(EXAMPLE_INPUT_DIR),
+            "--output-dir",
+            str(tmp_path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "PASS generated reviewer demo outputs" in completed.stdout
+    assert "PASS validated reviewer demo outputs" in completed.stdout
+    assert "PASS generated reviewer demo report" in completed.stdout
+    assert (tmp_path / "reviewer-demo-report.md").is_file()
+
+
+def test_suite_cli_requires_output_mode() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--input-dir",
+            str(EXAMPLE_INPUT_DIR),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode != 0
+    assert "--output-dir or --write-example-output is required" in completed.stderr
+
+
+def test_suite_can_run_twice_in_temporary_output_dir(tmp_path: Path) -> None:
+    first_result = suite.run_reviewer_demo_suite(
+        EXAMPLE_INPUT_DIR,
+        output_dir=tmp_path,
+    )
+    second_result = suite.run_reviewer_demo_suite(
+        EXAMPLE_INPUT_DIR,
+        output_dir=tmp_path,
+    )
+
+    assert first_result.report_path == second_result.report_path
+    assert (tmp_path / "reviewer-demo-report.md").is_file()
+    validate_reviewer_demo(tmp_path)


### PR DESCRIPTION
### Motivation

- Provide a thin, non-runtime orchestration that runs the full Evaluation Governance reviewer demo workflow (generate outputs, validate them, and produce a Markdown reviewer report) as a single safe command for reviewers and maintainers.
- Keep the change helper/docs/tests-only and avoid any runtime, schema, admissibility, or `/v1/decide` changes or production configuration mutation.
- Make it easy for maintainers to intentionally refresh checked-in generated examples while preventing accidental repository mutations by default.

### Description

- Add `scripts/demo/run_evaluation_governance_reviewer_demo_suite.py` which implements `run_reviewer_demo_suite(input_dir, output_dir=None, write_example_output=False)`, `resolve_output_dir`, `select_report_output_path`, and a clean `main()`; it reuses `run_reviewer_demo`, `validate_reviewer_demo`, and `generate_reviewer_demo_report` and enforces mutually exclusive output modes.
- Add tests `tests/demo/test_evaluation_governance_reviewer_demo_suite.py` covering import safety, artifact generation, report contents, CLI success, required output-mode error, and repeat-run behavior to temporary directories.
- Update docs minimally to document the suite command: `docs/en/demo/evaluation-governance-reviewer-demo-quickstart-v1.md`, `docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/README.md`, and `docs/en/demo/external-reviewer-quickstart.md` with the recommended reviewer command and maintainer `--write-example-output` note.
- Safety rules preserved: no `/v1/decide` calls, no network access, no production config or schema edits, and checked-in examples are only overwritten when `--write-example-output` is explicitly passed.

### Testing

- Ran static checks: `python -m ruff check scripts/demo/run_evaluation_governance_reviewer_demo_suite.py tests/demo/test_evaluation_governance_reviewer_demo_suite.py` which passed.
- Ran targeted pytest for the demo helpers: `PYENV_VERSION=3.12.13 python -m pytest tests/demo/test_evaluation_governance_reviewer_demo_suite.py tests/demo/test_evaluation_governance_reviewer_demo_runner.py tests/demo/test_evaluation_governance_reviewer_demo_validator.py tests/demo/test_evaluation_governance_reviewer_demo_report.py tests/demo/test_evaluation_governance_chain_reviewer_packet.py -q` and received all tests passing (25 passed, 1 warning in this environment).
- Environment note: attempting `pytest tests/demo -q` initially hit unrelated collection errors in this environment due to a missing optional `yaml` package for other demo tests; the new suite-related tests and the targeted demo tests passed in the CI-like run shown above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2620361da083268ae297cdf63b03d5)