### PR TITLE
Add Evidence Bundle verification JSON Schema and schema-driven tests

### DIFF
--- a/docs/en/validation/evidence-bundle-verification-json-contract.md
+++ b/docs/en/validation/evidence-bundle-verification-json-contract.md
@@ -16,6 +16,9 @@ Trusted public keys must come from an out-of-band reviewer/operator trust
 channel; a public key copied only from the Evidence Bundle is not trusted by
 itself.
 
+Machine-readable validation is pinned in the JSON Schema at
+[`schemas/evidence_bundle_verification_result.schema.json`](../../../schemas/evidence_bundle_verification_result.schema.json).
+
 ## Contract scope
 
 The contract separates two reviewer decisions that external UI and audit tooling

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ dev = [
   "pytest==9.0.3",
   "pytest-asyncio==1.3.0",
   "pytest-cov==6.0.0",
+  "jsonschema==4.23.0",
   "fastapi==0.121.0",
   "httpx==0.27.2",
   "mypy==1.13.0",

--- a/schemas/evidence_bundle_verification_result.schema.json
+++ b/schemas/evidence_bundle_verification_result.schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://veritas-os.example/schemas/evidence_bundle_verification_result.schema.json",
+  "title": "Evidence Bundle Verification Result",
+  "description": "Machine-readable reviewer-facing result contract emitted by `veritas-evidence-bundle verify --json`. This schema supports reviewer/UI integration and CI/external audit tooling validation; it is not regulatory certification or completed third-party audit approval.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "ok",
+    "tampered",
+    "hash_integrity_ok",
+    "signature_status",
+    "signature_verified",
+    "authenticity_ok",
+    "authenticity_failure",
+    "errors",
+    "warnings"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "description": "Overall CLI verification result. In strict reviewer verification, true requires file/hash integrity and required manifest signature authenticity checks to pass."
+    },
+    "tampered": {
+      "type": "boolean",
+      "description": "True when the verifier detected a condition that invalidates the bundle verification result, such as hash mismatch, missing required content, manifest hash failure, required signature failure, or missing required signature."
+    },
+    "hash_integrity_ok": {
+      "type": "boolean",
+      "description": "True means all hash-covered files match manifest.json and the manifest hash check did not fail. Hash integrity is not authenticity; this field does not prove who authored, approved, or signed the manifest."
+    },
+    "signature_status": {
+      "type": "string",
+      "enum": [
+        "pass",
+        "fail",
+        "missing",
+        "not_verified"
+      ],
+      "description": "Reviewer-facing manifest signature state. `pass` is only valid when the signature cryptographically verifies; `missing` means no manifest signature was present; `not_verified` means authenticity was not checked under a trusted key."
+    },
+    "signature_verified": {
+      "type": "boolean",
+      "description": "True requires manifest signature verification under a trusted Ed25519 public key supplied through the reviewer/operator trust channel. A public key copied only from the bundle is not trusted by itself."
+    },
+    "authenticity_ok": {
+      "type": "boolean",
+      "description": "Reviewer-facing manifest authenticity result. True means authenticity was established by signature verification under the trusted Ed25519 public key; false means authenticity is not established, even when hash_integrity_ok is true."
+    },
+    "authenticity_failure": {
+      "enum": [
+        null,
+        "signature_not_verified",
+        "signature_verification_failed",
+        "signature_verification_error",
+        "signature_missing"
+      ],
+      "description": "Machine-readable authenticity failure reason. Null is expected only when authenticity_ok is true; otherwise use one of the signature-related failure values."
+    },
+    "errors": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Blocking diagnostics for reviewer/UI display. If this array is non-empty, ok is false."
+    },
+    "warnings": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Non-blocking diagnostics for the current posture/mode. Warnings may require reviewer attention but do not by themselves make ok false."
+    }
+  }
+}

--- a/veritas_os/requirements.txt
+++ b/veritas_os/requirements.txt
@@ -68,4 +68,5 @@ alembic==1.18.4
 pytest==9.0.3
 pytest-asyncio==1.3.0
 pytest-cov==6.0.0
+jsonschema==4.23.0
 mypy==1.13.0

