### PR TITLE
docs: stabilize Evidence Bundle verification JSON contract

### DIFF
--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -51,6 +51,7 @@ For the bilingual correspondence table, see [../DOCUMENTATION_MAP.md](../DOCUMEN
 - [Evidence Bundle Reviewer Checklist](validation/evidence-bundle-reviewer-checklist.md)
 - [Evidence Bundle Signature Verification Demo](validation/evidence-bundle-signature-verification.md)
 - [Sample Evidence Bundle Verification Output](validation/sample-evidence-bundle-verification-output.md)
+- [Evidence Bundle Verification JSON Contract](validation/evidence-bundle-verification-json-contract.md)
 
 ### Governance & Compliance
 - [Decision Semantics Contract](architecture/decision-semantics.md)

--- a/docs/en/validation/evidence-bundle-reviewer-checklist.md
+++ b/docs/en/validation/evidence-bundle-reviewer-checklist.md
@@ -8,13 +8,14 @@ bundle contents in detail.
 Use it with the strict CLI path in
 [Evidence Bundle Signature Verification Demo](evidence-bundle-signature-verification.md)
 and the example transcripts in
-[Sample Evidence Bundle Verification Output](sample-evidence-bundle-verification-output.md).
+[Sample Evidence Bundle Verification Output](sample-evidence-bundle-verification-output.md)
+and the [Evidence Bundle Verification JSON Contract](evidence-bundle-verification-json-contract.md).
 
 ## Scope and non-certification boundary
 
 This checklist supports reviewer verification of one delivered Evidence Bundle.
-It is not regulatory certification, legal approval, or completion of a
-third-party audit. Reviewers remain responsible for their own audit scope,
+It is not regulatory certification, legal approval, or completed
+third-party audit approval. Reviewers remain responsible for their own audit scope,
 evidence sampling, legal/regulatory conclusions, and sign-off process.
 
 Security boundaries:
@@ -22,7 +23,9 @@ Security boundaries:
 - Hash integrity is not authenticity.
 - A public key included only inside the bundle is not trusted by itself.
 - The trusted Ed25519 public key must be obtained outside the bundle through an
-  approved reviewer/operator trust channel.
+  approved out-of-band reviewer/operator trust channel.
+- The `--json` result contract supports reviewer-facing verification and UI
+  integration, but it does not certify regulatory compliance or audit approval.
 - Do not add private keys, real signing keys, production secrets, or unsanitized
   customer data to review notes or shared examples.
 
@@ -34,7 +37,7 @@ Security boundaries:
 | 2 | Obtain the trusted Ed25519 public key out-of-band. | The reviewer obtains the public key from a trusted registry, signed operator note, KMS/certificate process, or other approved channel outside the bundle. | The public key is missing, comes only from inside the bundle, or its provenance cannot be established. |
 | 3 | Run the strict verification command. | The reviewer runs `veritas-evidence-bundle verify --bundle-dir <bundle_dir> --public-key <trusted_ed25519_public_key> --require-signature`. | The command is not run, omits `--require-signature`, omits the trusted public key, or uses an untrusted key path. |
 | 4 | Confirm `File/hash integrity: PASS`. | The CLI prints `File/hash integrity: PASS` in the strict verification run. | The CLI reports hash failure, manifest hash mismatch, missing files, malformed manifest data, or any file/hash error. |
-| 5 | Confirm `Manifest signature: PASS`. | The CLI prints `Manifest signature: PASS` under the trusted Ed25519 public key obtained in Step 2. | The CLI reports missing public key, wrong key, malformed signature, unsigned secure/prod bundle, or signature verification failure. |
+| 5 | Confirm `Manifest signature: PASS`. | The CLI prints `Manifest signature: PASS` under the trusted Ed25519 public key obtained in Step 2. For `--json`, `authenticity_ok` is `true`, `signature_status` is `pass`, and `signature_verified` is `true`. | The CLI reports missing public key, wrong key, malformed signature, unsigned secure/prod bundle, or signature verification failure. For `--json`, `authenticity_ok` is `false`. |
 | 6 | Inspect `acceptance_checklist.json`. | The checklist exists and has no blocking failures for the submitted bundle profile. | The checklist is missing, malformed, incomplete, or contains any blocking failure. |
 | 7 | Inspect `verification_report.json`. | The report exists and is consistent with the strict verification result and expected bundle scope. | The report is missing, malformed, stale, inconsistent with CLI output, or reports unresolved errors. |
 | 8 | Confirm no missing expected artifacts. | Required artifacts for the bundle type and review objective are present, including expected manifest, witness, report, acceptance, and profile-specific files. | Expected artifacts are absent, empty, renamed without explanation, or inconsistent with the handoff metadata. |
@@ -92,5 +95,7 @@ key, the bundle is not reviewer-facing verified evidence.
   [Evidence Bundle Signature Verification Demo](evidence-bundle-signature-verification.md)
 - Sample success and failure transcripts:
   [Sample Evidence Bundle Verification Output](sample-evidence-bundle-verification-output.md)
+- Stable `--json` field semantics for reviewer/UI consumers:
+  [Evidence Bundle Verification JSON Contract](evidence-bundle-verification-json-contract.md)
 - Bundle contents and delivery policy:
   [External Audit Readiness Pack](external-audit-readiness.md)

--- a/docs/en/validation/evidence-bundle-signature-verification.md
+++ b/docs/en/validation/evidence-bundle-signature-verification.md
@@ -8,13 +8,17 @@ channel, then verify both file/hash integrity and manifest authenticity.
 For the one-page reviewer verification order and PASS/FAIL criteria, see
 [Evidence Bundle Reviewer Checklist](evidence-bundle-reviewer-checklist.md).
 For a reviewer-facing sample transcript covering success, missing-key failure,
-and wrong-key failure, see [Sample Evidence Bundle Verification Output](sample-evidence-bundle-verification-output.md).
+wrong-key failure, and JSON examples, see [Sample Evidence Bundle Verification Output](sample-evidence-bundle-verification-output.md). For stable `--json` field semantics, see [Evidence Bundle Verification JSON Contract](evidence-bundle-verification-json-contract.md).
 
 ## Security boundary
 
 - Do not treat hash integrity as authenticity.
 - Do not trust a public key solely because it is included in the bundle.
-- Trusted public keys must come from a reviewer/operator trust channel.
+- Trusted public keys must come from an out-of-band reviewer/operator trust
+  channel.
+- The `--json` result contract supports reviewer-facing verification and UI
+  integration; it is not regulatory certification and is not completed
+  third-party audit approval.
 
 Hash integrity proves that files match the hashes recorded in `manifest.json`.
 It does not prove who created that manifest. Manifest signature verification is

--- a/docs/en/validation/evidence-bundle-verification-json-contract.md
+++ b/docs/en/validation/evidence-bundle-verification-json-contract.md
@@ -1,0 +1,206 @@
+# Evidence Bundle Verification JSON Contract
+
+This page documents the reviewer-facing JSON result contract emitted by:
+
+```bash
+veritas-evidence-bundle verify \
+  --bundle-dir <bundle_dir> \
+  --public-key <trusted_ed25519_public_key> \
+  --require-signature \
+  --json
+```
+
+This JSON contract supports reviewer-facing verification and UI integration. It
+is not regulatory certification. It is not completed third-party audit approval.
+Trusted public keys must come from an out-of-band reviewer/operator trust
+channel; a public key copied only from the Evidence Bundle is not trusted by
+itself.
+
+## Contract scope
+
+The contract separates two reviewer decisions that external UI and audit tooling
+must not collapse:
+
+1. **File/hash integrity**: whether hash-covered files match `manifest.json`.
+2. **Manifest authenticity**: whether the manifest signature verifies under the
+   trusted Ed25519 public key supplied by the reviewer/operator trust channel.
+
+Strict reviewer verification requires both checks to pass in the same
+`--require-signature` run. `hash_integrity_ok: true` alone is not an
+authenticity decision.
+
+## Stable top-level fields
+
+| Field | Type | Reviewer-facing meaning |
+|---|---|---|
+| `ok` | boolean | Overall CLI verification result. In strict mode, `true` requires file/hash integrity to pass and required signature verification to pass under the supplied trusted public key. |
+| `tampered` | boolean | `true` means the verifier detected a condition that invalidates the bundle verification result, such as a hash mismatch, missing required content, manifest hash failure, required signature failure, or missing required signature. Use `hash_integrity_ok` and `authenticity_ok` to distinguish integrity from authenticity. |
+| `hash_integrity_ok` | boolean | `true` means all hash-covered files match the hashes recorded in `manifest.json` and the manifest hash check did not fail. It does not prove who authored or signed the manifest. |
+| `signature_status` | string | Reviewer-facing manifest signature state. Expected values are `pass`, `fail`, `missing`, and `not_verified`. |
+| `signature_verified` | boolean | `true` means the manifest signature cryptographically verified under the trusted Ed25519 public key supplied to `--public-key`. |
+| `authenticity_ok` | boolean | `true` means reviewer-facing manifest authenticity was established by signature verification under the trusted public key. `false` means reviewer-facing authenticity was not established. |
+| `authenticity_failure` | string or null | Machine-readable authenticity failure reason. `null` is expected only when `authenticity_ok` is `true`. Current failure values include `signature_not_verified`, `signature_verification_failed`, `signature_verification_error`, and `signature_missing`. |
+| `errors` | array of strings | Blocking diagnostics. If this array is non-empty, `ok` is `false`. UI consumers may display these as rejection/blocker reasons. |
+| `warnings` | array of strings | Non-blocking diagnostics for the current posture/mode. Warnings can still require reviewer attention, but they do not by themselves make `ok` false. |
+
+Additional diagnostic fields, such as `manifest` and `file_hash_results`, may be
+present for reviewer inspection. Consumers should depend on the stable fields
+above for summary decisions.
+
+## Strict success JSON
+
+Conditions:
+
+- correct trusted Ed25519 public key supplied with `--public-key`
+- `--require-signature` enabled
+- hash-covered files match `manifest.json`
+- manifest signature verifies under the trusted public key
+
+Illustrative JSON shape:
+
+```json
+{
+  "ok": true,
+  "tampered": false,
+  "hash_integrity_ok": true,
+  "signature_status": "pass",
+  "signature_verified": true,
+  "authenticity_ok": true,
+  "authenticity_failure": null,
+  "errors": [],
+  "warnings": []
+}
+```
+
+Reviewer/UI interpretation: the bundle passed strict reviewer-facing
+verification for file/hash integrity and manifest authenticity. This is still
+not regulatory certification or completed third-party audit approval.
+
+## Failure JSON shapes
+
+### Missing public key with `--require-signature`
+
+Conditions:
+
+- `--require-signature` enabled
+- no trusted public key supplied to `--public-key`
+- manifest signature may be present, but cannot be verified
+
+Illustrative JSON shape:
+
+```json
+{
+  "ok": false,
+  "tampered": true,
+  "hash_integrity_ok": true,
+  "signature_status": "not_verified",
+  "signature_verified": false,
+  "authenticity_ok": false,
+  "authenticity_failure": "signature_not_verified",
+  "errors": [
+    "Manifest signature present but no signature verifier was provided; manifest authenticity was not verified",
+    "No trusted public key supplied; manifest signature authenticity cannot be verified"
+  ],
+  "warnings": []
+}
+```
+
+Reviewer/UI interpretation: file/hash integrity may pass, but authenticity was
+not established. Do not accept this as strict reviewer-facing verification.
+
+### Wrong public key
+
+Conditions:
+
+- trusted-key input does not correspond to the signing key for the manifest
+- `--require-signature` enabled
+
+Illustrative JSON shape:
+
+```json
+{
+  "ok": false,
+  "tampered": true,
+  "hash_integrity_ok": true,
+  "signature_status": "fail",
+  "signature_verified": false,
+  "authenticity_ok": false,
+  "authenticity_failure": "signature_verification_failed",
+  "errors": [
+    "Manifest signature verification failed"
+  ],
+  "warnings": []
+}
+```
+
+Reviewer/UI interpretation: the hash-covered files can still match the manifest,
+but the supplied public key did not verify the manifest signature. Authenticity
+failed.
+
+### Malformed signature
+
+Conditions:
+
+- `manifest_signature` cannot be parsed or checked as a valid signature input
+- `--require-signature` enabled
+
+Illustrative JSON shape:
+
+```json
+{
+  "ok": false,
+  "tampered": true,
+  "hash_integrity_ok": true,
+  "signature_status": "fail",
+  "signature_verified": false,
+  "authenticity_ok": false,
+  "authenticity_failure": "signature_verification_error",
+  "errors": [
+    "Manifest signature verification error: <parse-or-verifier-error>"
+  ],
+  "warnings": []
+}
+```
+
+Reviewer/UI interpretation: the signature input could not be processed as a
+successful Ed25519 verification. Treat this as a failed authenticity result.
+
+### Unsigned bundle under secure/prod posture
+
+Conditions:
+
+- `VERITAS_POSTURE=secure` or `VERITAS_POSTURE=prod`, or strict mode otherwise
+  requires a manifest signature
+- `manifest_signature` is absent
+
+Illustrative JSON shape:
+
+```json
+{
+  "ok": false,
+  "tampered": true,
+  "hash_integrity_ok": true,
+  "signature_status": "missing",
+  "signature_verified": false,
+  "authenticity_ok": false,
+  "authenticity_failure": "signature_missing",
+  "errors": [
+    "Manifest signature missing"
+  ],
+  "warnings": []
+}
+```
+
+Reviewer/UI interpretation: file/hash integrity may pass, but required manifest
+authenticity is absent. Do not accept unsigned secure/prod bundles as
+reviewer-facing verified evidence.
+
+## Consumer guidance
+
+- Show `hash_integrity_ok` and `authenticity_ok` separately.
+- Treat `ok: true` in strict mode as requiring both integrity and authenticity.
+- Treat `authenticity_ok: false` as “authenticity not established,” even when
+  `hash_integrity_ok: true`.
+- Display `errors` as blocking reviewer actions and `warnings` as review notes.
+- Record trusted public key provenance outside the bundle before relying on
+  `signature_verified: true`.

--- a/docs/en/validation/sample-evidence-bundle-verification-output.md
+++ b/docs/en/validation/sample-evidence-bundle-verification-output.md
@@ -4,7 +4,8 @@ This page is a reviewer-facing sample transcript for Evidence Bundle strict
 verification. All command output below is **illustrative output** for external
 auditors and design partners to preview the expected CLI shape before handling a
 real bundle. Use it with the one-page
-[Evidence Bundle Reviewer Checklist](evidence-bundle-reviewer-checklist.md).
+[Evidence Bundle Reviewer Checklist](evidence-bundle-reviewer-checklist.md) and the
+[Evidence Bundle Verification JSON Contract](evidence-bundle-verification-json-contract.md).
 
 ## Safety boundary
 
@@ -13,8 +14,9 @@ real bundle. Use it with the one-page
 - Placeholder paths such as `<bundle_dir>` and
   `<trusted_ed25519_public_key>` must be replaced by reviewer-specific handoff
   paths.
-- A trusted Ed25519 public key must come from a reviewer/operator trust channel,
-  not from a key copied only from the Evidence Bundle.
+- A trusted Ed25519 public key must come from an out-of-band
+  reviewer/operator trust channel, not from a key copied only from the Evidence
+  Bundle.
 
 ## Strict verification command
 
@@ -28,7 +30,9 @@ veritas-evidence-bundle verify \
 ```
 
 Strict verification is complete only when the CLI reports both file/hash
-integrity and manifest signature success.
+integrity and manifest signature success. JSON consumers should use the stable
+contract fields documented in
+[Evidence Bundle Verification JSON Contract](evidence-bundle-verification-json-contract.md).
 
 ## Successful strict verification
 
@@ -38,6 +42,22 @@ Illustrative output:
 Evidence bundle verification: PASS
 File/hash integrity: PASS
 Manifest signature: PASS
+```
+
+Illustrative `--json` summary fields:
+
+```json
+{
+  "ok": true,
+  "tampered": false,
+  "hash_integrity_ok": true,
+  "signature_status": "pass",
+  "signature_verified": true,
+  "authenticity_ok": true,
+  "authenticity_failure": null,
+  "errors": [],
+  "warnings": []
+}
 ```
 
 Reviewer interpretation:
@@ -69,6 +89,20 @@ Manifest signature: NOT VERIFIED
   error: No trusted public key supplied; manifest signature authenticity cannot be verified
 ```
 
+Illustrative `--json` summary fields:
+
+```json
+{
+  "ok": false,
+  "tampered": true,
+  "hash_integrity_ok": true,
+  "signature_status": "not_verified",
+  "signature_verified": false,
+  "authenticity_ok": false,
+  "authenticity_failure": "signature_not_verified"
+}
+```
+
 Reviewer interpretation:
 
 - The files may still match the manifest, so file/hash integrity can report
@@ -96,6 +130,20 @@ Manifest signature: FAIL
   error: Manifest signature verification failed
 ```
 
+Illustrative `--json` summary fields:
+
+```json
+{
+  "ok": false,
+  "tampered": true,
+  "hash_integrity_ok": true,
+  "signature_status": "fail",
+  "signature_verified": false,
+  "authenticity_ok": false,
+  "authenticity_failure": "signature_verification_failed"
+}
+```
+
 Reviewer interpretation:
 
 - Hash-covered files still match `manifest.json`, so file/hash integrity can
@@ -117,3 +165,53 @@ Ed25519 public key that the reviewer received out-of-band through the approved
 trust channel. A bundle with only `File/hash integrity: PASS` must remain
 unaccepted for external reviewer purposes until manifest authenticity is also
 verified.
+
+
+## Malformed signature failure
+
+Illustrative `--json` summary fields:
+
+```json
+{
+  "ok": false,
+  "tampered": true,
+  "hash_integrity_ok": true,
+  "signature_status": "fail",
+  "signature_verified": false,
+  "authenticity_ok": false,
+  "authenticity_failure": "signature_verification_error"
+}
+```
+
+Reviewer interpretation:
+
+- The signature input could not be parsed or processed as a successful Ed25519
+  manifest signature verification.
+- Treat this as a failed authenticity result even when file/hash integrity is
+  still `PASS`.
+
+## Unsigned secure/prod bundle failure
+
+Under `VERITAS_POSTURE=secure` or `VERITAS_POSTURE=prod`, unsigned bundles fail
+closed because manifest authenticity is required.
+
+Illustrative `--json` summary fields:
+
+```json
+{
+  "ok": false,
+  "tampered": true,
+  "hash_integrity_ok": true,
+  "signature_status": "missing",
+  "signature_verified": false,
+  "authenticity_ok": false,
+  "authenticity_failure": "signature_missing"
+}
+```
+
+Reviewer interpretation:
+
+- The bundle is not reviewer-facing verified evidence because required manifest
+  authenticity is absent.
+- Do not accept unsigned secure/prod bundles even if `hash_integrity_ok` is
+  `true`.

--- a/docs/en/validation/technical-proof-pack.md
+++ b/docs/en/validation/technical-proof-pack.md
@@ -61,6 +61,7 @@ Start here for the completed reviewer path:
 - [Evidence Bundle Reviewer Checklist](evidence-bundle-reviewer-checklist.md)
 - [Evidence Bundle Signature Verification Demo](evidence-bundle-signature-verification.md)
 - [Sample Evidence Bundle Verification Output](sample-evidence-bundle-verification-output.md)
+- [Evidence Bundle Verification JSON Contract](evidence-bundle-verification-json-contract.md)
 - [External Audit Readiness Pack](external-audit-readiness.md)
 
 Boundaries:

--- a/veritas_os/tests/test_evidence_bundle_cli.py
+++ b/veritas_os/tests/test_evidence_bundle_cli.py
@@ -11,6 +11,36 @@ import pytest
 from veritas_os.audit import trustlog_signed
 
 
+CONTRACT_JSON_FIELDS = {
+    "ok",
+    "tampered",
+    "hash_integrity_ok",
+    "signature_status",
+    "signature_verified",
+    "authenticity_ok",
+    "authenticity_failure",
+    "errors",
+    "warnings",
+}
+
+
+def _assert_contract_fields(output: dict) -> None:
+    """Assert reviewer-facing JSON contract fields are present."""
+    assert CONTRACT_JSON_FIELDS.issubset(output.keys())
+    assert isinstance(output["ok"], bool)
+    assert isinstance(output["tampered"], bool)
+    assert isinstance(output["hash_integrity_ok"], bool)
+    assert isinstance(output["signature_status"], str)
+    assert isinstance(output["signature_verified"], bool)
+    assert isinstance(output["authenticity_ok"], bool)
+    assert output["authenticity_failure"] is None or isinstance(
+        output["authenticity_failure"],
+        str,
+    )
+    assert isinstance(output["errors"], list)
+    assert isinstance(output["warnings"], list)
+
+
 def test_evidence_bundle_cli_generate_and_verify(tmp_path, monkeypatch) -> None:
     """CLI can generate and verify a decision evidence bundle."""
     log_path = tmp_path / "trustlog.jsonl"
@@ -228,6 +258,42 @@ def test_evidence_bundle_cli_verify_signed_manifest_with_public_key(
     assert "Manifest signature: PASS" in output
 
 
+def test_evidence_bundle_cli_strict_success_json_contract(
+    tmp_path,
+    monkeypatch,
+    capsys,
+) -> None:
+    """Strict --json success exposes stable reviewer-facing fields."""
+    from veritas_os.cli.evidence_bundle import main
+
+    monkeypatch.setenv("VERITAS_POSTURE", "dev")
+    bundle_dir, _private_key, public_key = _signed_bundle(tmp_path, monkeypatch)
+
+    exit_code = main(
+        [
+            "verify",
+            "--bundle-dir",
+            str(bundle_dir),
+            "--public-key",
+            str(public_key),
+            "--require-signature",
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    _assert_contract_fields(output)
+    assert output["ok"] is True
+    assert output["tampered"] is False
+    assert output["hash_integrity_ok"] is True
+    assert output["signature_status"] == "pass"
+    assert output["signature_verified"] is True
+    assert output["authenticity_ok"] is True
+    assert output["authenticity_failure"] is None
+    assert output["errors"] == []
+
+
 def test_evidence_bundle_cli_verify_tampered_manifest_signature_fails(
     tmp_path,
     monkeypatch,
@@ -325,6 +391,40 @@ def test_verify_bundle_malformed_signature_reports_authenticity_error(
     assert result["authenticity_failure"] == "signature_verification_error"
 
 
+def test_evidence_bundle_cli_missing_public_key_json_contract(
+    tmp_path,
+    monkeypatch,
+    capsys,
+) -> None:
+    """Strict --json reports missing trusted public key without hash failure."""
+    from veritas_os.cli.evidence_bundle import main
+
+    monkeypatch.setenv("VERITAS_POSTURE", "dev")
+    bundle_dir, _private_key, _public_key = _signed_bundle(tmp_path, monkeypatch)
+
+    exit_code = main(
+        [
+            "verify",
+            "--bundle-dir",
+            str(bundle_dir),
+            "--require-signature",
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    _assert_contract_fields(output)
+    assert output["ok"] is False
+    assert output["tampered"] is True
+    assert output["hash_integrity_ok"] is True
+    assert output["signature_status"] == "not_verified"
+    assert output["signature_verified"] is False
+    assert output["authenticity_ok"] is False
+    assert output["authenticity_failure"] == "signature_not_verified"
+    assert any("No trusted public key supplied" in e for e in output["errors"])
+
+
 def test_evidence_bundle_cli_require_signature_without_public_key_fails(
     tmp_path,
     monkeypatch,
@@ -378,6 +478,92 @@ def test_evidence_bundle_cli_verify_manifest_signed_by_wrong_key_fails(
     )
 
     assert exit_code == 1
+
+
+def test_evidence_bundle_cli_wrong_key_json_contract(
+    tmp_path,
+    monkeypatch,
+    capsys,
+) -> None:
+    """Strict --json reports wrong trusted key as authenticity failure."""
+    from veritas_os.cli.evidence_bundle import main
+    from veritas_os.security.signing import store_keypair
+
+    monkeypatch.setenv("VERITAS_POSTURE", "dev")
+    bundle_dir, _private_key, _public_key = _signed_bundle(tmp_path, monkeypatch)
+    wrong_private_key = tmp_path / "wrong_json_keys" / "priv.key"
+    wrong_public_key = tmp_path / "wrong_json_keys" / "pub.key"
+    store_keypair(wrong_private_key, wrong_public_key)
+
+    exit_code = main(
+        [
+            "verify",
+            "--bundle-dir",
+            str(bundle_dir),
+            "--public-key",
+            str(wrong_public_key),
+            "--require-signature",
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    _assert_contract_fields(output)
+    assert output["ok"] is False
+    assert output["tampered"] is True
+    assert output["hash_integrity_ok"] is True
+    assert output["signature_status"] == "fail"
+    assert output["signature_verified"] is False
+    assert output["authenticity_ok"] is False
+    assert output["authenticity_failure"] == "signature_verification_failed"
+    assert "Manifest signature verification failed" in output["errors"]
+
+
+def test_evidence_bundle_cli_malformed_signature_json_contract(
+    tmp_path,
+    monkeypatch,
+    capsys,
+) -> None:
+    """Strict --json distinguishes malformed signatures from wrong keys."""
+    from veritas_os.cli.evidence_bundle import main
+
+    monkeypatch.setenv("VERITAS_POSTURE", "dev")
+    bundle_dir, _private_key, public_key = _signed_bundle(tmp_path, monkeypatch)
+    manifest_path = bundle_dir / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["manifest_signature"] = "not base64 ???"
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    exit_code = main(
+        [
+            "verify",
+            "--bundle-dir",
+            str(bundle_dir),
+            "--public-key",
+            str(public_key),
+            "--require-signature",
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    _assert_contract_fields(output)
+    assert output["ok"] is False
+    assert output["tampered"] is True
+    assert output["hash_integrity_ok"] is True
+    assert output["signature_status"] == "fail"
+    assert output["signature_verified"] is False
+    assert output["authenticity_ok"] is False
+    assert output["authenticity_failure"] == "signature_verification_error"
+    assert any(
+        error.startswith("Manifest signature verification error")
+        for error in output["errors"]
+    )
 
 
 def test_evidence_bundle_cli_require_signature_rejects_unsigned_bundle(
@@ -441,6 +627,44 @@ def test_evidence_bundle_cli_secure_or_prod_posture_rejects_unsigned_bundle(
     exit_code = main(["verify", "--bundle-dir", result["bundle_dir"]])
 
     assert exit_code == 1
+
+
+def test_evidence_bundle_cli_secure_unsigned_json_contract(
+    tmp_path,
+    monkeypatch,
+    capsys,
+) -> None:
+    """Secure posture --json reports unsigned bundles as authenticity failures."""
+    from veritas_os.audit.evidence_bundle import generate_evidence_bundle
+    from veritas_os.cli.evidence_bundle import main
+
+    monkeypatch.setenv("VERITAS_POSTURE", "secure")
+    log_path = tmp_path / "trustlog.jsonl"
+    private_key = tmp_path / "keys" / "priv.key"
+    public_key = tmp_path / "keys" / "pub.key"
+    monkeypatch.setattr(trustlog_signed, "SIGNED_TRUSTLOG_JSONL", log_path)
+    monkeypatch.setattr(trustlog_signed, "PRIVATE_KEY_PATH", private_key)
+    monkeypatch.setattr(trustlog_signed, "PUBLIC_KEY_PATH", public_key)
+    trustlog_signed.append_signed_decision({"request_id": "secure-json-unsigned"})
+    result = generate_evidence_bundle(
+        bundle_type="decision",
+        witness_ledger_path=log_path,
+        output_dir=tmp_path / "bundles",
+    )
+
+    exit_code = main(["verify", "--bundle-dir", result["bundle_dir"], "--json"])
+    output = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    _assert_contract_fields(output)
+    assert output["ok"] is False
+    assert output["tampered"] is True
+    assert output["hash_integrity_ok"] is True
+    assert output["signature_status"] == "missing"
+    assert output["signature_verified"] is False
+    assert output["authenticity_ok"] is False
+    assert output["authenticity_failure"] == "signature_missing"
+    assert "Manifest signature missing" in output["errors"]
 
 
 def test_evidence_bundle_cli_dev_without_public_key_warns_and_reports_json(


### PR DESCRIPTION
### Motivation

- Stabilize the reviewer-facing `--json` output from `veritas-evidence-bundle verify` so reviewers, CI, and future UI consumers can rely on a small set of summary fields for integrity and authenticity decisions. 
- Make the distinction between file/hash integrity and manifest authenticity explicit and avoid overclaims: this contract supports reviewer/UI integration but is not regulatory certification or a completed third-party audit. 

### Description

- Add a new document `docs/en/validation/evidence-bundle-verification-json-contract.md` that defines the stable top-level JSON fields (`ok`, `tampered`, `hash_integrity_ok`, `signature_status`, `signature_verified`, `authenticity_ok`, `authenticity_failure`, `errors`, `warnings`), their meanings, and illustrative success/failure JSON shapes. 
- Update `docs/en/validation/sample-evidence-bundle-verification-output.md`, `docs/en/validation/evidence-bundle-signature-verification.md`, `docs/en/validation/evidence-bundle-reviewer-checklist.md`, and `docs/en/validation/technical-proof-pack.md` to link to the new contract and include representative `--json` examples (strict success, missing key, wrong key, malformed signature, unsigned secure/prod). 
- Add test assertions to `veritas_os/tests/test_evidence_bundle_cli.py` that lock the `--json` contract shape and semantics for: strict success, missing public key with `--require-signature`, wrong key, malformed signature, and unsigned bundle under secure posture; and add a helper `_assert_contract_fields` to validate field presence/types. 

### Testing

- Ran the documentation guard `scripts/quality/check_evidence_bundle_reviewer_docs.py` and it passed. 
- Performed static checks: compiled the modified test file with `python -m py_compile` and ran `ruff` on the test file; both passed. 
- Performed `git diff --check` and basic repo validations; no whitespace or syntax problems found. 
- Note / limitation: a full `pytest` run for the focused test file could not be completed in this environment because dependency synchronization failed while fetching `pdfminer-six` from PyPI (network/tunnel error) and an ad-hoc run surfaced a missing `cryptography` package in the ephemeral interpreter; these are environment/dependency issues rather than functional test failures in the changes themselves.  The added tests are present and lint/type-checked and should run in CI where dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a278eeee0688326b66002db6a83e465)