### PR TITLE
Integrate local hash verification into Evaluation Governance reviewer demo suite

### DIFF
--- a/docs/en/demo/evaluation-governance-reviewer-demo-quickstart-v1.md
+++ b/docs/en/demo/evaluation-governance-reviewer-demo-quickstart-v1.md
@@ -129,6 +129,23 @@ python scripts/demo/run_evaluation_governance_reviewer_demo_suite.py \
 `--write-example-output` intentionally updates checked-in generated examples.
 Normal reviewers should prefer `--output-dir`.
 
+## Run the full demo suite with local hash verification
+
+```bash
+python scripts/demo/run_evaluation_governance_reviewer_demo_suite.py \
+  --input-dir docs/en/demo/examples/evaluation-governance-offline-chain-v1 \
+  --output-dir /tmp/evaluation-governance-reviewer-demo \
+  --artifact-base-dir docs/en/demo/examples/evaluation-governance-offline-chain-v1 \
+  --verify-local-hashes
+```
+
+This runs generation, validation, local hash consistency checks, and Markdown
+report generation in one local command. Local hash verification only checks
+files that can be resolved locally from the generated demo directory or the
+provided `--artifact-base-dir`. It does not follow external refs, does not
+require network access, does not establish legitimacy, does not certify
+compliance, and does not call `/v1/decide`.
+
 ## 8. Expected outputs
 
 The output directory should contain:

--- a/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/README.md
+++ b/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/README.md
@@ -33,14 +33,21 @@ python scripts/demo/run_evaluation_governance_reviewer_demo.py \
 
 ## Run the full demo suite
 
+Maintainer command for intentionally regenerating checked-in examples with
+local hash verification:
+
 ```bash
 python scripts/demo/run_evaluation_governance_reviewer_demo_suite.py \
   --input-dir docs/en/demo/examples/evaluation-governance-offline-chain-v1 \
+  --artifact-base-dir docs/en/demo/examples/evaluation-governance-offline-chain-v1 \
+  --verify-local-hashes \
   --write-example-output
 ```
 
-This regenerates the checked-in generated examples, validates them, and writes
-`generated/reviewer-demo-report.generated.example.md`.
+This intentionally regenerates the checked-in generated examples, validates
+local hash consistency before producing the report, and writes
+`generated/reviewer-demo-report.generated.example.md`. Normal reviewers should
+prefer `--output-dir` so repository files are not modified.
 
 ## Validate checked-in generated examples
 

--- a/scripts/demo/generate_evaluation_governance_reviewer_demo_report.py
+++ b/scripts/demo/generate_evaluation_governance_reviewer_demo_report.py
@@ -88,6 +88,7 @@ class ReportInputs:
     trajectory_monitor: TrajectoryMonitorSummary
     legitimacy_review: LegitimacyReviewSummary
     validation_result: ReviewerDemoValidationResult | None
+    local_hash_verification_enabled: bool = False
 
 
 def load_json(path: Path) -> dict[str, Any]:
@@ -450,6 +451,19 @@ def render_markdown_report(report_inputs: ReportInputs) -> str:
                 "- reviewer packet attachments checked",
             ]
         )
