### PR TITLE
feat(evidence): include public_key_fingerprint_sha256 in verify --json output

### DIFF
--- a/docs/en/validation/evidence-bundle-reviewer-checklist.md
+++ b/docs/en/validation/evidence-bundle-reviewer-checklist.md
@@ -22,8 +22,12 @@ Security boundaries:
 
 - Hash integrity is not authenticity.
 - A public key included only inside the bundle is not trusted by itself.
+- The `public_key_fingerprint_sha256` JSON field records which public key
+  material was used for verification; it is key-provenance evidence, not a trust
+  proof.
 - The trusted Ed25519 public key must be obtained outside the bundle through an
-  approved out-of-band reviewer/operator trust channel.
+  approved out-of-band reviewer/operator trust channel, and reviewers should
+  record and compare that out-of-band key fingerprint in their review notes.
 - The `--json` result contract supports reviewer-facing verification and UI
   integration, but it does not certify regulatory compliance or audit approval.
 - Do not add private keys, real signing keys, production secrets, or unsanitized
@@ -34,10 +38,10 @@ Security boundaries:
 | Step | Reviewer action | PASS criterion | FAIL / follow-up criterion |
 |---|---|---|---|
 | 1 | Confirm bundle origin and expected handoff channel. | The bundle source, transfer channel, bundle type, and review objective match the expected handoff. | The source or channel is unexpected, undocumented, or inconsistent with the review request. |
-| 2 | Obtain the trusted Ed25519 public key out-of-band. | The reviewer obtains the public key from a trusted registry, signed operator note, KMS/certificate process, or other approved channel outside the bundle. | The public key is missing, comes only from inside the bundle, or its provenance cannot be established. |
+| 2 | Obtain the trusted Ed25519 public key out-of-band. | The reviewer obtains the public key from a trusted registry, signed operator note, KMS/certificate process, or other approved channel outside the bundle, and records the expected SHA-256 fingerprint. | The public key is missing, comes only from inside the bundle, its fingerprint is copied only from bundle-adjacent material, or its provenance cannot be established. |
 | 3 | Run the strict verification command. | The reviewer runs `veritas-evidence-bundle verify --bundle-dir <bundle_dir> --public-key <trusted_ed25519_public_key> --require-signature`. | The command is not run, omits `--require-signature`, omits the trusted public key, or uses an untrusted key path. |
 | 4 | Confirm `File/hash integrity: PASS`. | The CLI prints `File/hash integrity: PASS` in the strict verification run. | The CLI reports hash failure, manifest hash mismatch, missing files, malformed manifest data, or any file/hash error. |
-| 5 | Confirm `Manifest signature: PASS`. | The CLI prints `Manifest signature: PASS` under the trusted Ed25519 public key obtained in Step 2. For `--json`, `authenticity_ok` is `true`, `signature_status` is `pass`, and `signature_verified` is `true`. | The CLI reports missing public key, wrong key, malformed signature, unsigned secure/prod bundle, or signature verification failure. For `--json`, `authenticity_ok` is `false`. |
+| 5 | Confirm `Manifest signature: PASS`. | The CLI prints `Manifest signature: PASS` under the trusted Ed25519 public key obtained in Step 2. For `--json`, `authenticity_ok` is `true`, `signature_status` is `pass`, `signature_verified` is `true`, and `public_key_fingerprint_sha256` matches the out-of-band key fingerprint recorded by the reviewer. | The CLI reports missing public key, wrong key, malformed signature, unsigned secure/prod bundle, signature verification failure, or a fingerprint mismatch against the out-of-band reviewer record. For `--json`, `authenticity_ok` is `false`. |
 | 6 | Inspect `acceptance_checklist.json`. | The checklist exists and has no blocking failures for the submitted bundle profile. | The checklist is missing, malformed, incomplete, or contains any blocking failure. |
 | 7 | Inspect `verification_report.json`. | The report exists and is consistent with the strict verification result and expected bundle scope. | The report is missing, malformed, stale, inconsistent with CLI output, or reports unresolved errors. |
 | 8 | Confirm no missing expected artifacts. | Required artifacts for the bundle type and review objective are present, including expected manifest, witness, report, acceptance, and profile-specific files. | Expected artifacts are absent, empty, renamed without explanation, or inconsistent with the handoff metadata. |
