### PR TITLE
docs: add Reviewer-Facing Visibility Roadmap v0

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,6 +506,7 @@ External reviewers can use the Regulated Action Governance External Reviewer Fee
   - Governance Evidence Packet contract test: `frontend/app/api/veritas/v1/report/governance/governance-evidence-packet-contract.test.ts`
   - Non-claims: not certification; not production security guarantee; not automatic enforcement; not scoring model; not legal conclusion.
   - VERITAS also documents Governance Recognizability Conditions v0, clarifying that visibility conditions can become a governance function when reviewers must later recognize maneuverability contraction despite procedural admissibility.
+  - VERITAS also documents Reviewer-Facing Visibility Roadmap v0, a docs-only roadmap for distinguishing procedural admissibility evidence, maneuverability contraction evidence, and recognizability evidence before any future packet expansion.
 - **Mini proof: covered `/v1/decide` pre-bind formation refusal**: [`docs/en/validation/pre-bind-formation-refusal-mini-proof.md`](docs/en/validation/pre-bind-formation-refusal-mini-proof.md)
 - **Regulated Action Governance Kernel**: [`docs/en/architecture/regulated-action-governance-kernel.md`](docs/en/architecture/regulated-action-governance-kernel.md)
 - **Authority Evidence vs Audit Log**: [`docs/en/architecture/authority-evidence-vs-audit-log.md`](docs/en/architecture/authority-evidence-vs-audit-log.md)

--- a/README_JP.md
+++ b/README_JP.md
@@ -275,6 +275,7 @@ VERITAS は、本番の enforce と開発時の observe を区別します。本
   - Governance Evidence Packet contract test: `frontend/app/api/veritas/v1/report/governance/governance-evidence-packet-contract.test.ts`
   - Non-claims: not certification; not production security guarantee; not automatic enforcement; not scoring model; not legal conclusion.
 - VERITAS は Governance Recognizability Conditions v0 も文書化し、手続き上の許容可能性が保たれている場合でも、reviewer が maneuverability の収縮を後から認識するための visibility conditions が governance function になり得ることを整理しています。
+- VERITAS は Reviewer-Facing Visibility Roadmap v0 も文書化し、将来の packet expansion 前に、procedural admissibility evidence、maneuverability contraction evidence、recognizability evidence を区別するための docs-only roadmap を整理しています。
 
 ## 何を解決するか
 

--- a/docs/en/demo/external-reviewer-artifact-index.md
+++ b/docs/en/demo/external-reviewer-artifact-index.md
@@ -6,6 +6,8 @@ Key local/offline reviewer-facing artifacts:
   - Procedural Admissibility vs. Maneuverability Observables v0: a reviewer-facing note clarifying that a process can remain admissible, documented, inspectable, and procedurally coherent while practical maneuverability contracts upstream. The note frames visibility of that contraction as a governance function, without adding production claims or runtime behavior.
 - `docs/en/demos/pre_boundary_collapse_demo.md#governance-recognizability-conditions-v0`
   - Governance Recognizability Conditions v0: A reviewer-facing note clarifying the visibility conditions under which governance remains recognizable to later reviewers. It explains that preserving evidence of maneuverability contraction may become as important as preserving evidence of procedural admissibility, without adding runtime behavior, production claims, or certification language.
+- `docs/en/demos/pre_boundary_collapse_demo.md#reviewer-facing-visibility-roadmap-v0`
+  - Reviewer-Facing Visibility Roadmap v0: A docs-only roadmap note describing how reviewer-facing visibility may evolve before any future Governance Evidence Packet v1 expansion. It distinguishes procedural admissibility evidence, maneuverability contraction evidence, and recognizability evidence without changing runtime behavior, schemas, fixtures, or packet contracts.
 - `scripts/demo/saas_permission_change_governed_demo.py`
   - deterministic local/offline SaaS permission-change governed execution demo
 - `scripts/demo/export_reviewer_evidence_packet.py`

--- a/docs/en/demos/pre_boundary_collapse_demo.md
+++ b/docs/en/demos/pre_boundary_collapse_demo.md
@@ -551,3 +551,49 @@ not production security, not automatic enforcement, not automatic blocking, not
 automatic attack detection, not a scoring model, not a prediction claim, not an
 inevitability claim, not a psychological inference, not actor psychology
 inference, and not a legal conclusion.
