### PR TITLE
docs: surface Evidence Bundle verification path in Technical Proof Pack and reviewer indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ For a 10-minute implementation snapshot, start here:
 
 External reviewers can start with the [External Reviewer Quickstart v1](docs/en/demo/external-reviewer-quickstart.md), which explains how to inspect the golden fixture, run the validation report, review the JSON Schema, and understand the local/offline evidence chain in 10–15 minutes. See also the [External Reviewer Artifact Index](docs/en/demo/external-reviewer-artifact-index.md).
 
+Evidence Bundle verification separates file/hash integrity from manifest authenticity and supports strict Ed25519 manifest verification using a trusted public key; start from the [Technical Proof Pack](docs/en/validation/technical-proof-pack.md) for the reviewer checklist, signature verification demo, sample outputs, and external audit readiness. This is reviewer-facing verification support, not regulatory certification or completed third-party audit approval; trusted public keys must come from an out-of-band reviewer/operator trust channel.
+
 For a concise business-facing overview, see [Enterprise Value Brief](docs/en/positioning/enterprise-value-brief.md).
 日本語補助版: [企業向け価値説明ブリーフ](docs/ja/positioning/enterprise-value-brief.md)
 

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -49,6 +49,7 @@ For the bilingual correspondence table, see [../DOCUMENTATION_MAP.md](../DOCUMEN
 - [Third-Party Review Readiness (compact index)](validation/third-party-review-readiness.md)
 - [Current Implementation Matrix (10-minute reviewer view)](validation/current-implementation-matrix.md)
 - [Evidence Bundle Reviewer Checklist](validation/evidence-bundle-reviewer-checklist.md)
+- [Evidence Bundle Signature Verification Demo](validation/evidence-bundle-signature-verification.md)
 - [Sample Evidence Bundle Verification Output](validation/sample-evidence-bundle-verification-output.md)
 
 ### Governance & Compliance

--- a/docs/en/validation/technical-proof-pack.md
+++ b/docs/en/validation/technical-proof-pack.md
@@ -48,7 +48,32 @@ Primary references:
 
 ---
 
-## 4) Explicit non-guarantees (important)
+## 4) Evidence Bundle verification path
+
+Evidence Bundle verification separates file/hash integrity from manifest
+authenticity and supports strict Ed25519 manifest verification using a trusted
+public key. This is reviewer-facing verification support: it helps external
+reviewers confirm that hash-covered files match the manifest and that the
+manifest signature verifies under a reviewer-supplied trusted public key.
+
+Start here for the completed reviewer path:
+
+- [Evidence Bundle Reviewer Checklist](evidence-bundle-reviewer-checklist.md)
+- [Evidence Bundle Signature Verification Demo](evidence-bundle-signature-verification.md)
+- [Sample Evidence Bundle Verification Output](sample-evidence-bundle-verification-output.md)
+- [External Audit Readiness Pack](external-audit-readiness.md)
+
+Boundaries:
+
+- This is reviewer-facing verification support.
+- It is not regulatory certification.
+- It is not completed third-party audit approval.
+- Trusted public keys must come from an out-of-band reviewer/operator trust
+  channel.
+
+---
+
+## 5) Explicit non-guarantees (important)
 
 This pack does **not** claim any of the following:
 
@@ -62,10 +87,11 @@ For concrete boundaries, see:
 
 ---
 
-## 5) Reviewer handoff note
+## 6) Reviewer handoff note
 
 If you are an external reviewer, start with:
 
 1. `short-dd-summary.md` (5–10 minutes)
 2. `implemented-vs-pending-boundary.md` (boundary control)
 3. `external-reviewer-checklist.md` (evidence verification flow)
+4. `evidence-bundle-reviewer-checklist.md` (Evidence Bundle verification)

--- a/docs/en/validation/third-party-review-readiness.md
+++ b/docs/en/validation/third-party-review-readiness.md
@@ -36,6 +36,14 @@ Use these as the shortest implementation entrypoints:
    - `veritas_os/api/routes_system.py`
 4. **Scope boundary statement**
    - [Implemented vs Pending Boundary](implemented-vs-pending-boundary.md)
+5. **Evidence Bundle reviewer verification**
+   - Evidence Bundle verification separates file/hash integrity from manifest
+     authenticity and supports strict Ed25519 manifest verification using a
+     trusted public key.
+   - [Evidence Bundle Reviewer Checklist](evidence-bundle-reviewer-checklist.md)
+   - [Evidence Bundle Signature Verification Demo](evidence-bundle-signature-verification.md)
+   - [Sample Evidence Bundle Verification Output](sample-evidence-bundle-verification-output.md)
+   - [External Audit Readiness Pack](external-audit-readiness.md)
 
 Related documentation map:
 
@@ -70,8 +78,14 @@ Representative bind/governance test surfaces:
 Treat the following as explicitly out-of-scope for repository-only assurance:
 
 - Independent third-party certification completion.
+- Regulatory certification.
+- Completed third-party audit approval.
 - Tenant-specific production controls (IdP, key custody, retention, HA/DR, ops execution quality).
 - Universal guarantee across all deployment environments.
+
+Evidence Bundle verification is reviewer-facing verification support, not a
+certification or audit approval claim. Trusted public keys must come from an
+out-of-band reviewer/operator trust channel, not from the Evidence Bundle alone.
 
 Primary boundary sources:
 
@@ -90,5 +104,7 @@ Primary boundary sources:
 4. Read [Recent Hardening Notes](../development/recent-hardening.md) for recent auditability, observability, CI gate, API compatibility, and dependency-risk visibility updates.
 5. Spot-check API contract in `openapi.yaml` and one bind mutation path.
 6. Confirm validation gates in [Production Validation Strategy](production-validation.md).
+7. For Evidence Bundle verification, run through the
+   [Evidence Bundle Reviewer Checklist](evidence-bundle-reviewer-checklist.md).
 
 If deeper verification is needed, continue with [External Reviewer Checklist](external-reviewer-checklist.md).


### PR DESCRIPTION
### Motivation
- Make the completed Evidence Bundle reviewer verification path discoverable from the top-level Technical Proof Pack and external reviewer entry points so external reviewers, design partners, and investors can quickly follow the reviewer-facing verification flow.
- Emphasize reviewer-facing scope and avoid overclaiming certification or audit completion while pointing to the strict Ed25519 manifest verification demo and related artifacts.

### Description
- Add a short Evidence Bundle verification summary and explicit reviewer-facing boundaries to `docs/en/validation/technical-proof-pack.md` describing separation of file/hash integrity and manifest authenticity and the need for a trusted out-of-band Ed25519 public key.
- Add the same short summary and links to `docs/en/validation/third-party-review-readiness.md` and include the Evidence Bundle reviewer checklist in the reviewer handoff path.
- Add a concise 1-paragraph pointer to the Technical Proof Pack and the Evidence Bundle verification guidance in `README.md` (external reviewer fast path), and add the signature verification demo link in `docs/en/README.md` validation index.
- Linked artifacts added/pointed to: `evidence-bundle-reviewer-checklist.md`, `evidence-bundle-signature-verification.md`, `sample-evidence-bundle-verification-output.md`, and `external-audit-readiness.md`; no code, keys, or production data were added (docs-only change).

### Testing
- Ran operational docs consistency checks with `python scripts/quality/check_operational_docs_consistency.py` and `python scripts/quality/check_frontend_docs_consistency.py`, both passed.
- Ran review/backlog/docs checks with `python scripts/quality/check_review_improvements_consistency.py` and bilingual docs checks with `python scripts/quality/check_bilingual_docs.py`, both passed.
- Ran `git diff --check` to ensure no trailing whitespace/link issues; it passed.
- All automated docs consistency checks reported success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a270ab488608326b974dbef8bb8ce2f)