@@ -49,8 +53,10 @@ Record `ACCEPT` only when all of the following are true:
 
 - `File/hash integrity: PASS` is present in the strict verification output.
 - `Manifest signature: PASS` is present in the same strict verification output.
-- The trusted Ed25519 public key was obtained outside the bundle and its
-  provenance is documented by the reviewer.
+- The trusted Ed25519 public key was obtained outside the bundle, its
+  provenance is documented by the reviewer, and its out-of-band SHA-256
+  fingerprint matches `public_key_fingerprint_sha256` in the strict `--json`
+  result.
 - `acceptance_checklist.json` has no blocking failures.
 - Expected artifacts for the bundle type and review objective are present.
 - Any non-blocking notes in `verification_report.json` have been reviewed and

--- a/docs/en/validation/evidence-bundle-verification-json-contract.md
+++ b/docs/en/validation/evidence-bundle-verification-json-contract.md
@@ -43,6 +43,7 @@ authenticity decision.
 | `signature_verified` | boolean | `true` means the manifest signature cryptographically verified under the trusted Ed25519 public key supplied to `--public-key`. |
 | `authenticity_ok` | boolean | `true` means reviewer-facing manifest authenticity was established by signature verification under the trusted public key. `false` means reviewer-facing authenticity was not established. |
 | `authenticity_failure` | string or null | Machine-readable authenticity failure reason. `null` is expected only when `authenticity_ok` is `true`. Current failure values include `signature_not_verified`, `signature_verification_failed`, `signature_verification_error`, and `signature_missing`. |
+| `public_key_fingerprint_sha256` | string or null | SHA-256 hex fingerprint of the public key file bytes supplied with `--public-key`, or `null` when no public key was supplied. This records which key material was used for verification; it does not by itself establish trust. Reviewers must still use an out-of-band reviewer/operator trust channel. |
 | `errors` | array of strings | Blocking diagnostics. If this array is non-empty, `ok` is `false`. UI consumers may display these as rejection/blocker reasons. |
 | `warnings` | array of strings | Non-blocking diagnostics for the current posture/mode. Warnings can still require reviewer attention, but they do not by themselves make `ok` false. |
 
@@ -70,14 +71,17 @@ Illustrative JSON shape:
   "signature_verified": true,
   "authenticity_ok": true,
   "authenticity_failure": null,
+  "public_key_fingerprint_sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
   "errors": [],
   "warnings": []
 }
 ```
 
 Reviewer/UI interpretation: the bundle passed strict reviewer-facing
-verification for file/hash integrity and manifest authenticity. This is still
-not regulatory certification or completed third-party audit approval.
+verification for file/hash integrity and manifest authenticity. The
+`public_key_fingerprint_sha256` value is supporting key-provenance evidence for
+which out-of-band key material was used; it is not a trust proof. This result is
+still not regulatory certification or completed third-party audit approval.
 
 ## Failure JSON shapes
 
@@ -100,6 +104,7 @@ Illustrative JSON shape:
   "signature_verified": false,
   "authenticity_ok": false,
   "authenticity_failure": "signature_not_verified",
+  "public_key_fingerprint_sha256": null,
   "errors": [
     "Manifest signature present but no signature verifier was provided; manifest authenticity was not verified",
     "No trusted public key supplied; manifest signature authenticity cannot be verified"
@@ -129,6 +134,7 @@ Illustrative JSON shape:
   "signature_verified": false,
   "authenticity_ok": false,
   "authenticity_failure": "signature_verification_failed",
+  "public_key_fingerprint_sha256": "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210",
   "errors": [
     "Manifest signature verification failed"
   ],
@@ -137,7 +143,9 @@ Illustrative JSON shape:
 ```
 
 Reviewer/UI interpretation: the hash-covered files can still match the manifest,
-but the supplied public key did not verify the manifest signature. Authenticity
+but the supplied public key did not verify the manifest signature. The
+fingerprint records the wrong supplied key material for later review; matching a
+fingerprint alone must not make a bundle-trusted key trustworthy. Authenticity
 failed.
 
 ### Malformed signature
@@ -158,6 +166,7 @@ Illustrative JSON shape:
   "signature_verified": false,
   "authenticity_ok": false,
   "authenticity_failure": "signature_verification_error",
+  "public_key_fingerprint_sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
   "errors": [
     "Manifest signature verification error: <parse-or-verifier-error>"
   ],
@@ -187,6 +196,7 @@ Illustrative JSON shape:
   "signature_verified": false,
   "authenticity_ok": false,
   "authenticity_failure": "signature_missing",
