### PR TITLE
docs: add evidence-bundle signature verification demo and reviewer CLI test

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,7 @@ External reviewers can use the Regulated Action Governance External Reviewer Fee
 - **AML/KYC Beachhead (1-day PoC quickstart)**: [`docs/en/guides/poc-pack-financial-quickstart.md`](docs/en/guides/poc-pack-financial-quickstart.md)
 - **AML/KYC Governance Template Contract**: [`docs/en/guides/financial-governance-templates.md`](docs/en/guides/financial-governance-templates.md)
 - **External Audit / Evidence Bundle Readiness**: [`docs/en/validation/external-audit-readiness.md`](docs/en/validation/external-audit-readiness.md)
+- **Evidence Bundle Signature Verification Demo**: [`docs/en/validation/evidence-bundle-signature-verification.md`](docs/en/validation/evidence-bundle-signature-verification.md)
 - **External Technical Proof Pack (review/pilot/DD/audit)**: [`docs/en/validation/technical-proof-pack.md`](docs/en/validation/technical-proof-pack.md)
 - **Third-Party Review Readiness (compact index)**: [`docs/en/validation/third-party-review-readiness.md`](docs/en/validation/third-party-review-readiness.md)
 - **Current Implementation Matrix (external reviewer snapshot)**: [`docs/en/validation/current-implementation-matrix.md`](docs/en/validation/current-implementation-matrix.md)