+        if report_inputs.local_hash_verification_enabled:
+            lines.extend(
+                [
+                    "- Local hash consistency: PASS",
+                    (
+                        "- Local hash checks: "
+                        f"{report_inputs.validation_result.local_hash_checks_passed} "
+                        "passed, "
+                        f"{report_inputs.validation_result.local_hash_checks_skipped} "
+                        "skipped"
+                    ),
+                ]
+            )
 
     lines.extend(
         [
@@ -481,12 +495,19 @@ def render_markdown_report(report_inputs: ReportInputs) -> str:
 def generate_reviewer_demo_report(
     demo_dir: Path | str,
     validate: bool = True,
+    verify_local_hashes: bool = False,
+    artifact_base_dir: Path | str | None = None,
 ) -> str:
     """Generate a Markdown report from a local reviewer demo output directory.
 
     Args:
         demo_dir: Directory containing generated reviewer demo artifacts.
         validate: Whether to run the local reviewer demo validator first.
+        verify_local_hashes: When true and validation is enabled, compare
+            artifact_hash values with local files that can be resolved without
+            network access.
+        artifact_base_dir: Optional local base directory for resolving artifact
+            references during local hash verification.
 
     Returns:
         Human-readable Markdown report content.
@@ -497,7 +518,20 @@ def generate_reviewer_demo_report(
         FileNotFoundError: If required report input files are missing.
     """
     resolved_demo_dir = Path(demo_dir).resolve()
-    validation_result = validate_reviewer_demo(resolved_demo_dir) if validate else None
+    resolved_artifact_base_dir = (
+        Path(artifact_base_dir).resolve()
+        if artifact_base_dir is not None
+        else None
+    )
+    validation_result = (
+        validate_reviewer_demo(
+            resolved_demo_dir,
+            verify_local_hashes=verify_local_hashes,
+            artifact_base_dir=resolved_artifact_base_dir,
+        )
+        if validate
+        else None
+    )
 
     demo_summary = load_json(resolved_demo_dir / DEMO_SUMMARY_FILE_NAME)
     _require_demo_boundaries(demo_summary)
@@ -513,6 +547,7 @@ def generate_reviewer_demo_report(
         trajectory_monitor=summarize_trajectory_monitor(trajectory_monitor),
         legitimacy_review=summarize_legitimacy_review(legitimacy_review),
         validation_result=validation_result,
+        local_hash_verification_enabled=verify_local_hashes,
     )
     return render_markdown_report(report_inputs)
 
@@ -548,6 +583,22 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         dest="validate",
         help="Skip validation and render only from local JSON inputs.",
     )
+    parser.add_argument(
+        "--artifact-base-dir",
+        type=Path,
+        help=(
+            "Optional local base directory used only for resolving artifact "
+            "references during --verify-local-hashes."
+        ),
+    )
+    parser.add_argument(
+        "--verify-local-hashes",
+        action="store_true",
+        help=(
+            "Optionally verify artifact_hash values for local files that can "
+            "be resolved without dereferencing external refs."
+        ),
+    )
     return parser.parse_args(argv)
 
 
@@ -566,7 +617,12 @@ def main(argv: list[str] | None = None) -> int:
     """Run the reviewer demo report generator CLI."""
     args = _parse_args(argv)
     try:
-        report = generate_reviewer_demo_report(args.demo_dir, args.validate)
+        report = generate_reviewer_demo_report(
+            args.demo_dir,
+            args.validate,
+            verify_local_hashes=args.verify_local_hashes,
+            artifact_base_dir=args.artifact_base_dir,
+        )
         if args.output is not None:
             args.output.parent.mkdir(parents=True, exist_ok=True)
             args.output.write_text(report, encoding="utf-8")

--- a/scripts/demo/run_evaluation_governance_reviewer_demo_suite.py
+++ b/scripts/demo/run_evaluation_governance_reviewer_demo_suite.py
@@ -33,6 +33,7 @@ from scripts.demo.run_evaluation_governance_reviewer_demo import (
     run_reviewer_demo,
 )
 from scripts.demo.validate_evaluation_governance_reviewer_demo import (
+    ReviewerDemoValidationError,
     ReviewerDemoValidationResult,
     validate_reviewer_demo,
 )
@@ -95,6 +96,8 @@ def run_reviewer_demo_suite(
     input_dir: Path,
     output_dir: Path | None = None,
     write_example_output: bool = False,
+    verify_local_hashes: bool = False,
+    artifact_base_dir: Path | None = None,
 ) -> ReviewerDemoSuiteResult:
     """Run generation, validation, and report creation for the reviewer demo.
 
@@ -104,6 +107,10 @@ def run_reviewer_demo_suite(
             ``write_example_output`` is true.
         write_example_output: Intentionally write the checked-in generated
             example output directory and generated example report.
+        verify_local_hashes: When true, validate local artifact hash
+            consistency for resolvable files before report generation.
+        artifact_base_dir: Optional local base directory for resolving
+            artifact references during local hash verification.
 
     Returns:
         Paths and validation metadata for the completed suite run.
@@ -115,8 +122,17 @@ def run_reviewer_demo_suite(
     """
     resolved_output_dir = resolve_output_dir(output_dir, write_example_output)
     run_result = run_reviewer_demo(input_dir, resolved_output_dir)
-    validation_result = validate_reviewer_demo(run_result.output_dir)
-    report = generate_reviewer_demo_report(run_result.output_dir, validate=True)
+    validation_result = validate_reviewer_demo(
+        run_result.output_dir,
+        verify_local_hashes=verify_local_hashes,
+        artifact_base_dir=artifact_base_dir,
+    )
+    report = generate_reviewer_demo_report(
+        run_result.output_dir,
+        validate=True,
+        verify_local_hashes=verify_local_hashes,
+        artifact_base_dir=artifact_base_dir,
+    )
     report_path = select_report_output_path(
         run_result.output_dir,
         write_example_output,
@@ -161,6 +177,22 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "examples and the generated example report."
         ),
     )
