### PR TITLE
Add Evaluation Governance reviewer demo suite smoke test

### DIFF
--- a/docs/en/demo/evaluation-governance-reviewer-demo-quickstart-v1.md
+++ b/docs/en/demo/evaluation-governance-reviewer-demo-quickstart-v1.md
@@ -129,6 +129,13 @@ python scripts/demo/run_evaluation_governance_reviewer_demo_suite.py \
 `--write-example-output` intentionally updates checked-in generated examples.
 Normal reviewers should prefer `--output-dir`.
 
+## CI smoke coverage
+
+The reviewer demo suite has a focused smoke test that runs the full synthetic
+offline path into a temporary directory. The smoke test verifies generation,
+validation, local hash consistency, and report creation. It remains
+non-runtime and does not call `/v1/decide`.
+
 ## Run the full demo suite with local hash verification
 
 ```bash

--- a/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/README.md
+++ b/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/README.md
@@ -49,6 +49,9 @@ local hash consistency before producing the report, and writes
 `generated/reviewer-demo-report.generated.example.md`. Normal reviewers should
 prefer `--output-dir` so repository files are not modified.
 
+The suite is covered by a focused CI-safe smoke test using temporary
+output directories.
+
 ## Validate checked-in generated examples
 
 ```bash

--- a/tests/demo/test_evaluation_governance_reviewer_demo_suite_smoke.py
+++ b/tests/demo/test_evaluation_governance_reviewer_demo_suite_smoke.py
@@ -1,0 +1,84 @@
+"""CI-safe smoke test for the Evaluation Governance reviewer demo suite."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from scripts.demo.run_evaluation_governance_reviewer_demo_suite import (
+    run_reviewer_demo_suite,
+)
+
+INPUT_DIR = Path(
+    "docs/en/demo/examples/evaluation-governance-offline-chain-v1"
+)
+EXPECTED_OUTPUT_FILES = (
+    "outcome-delta-attribution-1.generated.example.json",
+    "outcome-delta-attribution-2.generated.example.json",
+    "evaluation-drift-detection-1.generated.example.json",
+    "evaluation-drift-detection-2.generated.example.json",
+    "trajectory-admissibility-monitor.generated.example.json",
+    "legitimacy-impact-review.generated.example.json",
+    "chain-manifest.generated.example.json",
+    "reviewer-evidence-packet.generated.example.json",
+    "demo-summary.generated.example.json",
+    "reviewer-demo-report.md",
+)
+EXPECTED_ARTIFACT_TYPES = {
+    "evaluation_receipt",
+    "manifest_change_receipt",
+    "outcome_delta_attribution",
+    "evaluation_drift_detection",
+    "trajectory_admissibility_monitor",
+    "legitimacy_impact_review",
+}
+EXPECTED_NON_GOALS = {
+    "does_not_call_v1_decide",
+    "does_not_establish_legitimacy",
+    "does_not_certify_compliance",
+}
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    """Load a generated JSON object from the smoke-test output directory."""
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_reviewer_demo_suite_smoke_with_local_hashes(
+    tmp_path: Path,
+) -> None:
+    """Run the full non-runtime reviewer demo suite in a temp directory."""
+    result = run_reviewer_demo_suite(
+        input_dir=INPUT_DIR,
+        output_dir=tmp_path,
+        verify_local_hashes=True,
+        artifact_base_dir=INPUT_DIR,
+    )
+
+    assert result.output_dir == tmp_path.resolve()
+    assert result.report_path == tmp_path / "reviewer-demo-report.md"
+    assert result.validation_result.local_hash_checks_passed > 0
+    assert result.validation_result.local_hash_failures == ()
+
+    for file_name in EXPECTED_OUTPUT_FILES:
+        assert (tmp_path / file_name).is_file()
+
+    report = result.report_path.read_text(encoding="utf-8")
+    assert "Evaluation Governance Reviewer Demo Report" in report
+    assert "Validation status: PASS" in report
+    assert "Local hash consistency: PASS" in report
+    assert "does not establish legitimacy" in report
+    assert "does not certify regulatory compliance" in report
+
+    evidence_packet = _load_json(
+        tmp_path / "reviewer-evidence-packet.generated.example.json"
+    )
+    artifacts = evidence_packet["evaluation_governance_artifacts"]
+    artifact_types = {artifact["artifact_type"] for artifact in artifacts}
+    assert EXPECTED_ARTIFACT_TYPES <= artifact_types
+
+    demo_summary = _load_json(tmp_path / "demo-summary.generated.example.json")
+    assert demo_summary["non_runtime"] is True
+    assert demo_summary["non_enforcing"] is True
+    assert EXPECTED_NON_GOALS <= set(demo_summary["non_goals"])


### PR DESCRIPTION
### Motivation

- Provide a small, CI-safe smoke test that verifies the full non-runtime Evaluation Governance reviewer demo suite end-to-end without touching checked-in examples.
- Ensure the new reviewer-facing offline flow (generate → validate → local-hash-check → report) remains functional in CI as a single focused check.
- Security note: the smoke test intentionally avoids network access, secrets, PII, and runtime `/v1/decide` calls to prevent exposing sensitive data or changing production behavior.

### Description

- Add a new smoke test `tests/demo/test_evaluation_governance_reviewer_demo_suite_smoke.py` that calls `run_reviewer_demo_suite` with `verify_local_hashes=True` into a `tmp_path` output directory and asserts expected generated files, report contents, evidence packet artifact types, and demo-summary non-goals.
- Update docs to briefly document CI smoke coverage in `docs/en/demo/evaluation-governance-reviewer-demo-quickstart-v1.md` and add a short note to `docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/README.md` describing temporary-output CI coverage.
- This PR is tests/docs-only and does not modify runtime behavior, production governance configuration, schemas, admissibility logic, `/v1/decide` behavior, or add fail-closed/runtime enforcement.

### Testing

- Ran the new smoke test with `pytest tests/demo/test_evaluation_governance_reviewer_demo_suite_smoke.py` and it passed (`1 passed`).
- Ran the demo-suite-related test group with `pytest tests/demo/test_evaluation_governance_reviewer_demo_suite_smoke.py tests/demo/test_evaluation_governance_reviewer_demo_suite.py tests/demo/test_evaluation_governance_reviewer_demo_suite_hashes.py tests/demo/test_evaluation_governance_reviewer_demo_validator_hashes.py tests/demo/test_evaluation_governance_reviewer_demo_report.py` and all tests passed (`21 passed`).
- Ran linters with `ruff check tests/demo/test_evaluation_governance_reviewer_demo_suite_smoke.py` and it passed.
- Note: an earlier environment bootstrap attempt hit a transient network/pyenv install issue; that did not affect the smoke test execution since the test itself is offline and passed in the CI-like run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a263a03c3b08326b826d251da264ae6)