### PR TITLE
Add Evaluation Governance reviewer demo local hash verification v1

### DIFF
--- a/docs/en/demo/evaluation-governance-reviewer-demo-quickstart-v1.md
+++ b/docs/en/demo/evaluation-governance-reviewer-demo-quickstart-v1.md
@@ -78,6 +78,19 @@ non-runtime / non-enforcing boundaries, and Reviewer Evidence Packet
 attachments. It does not establish legitimacy, does not certify compliance, and
 does not call `/v1/decide`.
 
+### Optional local hash verification
+
+```bash
+python scripts/demo/validate_evaluation_governance_reviewer_demo.py \
+  --demo-dir /tmp/evaluation-governance-reviewer-demo \
+  --artifact-base-dir docs/en/demo/examples/evaluation-governance-offline-chain-v1 \
+  --verify-local-hashes
+```
+
+This optional check verifies artifact hashes where referenced files can be
+resolved locally. It does not follow external refs, does not require network
+access, does not establish legitimacy, and does not certify compliance.
+
 ## 6. Generate a reviewer report
 
 ```bash

--- a/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/README.md
+++ b/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/README.md
@@ -54,6 +54,18 @@ non-runtime / non-enforcing boundaries, and Reviewer Evidence Packet
 attachments. It does not establish legitimacy, certify compliance, or call
 `/v1/decide`.
 
+Optional local hash verification for checked-in examples:
+
+```bash
+python scripts/demo/validate_evaluation_governance_reviewer_demo.py \
+  --demo-dir docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated \
+  --artifact-base-dir docs/en/demo/examples/evaluation-governance-offline-chain-v1 \
+  --verify-local-hashes
+```
+
+This optional check verifies local artifact hashes where files can be resolved;
+it does not follow external refs or require network access.
+
 ## Generate the checked-in reviewer report example
 
 ```bash

--- a/scripts/demo/validate_evaluation_governance_reviewer_demo.py
+++ b/scripts/demo/validate_evaluation_governance_reviewer_demo.py
@@ -11,6 +11,7 @@ modifying files.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import importlib.util
 import json
 import re
@@ -97,6 +98,32 @@ class ReviewerDemoValidationResult:
     expected_files_count: int
     schema_validated_count: int
     reviewer_attachment_count: int
+    local_hash_checks_total: int = 0
+    local_hash_checks_passed: int = 0
+    local_hash_checks_skipped: int = 0
+    local_hash_failures: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class LocalHashCheckResult:
+    """Local artifact hash verification counters for optional checks."""
+
+    passed: int = 0
+    skipped: int = 0
+    failures: tuple[str, ...] = ()
+
+    @property
+    def total(self) -> int:
+        """Return the number of resolved or skipped local hash checks."""
+        return self.passed + self.skipped + len(self.failures)
+
+    def merged(self, other: "LocalHashCheckResult") -> "LocalHashCheckResult":
+        """Return a combined immutable local hash check result."""
+        return LocalHashCheckResult(
+            passed=self.passed + other.passed,
+            skipped=self.skipped + other.skipped,
+            failures=(*self.failures, *other.failures),
+        )
 
 
 class ReviewerDemoValidationError(ValueError):
@@ -140,6 +167,122 @@ def load_json(path: Path) -> dict[str, Any]:
     if not isinstance(payload, dict):
         raise TypeError(f"expected JSON object in {_display_path(path)}")
     return payload