+    parser.add_argument(
+        "--artifact-base-dir",
+        type=Path,
+        help=(
+            "Optional local base directory used only for resolving artifact "
+            "references during --verify-local-hashes."
+        ),
+    )
+    parser.add_argument(
+        "--verify-local-hashes",
+        action="store_true",
+        help=(
+            "Optionally verify artifact_hash values for local files that can "
+            "be resolved without dereferencing external refs."
+        ),
+    )
     return parser.parse_args(argv)
 
 
@@ -172,7 +204,15 @@ def main(argv: list[str] | None = None) -> int:
             input_dir=args.input_dir,
             output_dir=args.output_dir,
             write_example_output=args.write_example_output,
+            verify_local_hashes=args.verify_local_hashes,
+            artifact_base_dir=args.artifact_base_dir,
         )
+    except ReviewerDemoValidationError as exc:
+        print("Evaluation Governance Reviewer Demo Suite", file=sys.stderr)
+        print(f"FAIL {exc.check}", file=sys.stderr)
+        print(f"File: {exc.path}", file=sys.stderr)
+        print(f"Error: {exc.message}", file=sys.stderr)
+        return 1
     except Exception as exc:  # noqa: BLE001 - CLI presents concise errors.
         print(f"error: {exc}", file=sys.stderr)
         return 1
@@ -181,6 +221,8 @@ def main(argv: list[str] | None = None) -> int:
     print("")
     print("PASS generated reviewer demo outputs")
     print("PASS validated reviewer demo outputs")
+    if args.verify_local_hashes:
+        print("PASS local hash consistency")
     print("PASS generated reviewer demo report")
     print("")
     print(f"Output directory: {result.output_dir}")

