### PR TITLE
ci: add Evidence Bundle reviewer docs consistency guard

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,6 +74,9 @@ jobs:
       - name: Review improvements consistency check
         run: python scripts/quality/check_review_improvements_consistency.py
 
+      - name: Evidence Bundle reviewer docs consistency check
+        run: python scripts/quality/check_evidence_bundle_reviewer_docs.py
+
       - name: requirements.txt sync check
         run: python scripts/quality/check_requirements_sync.py
 

--- a/scripts/quality/check_evidence_bundle_reviewer_docs.py
+++ b/scripts/quality/check_evidence_bundle_reviewer_docs.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Validate Evidence Bundle reviewer verification documentation links.
+
+This guard keeps the external reviewer path for Evidence Bundle verification
+intact. It verifies that required reviewer-facing documents exist, that the
+main review-readiness entry points link to the verification materials, and that
+safety boundary language remains present before documentation edits reach CI.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+VALIDATION_DIR = REPO_ROOT / "docs/en/validation"
+
+REQUIRED_DOCS = (
+    VALIDATION_DIR / "evidence-bundle-reviewer-checklist.md",
+    VALIDATION_DIR / "evidence-bundle-signature-verification.md",
+    VALIDATION_DIR / "sample-evidence-bundle-verification-output.md",
+    VALIDATION_DIR / "external-audit-readiness.md",
+    VALIDATION_DIR / "technical-proof-pack.md",
+    VALIDATION_DIR / "third-party-review-readiness.md",
+)
+
+REVIEWER_VERIFICATION_LINKS = (
+    "evidence-bundle-reviewer-checklist.md",
+    "evidence-bundle-signature-verification.md",
+    "sample-evidence-bundle-verification-output.md",
+    "external-audit-readiness.md",
+)
+
+LINK_SOURCE_PATHS = (
+    VALIDATION_DIR / "technical-proof-pack.md",
+    VALIDATION_DIR / "third-party-review-readiness.md",
+)
+
+README_ENTRYPOINT_PATHS = (
+    REPO_ROOT / "README.md",
+    REPO_ROOT / "docs/en/README.md",
+)
+
+README_VERIFICATION_LINKS = (
+    "evidence-bundle-reviewer-checklist.md",
+    "evidence-bundle-signature-verification.md",
+    "sample-evidence-bundle-verification-output.md",
+)
+
+SAFETY_BOUNDARY_PHRASES = (
+    "reviewer-facing verification support",
+    "not regulatory certification",
+    "not completed third-party audit approval",
+    (
+        "trusted public keys must come from an out-of-band "
+        "reviewer/operator trust channel"
+    ),
+)
+
+VERIFICATION_CONCEPTS = (
+    "file/hash integrity",
+    "manifest authenticity",
+    "Ed25519",
+    "trusted public key",
+)
+
+BOUNDARY_SOURCE_PATHS = (
+    VALIDATION_DIR / "technical-proof-pack.md",
+    VALIDATION_DIR / "third-party-review-readiness.md",
+)
+
+WHITESPACE_PATTERN = re.compile(r"\s+")
+
+
+def _relative(path: pathlib.Path) -> str:
+    """Return a repository-relative path for readable diagnostics."""
+    return str(path.relative_to(REPO_ROOT))
+
+
+def _read_existing_documents(paths: tuple[pathlib.Path, ...]) -> dict[pathlib.Path, str]:
+    """Read the existing files from ``paths`` using UTF-8."""
+    return {
+        path: path.read_text(encoding="utf-8")
+        for path in paths
+        if path.exists()
+    }
+
+
+def _normalize_text(text: str) -> str:
+    """Normalize case and whitespace so wrapped Markdown still matches."""
+    return WHITESPACE_PATTERN.sub(" ", text.lower()).strip()
+
+
+def collect_missing_files(paths: tuple[pathlib.Path, ...]) -> list[str]:
+    """Return diagnostics for required documentation files that are absent."""
+    return [f"Missing file: {_relative(path)}" for path in paths if not path.exists()]
+
+
+def collect_missing_links(
+    documents: dict[pathlib.Path, str],
+    source_paths: tuple[pathlib.Path, ...],
+    required_links: tuple[str, ...],
+) -> list[str]:
+    """Return diagnostics for links missing from required source documents."""
+    problems = []
+    for path in source_paths:
+        content = documents.get(path)
+        if content is None:
+            continue
+        for link in required_links:
+            if link not in content:
+                problems.append(f"{_relative(path)}: missing link: {link}")
+    return problems
+
+
+def collect_missing_readme_entrypoint(
+    documents: dict[pathlib.Path, str],
+    readme_paths: tuple[pathlib.Path, ...],
+    verification_links: tuple[str, ...],
+) -> list[str]:
+    """Return a diagnostic when no README links to verification materials."""
+    for path in readme_paths:
+        content = documents.get(path)
+        if content is None:
+            continue
+        if any(link in content for link in verification_links):
+            return []
+
+    readmes = ", ".join(_relative(path) for path in readme_paths)
+    links = ", ".join(verification_links)
+    return [
+        f"{readmes}: missing reachable Evidence Bundle verification docs link "
+        f"(expected one of: {links})"
+    ]
+
+
+def collect_missing_boundary_phrases(
+    documents: dict[pathlib.Path, str],
+    source_paths: tuple[pathlib.Path, ...],
+    required_phrases: tuple[str, ...],
+) -> list[str]:
+    """Return diagnostics for safety boundary phrases missing from all sources."""
+    normalized_sources = {
+        path: _normalize_text(documents.get(path, "")) for path in source_paths
+    }
+    combined = "\n".join(normalized_sources.values())
+    problems = []
+    for phrase in required_phrases:
+        if _normalize_text(phrase) not in combined:
+            sources = ", ".join(_relative(path) for path in source_paths)
+            problems.append(
+                f"{sources}: missing required safety boundary phrase: {phrase}"
+            )
+    return problems
+
+
+def collect_missing_concepts(
+    documents: dict[pathlib.Path, str],
+    required_concepts: tuple[str, ...],
+) -> list[str]:
+    """Return diagnostics for verification concepts missing from all docs."""
+    combined = "\n".join(documents.values())
+    normalized_combined = _normalize_text(combined)
+    problems = []
+    for concept in required_concepts:
+        if _normalize_text(concept) not in normalized_combined:
+            problems.append(
+                "Evidence Bundle reviewer docs: missing required concept: "
+                f"{concept}"
+            )
+    return problems
+
+
+def validate_evidence_bundle_reviewer_docs() -> list[str]:
+    """Validate the Evidence Bundle external reviewer documentation path."""
+    paths_to_read = tuple(
+        dict.fromkeys(REQUIRED_DOCS + README_ENTRYPOINT_PATHS).keys()
+    )
+    documents = _read_existing_documents(paths_to_read)
+
+    problems = []
+    problems.extend(collect_missing_files(REQUIRED_DOCS))
+    problems.extend(
+        collect_missing_links(
+            documents,
+            LINK_SOURCE_PATHS,
+            REVIEWER_VERIFICATION_LINKS,
+        )
+    )
+    problems.extend(
+        collect_missing_readme_entrypoint(
+            documents,
+            README_ENTRYPOINT_PATHS,
+            README_VERIFICATION_LINKS,
+        )
+    )
+    problems.extend(
+        collect_missing_boundary_phrases(
+            documents,
+            BOUNDARY_SOURCE_PATHS,
+            SAFETY_BOUNDARY_PHRASES,
+        )
+    )
+    problems.extend(collect_missing_concepts(documents, VERIFICATION_CONCEPTS))
+    return problems
+
+
+def main() -> int:
+    """Run the Evidence Bundle reviewer documentation consistency check."""
+    problems = validate_evidence_bundle_reviewer_docs()
+    if not problems:
+        print("Evidence Bundle reviewer documentation checks passed.")
+        return 0
+
+    print("[DOCS] Evidence Bundle reviewer documentation path is incomplete:")
+    for problem in problems:
+        print(f"- {problem}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/docs/test_evidence_bundle_reviewer_docs_consistency.py
+++ b/tests/docs/test_evidence_bundle_reviewer_docs_consistency.py
@@ -1,0 +1,76 @@
+from scripts.quality import check_evidence_bundle_reviewer_docs as checker
+
+
+def test_collect_missing_links_reports_each_missing_link(tmp_path, monkeypatch):
+    source = tmp_path / "technical-proof-pack.md"
+    source.write_text(
+        "See evidence-bundle-reviewer-checklist.md only.", encoding="utf-8"
+    )
+    monkeypatch.setattr(checker, "REPO_ROOT", tmp_path)
+
+    problems = checker.collect_missing_links(
+        {source: source.read_text(encoding="utf-8")},
+        (source,),
+        (
+            "evidence-bundle-reviewer-checklist.md",
+            "evidence-bundle-signature-verification.md",
+        ),
+    )
+
+    assert problems == [
+        "technical-proof-pack.md: missing link: "
+        "evidence-bundle-signature-verification.md"
+    ]
+
+
+def test_boundary_phrase_check_normalizes_case_and_wrapped_lines(
+    tmp_path, monkeypatch
+):
+    source = tmp_path / "third-party-review-readiness.md"
+    source.write_text(
+        "Trusted public keys must come from an out-of-band\n"
+        "reviewer/operator trust channel.",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(checker, "REPO_ROOT", tmp_path)
+
+    problems = checker.collect_missing_boundary_phrases(
+        {source: source.read_text(encoding="utf-8")},
+        (source,),
+        (
+            "trusted public keys must come from an out-of-band "
+            "reviewer/operator trust channel",
+        ),
+    )
+
+    assert problems == []
+
+
+def test_readme_entrypoint_fails_when_no_readme_links_to_verification_docs(
+    tmp_path, monkeypatch
+):
+    readme = tmp_path / "README.md"
+    docs_readme = tmp_path / "docs/en/README.md"
+    docs_readme.parent.mkdir(parents=True)
+    readme.write_text("No reviewer docs here.", encoding="utf-8")
+    docs_readme.write_text("No reviewer docs here either.", encoding="utf-8")
+    monkeypatch.setattr(checker, "REPO_ROOT", tmp_path)
+
+    problems = checker.collect_missing_readme_entrypoint(
+        {
+            readme: readme.read_text(encoding="utf-8"),
+            docs_readme: docs_readme.read_text(encoding="utf-8"),
+        },
+        (readme, docs_readme),
+        ("evidence-bundle-signature-verification.md",),
+    )
+
+    assert problems == [
+        "README.md, docs/en/README.md: missing reachable Evidence Bundle "
+        "verification docs link (expected one of: "
+        "evidence-bundle-signature-verification.md)"
+    ]
+
+
+def test_current_evidence_bundle_reviewer_docs_are_consistent():
+    assert checker.validate_evidence_bundle_reviewer_docs() == []


### PR DESCRIPTION
### Motivation

- Prevent accidental documentation regressions that break the external Evidence Bundle reviewer verification path by adding an automated CI guard.
- Ensure future docs edits preserve reviewer-facing links, safety boundary wording, and key verification concepts introduced by recent Evidence Bundle work.

### Description

- Add `scripts/quality/check_evidence_bundle_reviewer_docs.py`, a small, documented guard that verifies required docs exist, ensures `technical-proof-pack.md` and `third-party-review-readiness.md` include required verification links, checks README reachability to the verification docs, and asserts required safety boundary phrases and verification concepts are present.
- Add unit tests at `tests/docs/test_evidence_bundle_reviewer_docs_consistency.py` that cover missing-link diagnostics, case/whitespace-normalized boundary-phrase matching, README entrypoint detection, and the current repository state.
- Wire the new guard into the lint CI job in `.github/workflows/main.yml` so it runs alongside existing docs consistency checks, and keep the change limited to docs/tests/CI without adding secrets or runtime cryptography.

### Testing

- Executed `python3 scripts/quality/check_evidence_bundle_reviewer_docs.py` which returned success (exit code 0) and printed a passing message.
- Ran the unit tests with `PYENV_VERSION=3.12.13 python -m pytest tests/docs/test_evidence_bundle_reviewer_docs_consistency.py -q` and they passed (`4 passed, 1 warning`).
- Ran static checks with `PYENV_VERSION=3.12.13 ruff check scripts/quality/check_evidence_bundle_reviewer_docs.py tests/docs/test_evidence_bundle_reviewer_docs_consistency.py` and the files passed linting, and the workflow YAML was validated separately (parsed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a275aa9a24c832696ef21ae1e54a22a)