### PR TITLE
Add Ed25519 manifest signature verification to evidence bundle CLI and verifier

### DIFF
--- a/docs/en/validation/external-audit-readiness.md
+++ b/docs/en/validation/external-audit-readiness.md
@@ -329,7 +329,9 @@ veritas-evidence-bundle generate \
   --decision-record-profile full
 
 veritas-evidence-bundle verify \
-  --bundle-dir ./bundles/veritas_bundle_decision_<uuid>
+  --bundle-dir ./bundles/veritas_bundle_decision_<uuid> \
+  --public-key /path/to/trusted_ed25519_public.key \
+  --require-signature
 ```
 
 ### Financial template sample bundle
@@ -350,14 +352,19 @@ archive = create_bundle_archive(Path("veritas_bundle_decision_<uuid>"))
 ### External delivery policy (auditor/customer/legal)
 
 1. Generate bundle with explicit decision_record profile (`minimum` or `full`).
-2. Verify with `veritas-evidence-bundle verify`.
+2. Verify with `veritas-evidence-bundle verify --public-key <trusted-ed25519-public-key>`.
+   Use a trusted public key from the reviewer/operator trust channel; in
+   `secure` and `prod` posture, missing or unverifiable manifest signatures
+   fail closed.
 3. Confirm all `acceptance_checklist.json` items are PASS.
 4. Include `README.txt` unchanged in handoff package.
 5. Deliver as read-only `.tar.gz` plus detached transfer checksum.
 
 Security note: Any tampering with `manifest.json`, `witness_entries.jsonl`,
 or hash-referenced files invalidates the delivery contract and requires
-regeneration from TrustLog source data.
+regeneration from TrustLog source data. Hash checks prove file integrity only;
+reviewers must provide the trusted Ed25519 public key at verify time to prove
+manifest authenticity and non-repudiation.
 
 ---
 

--- a/veritas_os/audit/evidence_bundle.py
+++ b/veritas_os/audit/evidence_bundle.py
@@ -543,7 +543,10 @@ def generate_evidence_bundle(
             "decision_record_profile": decision_record_profile,
             "acceptance_checklist_path": "acceptance_checklist.json",
             "readme_path": "README.txt",
-            "verify_command": "veritas-evidence-bundle verify --bundle-dir <bundle_dir>",
+            "verify_command": (
+                "veritas-evidence-bundle verify --bundle-dir <bundle_dir> "
+                "--public-key <trusted_ed25519_public_key> --require-signature"
+            ),
         },
     )
     written_files.append("ui_delivery_hook.json")

--- a/veritas_os/audit/verify_bundle.py
+++ b/veritas_os/audit/verify_bundle.py
@@ -39,6 +39,7 @@ def verify_evidence_bundle(
     bundle_dir: Path,
     *,
     verify_signature_fn: Optional[Callable[[str, str], bool]] = None,
+    require_signature: bool = False,
     verify_witness_signatures: bool = False,
     witness_signature_fn: Optional[Callable[[Dict[str, Any]], bool]] = None,
 ) -> Dict[str, Any]:
@@ -48,6 +49,8 @@ def verify_evidence_bundle(
         bundle_dir: Path to the evidence bundle directory.
         verify_signature_fn: Optional callable (payload_hash, signature) -> bool
             for verifying the manifest signature.
+        require_signature: Fail verification when a manifest signature is missing
+            or cannot be cryptographically verified.
         verify_witness_signatures: Whether to verify witness entry signatures.
         witness_signature_fn: Optional callable for witness signature verification.
 
@@ -58,6 +61,9 @@ def verify_evidence_bundle(
         - errors: list of error descriptions
         - manifest: the manifest contents
         - file_hash_results: per-file hash comparison
+        - hash_integrity_ok: bool for file/hash integrity only
+        - signature_status: pass/fail/missing/not_verified
+        - signature_verified: bool
     """
     result: Dict[str, Any] = {
         "ok": True,
@@ -66,6 +72,9 @@ def verify_evidence_bundle(
         "warnings": [],
         "manifest": None,
         "file_hash_results": {},
+        "hash_integrity_ok": True,
+        "signature_status": "not_verified",
+        "signature_verified": False,
     }
     errors: List[str] = result["errors"]
     warnings: List[str] = result["warnings"]
@@ -76,6 +85,8 @@ def verify_evidence_bundle(
         errors.append("manifest.json not found in bundle")
         result["ok"] = False
         result["tampered"] = True
+        result["hash_integrity_ok"] = False
+        result["signature_status"] = "missing"
         return result
 
     try:
@@ -84,6 +95,8 @@ def verify_evidence_bundle(
         errors.append(f"Failed to read manifest.json: {exc}")
         result["ok"] = False
         result["tampered"] = True
+        result["hash_integrity_ok"] = False
+        result["signature_status"] = "missing"
         return result
 
     result["manifest"] = manifest
@@ -157,6 +170,7 @@ def verify_evidence_bundle(
             }
             errors.append(f"File missing: {rel_path}")
             result["tampered"] = True
+            result["hash_integrity_ok"] = False
             continue
 
         actual_hash = _sha256_file(file_path)
@@ -169,6 +183,7 @@ def verify_evidence_bundle(
             }
             errors.append(f"Hash mismatch: {rel_path}")
             result["tampered"] = True
+            result["hash_integrity_ok"] = False
         else:
             hash_results[rel_path] = {"ok": True}
 
@@ -196,16 +211,50 @@ def verify_evidence_bundle(
         if recomputed != stored_manifest_hash:
             errors.append("Manifest hash integrity check failed")
             result["tampered"] = True
+            result["hash_integrity_ok"] = False
 
     # Verify manifest signature
     manifest_signature = manifest.get("manifest_signature")
-    if manifest_signature and verify_signature_fn:
-        try:
-            if not verify_signature_fn(stored_manifest_hash or "", manifest_signature):
-                errors.append("Manifest signature verification failed")
+    if manifest_signature:
+        if verify_signature_fn is None:
+            message = (
+                "Manifest signature present but no signature verifier was provided; "
+                "manifest authenticity was not verified"
+            )
+            result["signature_status"] = "not_verified"
+            if require_signature:
+                errors.append(message)
                 result["tampered"] = True
-        except Exception as exc:  # noqa: BLE001
-            warnings.append(f"Manifest signature verification error: {exc}")
+            else:
+                warnings.append(message)
+        else:
+            try:
+                signature_ok = verify_signature_fn(
+                    stored_manifest_hash or "",
+                    manifest_signature,
+                )
+            except Exception as exc:  # noqa: BLE001
+                result["signature_status"] = "fail"
+                errors.append(f"Manifest signature verification error: {exc}")
+                result["tampered"] = True
+            else:
+                if signature_ok:
+                    result["signature_status"] = "pass"
+                    result["signature_verified"] = True
+                else:
+                    result["signature_status"] = "fail"
+                    errors.append("Manifest signature verification failed")
+                    result["tampered"] = True
+    else:
+        result["signature_status"] = "missing"
+        message = "Manifest signature missing"
+        if require_signature:
+            errors.append(message)
+            result["tampered"] = True
+        else:
+            warnings.append(
+                f"{message}; manifest authenticity was not verified"
+            )
 
     # Verify witness entries
     witness_path = bundle_dir / "witness_entries.jsonl"

--- a/veritas_os/audit/verify_bundle.py
+++ b/veritas_os/audit/verify_bundle.py
@@ -64,6 +64,8 @@ def verify_evidence_bundle(
         - hash_integrity_ok: bool for file/hash integrity only
         - signature_status: pass/fail/missing/not_verified
         - signature_verified: bool
+        - authenticity_ok: bool for verified manifest authenticity
+        - authenticity_failure: optional signature-authenticity failure reason
     """
     result: Dict[str, Any] = {
         "ok": True,
@@ -75,6 +77,8 @@ def verify_evidence_bundle(
         "hash_integrity_ok": True,
         "signature_status": "not_verified",
         "signature_verified": False,
+        "authenticity_ok": False,
+        "authenticity_failure": None,
     }
     errors: List[str] = result["errors"]
     warnings: List[str] = result["warnings"]
@@ -87,6 +91,8 @@ def verify_evidence_bundle(
         result["tampered"] = True
         result["hash_integrity_ok"] = False
         result["signature_status"] = "missing"
+        if require_signature:
+            result["authenticity_failure"] = "manifest_missing"
         return result
 
     try:
@@ -97,6 +103,8 @@ def verify_evidence_bundle(
         result["tampered"] = True
         result["hash_integrity_ok"] = False
         result["signature_status"] = "missing"
+        if require_signature:
+            result["authenticity_failure"] = "manifest_unreadable"
         return result
 
     result["manifest"] = manifest
@@ -225,6 +233,7 @@ def verify_evidence_bundle(
             if require_signature:
                 errors.append(message)
                 result["tampered"] = True
+                result["authenticity_failure"] = "signature_verifier_missing"
             else:
                 warnings.append(message)
         else:
@@ -235,14 +244,17 @@ def verify_evidence_bundle(
                 )
             except Exception as exc:  # noqa: BLE001
                 result["signature_status"] = "fail"
+                result["authenticity_failure"] = "signature_verification_error"
                 errors.append(f"Manifest signature verification error: {exc}")
                 result["tampered"] = True
             else:
                 if signature_ok:
                     result["signature_status"] = "pass"
                     result["signature_verified"] = True
+                    result["authenticity_ok"] = True
                 else:
                     result["signature_status"] = "fail"
+                    result["authenticity_failure"] = "signature_verification_failed"
                     errors.append("Manifest signature verification failed")
                     result["tampered"] = True
     else:
@@ -251,6 +263,7 @@ def verify_evidence_bundle(
         if require_signature:
             errors.append(message)
             result["tampered"] = True
+            result["authenticity_failure"] = "signature_missing"
         else:
             warnings.append(
                 f"{message}; manifest authenticity was not verified"

--- a/veritas_os/cli/evidence_bundle.py
+++ b/veritas_os/cli/evidence_bundle.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
 from veritas_os.audit.evidence_bundle import generate_evidence_bundle
 from veritas_os.audit.verify_bundle import verify_evidence_bundle
+from veritas_os.security.signing import verify_payload_signature
 
 
 def _parse_key_value_pairs(values: Optional[list[str]]) -> Dict[str, str]:
@@ -22,6 +24,37 @@ def _parse_key_value_pairs(values: Optional[list[str]]) -> Dict[str, str]:
         key, value = item.split("=", 1)
         result[key.strip()] = value.strip()
     return result
+
+
+SECURE_POSTURES = {"secure", "prod"}
+
+
+def _is_fail_closed_posture() -> bool:
+    """Return whether evidence-bundle verification must fail closed."""
+    return os.getenv("VERITAS_POSTURE", "dev").strip().lower() in SECURE_POSTURES
+
+
+def _signature_status_label(status: str) -> str:
+    """Render a reviewer-facing manifest signature status label."""
+    return {
+        "pass": "PASS",
+        "fail": "FAIL",
+        "missing": "FAIL",
+        "not_verified": "NOT VERIFIED",
+    }.get(status, "NOT VERIFIED")
+
+
+def _build_signature_verifier(
+    public_key_path: Optional[Path],
+) -> Optional[Callable[[str, str], bool]]:
+    """Build the Ed25519 verifier used for manifest authenticity checks."""
+    if public_key_path is None:
+        return None
+
+    def _verify(payload_hash: str, signature_b64: str) -> bool:
+        return verify_payload_signature(payload_hash, signature_b64, public_key_path)
+
+    return _verify
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -49,6 +82,16 @@ def build_parser() -> argparse.ArgumentParser:
 
     verify = sub.add_parser("verify", help="Verify evidence bundle")
     verify.add_argument("--bundle-dir", required=True, type=Path)
+    verify.add_argument(
+        "--public-key",
+        type=Path,
+        help="Trusted Ed25519 public key for manifest signature verification",
+    )
+    verify.add_argument(
+        "--require-signature",
+        action="store_true",
+        help="Fail when the manifest signature is missing or cannot be verified",
+    )
     verify.add_argument("--json", action="store_true")
 
     return parser
@@ -89,12 +132,36 @@ def main(argv: Optional[list[str]] = None) -> int:
             print(f"entry_count={result['entry_count']}")
         return 0
 
-    verify_result: Dict[str, Any] = verify_evidence_bundle(args.bundle_dir)
+    require_signature = args.require_signature or _is_fail_closed_posture()
+    verify_signature_fn = _build_signature_verifier(args.public_key)
+    verify_result: Dict[str, Any] = verify_evidence_bundle(
+        args.bundle_dir,
+        verify_signature_fn=verify_signature_fn,
+        require_signature=require_signature,
+    )
+    if args.public_key is None:
+        key_warning = (
+            "No trusted public key supplied; manifest signature authenticity "
+            "cannot be verified"
+        )
+        if require_signature:
+            if key_warning not in verify_result["errors"]:
+                verify_result["errors"].append(key_warning)
+            verify_result["ok"] = False
+        elif key_warning not in verify_result["warnings"]:
+            verify_result["warnings"].append(key_warning)
+
     if args.json:
         print(json.dumps(verify_result, indent=2, sort_keys=True, ensure_ascii=False))
     else:
         status = "PASS" if verify_result.get("ok") else "FAIL"
+        hash_status = "PASS" if verify_result.get("hash_integrity_ok") else "FAIL"
+        signature_status = _signature_status_label(
+            str(verify_result.get("signature_status", "not_verified"))
+        )
         print(f"Evidence bundle verification: {status}")
+        print(f"File/hash integrity: {hash_status}")
+        print(f"Manifest signature: {signature_status}")
         for err in verify_result.get("errors", []):
             print(f"  error: {err}")
         for warning in verify_result.get("warnings", []):

--- a/veritas_os/tests/test_evidence_bundle_cli.py
+++ b/veritas_os/tests/test_evidence_bundle_cli.py
@@ -57,6 +57,9 @@ def test_evidence_bundle_cli_generate_and_verify(tmp_path, monkeypatch) -> None:
     generated_dirs = list(out_dir.glob("veritas_bundle_decision_*"))
     assert generated_dirs
     bundle_dir = generated_dirs[0]
+    ui_hook = json.loads((bundle_dir / "ui_delivery_hook.json").read_text())
+    assert "--public-key" in ui_hook["verify_command"]
+    assert "--require-signature" in ui_hook["verify_command"]
 
     verify_exit = main(["verify", "--bundle-dir", str(bundle_dir), "--json"])
     assert verify_exit == 0
@@ -330,7 +333,43 @@ def test_evidence_bundle_cli_dev_without_public_key_warns_and_reports_json(
     assert exit_code == 0
     assert output["signature_verified"] is False
     assert output["signature_status"] == "not_verified"
+    assert output["authenticity_ok"] is False
+    assert output["authenticity_failure"] is None
     assert any("authenticity was not verified" in w for w in output["warnings"])
+
+
+def test_verify_bundle_signature_failure_reports_authenticity_failure(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    """Signature failures are explicit without conflating hash tampering."""
+    from veritas_os.audit.verify_bundle import verify_evidence_bundle
+    from veritas_os.security.signing import verify_payload_signature
+
+    bundle_dir, _private_key, public_key = _signed_bundle(tmp_path, monkeypatch)
+    manifest_path = bundle_dir / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["manifest_signature"] = manifest["manifest_signature"][::-1]
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    result = verify_evidence_bundle(
+        bundle_dir,
+        verify_signature_fn=lambda payload_hash, signature: verify_payload_signature(
+            payload_hash,
+            signature,
+            public_key,
+        ),
+        require_signature=True,
+    )
+
+    assert result["ok"] is False
+    assert result["tampered"] is True
+    assert result["hash_integrity_ok"] is True
+    assert result["authenticity_ok"] is False
+    assert result["authenticity_failure"] == "signature_verification_failed"
 
 
 def test_verify_bundle_signed_manifest_without_verifier_warns(
@@ -347,4 +386,6 @@ def test_verify_bundle_signed_manifest_without_verifier_warns(
     assert result["ok"] is True
     assert result["signature_verified"] is False
     assert result["signature_status"] == "not_verified"
+    assert result["authenticity_ok"] is False
+    assert result["authenticity_failure"] is None
     assert any("no signature verifier" in w for w in result["warnings"])

--- a/veritas_os/tests/test_evidence_bundle_cli.py
+++ b/veritas_os/tests/test_evidence_bundle_cli.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from veritas_os.audit import trustlog_signed
 
 
@@ -121,3 +123,228 @@ def test_evidence_bundle_decision_record_canonicalizes_gate_decision(
     assert decision_record["gate_decision"] == "proceed"
     assert decision_record["business_decision"] == "APPROVE"
     assert decision_record["next_action"] == "PREPARE_HUMAN_REVIEW_PACKET"
+
+
+def _signed_bundle(tmp_path, monkeypatch):
+    """Create a signed decision evidence bundle and its verification keys."""
+    from veritas_os.audit.evidence_bundle import generate_evidence_bundle
+    from veritas_os.security.signing import sign_payload_hash, store_keypair
+
+    log_path = tmp_path / "trustlog.jsonl"
+    trustlog_private_key = tmp_path / "trustlog_keys" / "priv.key"
+    trustlog_public_key = tmp_path / "trustlog_keys" / "pub.key"
+    manifest_private_key = tmp_path / "manifest_keys" / "priv.key"
+    manifest_public_key = tmp_path / "manifest_keys" / "pub.key"
+
+    monkeypatch.setattr(trustlog_signed, "SIGNED_TRUSTLOG_JSONL", log_path)
+    monkeypatch.setattr(trustlog_signed, "PRIVATE_KEY_PATH", trustlog_private_key)
+    monkeypatch.setattr(trustlog_signed, "PUBLIC_KEY_PATH", trustlog_public_key)
+    store_keypair(manifest_private_key, manifest_public_key)
+    trustlog_signed.append_signed_decision(
+        {"request_id": "signed-cli-bundle", "decision": "allow"}
+    )
+    result = generate_evidence_bundle(
+        bundle_type="decision",
+        witness_ledger_path=log_path,
+        output_dir=tmp_path / "bundles",
+        signer_fn=lambda payload_hash: sign_payload_hash(
+            payload_hash,
+            manifest_private_key,
+        ),
+        signer_metadata={"type": "ed25519-file-test"},
+    )
+    return Path(result["bundle_dir"]), manifest_private_key, manifest_public_key
+
+
+def test_evidence_bundle_cli_verify_signed_manifest_with_public_key(
+    tmp_path,
+    monkeypatch,
+    capsys,
+) -> None:
+    """Correct Ed25519 manifest signature and public key pass verification."""
+    from veritas_os.cli.evidence_bundle import main
+
+    monkeypatch.setenv("VERITAS_POSTURE", "dev")
+    bundle_dir, _private_key, public_key = _signed_bundle(tmp_path, monkeypatch)
+
+    exit_code = main(
+        [
+            "verify",
+            "--bundle-dir",
+            str(bundle_dir),
+            "--public-key",
+            str(public_key),
+            "--require-signature",
+        ]
+    )
+    output = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "File/hash integrity: PASS" in output
+    assert "Manifest signature: PASS" in output
+
+
+def test_evidence_bundle_cli_verify_tampered_manifest_signature_fails(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    """Tampering manifest_signature causes strict CLI verification to fail."""
+    from veritas_os.cli.evidence_bundle import main
+
+    monkeypatch.setenv("VERITAS_POSTURE", "dev")
+    bundle_dir, _private_key, public_key = _signed_bundle(tmp_path, monkeypatch)
+    manifest_path = bundle_dir / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["manifest_signature"] = manifest["manifest_signature"][::-1]
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    exit_code = main(
+        [
+            "verify",
+            "--bundle-dir",
+            str(bundle_dir),
+            "--public-key",
+            str(public_key),
+            "--require-signature",
+        ]
+    )
+
+    assert exit_code == 1
+
+
+def test_evidence_bundle_cli_verify_manifest_signed_by_wrong_key_fails(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    """A manifest signature made by another key fails authenticity checks."""
+    from veritas_os.cli.evidence_bundle import main
+    from veritas_os.security.signing import store_keypair
+
+    monkeypatch.setenv("VERITAS_POSTURE", "dev")
+    bundle_dir, _private_key, _public_key = _signed_bundle(tmp_path, monkeypatch)
+    wrong_private_key = tmp_path / "wrong_keys" / "priv.key"
+    wrong_public_key = tmp_path / "wrong_keys" / "pub.key"
+    store_keypair(wrong_private_key, wrong_public_key)
+
+    exit_code = main(
+        [
+            "verify",
+            "--bundle-dir",
+            str(bundle_dir),
+            "--public-key",
+            str(wrong_public_key),
+            "--require-signature",
+        ]
+    )
+
+    assert exit_code == 1
+
+
+def test_evidence_bundle_cli_require_signature_rejects_unsigned_bundle(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    """--require-signature fails closed when a bundle has no manifest signature."""
+    from veritas_os.audit.evidence_bundle import generate_evidence_bundle
+    from veritas_os.cli.evidence_bundle import main
+
+    monkeypatch.setenv("VERITAS_POSTURE", "dev")
+    log_path = tmp_path / "trustlog.jsonl"
+    private_key = tmp_path / "keys" / "priv.key"
+    public_key = tmp_path / "keys" / "pub.key"
+    monkeypatch.setattr(trustlog_signed, "SIGNED_TRUSTLOG_JSONL", log_path)
+    monkeypatch.setattr(trustlog_signed, "PRIVATE_KEY_PATH", private_key)
+    monkeypatch.setattr(trustlog_signed, "PUBLIC_KEY_PATH", public_key)
+    trustlog_signed.append_signed_decision({"request_id": "unsigned", "decision": "allow"})
+    result = generate_evidence_bundle(
+        bundle_type="decision",
+        witness_ledger_path=log_path,
+        output_dir=tmp_path / "bundles",
+    )
+
+    exit_code = main(
+        [
+            "verify",
+            "--bundle-dir",
+            result["bundle_dir"],
+            "--require-signature",
+        ]
+    )
+
+    assert exit_code == 1
+
+
+@pytest.mark.parametrize("posture", ["secure", "prod"])
+def test_evidence_bundle_cli_secure_or_prod_posture_rejects_unsigned_bundle(
+    tmp_path,
+    monkeypatch,
+    posture,
+) -> None:
+    """VERITAS_POSTURE=secure/prod requires manifest signature verification."""
+    from veritas_os.audit.evidence_bundle import generate_evidence_bundle
+    from veritas_os.cli.evidence_bundle import main
+
+    monkeypatch.setenv("VERITAS_POSTURE", posture)
+    log_path = tmp_path / "trustlog.jsonl"
+    private_key = tmp_path / "keys" / "priv.key"
+    public_key = tmp_path / "keys" / "pub.key"
+    monkeypatch.setattr(trustlog_signed, "SIGNED_TRUSTLOG_JSONL", log_path)
+    monkeypatch.setattr(trustlog_signed, "PRIVATE_KEY_PATH", private_key)
+    monkeypatch.setattr(trustlog_signed, "PUBLIC_KEY_PATH", public_key)
+    trustlog_signed.append_signed_decision({"request_id": "secure-unsigned"})
+    result = generate_evidence_bundle(
+        bundle_type="decision",
+        witness_ledger_path=log_path,
+        output_dir=tmp_path / "bundles",
+    )
+
+    exit_code = main(["verify", "--bundle-dir", result["bundle_dir"]])
+
+    assert exit_code == 1
+
+
+def test_evidence_bundle_cli_dev_without_public_key_warns_and_reports_json(
+    tmp_path,
+    monkeypatch,
+    capsys,
+) -> None:
+    """dev posture may skip authenticity checks but reports an explicit warning."""
+    from veritas_os.cli.evidence_bundle import main
+
+    monkeypatch.setenv("VERITAS_POSTURE", "dev")
+    bundle_dir, _private_key, _public_key = _signed_bundle(tmp_path, monkeypatch)
+
+    exit_code = main(
+        [
+            "verify",
+            "--bundle-dir",
+            str(bundle_dir),
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert output["signature_verified"] is False
+    assert output["signature_status"] == "not_verified"
+    assert any("authenticity was not verified" in w for w in output["warnings"])
+
+
+def test_verify_bundle_signed_manifest_without_verifier_warns(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    """verify_evidence_bundle does not silently skip present manifest signatures."""
+    from veritas_os.audit.verify_bundle import verify_evidence_bundle
+
+    bundle_dir, _private_key, _public_key = _signed_bundle(tmp_path, monkeypatch)
+
+    result = verify_evidence_bundle(bundle_dir)
+
+    assert result["ok"] is True
+    assert result["signature_verified"] is False
+    assert result["signature_status"] == "not_verified"
+    assert any("no signature verifier" in w for w in result["warnings"])


### PR DESCRIPTION
### Motivation

- The verifier previously skipped cryptographic verification when `verify_signature_fn` was not provided, causing CLI "PASS" results to reflect only hash integrity and not manifest authenticity. 
- The goal is to make manifest Ed25519 verification explicit, reviewer-facing, and fail-closed in secure/prod postures. 
- The change separates file/hash integrity from signature authenticity so reviewers and automation can distinguish tampering vs absent/unverified signatures. 
- Security note: signature authenticity depends on a trusted public-key distribution channel, and operators must validate public-key provenance to avoid substitution attacks.

### Description

- Added a `require_signature: bool` parameter and explicit fields `hash_integrity_ok`, `signature_status`, and `signature_verified` to `verify_evidence_bundle()` to separate hash checks from signature state and to allow fail-closed behavior when required. (modified `veritas_os/audit/verify_bundle.py`)
- Implemented detailed manifest-signature handling in `verify_evidence_bundle()`: when `manifest_signature` exists but no verifier is provided it issues warnings or errors per `require_signature`, and when a verifier is provided it runs the callable and sets `signature_status`/`signature_verified` accordingly. (modified `veritas_os/audit/verify_bundle.py`)
- Added CLI options `--public-key` and `--require-signature` to `veritas-evidence-bundle verify`, built an Ed25519 verifier using `veritas_os.security.signing.verify_payload_signature`, and made `VERITAS_POSTURE` in `secure`/`prod` implicitly enable fail-closed behavior. CLI output now reports `File/hash integrity: PASS|FAIL` and `Manifest signature: PASS|FAIL|NOT VERIFIED`. (modified `veritas_os/cli/evidence_bundle.py`)
- Added reviewer-facing tests that cover correct Ed25519 signature verification, tampered signature, wrong-key verification failure, `--require-signature` rejection of unsigned bundles, posture-driven fail-closed behavior, and dev-mode warnings and JSON signature fields; and updated the external audit readiness doc to recommend passing a trusted public key at verify time. (modified `veritas_os/tests/test_evidence_bundle_cli.py` and `docs/en/validation/external-audit-readiness.md`)
- The implementation reuses the existing helper `verify_payload_signature(payload_hash, signature_b64, public_key_path)` from `veritas_os.security.signing`. 

### Testing

- Ran `ruff` checks on the changed files with `PYENV_VERSION=3.12.13 ruff check veritas_os/audit/verify_bundle.py veritas_os/cli/evidence_bundle.py veritas_os/tests/test_evidence_bundle_cli.py` and the linter passed. 
- Performed bytecode sanity checks with `python -m py_compile` on the modified modules and they compiled successfully. 
- Attempted to run `pytest -q veritas_os/tests/test_evidence_bundle_cli.py` but the run was blocked by missing environment dependency `pydantic` in the sandbox, so the new tests could not be executed locally; CI should run the full test suite where dependencies are present. 
- Note: packaging installation attempts to fetch build deps were constrained by the environment (network/index access) during this run; CI will validate all added tests and integration checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26bfdbf0388326babd159fa009d9c8)