--- a/docs/en/validation/evidence-bundle-signature-verification.md
+++ b/docs/en/validation/evidence-bundle-signature-verification.md
@@ -1,0 +1,137 @@
+# Evidence Bundle Signature Verification Demo
+
+This page fixes the reviewer-facing Evidence Bundle verification path for
+external auditors and design partners. It is intentionally minimal: generate a
+signed bundle, obtain the trusted Ed25519 public key from a separate trust
+channel, then verify both file/hash integrity and manifest authenticity.
+
+## Security boundary
+
+- Do not treat hash integrity as authenticity.
+- Do not trust a public key solely because it is included in the bundle.
+- Trusted public keys must come from a reviewer/operator trust channel.
+
+Hash integrity proves that files match the hashes recorded in `manifest.json`.
+It does not prove who created that manifest. Manifest signature verification is
+the authenticity check, and it is only meaningful when the reviewer supplies a
+trusted Ed25519 public key received out-of-band from the bundle.
+
+## Minimal reproducible demo
+
+### 1. Generate a signed evidence bundle
+
+Use the same signing key management policy that applies to the handoff. The
+example below is local/dev only; production handoff should use the configured
+managed signer and distribute the public key through the reviewer/operator trust
+channel.
+
+```python
+from pathlib import Path
+
+from veritas_os.audit.evidence_bundle import generate_evidence_bundle
+from veritas_os.security.signing import sign_payload_hash, store_keypair
+
+private_key = Path("./demo_keys/manifest_ed25519_private.key")
+public_key = Path("./demo_keys/manifest_ed25519_public.key")
+store_keypair(private_key, public_key)
+
+result = generate_evidence_bundle(
+    bundle_type="decision",
+    witness_ledger_path=Path("runtime/dev/logs/trustlog.jsonl"),
+    output_dir=Path("./bundles"),
+    request_ids=["req-12345"],
+    signer_fn=lambda payload_hash: sign_payload_hash(payload_hash, private_key),
+    signer_metadata={"type": "ed25519", "trust_channel": "operator-provided"},
+)
+print(result["bundle_dir"])
+print(public_key)
+```
+
+The bundle directory contains `manifest.json` with `manifest_hash` and
+`manifest_signature`. The public key path printed above is shown only for the
+operator side of the demo. Reviewers must receive the trusted public key through
+a separate channel, not by trusting a copy embedded in the bundle.
+
+### 2. Obtain the trusted public key out-of-band
+
+Before verification, the reviewer must obtain
+`<trusted_ed25519_public_key>` from a reviewer/operator trust channel, such as:
+
+- a pre-approved key registry entry;
+- a signed operator handoff note outside the bundle transfer;
+- an enterprise key-management or certificate-management process.
+
+A public key that appears only inside the bundle is not enough, because an
+attacker who can replace the bundle may also replace an included key.
+
+### 3. Run strict verification
+
+```bash
+veritas-evidence-bundle verify \
+  --bundle-dir <bundle_dir> \
+  --public-key <trusted_ed25519_public_key> \
+  --require-signature
+```
+
+The same strict command is also written into generated bundle handoff metadata
+(`README.txt` and `ui_delivery_hook.json`) so reviewers and future UI delivery
+flows use one consistent verification path.
+
+### 4. Read the two PASS lines separately
+
+Expected success output includes two separate checks:
+
+```text
+Evidence bundle verification: PASS
+File/hash integrity: PASS
+Manifest signature: PASS
+```
+
+Interpretation:
+
+| Line | PASS means | PASS does not mean |
+|---|---|---|
+| `File/hash integrity` | The files in the bundle match the hashes recorded in `manifest.json`; no hash-covered file tampering was detected. | The manifest is authentic, or the signer is trusted. |
+| `Manifest signature` | The manifest signature verifies under the trusted Ed25519 public key supplied by the reviewer. | The public key itself is trustworthy unless it came from the reviewer/operator trust channel. |
+
+Reviewer-facing Evidence Bundle verification is established only when both
+`File/hash integrity: PASS` and `Manifest signature: PASS` are present in the
+strict verification run.
+
+## Expected failure examples
+
+| Scenario | Example command or setup | Expected result |
+|---|---|---|
+| Public key missing | Run the strict command without `--public-key`. | `FAIL`; authenticity cannot be verified because no trusted public key was supplied. |
+| Wrong public key | Use a valid Ed25519 public key that did not sign the manifest. | `FAIL`; `Manifest signature` fails even when file/hash integrity may still pass. |
+| Malformed signature | Replace `manifest_signature` with invalid base64 or invalid signature bytes. | `FAIL`; signature verification is reported as an authenticity error/failure. |
+| Unsigned bundle under secure/prod posture | Set `VERITAS_POSTURE=secure` or `VERITAS_POSTURE=prod` and verify an unsigned bundle. | `FAIL`; secure/prod posture requires manifest signature verification and fails closed. |
+
+A common failure shape is:
+
+```text
+Evidence bundle verification: FAIL
+File/hash integrity: PASS
+Manifest signature: FAIL
+```
+
+That output means the bundle files still match the manifest, but the manifest's
+authenticity was not established. Do not accept it as reviewer-facing evidence
+bundle verification.
+
+## CI reviewer path
+
+The evidence-bundle CLI tests lock the reviewer path by covering:
+
+1. signed bundle generation;
+2. successful strict verification with the correct trusted public key;
+3. strict verification failure with the wrong public key;
+4. secure/prod posture failure for unsigned bundles;
+5. strict verification failure when the public key is missing;
+6. malformed signature classification.
+
+Run the focused test file:
+
+```bash
+pytest -q veritas_os/tests/test_evidence_bundle_cli.py
+```

--- a/docs/en/validation/external-audit-readiness.md
+++ b/docs/en/validation/external-audit-readiness.md
@@ -244,6 +244,18 @@ Each bundle now ships `acceptance_checklist.json` with machine-readable checks:
 This checklist is intended to be the explicit pre-submission gate for
 external auditors/customers/legal.
 
+### Reviewer-facing signature verification demo
+
+Use the fixed reviewer-facing demo for Ed25519 manifest verification:
+
+- [Evidence Bundle Signature Verification Demo](evidence-bundle-signature-verification.md)
+
+Security notes for every external handoff:
+
+- Do not treat hash integrity as authenticity.
+- Do not trust a public key solely because it is included in the bundle.
+- Trusted public keys must come from a reviewer/operator trust channel.
+
 ### Evidence-bundle readiness path for AML/KYC PoC
 
 Use this sequence after completing the 1-day AML/KYC quickstart:
@@ -317,6 +329,31 @@ else:
     for error in result["errors"]:
         print(f"  - {error}")
 ```
+
+### Reviewer verification semantics
+
+The strict reviewer command is:
+
+```bash
+veritas-evidence-bundle verify \
+  --bundle-dir <bundle_dir> \
+  --public-key <trusted_ed25519_public_key> \
+  --require-signature
+```
+
+Read the output as two independent checks:
+
+- `File/hash integrity: PASS` means the bundle files match the hashes recorded
+  in `manifest.json`; it detects file tampering but does not establish
+  authenticity.
+- `Manifest signature: PASS` means the manifest signature verifies under the
+  trusted Ed25519 public key supplied by the reviewer.
+- Treat the bundle as reviewer-facing verified evidence only when both lines are
+  `PASS` in the strict verification run.
+
+Expected strict failures include a missing public key, the wrong public key, a
+malformed `manifest_signature`, or an unsigned bundle under `secure`/`prod`
+posture.
 
 ### CLI (recommended for ops runbooks)
 

--- a/veritas_os/tests/test_evidence_bundle_cli.py
+++ b/veritas_os/tests/test_evidence_bundle_cli.py
@@ -325,6 +325,33 @@ def test_verify_bundle_malformed_signature_reports_authenticity_error(
     assert result["authenticity_failure"] == "signature_verification_error"
 
 
+def test_evidence_bundle_cli_require_signature_without_public_key_fails(
+    tmp_path,
+    monkeypatch,
+    capsys,
+) -> None:
+    """Strict reviewer verification fails when no trusted key is supplied."""
+    from veritas_os.cli.evidence_bundle import main
+
+    monkeypatch.setenv("VERITAS_POSTURE", "dev")
+    bundle_dir, _private_key, _public_key = _signed_bundle(tmp_path, monkeypatch)
+
+    exit_code = main(
+        [
+            "verify",
+            "--bundle-dir",
+            str(bundle_dir),
+            "--require-signature",
+        ]
+    )
+    output = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "File/hash integrity: PASS" in output
+    assert "Manifest signature: NOT VERIFIED" in output
+    assert "No trusted public key supplied" in output
+
+
 def test_evidence_bundle_cli_verify_manifest_signed_by_wrong_key_fails(
     tmp_path,
     monkeypatch,


### PR DESCRIPTION
### Motivation

- Provide an unambiguous, reviewer-facing minimal demo for verifying Evidence Bundles (so external auditors / design partners can reproduce the strict Ed25519 verification path). 
- Make the semantics of `PASS` explicit by separating file/hash integrity from manifest signature authenticity, and record expected failure cases for reviewer guidance.

### Description

- Add a new reviewer-facing doc `docs/en/validation/evidence-bundle-signature-verification.md` that shows a minimal reproducible demo: generate a signed bundle, obtain a trusted Ed25519 public key out-of-band, run the strict CLI verification, and interpret the two PASS lines separately. 
- Update `docs/en/validation/external-audit-readiness.md` to link the new demo, add the reviewer verification semantics section, and surface short external-handoff security notes (`Do not treat hash integrity as authenticity`, `Do not trust a public key only because it is included in the bundle`, `Trusted public keys must come from a reviewer/operator trust channel`).
- Add the demo to the README quick links (`README.md`) for discoverability. 
- Add a CLI regression test in `veritas_os/tests/test_evidence_bundle_cli.py`: `test_evidence_bundle_cli_require_signature_without_public_key_fails` which asserts that using `--require-signature` without supplying a trusted `--public-key` fails with clear output showing hash integrity may PASS while manifest authenticity is `NOT VERIFIED` and an explicit error/warning is reported.

### Testing

- Ran `git diff --check` (no whitespace/errors reported). 
- Ran Python byte-compile on the modified test file with `python -m py_compile veritas_os/tests/test_evidence_bundle_cli.py` which succeeded. 
- Attempted to run the focused test suite `pytest -q veritas_os/tests/test_evidence_bundle_cli.py` but full execution could not be completed in this environment due to interpreter / dependency resolution limitations (configured `.python-version` mismatch and missing test dependencies such as `pydantic` and inability to fetch PyPI packages). 
- Notes: the new test is designed to be executed in CI and locally with dependencies installed; run `pytest -q veritas_os/tests/test_evidence_bundle_cli.py` in a correctly provisioned dev/CI environment to validate the reviewer path end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26f2f1dee08326b4dbc509bd3f1743)