+  "public_key_fingerprint_sha256": null,
   "errors": [
     "Manifest signature missing"
   ],
@@ -205,5 +215,10 @@ reviewer-facing verified evidence.
 - Treat `authenticity_ok: false` as “authenticity not established,” even when
   `hash_integrity_ok: true`.
 - Display `errors` as blocking reviewer actions and `warnings` as review notes.
+- Record `public_key_fingerprint_sha256` with the reviewer/operator key handoff
+  notes as key-provenance evidence.
+- Never trust a key because its fingerprint matches a value copied from the
+  bundle or its adjacent artifacts; fingerprint matching is only useful after the
+  reviewer obtained the key through an out-of-band trust channel.
 - Record trusted public key provenance outside the bundle before relying on
   `signature_verified: true`.

--- a/docs/en/validation/sample-evidence-bundle-verification-output.md
+++ b/docs/en/validation/sample-evidence-bundle-verification-output.md
@@ -17,6 +17,10 @@ real bundle. Use it with the one-page
 - A trusted Ed25519 public key must come from an out-of-band
   reviewer/operator trust channel, not from a key copied only from the Evidence
   Bundle.
+- `public_key_fingerprint_sha256` records which public key file bytes were used
+  for verification. It is key-provenance evidence, not a trust proof; matching a
+  fingerprint copied from the bundle must never replace the out-of-band trust
+  channel.
 
 ## Strict verification command
 
@@ -55,6 +59,7 @@ Illustrative `--json` summary fields:
   "signature_verified": true,
   "authenticity_ok": true,
   "authenticity_failure": null,
+  "public_key_fingerprint_sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
   "errors": [],
   "warnings": []
 }
@@ -66,6 +71,8 @@ Reviewer interpretation:
   hashes recorded in `manifest.json`.
 - `Manifest signature: PASS` means the manifest signature verifies under the
   trusted Ed25519 public key supplied by the reviewer.
+- `public_key_fingerprint_sha256` should match the fingerprint the reviewer
+  recorded from the out-of-band trusted-key handoff.
 - The bundle is reviewer-facing verified only when both lines are `PASS` in the
   same strict verification run.
 
@@ -99,7 +106,8 @@ Illustrative `--json` summary fields:
   "signature_status": "not_verified",
   "signature_verified": false,
   "authenticity_ok": false,
-  "authenticity_failure": "signature_not_verified"
+  "authenticity_failure": "signature_not_verified",
+  "public_key_fingerprint_sha256": null
 }
 ```
 
@@ -140,7 +148,8 @@ Illustrative `--json` summary fields:
   "signature_status": "fail",
   "signature_verified": false,
   "authenticity_ok": false,
-  "authenticity_failure": "signature_verification_failed"
+  "authenticity_failure": "signature_verification_failed",
+  "public_key_fingerprint_sha256": "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
 }
 ```
 
@@ -149,7 +158,8 @@ Reviewer interpretation:
 - Hash-covered files still match `manifest.json`, so file/hash integrity can
   pass.
 - The supplied public key did not verify the manifest signature, so manifest
-  authenticity failed.
+  authenticity failed. The fingerprint records the supplied wrong key for later
+  evidence review; it does not make that key trustworthy.
 - Treat this as a failed reviewer verification even if the bundle content has
   not been hash-tampered.
 
@@ -162,9 +172,11 @@ alongside the files.
 
 Manifest authenticity requires `Manifest signature: PASS` under a trusted
 Ed25519 public key that the reviewer received out-of-band through the approved
-trust channel. A bundle with only `File/hash integrity: PASS` must remain
-unaccepted for external reviewer purposes until manifest authenticity is also
-verified.
+trust channel. The reviewer should record that trusted key fingerprint and
+compare it with `public_key_fingerprint_sha256`; a bundle-internal key or
+fingerprint is not sufficient. A bundle with only `File/hash integrity: PASS`
+must remain unaccepted for external reviewer purposes until manifest
+authenticity is also verified.
 
 
 ## Malformed signature failure
@@ -179,7 +191,8 @@ Illustrative `--json` summary fields:
   "signature_status": "fail",
   "signature_verified": false,
   "authenticity_ok": false,