+
+
+def sha256_file(path: Path) -> str:
+    """Return the SHA-256 digest for the exact local file bytes at ``path``."""
+    digest = hashlib.sha256()
+    with path.open("rb") as file_handle:
+        for chunk in iter(lambda: file_handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _canonical_json_file_hash(path: Path) -> str | None:
+    """Return canonical JSON hash for legacy generated JSON artifacts if valid."""
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    canonical = json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def _is_external_artifact_ref(artifact_ref: str) -> bool:
+    """Return true for refs the validator must not dereference locally."""
+    lowered = artifact_ref.lower()
+    return "://" in lowered or lowered.startswith(("urn:", "mailto:"))
+
+
+def _safe_join(base_dir: Path, artifact_ref: str) -> Path | None:
+    """Resolve a relative artifact ref under ``base_dir`` without escaping it."""
+    if _is_external_artifact_ref(artifact_ref):
+        return None
+    ref_path = Path(artifact_ref)
+    if ref_path.is_absolute():
+        return ref_path if ref_path.is_file() else None
+    candidate = (base_dir / ref_path).resolve()
+    try:
+        candidate.relative_to(base_dir.resolve())
+    except ValueError:
+        return None
+    return candidate if candidate.is_file() else None
+
+
+def resolve_local_artifact_ref(
+    artifact_ref: str,
+    demo_dir: Path,
+    artifact_base_dir: Path | None = None,
+) -> Path | None:
+    """Resolve a demo artifact reference using local-only lookup order.
+
+    The resolver never follows URLs or dereferences external artifact refs. It
+    checks ``demo_dir / artifact_ref``, then ``artifact_base_dir / artifact_ref``,
+    then ``artifact_base_dir / generated / artifact_ref`` when a base directory
+    is provided.
+    """
+    candidate = _safe_join(demo_dir, artifact_ref)
+    if candidate is not None:
+        return candidate
+
+    if artifact_base_dir is None:
+        return None
+
+    base_dir = artifact_base_dir.resolve()
+    candidate = _safe_join(base_dir, artifact_ref)
+    if candidate is not None:
+        return candidate
+    return _safe_join(base_dir / "generated", artifact_ref)
+
+
+def _hash_matches(local_path: Path, expected_hash: str) -> tuple[bool, str]:
+    """Compare expected hash with local file bytes, with legacy JSON support."""
+    actual_hash = sha256_file(local_path)
+    if actual_hash == expected_hash:
+        return True, actual_hash
+
+    canonical_hash = _canonical_json_file_hash(local_path)
+    if canonical_hash == expected_hash:
+        return True, actual_hash
+    return False, actual_hash
+
+
+def _hash_mismatch_message(
+    source_path: Path,
+    field_path: str,
+    local_path: Path,
+    expected_hash: str,
+    actual_hash: str,
+) -> str:
+    """Build a clear hash mismatch message for CLI and tests."""
+    return (
+        "hash mismatch; "
+        f"source={_display_path(source_path)} {field_path}; "
+        f"file={_display_path(local_path)}; "
+        f"expected hash={expected_hash}; actual hash={actual_hash}"
+    )
+
+
+def _required_artifact_string(
+    artifact: dict[str, Any],
+    field: str,
+    source_path: Path,
+    field_path: str,
+) -> str:
+    """Return a required string from a local hash-check artifact entry."""
+    value = artifact.get(field)
+    if not isinstance(value, str) or not value:
+        raise ReviewerDemoValidationError(
+            "local hash consistency",
+            source_path,
+            f"{field_path}.{field} must be a non-empty string",
+        )
+    return value
 
 
 def _resolve_ref(ref: str, root_schema: dict[str, Any]) -> dict[str, Any]:
@@ -539,11 +682,212 @@ def _validate_schemas(demo_dir: Path) -> int:
     return len(SCHEMA_FILE_NAMES_BY_ARTIFACT)
 
 
-def validate_reviewer_demo(demo_dir: Path) -> ReviewerDemoValidationResult:
+def _verify_artifact_hash_entry(
+    source_path: Path,
+    artifact_ref: str,
+    expected_hash: str,
+    field_path: str,
+    demo_dir: Path,
+    artifact_base_dir: Path | None,
+    fail_if_missing: bool,
+) -> LocalHashCheckResult:
+    """Verify one artifact hash entry when it resolves to a local file."""
+    local_path = resolve_local_artifact_ref(
+        artifact_ref,
+        demo_dir,
+        artifact_base_dir,
+    )
+    if local_path is None:
+        if fail_if_missing:
+            return LocalHashCheckResult(
+                failures=(
+                    (
+                        "missing local artifact for hash check; "
+                        f"source={_display_path(source_path)} {field_path}; "
+                        f"artifact_ref={artifact_ref}"
+                    ),
+                )
+            )
+        return LocalHashCheckResult(skipped=1)
+
+    matches, actual_hash = _hash_matches(local_path, expected_hash)
+    if matches:
+        return LocalHashCheckResult(passed=1)
+
+    return LocalHashCheckResult(
+        failures=(
+            _hash_mismatch_message(
+                source_path,
+                f"{field_path}.artifact_hash",
+                local_path,
+                expected_hash,
+                actual_hash,
+            ),
+        )
+    )
+
+
+def verify_chain_manifest_hashes(
+    path: Path,
+    demo_dir: Path,
+    artifact_base_dir: Path | None = None,
+) -> LocalHashCheckResult:
+    """Optionally verify chain-manifest artifact hashes against local files."""
+    manifest = load_json(path)
+    artifacts = manifest.get("artifacts", [])
+    result = LocalHashCheckResult()
+    for index, artifact in enumerate(artifacts):
+        if not isinstance(artifact, dict):
+            continue
+        field_path = f"artifacts[{index}]"
+        artifact_ref = _required_artifact_string(
+            artifact,
+            "artifact_ref",
+            path,
+            field_path,
+        )
+        expected_hash = _required_artifact_string(
+            artifact,
+            "artifact_hash",
+            path,
+            field_path,
+        )
+        fail_if_missing = artifact_ref in EXPECTED_FILE_NAMES
+        result = result.merged(
+            _verify_artifact_hash_entry(
+                path,
+                artifact_ref,
+                expected_hash,
+                field_path,
+                demo_dir,
+                artifact_base_dir,
+                fail_if_missing,
+            )
+        )
+    return result
+
+
+def verify_demo_summary_hashes(path: Path, demo_dir: Path) -> LocalHashCheckResult:
+    """Verify demo-summary generated artifact hashes under ``demo_dir``."""
+    summary = load_json(path)
+    artifacts = summary.get("generated_artifacts", [])
+    result = LocalHashCheckResult()
+    for index, artifact in enumerate(artifacts):
+        if not isinstance(artifact, dict):
+            continue
+        field_path = f"generated_artifacts[{index}]"
+        artifact_ref = _required_artifact_string(
+            artifact,
+            "artifact_ref",
+            path,
+            field_path,
+        )
+        expected_hash = _required_artifact_string(
+            artifact,
+            "artifact_hash",
+            path,
+            field_path,
+        )
+        result = result.merged(
+            _verify_artifact_hash_entry(
+                path,
+                artifact_ref,
+                expected_hash,
+                field_path,
+                demo_dir,
+                None,
+                True,
+            )
+        )
+    return result
+
+
+def verify_reviewer_packet_attachment_hashes(
+    path: Path,
+    demo_dir: Path,
+    artifact_base_dir: Path | None = None,
+) -> LocalHashCheckResult:
+    """Verify reviewer-packet attachment hashes when refs resolve locally."""
+    packet = load_json(path)
+    artifacts = packet.get("evaluation_governance_artifacts", [])
+    result = LocalHashCheckResult()
+    for index, artifact in enumerate(artifacts):
+        if not isinstance(artifact, dict):
+            continue
+        field_path = f"evaluation_governance_artifacts[{index}]"
+        artifact_ref = _required_artifact_string(
+            artifact,
+            "artifact_ref",
+            path,
+            field_path,
+        )
+        expected_hash = _required_artifact_string(
+            artifact,
+            "artifact_hash",
+            path,
+            field_path,
+        )
+        result = result.merged(
+            _verify_artifact_hash_entry(
+                path,
+                artifact_ref,
+                expected_hash,
+                field_path,
+                demo_dir,
+                artifact_base_dir,
+                False,
+            )
+        )
+    return result
+
+
+def verify_local_hash_consistency(
+    demo_dir: Path,
+    artifact_base_dir: Path | None = None,
+) -> LocalHashCheckResult:
+    """Verify local hash consistency for resolvable reviewer demo artifacts."""
+    checks = [
+        verify_chain_manifest_hashes(
+            demo_dir / "chain-manifest.generated.example.json",
+            demo_dir,
+            artifact_base_dir,
+        ),
+        verify_demo_summary_hashes(
+            demo_dir / "demo-summary.generated.example.json",
+            demo_dir,
+        ),
+        verify_reviewer_packet_attachment_hashes(
+            demo_dir / "reviewer-evidence-packet.generated.example.json",
+            demo_dir,
+            artifact_base_dir,
+        ),
+    ]
+    result = LocalHashCheckResult()
+    for check in checks:
+        result = result.merged(check)
+
+    if result.failures:
+        raise ReviewerDemoValidationError(
+            "local hash consistency",
+            demo_dir,
+            "\n".join(result.failures),
+        )
+    return result
+
+
+def validate_reviewer_demo(
+    demo_dir: Path,
+    verify_local_hashes: bool = False,
+    artifact_base_dir: Path | None = None,
+) -> ReviewerDemoValidationResult:
     """Validate a generated Evaluation Governance reviewer demo directory.
 
     Args:
         demo_dir: Directory containing generated reviewer-facing demo artifacts.
+        verify_local_hashes: When true, compare artifact_hash values with
+            local artifacts that can be resolved without network access.
+        artifact_base_dir: Optional local base directory for resolving chain or
+            reviewer packet artifact references outside ``demo_dir``.
 
     Returns:
         Counts for the validated expected files, schemas, and reviewer packet
@@ -571,15 +915,33 @@ def validate_reviewer_demo(demo_dir: Path) -> ReviewerDemoValidationResult:
         resolved_demo_dir / "reviewer-evidence-packet.generated.example.json"
     )
     validate_demo_summary(resolved_demo_dir / "demo-summary.generated.example.json")
+
+    hash_result = LocalHashCheckResult()
+    if verify_local_hashes:
+        resolved_artifact_base_dir = (
+            artifact_base_dir.resolve() if artifact_base_dir is not None else None
+        )
+        hash_result = verify_local_hash_consistency(
+            resolved_demo_dir,
+            resolved_artifact_base_dir,
+        )
+
     return ReviewerDemoValidationResult(
         demo_dir=resolved_demo_dir,
         expected_files_count=expected_count,
         schema_validated_count=schema_count,
         reviewer_attachment_count=attachment_count,
+        local_hash_checks_total=hash_result.total,
+        local_hash_checks_passed=hash_result.passed,
+        local_hash_checks_skipped=hash_result.skipped,
+        local_hash_failures=hash_result.failures,
     )
 
 
-def _print_success_report(result: ReviewerDemoValidationResult) -> None:
+def _print_success_report(
+    result: ReviewerDemoValidationResult,
+    verify_local_hashes: bool = False,
+) -> None:
     """Print a concise reviewer-friendly success report."""
     print("Evaluation Governance Reviewer Demo Validation")
     print()
@@ -588,6 +950,14 @@ def _print_success_report(result: ReviewerDemoValidationResult) -> None:
     print("PASS chain manifest safety boundaries")
     print("PASS reviewer evidence packet attachments")
     print("PASS demo summary safety boundaries")
+    if verify_local_hashes:
+        print("PASS local hash consistency")
+        if result.local_hash_checks_skipped:
+            print(
+                "Local hash checks: "
+                f"{result.local_hash_checks_passed} passed, "
+                f"{result.local_hash_checks_skipped} skipped."
+            )
     print()
     print(f"Validated reviewer demo output: {result.demo_dir}")
 
@@ -614,6 +984,22 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         type=Path,
         help="Directory containing generated reviewer demo artifacts.",
     )
+    parser.add_argument(
+        "--artifact-base-dir",
+        type=Path,
+        help=(
+            "Optional local base directory used only for resolving artifact "
+            "references during --verify-local-hashes."
+        ),
+    )
+    parser.add_argument(
+        "--verify-local-hashes",
+        action="store_true",
+        help=(
+            "Optionally verify artifact_hash values for local files that can "
+            "be resolved without dereferencing external refs."
+        ),
+    )
     return parser.parse_args(argv)
 
 
@@ -621,7 +1007,11 @@ def main(argv: list[str] | None = None) -> int:
     """Run the reviewer demo validator CLI."""
     args = _parse_args(argv)
     try:
-        result = validate_reviewer_demo(args.demo_dir)
+        result = validate_reviewer_demo(
+            args.demo_dir,
+            verify_local_hashes=args.verify_local_hashes,
+            artifact_base_dir=args.artifact_base_dir,
+        )
     except ReviewerDemoValidationError as exc:
         _print_failure_report(exc)
         return 1
@@ -631,7 +1021,7 @@ def main(argv: list[str] | None = None) -> int:
         _print_failure_report(error)
         return 1
 
-    _print_success_report(result)
+    _print_success_report(result, verify_local_hashes=args.verify_local_hashes)
     return 0
 
 

--- a/tests/demo/test_evaluation_governance_reviewer_demo_validator_hashes.py
+++ b/tests/demo/test_evaluation_governance_reviewer_demo_validator_hashes.py
@@ -1,0 +1,155 @@
+"""Tests for optional local hash verification in reviewer demo validator."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.demo import run_evaluation_governance_reviewer_demo as runner
+from scripts.demo import (
+    validate_evaluation_governance_reviewer_demo as validator,
+)
+
+EXAMPLE_INPUT_DIR = Path(
+    "docs/en/demo/examples/evaluation-governance-offline-chain-v1"
+)
+SCRIPT_PATH = Path(
+    "scripts/demo/validate_evaluation_governance_reviewer_demo.py"
+)
+SHA256_SHAPED_BUT_INVALID = "f" * 64
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(
+        f"{json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True)}\n",
+        encoding="utf-8",
+    )
+
+
+def _generate_demo(tmp_path: Path) -> Path:
+    runner.run_reviewer_demo(EXAMPLE_INPUT_DIR, tmp_path)
+    return tmp_path
+
+
+def test_validate_reviewer_demo_with_local_hashes_succeeds(
+    tmp_path: Path,
+) -> None:
+    demo_dir = _generate_demo(tmp_path)
+
+    result = validator.validate_reviewer_demo(
+        demo_dir,
+        verify_local_hashes=True,
+        artifact_base_dir=EXAMPLE_INPUT_DIR,
+    )
+
+    assert result.local_hash_checks_total > 0
+    assert result.local_hash_checks_passed > 0
+    assert result.local_hash_failures == ()
+
+
+def test_validator_cli_reports_local_hash_success(tmp_path: Path) -> None:
+    demo_dir = _generate_demo(tmp_path)
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--demo-dir",
+            str(demo_dir),
+            "--artifact-base-dir",
+            str(EXAMPLE_INPUT_DIR),
+            "--verify-local-hashes",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "PASS local hash consistency" in completed.stdout
+
+
+def test_validator_local_hash_mismatch_fails_clearly(tmp_path: Path) -> None:
+    demo_dir = _generate_demo(tmp_path)
+    summary_path = demo_dir / "demo-summary.generated.example.json"
+    summary = _load_json(summary_path)
+    summary["generated_artifacts"][0]["artifact_hash"] = SHA256_SHAPED_BUT_INVALID
+    _write_json(summary_path, summary)
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--demo-dir",
+            str(demo_dir),
+            "--artifact-base-dir",
+            str(EXAMPLE_INPUT_DIR),
+            "--verify-local-hashes",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode != 0
+    assert "hash mismatch" in completed.stderr
+    assert "expected hash" in completed.stderr
+    assert "actual hash" in completed.stderr
+    assert "demo-summary.generated.example.json" in completed.stderr
+
+
+def test_reviewer_packet_external_ref_is_skipped_not_dereferenced(
+    tmp_path: Path,
+) -> None:
+    demo_dir = _generate_demo(tmp_path)
+    packet_path = demo_dir / "reviewer-evidence-packet.generated.example.json"
+    packet = _load_json(packet_path)
+    packet["evaluation_governance_artifacts"][0]["artifact_ref"] = (
+        "https://example.invalid/nonlocal-artifact.json"
+    )
+    packet["evaluation_governance_artifacts"][0]["artifact_hash"] = "0" * 64
+    _write_json(packet_path, packet)
+
+    summary_path = demo_dir / "demo-summary.generated.example.json"
+    summary = _load_json(summary_path)
+    for artifact in summary["generated_artifacts"]:
+        if artifact["artifact_ref"] == "reviewer-evidence-packet.generated.example.json":
+            artifact["artifact_hash"] = runner.canonical_json_hash(packet)
+    _write_json(summary_path, summary)
+
+    result = validator.validate_reviewer_demo(
+        demo_dir,
+        verify_local_hashes=True,
+        artifact_base_dir=EXAMPLE_INPUT_DIR,
+    )
+
+    assert result.local_hash_checks_skipped >= 1
+    assert result.local_hash_failures == ()
+
+
+def test_demo_summary_missing_local_artifact_fails(tmp_path: Path) -> None:
+    demo_dir = _generate_demo(tmp_path)
+    summary_path = demo_dir / "demo-summary.generated.example.json"
+    summary = _load_json(summary_path)
+    summary["generated_artifacts"][0]["artifact_ref"] = "missing-local.json"
+    summary["generated_artifacts"][0]["artifact_hash"] = "0" * 64
+    _write_json(summary_path, summary)
+
+    with pytest.raises(validator.ReviewerDemoValidationError) as exc_info:
+        validator.validate_reviewer_demo(
+            demo_dir,
+            verify_local_hashes=True,
+            artifact_base_dir=EXAMPLE_INPUT_DIR,
+        )
+
+    assert exc_info.value.check == "local hash consistency"
+    assert "missing local artifact" in exc_info.value.message


### PR DESCRIPTION
### Motivation
- Provide an optional, offline-only check that verifies SHA-256 artifact hashes against local files when those artifacts can be resolved without network access.
- Preserve existing validator behavior by default and avoid any runtime enforcement, schema changes, or production governance modifications.
- Ensure the validator never dereferences URLs or external refs and reports skipped checks for nonlocal artifacts rather than failing.

### Description
- Add optional CLI flags `--verify-local-hashes` and `--artifact-base-dir` to `scripts/demo/validate_evaluation_governance_reviewer_demo.py` and extend the programmatic API with `validate_reviewer_demo(demo_dir, verify_local_hashes=False, artifact_base_dir=None)`.
- Implement local-only helpers: `sha256_file`, `resolve_local_artifact_ref`, `_canonical_json_file_hash`, `_safe_join`, `_is_external_artifact_ref`, and `_hash_matches` to resolve files securely and compute/compare hashes using `pathlib`, `json`, and `hashlib`.
- Add verification helpers `verify_chain_manifest_hashes`, `verify_demo_summary_hashes`, `verify_reviewer_packet_attachment_hashes`, `_verify_artifact_hash_entry`, and aggregator `verify_local_hash_consistency` that follow the specified resolution order and failure/skip semantics.
- Extend the validation result with local-check counters (`local_hash_checks_total`, `local_hash_checks_passed`, `local_hash_checks_skipped`, `local_hash_failures`), update CLI success output to include `PASS local hash consistency` when requested, and add minimal doc quickstart snippets in `docs/en/demo/evaluation-governance-reviewer-demo-quickstart-v1.md` and `docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/README.md`.

### Testing
- Ran the test suite with `python -m pytest tests/demo/test_evaluation_governance_reviewer_demo_validator.py tests/demo/test_evaluation_governance_reviewer_demo_validator_hashes.py tests/demo/test_evaluation_governance_reviewer_demo_suite.py tests/demo/test_evaluation_governance_reviewer_demo_report.py -q` under a suitable Python interpreter and observed all tests passing (`22 passed, 1 warning`).
- Verified `python3 -m py_compile scripts/demo/validate_evaluation_governance_reviewer_demo.py` compiled cleanly.
- Exercised the CLI both without and with local checks: `python3 scripts/demo/validate_evaluation_governance_reviewer_demo.py --demo-dir docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated` and `python3 scripts/demo/validate_evaluation_governance_reviewer_demo.py --demo-dir docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated --artifact-base-dir docs/en/demo/examples/evaluation-governance-offline-chain-v1 --verify-local-hashes`, both succeeded with expected PASS lines.
- Added `tests/demo/test_evaluation_governance_reviewer_demo_validator_hashes.py` covering API success, CLI success, hash mismatch failure messaging, skipped external refs, and missing-local-artifact failure semantics.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a262674e19083269e3ac35a51470ae4)