--- a/tests/demo/test_evaluation_governance_reviewer_demo_suite_hashes.py
+++ b/tests/demo/test_evaluation_governance_reviewer_demo_suite_hashes.py
@@ -1,0 +1,145 @@
+"""Tests for reviewer demo suite local hash verification integration."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.demo import run_evaluation_governance_reviewer_demo as runner
+from scripts.demo import run_evaluation_governance_reviewer_demo_suite as suite
+from scripts.demo import validate_evaluation_governance_reviewer_demo as validator
+from scripts.demo.generate_evaluation_governance_reviewer_demo_report import (
+    generate_reviewer_demo_report,
+)
+
+EXAMPLE_INPUT_DIR = Path(
+    "docs/en/demo/examples/evaluation-governance-offline-chain-v1"
+)
+SCRIPT_PATH = Path(
+    "scripts/demo/run_evaluation_governance_reviewer_demo_suite.py"
+)
+EXPECTED_OUTPUT_FILES = [
+    "outcome-delta-attribution-1.generated.example.json",
+    "outcome-delta-attribution-2.generated.example.json",
+    "evaluation-drift-detection-1.generated.example.json",
+    "evaluation-drift-detection-2.generated.example.json",
+    "trajectory-admissibility-monitor.generated.example.json",
+    "legitimacy-impact-review.generated.example.json",
+    "chain-manifest.generated.example.json",
+    "reviewer-evidence-packet.generated.example.json",
+    "demo-summary.generated.example.json",
+]
+SHA256_SHAPED_BUT_INVALID = "f" * 64
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(
+        f"{json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True)}\n",
+        encoding="utf-8",
+    )
+
+
+def test_suite_imports_cleanly_with_hash_options() -> None:
+    assert callable(suite.run_reviewer_demo_suite)
+    assert callable(suite.main)
+
+
+def test_run_reviewer_demo_suite_with_local_hashes_writes_report(
+    tmp_path: Path,
+) -> None:
+    result = suite.run_reviewer_demo_suite(
+        EXAMPLE_INPUT_DIR,
+        output_dir=tmp_path,
+        verify_local_hashes=True,
+        artifact_base_dir=EXAMPLE_INPUT_DIR,
+    )
+
+    for file_name in EXPECTED_OUTPUT_FILES:
+        assert (tmp_path / file_name).is_file()
+
+    report_path = tmp_path / "reviewer-demo-report.md"
+    assert result.report_path == report_path
+    assert report_path.is_file()
+    assert result.validation_result.local_hash_checks_passed > 0
+    assert result.validation_result.local_hash_failures == ()
+
+    report = report_path.read_text(encoding="utf-8")
+    assert "Evaluation Governance Reviewer Demo Report" in report
+    assert "Validation status: PASS" in report
+    assert "Local hash consistency: PASS" in report
+    assert "does not establish legitimacy" in report
+    assert "does not certify regulatory compliance" in report
+
+
+def test_suite_cli_reports_local_hash_success(tmp_path: Path) -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--input-dir",
+            str(EXAMPLE_INPUT_DIR),
+            "--output-dir",
+            str(tmp_path),
+            "--artifact-base-dir",
+            str(EXAMPLE_INPUT_DIR),
+            "--verify-local-hashes",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "PASS generated reviewer demo outputs" in completed.stdout
+    assert "PASS validated reviewer demo outputs" in completed.stdout
+    assert "PASS local hash consistency" in completed.stdout
+    assert "PASS generated reviewer demo report" in completed.stdout
+    assert (tmp_path / "reviewer-demo-report.md").is_file()
+
+
+def test_local_hash_mismatch_fails_before_report_generation(
+    tmp_path: Path,
+) -> None:
+    runner.run_reviewer_demo(EXAMPLE_INPUT_DIR, tmp_path)
+    summary_path = tmp_path / "demo-summary.generated.example.json"
+    summary = _load_json(summary_path)
+    summary["generated_artifacts"][0]["artifact_hash"] = (
+        SHA256_SHAPED_BUT_INVALID
+    )
+    _write_json(summary_path, summary)
+
+    with pytest.raises(validator.ReviewerDemoValidationError) as exc_info:
+        validator.validate_reviewer_demo(
+            tmp_path,
+            verify_local_hashes=True,
+            artifact_base_dir=EXAMPLE_INPUT_DIR,
+        )
+
+    assert exc_info.value.check == "local hash consistency"
+    assert "hash mismatch" in exc_info.value.message
+
+
+def test_report_generator_with_local_hashes_mentions_hash_status(
+    tmp_path: Path,
+) -> None:
+    runner.run_reviewer_demo(EXAMPLE_INPUT_DIR, tmp_path)
+
+    report = generate_reviewer_demo_report(
+        tmp_path,
+        validate=True,
+        verify_local_hashes=True,
+        artifact_base_dir=EXAMPLE_INPUT_DIR,
+    )
+
+    assert "Validation status: PASS" in report
+    assert "Local hash consistency: PASS" in report
+    assert "Local hash checks:" in report


### PR DESCRIPTION
### Motivation
- Provide an optional end-to-end local hash verification path for reviewers so the suite runner can generate outputs, validate local artifact hash consistency, and produce a report in one command. 
- Keep changes helper/docs/tests-only and preserve all runtime, schema, admissibility, and governance behavior boundaries.

### Description
- Added optional `--verify-local-hashes` and `--artifact-base-dir` flags to the suite CLI and wired `verify_local_hashes` and `artifact_base_dir` through `run_reviewer_demo_suite(...)` to `validate_reviewer_demo(...)` and `generate_reviewer_demo_report(...)` without changing default behavior. (files: `scripts/demo/run_evaluation_governance_reviewer_demo_suite.py`, `scripts/demo/generate_evaluation_governance_reviewer_demo_report.py`)
- Extended `generate_reviewer_demo_report(...)` API to accept `verify_local_hashes` and `artifact_base_dir` and to render local hash consistency information in the Validation section when enabled. (file: `scripts/demo/generate_evaluation_governance_reviewer_demo_report.py`)
- Updated CLI error handling so a validation failure from local hash checks produces a clear FAIL summary and prevents report generation. (file: `scripts/demo/run_evaluation_governance_reviewer_demo_suite.py`)
- Documented reviewer and maintainer usage examples for running the full suite with local hash verification and added a focused integration test exercising the new flags. (files: `docs/en/demo/evaluation-governance-reviewer-demo-quickstart-v1.md`, `docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/README.md`, `tests/demo/test_evaluation_governance_reviewer_demo_suite_hashes.py`)

### Testing
- Ran the relevant pytest suite: `pytest tests/demo/test_evaluation_governance_reviewer_demo_suite_hashes.py tests/demo/test_evaluation_governance_reviewer_demo_suite.py tests/demo/test_evaluation_governance_reviewer_demo_validator_hashes.py tests/demo/test_evaluation_governance_reviewer_demo_report.py` and observed all tests pass (`20 passed, 1 warning`).
- Executed the suite CLI with local hash verification to exercise the end-to-end flow and confirmed the human-friendly CLI output includes `PASS local hash consistency` and a generated report containing `Local hash consistency: PASS` and local hash counters. (`scripts/demo/run_evaluation_governance_reviewer_demo_suite.py --verify-local-hashes --artifact-base-dir ...`).
- Ran static checks with `ruff` over modified files and observed no lint violations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2634169e5c83268843216d945239cf)