### PR TITLE
fix: update evidence bundle reviewer verification hook

### DIFF
--- a/veritas_os/audit/evidence_bundle.py
+++ b/veritas_os/audit/evidence_bundle.py
@@ -63,6 +63,16 @@ _NEXT_ACTION_ALIASES = {
     "REJECT_REQUEST": "DO_NOT_EXECUTE",
 }
 
+_REVIEWER_VERIFY_COMMAND = (
+    "veritas-evidence-bundle verify --bundle-dir <bundle_dir> "
+    "--public-key <trusted_ed25519_public_key> --require-signature"
+)
+_SIGNATURE_REQUIRED_POSTURES = ["secure", "prod"]
+_VERIFICATION_SCOPE = [
+    "file_hash_integrity",
+    "manifest_signature_authenticity",
+]
+
 
 def _uuid7() -> str:
     """Generate a UUIDv7-compatible identifier."""
@@ -174,11 +184,34 @@ def _build_bundle_readme(
         "",
         "Verification",
         "------------",
-        "- Run: veritas-evidence-bundle verify --bundle-dir <this-directory>",
+        f"- Run: {_REVIEWER_VERIFY_COMMAND}",
+        "- Obtain the trusted public key from the reviewer/operator trust channel;",
+        "  do not trust a public key only because it is included in this bundle.",
         "- Inspect verification_report.json for chain and signature status.",
         "",
     ]
     return "\n".join(lines)
+
+
+def _build_ui_delivery_hook(
+    *,
+    bundle_id: str,
+    bundle_type: str,
+    decision_record_profile: str,
+) -> Dict[str, Any]:
+    """Build reviewer-facing UI handoff metadata for bundle verification."""
+    return {
+        "hook_version": "1.0",
+        "bundle_id": bundle_id,
+        "bundle_type": bundle_type,
+        "decision_record_profile": decision_record_profile,
+        "acceptance_checklist_path": "acceptance_checklist.json",
+        "readme_path": "README.txt",
+        "verify_command": _REVIEWER_VERIFY_COMMAND,
+        "requires_trusted_public_key": True,
+        "signature_required_in_postures": _SIGNATURE_REQUIRED_POSTURES,
+        "verification_scope": _VERIFICATION_SCOPE,
+    }
 
 
 def _sha256_file(path: Path) -> str:
@@ -536,15 +569,11 @@ def generate_evidence_bundle(
     _write_json_file(
         bundle_dir,
         "ui_delivery_hook.json",
-        {
-            "hook_version": "1.0",
-            "bundle_id": bundle_id,
-            "bundle_type": bundle_type,
-            "decision_record_profile": decision_record_profile,
-            "acceptance_checklist_path": "acceptance_checklist.json",
-            "readme_path": "README.txt",
-            "verify_command": "veritas-evidence-bundle verify --bundle-dir <bundle_dir>",
-        },
+        _build_ui_delivery_hook(
+            bundle_id=bundle_id,
+            bundle_type=bundle_type,
+            decision_record_profile=decision_record_profile,
+        ),
     )
     written_files.append("ui_delivery_hook.json")
 

--- a/veritas_os/tests/test_evidence_bundle_cli.py
+++ b/veritas_os/tests/test_evidence_bundle_cli.py
@@ -63,6 +63,49 @@ def test_evidence_bundle_cli_generate_and_verify(tmp_path, monkeypatch) -> None:
     assert verify_exit == 0
 
 
+def test_generated_ui_delivery_hook_requires_manifest_signature(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    """Generated reviewer handoff uses strict Ed25519 manifest verification."""
+    from veritas_os.audit.evidence_bundle import generate_evidence_bundle
+
+    log_path = tmp_path / "trustlog.jsonl"
+    private_key = tmp_path / "keys" / "priv.key"
+    public_key = tmp_path / "keys" / "pub.key"
+
+    monkeypatch.setattr(trustlog_signed, "SIGNED_TRUSTLOG_JSONL", log_path)
+    monkeypatch.setattr(trustlog_signed, "PRIVATE_KEY_PATH", private_key)
+    monkeypatch.setattr(trustlog_signed, "PUBLIC_KEY_PATH", public_key)
+    trustlog_signed.append_signed_decision(
+        {"request_id": "ui-hook-bundle", "decision": "allow"}
+    )
+
+    result = generate_evidence_bundle(
+        bundle_type="decision",
+        witness_ledger_path=log_path,
+        output_dir=tmp_path / "bundles",
+        request_ids=["ui-hook-bundle"],
+    )
+    bundle_dir = Path(result["bundle_dir"])
+    hook = json.loads(
+        (bundle_dir / "ui_delivery_hook.json").read_text(encoding="utf-8")
+    )
+
+    assert "--public-key" in hook["verify_command"]
+    assert "--require-signature" in hook["verify_command"]
+    assert hook["requires_trusted_public_key"] is True
+    assert {"secure", "prod"}.issubset(hook["signature_required_in_postures"])
+    assert hook["verification_scope"] == [
+        "file_hash_integrity",
+        "manifest_signature_authenticity",
+    ]
+
+    readme = (bundle_dir / "README.txt").read_text(encoding="utf-8")
+    assert "reviewer/operator trust channel" in readme
+    assert "do not trust a public key only because it is included" in readme
+
+
 def test_financial_bundle_sample_fixture_exists() -> None:
     """Repository includes a representative financial decision bundle sample."""
     fixture_path = Path(


### PR DESCRIPTION
### Motivation
- Align the reviewer-facing delivery hook with the Ed25519 manifest signature verification behavior added in the verifier by recommending a verifier invocation that includes a trusted public key and signature requirement.
- Make the UI handoff explicit about the need for an out-of-band trusted public key and the separation of hash integrity vs manifest authenticity checks.
- Reduce risk by warning reviewers/operators not to trust a public key solely because it is embedded in the bundle.

### Description
- Added `_REVIEWER_VERIFY_COMMAND`, `_SIGNATURE_REQUIRED_POSTURES`, and `_VERIFICATION_SCOPE` constants and used them to produce a stronger, reviewer-facing `verify_command` for `ui_delivery_hook.json` (now including `--public-key <trusted_ed25519_public_key> --require-signature`).
- Introduced `_build_ui_delivery_hook(...)` to centralize the UI handoff metadata and added the fields `requires_trusted_public_key`, `signature_required_in_postures`, and `verification_scope` to the generated `ui_delivery_hook.json`.
- Updated the bundle `README.txt` verification section to instruct reviewers/operators to obtain the trusted public key from the reviewer/operator trust channel and not to trust bundle-contained keys unconditionally.
- Added a unit test `test_generated_ui_delivery_hook_requires_manifest_signature` to assert the presence of the new `verify_command` flags, the new metadata fields, and the README trust-channel guidance, while preserving the existing `generate_evidence_bundle` return contract and other outputs.

### Testing
- Added a new unit test `test_generated_ui_delivery_hook_requires_manifest_signature` in `veritas_os/tests/test_evidence_bundle_cli.py` which asserts `--public-key` and `--require-signature` are present in the generated `ui_delivery_hook.json`, verifies `requires_trusted_public_key` and `signature_required_in_postures` include `secure`/`prod`, and checks README guidance text.
- Performed static compilation check with `python3 -m py_compile veritas_os/audit/evidence_bundle.py veritas_os/tests/test_evidence_bundle_cli.py`, which succeeded.
- Attempted to run the full test file with `pytest -q veritas_os/tests/test_evidence_bundle_cli.py` and variants, but automated test execution was blocked by the local environment (configured `pyenv` Python `3.12.12` not installed and missing runtime dependencies such as `pydantic` / PyPI fetch failures), so full pytest execution could not complete in this environment. Please run the provided pytest command in CI or a developer environment with dependencies installed to validate the new test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26eb424744832682581f92d0e5d91c)