+
+## Reviewer-Facing Visibility Roadmap v0
+
+Reviewer-Facing Visibility Roadmap v0 is a docs-only roadmap note for the
+reviewer-facing evidence architecture before any future Governance Evidence
+Packet v1 expansion. It does not implement Governance Evidence Packet v1,
+change packet semantics, or add new runtime markers. Instead, it identifies
+visibility distinctions that may need to remain stable before a future packet
+version can be considered.
+
+Reviewer-facing visibility should distinguish procedural admissibility evidence, maneuverability contraction evidence, and recognizability evidence before any future packet expansion.
+
+For this roadmap, reviewer-facing visibility means the later reviewer can
+separately inspect:
+
+1. evidence that the process remained procedurally admissible
+2. evidence that maneuverability contracted
+3. evidence that later reviewers could recognize that contraction
+
+This builds on the existing VERITAS layers rather than replacing them.
+Governance Evidence Packet v0 groups the current reviewer-facing evidence, and
+Governance Evidence Packet Contract v0 fixes the current packet structure.
+Procedural Admissibility vs. Maneuverability Observables v0 separates formal
+process admissibility from practical maneuverability. Governance Recognizability
+Conditions v0 describes visibility conditions under which later reviewers can
+recognize governance state and maneuverability contraction. Trajectory Shaping
+Lineage v0, Irreversibility Horizon v0, and Actor Recognition Gap v0 provide the
+underlying reviewer-visible sequence, horizon, and recognition-gap vocabulary
+without inferring actor beliefs, intent, or subjective experience.
+
+Future representative scenarios may test whether these distinctions remain
+visible under more dynamic conditions. Those scenarios would be used to examine
+whether reviewers can still distinguish process admissibility evidence,
+maneuverability contraction evidence, and recognizability evidence when the
+conditions around a decision change over time.
+
+This roadmap does not change the Governance Evidence Packet v0 contract.
+
+This roadmap is not a Governance Evidence Packet v1 implementation, not a
+schema change, not a runtime behavior change, not a Mission Control UI change,
+not certification, not production security, not a production security guarantee,
+not automatic enforcement, not automatic blocking, not automatic attack
+detection, not a scoring model, not a prediction claim, not an inevitability
+claim, not a psychological inference, not actor psychology inference, and not a
+legal conclusion.
+

--- a/docs/ja/demos/pre_boundary_collapse_demo.md
+++ b/docs/ja/demos/pre_boundary_collapse_demo.md
@@ -363,3 +363,38 @@ visibility は単なる documentation の性質ではなく、それ自体が go
 これは certification / production security / production security guarantee / automatic enforcement /
 automatic blocking / automatic attack detection / scoring model / prediction claim / inevitability claim /
 actor psychology inference / legal conclusion ではありません。
+
+## Reviewer-Facing Visibility Roadmap v0
+
+Reviewer-Facing Visibility Roadmap v0 は docs-only の roadmap note です。これは
+Governance Evidence Packet v1 を実装するものではなく、将来の packet v1 expansion
+の前に安定させるべき visibility distinction を整理します。新しい runtime marker、
+runtime behavior、schema、fixture、Mission Control UI、または packet contract は追加しません。
+
+reviewer-facing visibility は、後から reviewer が次の evidence を区別して確認できる状態を指します。
+
+1. process が procedural admissibility を保っていた evidence
+2. maneuverability が contraction していた evidence
+3. その contraction を後から reviewer が認識できる evidence
+
+この roadmap は、既存の VERITAS layer を置き換えるものではなく、それらに接続します。
+Governance Evidence Packet v0 は現在の reviewer-facing evidence を束ね、Governance Evidence
+Packet Contract v0 は現在の packet structure を固定します。Procedural Admissibility vs.
+Maneuverability Observables v0 は process の admissibility と practical maneuverability を
+区別し、Governance Recognizability Conditions v0 は later reviewer が governance state と
+maneuverability contraction を認識するための visibility conditions を整理します。Trajectory
+Shaping Lineage v0、Irreversibility Horizon v0、Actor Recognition Gap v0 は、actor の心理、
+intent、beliefs、subjective experience を推測せず、reviewer-visible な sequence、horizon、
+recognition gap の vocabulary を提供します。
+
+future representative scenarios では、より dynamic な conditions の下でも、procedural
+admissibility evidence、maneuverability contraction evidence、recognizability evidence の
+区別が visible に残るかを検証する可能性があります。
+
+この roadmap は Governance Evidence Packet v0 contract を変更しません。
+
+これは Governance Evidence Packet v1 implementation / schema change / runtime change /
+Mission Control UI change / certification / production security / production security guarantee /
+automatic enforcement / automatic blocking / automatic attack detection / scoring model /
+prediction claim / inevitability claim / actor psychology inference / legal conclusion ではありません。
+