--- a/veritas_os/tests/test_evidence_bundle_cli.py
+++ b/veritas_os/tests/test_evidence_bundle_cli.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import base64
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 from veritas_os.audit import trustlog_signed
 
 
+SCHEMA_PATH = Path("schemas/evidence_bundle_verification_result.schema.json")
 CONTRACT_JSON_FIELDS = {
     "ok",
     "tampered",
@@ -24,8 +26,15 @@ CONTRACT_JSON_FIELDS = {
 }
 
 
-def _assert_contract_fields(output: dict) -> None:
-    """Assert reviewer-facing JSON contract fields are present."""
+def _load_verification_result_schema() -> dict[str, Any]:
+    """Load the Evidence Bundle verification result JSON Schema."""
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def _assert_contract_fields(output: dict[str, Any]) -> None:
+    """Assert reviewer-facing JSON contract fields are present and schema-valid."""
+    import jsonschema
+
     assert CONTRACT_JSON_FIELDS.issubset(output.keys())
     assert isinstance(output["ok"], bool)
     assert isinstance(output["tampered"], bool)
@@ -39,6 +48,37 @@ def _assert_contract_fields(output: dict) -> None:
     )
     assert isinstance(output["errors"], list)
     assert isinstance(output["warnings"], list)
+
+    schema = _load_verification_result_schema()
+    jsonschema.Draft202012Validator.check_schema(schema)
+    jsonschema.Draft202012Validator(schema).validate(output)
+
+
+def test_evidence_bundle_verification_result_schema_contract() -> None:
+    """JSON Schema pins required reviewer-facing verification fields."""
+    schema = _load_verification_result_schema()
+
+    assert set(schema["required"]) == CONTRACT_JSON_FIELDS
+    assert schema["properties"]["signature_status"]["enum"] == [
+        "pass",
+        "fail",
+        "missing",
+        "not_verified",
+    ]
+    assert schema["properties"]["authenticity_failure"]["enum"] == [
+        None,
+        "signature_not_verified",
+        "signature_verification_failed",
+        "signature_verification_error",
+        "signature_missing",
+    ]
+    assert "Hash integrity is not authenticity" in (
+        schema["properties"]["hash_integrity_ok"]["description"]
+    )
+    assert "trusted Ed25519 public key" in (
+        schema["properties"]["signature_verified"]["description"]
+    )
+    assert "not regulatory certification" in schema["description"]
 
 
 def test_evidence_bundle_cli_generate_and_verify(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
### Motivation

- Provide a machine-readable JSON Schema for the reviewer-facing `veritas-evidence-bundle verify --json` contract so UIs, CI, and external tooling can validate verification results programmatically.
- Make the documented reviewer-facing JSON contract authoritative by pinning the same constraints to a schema and verifying existing test cases against it.
- Keep CLI human-readable output and verification semantics unchanged while enabling automated validation for common success/failure scenarios.

### Description

- Add the Draft 2020-12 JSON Schema at `schemas/evidence_bundle_verification_result.schema.json` that defines required top-level fields, `signature_status` and `authenticity_failure` enums, descriptions clarifying integrity vs authenticity, and Ed25519 verification expectations.
- Update `veritas_os/tests/test_evidence_bundle_cli.py` to load and validate the new schema and add `test_evidence_bundle_verification_result_schema_contract` which asserts the schema pins the required fields, enums, and documentation text.
- Link the machine-readable schema from the reviewer-facing docs at `docs/en/validation/evidence-bundle-verification-json-contract.md` and add `jsonschema` to dev/test dependency manifests (`pyproject.toml` and `veritas_os/requirements.txt`) so schema validation tests are explicit.
- Preserve existing CLI behavior and human-facing output; tests exercise only JSON contract validation in `--json` mode and do not introduce keys or secrets.

### Testing

- Validated schema JSON syntax with `python -m json.tool schemas/evidence_bundle_verification_result.schema.json`, which succeeded.
- Ran doc-level reviewer checks using `scripts/quality/check_evidence_bundle_reviewer_docs.py`, which passed.
- Ran dependency sync guard `scripts/quality/check_requirements_sync.py`, which passed.
- Ran `python -m py_compile` on modified test and guard files, which succeeded (syntax-only check passed).
- Attempted to run the targeted pytest invocation for the new schema test, but local `pytest` execution failed due to missing installed project dependencies (runtime imports such as `pydantic`) in the local environment; installing full build deps in this environment was blocked by package index access errors, so full `pytest` execution was not completed locally and is expected to be exercised in CI where dependencies are installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a279ba55f188326b4db1aca586bd4b6)