-  "authenticity_failure": "signature_verification_error"
+  "authenticity_failure": "signature_verification_error",
+  "public_key_fingerprint_sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 }
 ```
 
@@ -205,7 +218,8 @@ Illustrative `--json` summary fields:
   "signature_status": "missing",
   "signature_verified": false,
   "authenticity_ok": false,
-  "authenticity_failure": "signature_missing"
+  "authenticity_failure": "signature_missing",
+  "public_key_fingerprint_sha256": null
 }
 ```
 

--- a/schemas/evidence_bundle_verification_result.schema.json
+++ b/schemas/evidence_bundle_verification_result.schema.json
@@ -13,6 +13,7 @@
     "signature_verified",
     "authenticity_ok",
     "authenticity_failure",
+    "public_key_fingerprint_sha256",
     "errors",
     "warnings"
   ],
@@ -70,6 +71,14 @@
         "type": "string"
       },
       "description": "Non-blocking diagnostics for the current posture/mode. Warnings may require reviewer attention but do not by themselves make ok false."
+    },
+    "public_key_fingerprint_sha256": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^[0-9a-f]{64}$",
+      "description": "SHA-256 hex fingerprint of the public key file bytes supplied with `--public-key`, or null when no public key was supplied. This records the public key material used for verification. It does not by itself establish trust. Trust still requires an out-of-band reviewer/operator trust channel."
     }
   }
 }