--- a/tests/docs/test_reviewer_facing_visibility_roadmap_docs.py
+++ b/tests/docs/test_reviewer_facing_visibility_roadmap_docs.py
@@ -1,0 +1,92 @@
+"""Presence checks for Reviewer-Facing Visibility Roadmap v0 docs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+ENGLISH_DEMO_DOC = ROOT / "docs/en/demos/pre_boundary_collapse_demo.md"
+JAPANESE_DEMO_DOC = ROOT / "docs/ja/demos/pre_boundary_collapse_demo.md"
+REVIEWER_ARTIFACT_INDEX = (
+    ROOT / "docs/en/demo/external-reviewer-artifact-index.md"
+)
+ENGLISH_README = ROOT / "README.md"
+JAPANESE_README = ROOT / "README_JP.md"
+
+
+def _normalize_whitespace(text: str) -> str:
+    return " ".join(text.split())
+
+
+def test_english_demo_documents_reviewer_facing_visibility_roadmap() -> None:
+    text = _normalize_whitespace(
+        ENGLISH_DEMO_DOC.read_text(encoding="utf-8")
+    )
+
+    expected_fragments = [
+        "Reviewer-Facing Visibility Roadmap v0",
+        (
+            "Reviewer-facing visibility should distinguish procedural "
+            "admissibility evidence, maneuverability contraction evidence, "
+            "and recognizability evidence before any future packet expansion."
+        ),
+        (
+            "This roadmap does not change the Governance Evidence "
+            "Packet v0 contract."
+        ),
+        "Governance Evidence Packet v0",
+        "Governance Evidence Packet Contract v0",
+        "Procedural Admissibility vs. Maneuverability Observables v0",
+        "Governance Recognizability Conditions v0",
+        "not certification",
+        "not production security",
+        "not automatic enforcement",
+        "not a psychological inference",
+        "not a Governance Evidence Packet v1 implementation",
+    ]
+
+    for fragment in expected_fragments:
+        assert fragment in text
+
+
+def test_japanese_demo_documents_reviewer_facing_visibility_roadmap() -> None:
+    if not JAPANESE_DEMO_DOC.exists():
+        return
+
+    text = _normalize_whitespace(
+        JAPANESE_DEMO_DOC.read_text(encoding="utf-8")
+    )
+
+    expected_fragments = [
+        "Reviewer-Facing Visibility Roadmap v0",
+        "docs-only",
+        "Governance Evidence Packet v1",
+        "procedural admissibility",
+        "maneuverability",
+        "recognizability",
+        "reviewer",
+        "certification",
+        "production security",
+        "automatic enforcement",
+    ]
+
+    for fragment in expected_fragments:
+        assert fragment in text
+
+
+def test_reviewer_index_or_readme_references_visibility_roadmap() -> None:
+    candidate_paths = [
+        REVIEWER_ARTIFACT_INDEX,
+        ENGLISH_README,
+        JAPANESE_README,
+    ]
+    combined_text = _normalize_whitespace(
+        "\n".join(
+            path.read_text(encoding="utf-8")
+            for path in candidate_paths
+            if path.exists()
+        )
+    )
+
+    assert "Reviewer-Facing Visibility Roadmap v0" in combined_text


### PR DESCRIPTION
### Motivation

- Stabilize and document reviewer-facing visibility distinctions prior to any future Governance Evidence Packet v1 work so reviewers can separate process admissibility, maneuverability contraction, and recognizability evidence. 
- Provide a docs-only roadmap that ties these visibility distinctions to existing v0 layers (Governance Evidence Packet v0, Contract v0, Procedural Admissibility vs. Maneuverability Observables v0, Governance Recognizability Conditions v0, Trajectory Shaping Lineage v0, Irreversibility Horizon v0, Actor Recognition Gap v0) without adding runtime, schema, or contract changes.

### Description

- Added an English `Reviewer-Facing Visibility Roadmap v0` section to `docs/en/demos/pre_boundary_collapse_demo.md` that (a) defines reviewer-facing visibility, (b) lists the three required visibility distinctions, (c) explicitly states it is docs-only and not a Packet v1 implementation, and (d) includes the required exact sentences about distinction and contract non-change. 
- Added the matching Japanese section to `docs/ja/demos/pre_boundary_collapse_demo.md`. 
- Added an index entry for the roadmap in `docs/en/demo/external-reviewer-artifact-index.md` and short references in `README.md` and `README_JP.md`. 
- Added a docs presence test `tests/docs/test_reviewer_facing_visibility_roadmap_docs.py` that asserts the English doc contains the required phrases and also checks the Japanese doc and reviewer artifact index / README references when present. 
- No runtime behavior, API payloads, Mission Control UI, JSON schema, fixtures, or Governance Evidence Packet v0 contract were changed. 

### Testing

- Ran `PYENV_VERSION=3.12.13 pytest -q tests/docs/test_reviewer_facing_visibility_roadmap_docs.py` and the test suite for related docs checks; `tests/docs/test_reviewer_facing_visibility_roadmap_docs.py` passed (3 tests, 1 warning). 
- Ran `PYENV_VERSION=3.12.13 pytest -q tests/docs/test_governance_recognizability_conditions_docs.py tests/docs/test_procedural_admissibility_maneuverability_observables_docs.py tests/docs/test_governance_evidence_packet_contract_docs.py` and those docs tests passed (10 tests total, 1 warning). 
- Note: an initial `pytest` attempt used the repo `.python-version` (3.12.12) which was not available in the environment, so tests were executed with `PYENV_VERSION=3.12.13` to run successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2649bd2cb4832691cc1873071782c2)