--- a/veritas_os/cli/evidence_bundle.py
+++ b/veritas_os/cli/evidence_bundle.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -55,6 +56,22 @@ def _build_signature_verifier(
         return verify_payload_signature(payload_hash, signature_b64, public_key_path)
 
     return _verify
+
+
+def _public_key_fingerprint_sha256(public_key_path: Optional[Path]) -> Optional[str]:
+    """Return the SHA-256 hex fingerprint of supplied public key bytes.
+
+    The fingerprint records which public key material was supplied for
+    verification. It does not establish trust; reviewers must still obtain and
+    validate the public key through an out-of-band trust channel.
+    """
+    if public_key_path is None:
+        return None
+    try:
+        public_key_bytes = public_key_path.read_bytes()
+    except OSError:
+        return None
+    return hashlib.sha256(public_key_bytes).hexdigest()
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -133,12 +150,14 @@ def main(argv: Optional[list[str]] = None) -> int:
         return 0
 
     require_signature = args.require_signature or _is_fail_closed_posture()
+    public_key_fingerprint_sha256 = _public_key_fingerprint_sha256(args.public_key)
     verify_signature_fn = _build_signature_verifier(args.public_key)
     verify_result: Dict[str, Any] = verify_evidence_bundle(
         args.bundle_dir,
         verify_signature_fn=verify_signature_fn,
         require_signature=require_signature,
     )
+    verify_result["public_key_fingerprint_sha256"] = public_key_fingerprint_sha256
     if args.public_key is None:
         key_warning = (
             "No trusted public key supplied; manifest signature authenticity "

--- a/veritas_os/tests/test_evidence_bundle_cli.py
+++ b/veritas_os/tests/test_evidence_bundle_cli.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import base64
+import hashlib
 import json
+import re
 from pathlib import Path
 from typing import Any
 
@@ -21,6 +23,7 @@ CONTRACT_JSON_FIELDS = {
     "signature_verified",
     "authenticity_ok",
     "authenticity_failure",
+    "public_key_fingerprint_sha256",
     "errors",
     "warnings",
 }
@@ -44,6 +47,10 @@ def _assert_contract_fields(output: dict[str, Any]) -> None:
     assert isinstance(output["authenticity_ok"], bool)
     assert output["authenticity_failure"] is None or isinstance(
         output["authenticity_failure"],
+        str,
+    )
+    assert output["public_key_fingerprint_sha256"] is None or isinstance(
+        output["public_key_fingerprint_sha256"],
         str,
     )
     assert isinstance(output["errors"], list)
@@ -77,6 +84,15 @@ def test_evidence_bundle_verification_result_schema_contract() -> None:
     )
     assert "trusted Ed25519 public key" in (
         schema["properties"]["signature_verified"]["description"]
+    )
+    fingerprint_description = (
+        schema["properties"]["public_key_fingerprint_sha256"]["description"]
+    )
+    assert "public key material used for verification" in fingerprint_description
+    assert "does not by itself establish trust" in fingerprint_description
+    assert "out-of-band reviewer/operator trust channel" in fingerprint_description
+    assert schema["properties"]["public_key_fingerprint_sha256"]["pattern"] == (
+        "^[0-9a-f]{64}$"
     )
     assert "not regulatory certification" in schema["description"]
 
@@ -331,6 +347,13 @@ def test_evidence_bundle_cli_strict_success_json_contract(
     assert output["signature_verified"] is True
     assert output["authenticity_ok"] is True
     assert output["authenticity_failure"] is None
+    assert re.fullmatch(
+        r"[0-9a-f]{64}",
+        output["public_key_fingerprint_sha256"],
+    )
+    assert output["public_key_fingerprint_sha256"] == hashlib.sha256(
+        public_key.read_bytes()
+    ).hexdigest()
     assert output["errors"] == []
 
 
@@ -462,6 +485,7 @@ def test_evidence_bundle_cli_missing_public_key_json_contract(
     assert output["signature_verified"] is False
     assert output["authenticity_ok"] is False
     assert output["authenticity_failure"] == "signature_not_verified"
+    assert output["public_key_fingerprint_sha256"] is None
     assert any("No trusted public key supplied" in e for e in output["errors"])
 
 
@@ -557,6 +581,9 @@ def test_evidence_bundle_cli_wrong_key_json_contract(
     assert output["signature_verified"] is False
     assert output["authenticity_ok"] is False
     assert output["authenticity_failure"] == "signature_verification_failed"
+    assert output["public_key_fingerprint_sha256"] == hashlib.sha256(
+        wrong_public_key.read_bytes()
+    ).hexdigest()
     assert "Manifest signature verification failed" in output["errors"]
 
 
@@ -704,6 +731,7 @@ def test_evidence_bundle_cli_secure_unsigned_json_contract(
     assert output["signature_verified"] is False
     assert output["authenticity_ok"] is False
     assert output["authenticity_failure"] == "signature_missing"
+    assert output["public_key_fingerprint_sha256"] is None
     assert "Manifest signature missing" in output["errors"]
 
 
@@ -731,6 +759,7 @@ def test_evidence_bundle_cli_dev_without_public_key_warns_and_reports_json(
     assert exit_code == 0
     assert output["signature_verified"] is False
     assert output["signature_status"] == "not_verified"
+    assert output["public_key_fingerprint_sha256"] is None
     assert any("authenticity was not verified" in w for w in output["warnings"])
 
 


### PR DESCRIPTION
### Motivation
- Record which public-key material was used to perform manifest signature verification so reviewers can later correlate the trusted key provenance with the verification run.\n- The fingerprint must be an audit/provenance aid and explicitly must not be treated as a trust proof.\n- Keep human CLI output stable and focus the change on the machine-readable `--json` contract and schema.\n
### Description
- CLI: added `_public_key_fingerprint_sha256()` and attach `public_key_fingerprint_sha256` (SHA-256 hex of the public key file bytes) to the `verify --json` result, with `null` when no `--public-key` was supplied and OSError-safe reading.\n- Schema: updated `schemas/evidence_bundle_verification_result.schema.json` to require `public_key_fingerprint_sha256` as `string|null` with a `^[0-9a-f]{64}$` pattern and descriptive text noting it records key material but does not establish trust.\n- Docs: updated `docs/en/validation/evidence-bundle-verification-json-contract.md`, `docs/en/validation/evidence-bundle-reviewer-checklist.md`, and `docs/en/validation/sample-evidence-bundle-verification-output.md` to document fingerprint semantics, provenance guidance, and reviewer checklist changes.\n- Tests: extended `veritas_os/tests/test_evidence_bundle_cli.py` to validate the new contract field in success/missing/wrong-key/malformed-signature cases and to assert schema-driven expectations for the fingerprint.\n
### Testing
- Compiled modified modules: `python -m py_compile veritas_os/cli/evidence_bundle.py veritas_os/tests/test_evidence_bundle_cli.py` succeeded.\n- JSON schema sanitization: `python -m json.tool schemas/evidence_bundle_verification_result.schema.json` succeeded and the tests include `jsonschema.Draft202012Validator.check_schema` assertions.\n- Full test run: `pytest -q veritas_os/tests/test_evidence_bundle_cli.py` was attempted but blocked by the environment (missing runtime dependencies such as `pydantic`) and by network access needed to install test deps, so the updated test suite could not be executed end-to-end in this environment.\n- Note: human CLI output was intentionally not changed; this is a JSON-contract-first change and tests exercise the JSON results where possible.\n

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27a38bfab083269bb6e71401a5bb9c)