### PR TITLE
feat: add --output to veritas-evidence-bundle verify to persist JSON verification result

### DIFF
--- a/docs/en/validation/evidence-bundle-reviewer-checklist.md
+++ b/docs/en/validation/evidence-bundle-reviewer-checklist.md
@@ -33,13 +33,33 @@ Security boundaries:
 - Do not add private keys, real signing keys, production secrets, or unsanitized
   customer data to review notes or shared examples.
 
+## Saving JSON reviewer evidence
+
+Reviewers can preserve a machine-readable audit trail by adding
+`--json --output <path>` to strict verification:
+
+```bash
+veritas-evidence-bundle verify \
+  --bundle-dir <bundle_dir> \
+  --public-key <trusted_ed25519_public_key> \
+  --require-signature \
+  --json \
+  --output evidence-bundle-verification-result.json
+```
+
+The saved verification result is reviewer evidence, including when verification
+fails. It is not regulatory certification and is not completed third-party audit
+approval. Interpret the saved JSON with the out-of-band trusted public key
+handoff record; `public_key_fingerprint_sha256` helps correlate the saved result
+with that key provenance record, but does not itself establish trust.
+
 ## Verification order
 
 | Step | Reviewer action | PASS criterion | FAIL / follow-up criterion |
 |---|---|---|---|
 | 1 | Confirm bundle origin and expected handoff channel. | The bundle source, transfer channel, bundle type, and review objective match the expected handoff. | The source or channel is unexpected, undocumented, or inconsistent with the review request. |
 | 2 | Obtain the trusted Ed25519 public key out-of-band. | The reviewer obtains the public key from a trusted registry, signed operator note, KMS/certificate process, or other approved channel outside the bundle, and records the expected SHA-256 fingerprint. | The public key is missing, comes only from inside the bundle, its fingerprint is copied only from bundle-adjacent material, or its provenance cannot be established. |
-| 3 | Run the strict verification command. | The reviewer runs `veritas-evidence-bundle verify --bundle-dir <bundle_dir> --public-key <trusted_ed25519_public_key> --require-signature`. | The command is not run, omits `--require-signature`, omits the trusted public key, or uses an untrusted key path. |
+| 3 | Run the strict verification command. | The reviewer runs `veritas-evidence-bundle verify --bundle-dir <bundle_dir> --public-key <trusted_ed25519_public_key> --require-signature`; add `--json --output <path>` when a saved JSON evidence file is required. | The command is not run, omits `--require-signature`, omits the trusted public key, or uses an untrusted key path. |
 | 4 | Confirm `File/hash integrity: PASS`. | The CLI prints `File/hash integrity: PASS` in the strict verification run. | The CLI reports hash failure, manifest hash mismatch, missing files, malformed manifest data, or any file/hash error. |
 | 5 | Confirm `Manifest signature: PASS`. | The CLI prints `Manifest signature: PASS` under the trusted Ed25519 public key obtained in Step 2. For `--json`, `authenticity_ok` is `true`, `signature_status` is `pass`, `signature_verified` is `true`, and `public_key_fingerprint_sha256` matches the out-of-band key fingerprint recorded by the reviewer. | The CLI reports missing public key, wrong key, malformed signature, unsigned secure/prod bundle, signature verification failure, or a fingerprint mismatch against the out-of-band reviewer record. For `--json`, `authenticity_ok` is `false`. |
 | 6 | Inspect `acceptance_checklist.json`. | The checklist exists and has no blocking failures for the submitted bundle profile. | The checklist is missing, malformed, incomplete, or contains any blocking failure. |

--- a/docs/en/validation/evidence-bundle-verification-json-contract.md
+++ b/docs/en/validation/evidence-bundle-verification-json-contract.md
@@ -19,6 +19,37 @@ itself.
 Machine-readable validation is pinned in the JSON Schema at
 [`schemas/evidence_bundle_verification_result.schema.json`](../../../schemas/evidence_bundle_verification_result.schema.json).
 
+## Saving reviewer evidence to a file
+
+Use `--output <path>` with `--json` to save the exact JSON verification result
+as UTF-8 reviewer evidence while still emitting the same JSON to stdout:
+
+```bash
+veritas-evidence-bundle verify \
+  --bundle-dir <bundle_dir> \
+  --public-key <trusted_ed25519_public_key> \
+  --require-signature \
+  --json \
+  --output evidence-bundle-verification-result.json
+```
+
+The saved file is evidence of the verification result observed by the reviewer.
+It is not regulatory certification and is not completed third-party audit
+approval. Failed verification results are also written when `--output` is used,
+because failure JSON is important audit evidence for missing keys, wrong keys,
+tampering, or other verification blockers.
+
+`--output` is reserved for the machine-readable JSON result and therefore
+requires `--json`; human-oriented CLI output remains unchanged when `--json` is
+not selected. If the result file cannot be written, the CLI exits non-zero and
+prints a clear write-failure diagnostic.
+
+Saved results must be interpreted together with out-of-band trusted public key
+provenance. `public_key_fingerprint_sha256` helps correlate the saved result
+with the reviewer/operator key handoff record, but the fingerprint does not by
+itself establish trust and a key copied only from the bundle must not be used as
+a trust source.
+
 ## Contract scope
 
 The contract separates two reviewer decisions that external UI and audit tooling

--- a/docs/en/validation/sample-evidence-bundle-verification-output.md
+++ b/docs/en/validation/sample-evidence-bundle-verification-output.md
@@ -38,6 +38,27 @@ integrity and manifest signature success. JSON consumers should use the stable
 contract fields documented in
 [Evidence Bundle Verification JSON Contract](evidence-bundle-verification-json-contract.md).
 
+## Saving the JSON result
+
+When reviewers need a durable evidence artifact, add `--json --output <path>`:
+
+```bash
+veritas-evidence-bundle verify \
+  --bundle-dir <bundle_dir> \
+  --public-key <trusted_ed25519_public_key> \
+  --require-signature \
+  --json \
+  --output evidence-bundle-verification-result.json
+```
+
+The CLI writes the same JSON result to stdout and to the UTF-8 output file. The
+saved verification result is reviewer evidence, including for failed
+verification attempts such as missing public keys or wrong public keys. It is
+not regulatory certification and is not completed third-party audit approval.
+Reviewers must interpret the file with out-of-band trusted public key
+provenance; `public_key_fingerprint_sha256` helps correlate the saved result
+with the key handoff record, but does not make the key trustworthy on its own.
+
 ## Successful strict verification
 
 Illustrative output:

--- a/veritas_os/cli/evidence_bundle.py
+++ b/veritas_os/cli/evidence_bundle.py
@@ -6,6 +6,7 @@ import argparse
 import hashlib
 import json
 import os
+import sys
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional
 
@@ -74,6 +75,22 @@ def _public_key_fingerprint_sha256(public_key_path: Optional[Path]) -> Optional[
     return hashlib.sha256(public_key_bytes).hexdigest()
 
 
+def _dump_json_result(result: Dict[str, Any]) -> str:
+    """Serialize a verification result with the stable CLI JSON formatting."""
+    return json.dumps(result, indent=2, sort_keys=True, ensure_ascii=False)
+
+
+def _write_verification_result(output_path: Path, result: Dict[str, Any]) -> None:
+    """Write the verification result as UTF-8 JSON reviewer evidence.
+
+    Failed verification results are intentionally written too: they are audit
+    evidence that a reviewer attempted strict verification and received a
+    machine-readable failure result.
+    """
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(_dump_json_result(result) + "\n", encoding="utf-8")
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Build argparse parser for evidence bundle CLI."""
     parser = argparse.ArgumentParser(description="Generate/verify VERITAS evidence bundles")
@@ -110,6 +127,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="Fail when the manifest signature is missing or cannot be verified",
     )
     verify.add_argument("--json", action="store_true")
+    verify.add_argument(
+        "--output",
+        type=Path,
+        help=(
+            "Write the JSON verification result to this UTF-8 file. "
+            "Requires --json and does not suppress stdout JSON."
+        ),
+    )
 
     return parser
 
@@ -149,6 +174,10 @@ def main(argv: Optional[list[str]] = None) -> int:
             print(f"entry_count={result['entry_count']}")
         return 0
 
+    if args.output is not None and not args.json:
+        parser.error("verify --output requires --json")
+        return 2
+
     require_signature = args.require_signature or _is_fail_closed_posture()
     public_key_fingerprint_sha256 = _public_key_fingerprint_sha256(args.public_key)
     verify_signature_fn = _build_signature_verifier(args.public_key)
@@ -170,8 +199,18 @@ def main(argv: Optional[list[str]] = None) -> int:
         elif key_warning not in verify_result["warnings"]:
             verify_result["warnings"].append(key_warning)
 
+    if args.output is not None:
+        try:
+            _write_verification_result(args.output, verify_result)
+        except OSError as exc:
+            print(
+                f"error: failed to write verification result to {args.output}: {exc}",
+                file=sys.stderr,
+            )
+            return 2
+
     if args.json:
-        print(json.dumps(verify_result, indent=2, sort_keys=True, ensure_ascii=False))
+        print(_dump_json_result(verify_result))
     else:
         status = "PASS" if verify_result.get("ok") else "FAIL"
         hash_status = "PASS" if verify_result.get("hash_integrity_ok") else "FAIL"

--- a/veritas_os/tests/test_evidence_bundle_cli.py
+++ b/veritas_os/tests/test_evidence_bundle_cli.py
@@ -357,6 +357,196 @@ def test_evidence_bundle_cli_strict_success_json_contract(
     assert output["errors"] == []
 
 
+def _assert_written_result_matches_stdout(
+    output_path: Path,
+    stdout: str,
+) -> dict[str, Any]:
+    """Assert saved verification JSON exactly mirrors stdout and schema."""
+    assert output_path.read_text(encoding="utf-8") == stdout
+    output = json.loads(stdout)
+    _assert_contract_fields(output)
+    return output
+
+
+def test_evidence_bundle_cli_strict_success_json_output_file(
+    tmp_path,
+    monkeypatch,
+    capsys,
+) -> None:
+    """Strict success --json result can be saved as reviewer evidence."""
+    from veritas_os.cli.evidence_bundle import main
+
+    monkeypatch.setenv("VERITAS_POSTURE", "dev")
+    bundle_dir, _private_key, public_key = _signed_bundle(tmp_path, monkeypatch)
+    output_path = tmp_path / "review" / "strict-success-result.json"
+
+    exit_code = main(
+        [
+            "verify",
+            "--bundle-dir",
+            str(bundle_dir),
+            "--public-key",
+            str(public_key),
+            "--require-signature",
+            "--json",
+            "--output",
+            str(output_path),
+        ]
+    )
+    output = _assert_written_result_matches_stdout(
+        output_path,
+        capsys.readouterr().out,
+    )
+
+    assert exit_code == 0
+    assert output["ok"] is True
+    assert output["signature_status"] == "pass"
+    assert output["signature_verified"] is True
+    assert output["public_key_fingerprint_sha256"] == hashlib.sha256(
+        public_key.read_bytes()
+    ).hexdigest()
+
+
+def test_evidence_bundle_cli_missing_public_key_json_output_file(
+    tmp_path,
+    monkeypatch,
+    capsys,
+) -> None:
+    """Strict missing-key --json failure can be saved as audit evidence."""
+    from veritas_os.cli.evidence_bundle import main
+
+    monkeypatch.setenv("VERITAS_POSTURE", "dev")
+    bundle_dir, _private_key, _public_key = _signed_bundle(tmp_path, monkeypatch)
+    output_path = tmp_path / "missing-key-result.json"
+
+    exit_code = main(
+        [
+            "verify",
+            "--bundle-dir",
+            str(bundle_dir),
+            "--require-signature",
+            "--json",
+            "--output",
+            str(output_path),
+        ]
+    )
+    output = _assert_written_result_matches_stdout(
+        output_path,
+        capsys.readouterr().out,
+    )
+
+    assert exit_code == 1
+    assert output["ok"] is False
+    assert output["signature_status"] == "not_verified"
+    assert output["authenticity_failure"] == "signature_not_verified"
+    assert output["public_key_fingerprint_sha256"] is None
+
+
+def test_evidence_bundle_cli_wrong_key_json_output_file(
+    tmp_path,
+    monkeypatch,
+    capsys,
+) -> None:
+    """Strict wrong-key --json failure can be saved as audit evidence."""
+    from veritas_os.cli.evidence_bundle import main
+    from veritas_os.security.signing import store_keypair
+
+    monkeypatch.setenv("VERITAS_POSTURE", "dev")
+    bundle_dir, _private_key, _public_key = _signed_bundle(tmp_path, monkeypatch)
+    wrong_private_key = tmp_path / "wrong_output_keys" / "priv.key"
+    wrong_public_key = tmp_path / "wrong_output_keys" / "pub.key"
+    store_keypair(wrong_private_key, wrong_public_key)
+    output_path = tmp_path / "wrong-key-result.json"
+
+    exit_code = main(
+        [
+            "verify",
+            "--bundle-dir",
+            str(bundle_dir),
+            "--public-key",
+            str(wrong_public_key),
+            "--require-signature",
+            "--json",
+            "--output",
+            str(output_path),
+        ]
+    )
+    output = _assert_written_result_matches_stdout(
+        output_path,
+        capsys.readouterr().out,
+    )
+
+    assert exit_code == 1
+    assert output["ok"] is False
+    assert output["signature_status"] == "fail"
+    assert output["authenticity_failure"] == "signature_verification_failed"
+    assert output["public_key_fingerprint_sha256"] == hashlib.sha256(
+        wrong_public_key.read_bytes()
+    ).hexdigest()
+
+
+def test_evidence_bundle_cli_output_requires_json(
+    tmp_path,
+    monkeypatch,
+    capsys,
+) -> None:
+    """--output is reserved for JSON verification results."""
+    from veritas_os.cli.evidence_bundle import main
+
+    monkeypatch.setenv("VERITAS_POSTURE", "dev")
+    bundle_dir, _private_key, public_key = _signed_bundle(tmp_path, monkeypatch)
+
+    with pytest.raises(SystemExit) as excinfo:
+        main(
+            [
+                "verify",
+                "--bundle-dir",
+                str(bundle_dir),
+                "--public-key",
+                str(public_key),
+                "--require-signature",
+                "--output",
+                str(tmp_path / "result.json"),
+            ]
+        )
+
+    assert excinfo.value.code == 2
+    assert "verify --output requires --json" in capsys.readouterr().err
+
+
+def test_evidence_bundle_cli_output_write_failure_is_clear(
+    tmp_path,
+    monkeypatch,
+    capsys,
+) -> None:
+    """A result write failure exits non-zero with a clear stderr message."""
+    from veritas_os.cli.evidence_bundle import main
+
+    monkeypatch.setenv("VERITAS_POSTURE", "dev")
+    bundle_dir, _private_key, public_key = _signed_bundle(tmp_path, monkeypatch)
+    output_path = tmp_path / "existing-directory"
+    output_path.mkdir()
+
+    exit_code = main(
+        [
+            "verify",
+            "--bundle-dir",
+            str(bundle_dir),
+            "--public-key",
+            str(public_key),
+            "--require-signature",
+            "--json",
+            "--output",
+            str(output_path),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert captured.out == ""
+    assert "failed to write verification result" in captured.err
+
+
 def test_evidence_bundle_cli_verify_tampered_manifest_signature_fails(
     tmp_path,
     monkeypatch,


### PR DESCRIPTION
### Motivation
- Reviewers and auditors need a durable, machine-readable copy of `veritas-evidence-bundle verify --json` output for audit evidence and offline handoff. 
- The CLI must preserve existing stdout behavior while optionally writing the exact same JSON to a UTF-8 file for provenance and post-hoc review. 
- Saved results must be explicit about not being regulatory certification and must be correlated with out-of-band trusted-key provenance. 

### Description
- Add `--output <path>` to the `verify` subcommand and require `--json` when `--output` is supplied, returning a clear error when used incorrectly. (added argparse option and argument validation in `veritas_os/cli/evidence_bundle.py`).
- Implement `_dump_json_result` and `_write_verification_result` helpers and write the verification JSON to the requested path (creating parent dirs) while preserving the same JSON on stdout. Write failures print a descriptive stderr message and exit non-zero. (`veritas_os/cli/evidence_bundle.py`).
- Ensure `public_key_fingerprint_sha256` remains present in the persisted JSON and that failed verification results are intentionally written as audit evidence. (`verify_result` handling). 
- Add schema-validating tests that assert file write behavior and exact stdout/file equality for strict success, missing-public-key, wrong-key, the `--output` requires `--json` case, and a write-failure diagnostic. (tests added to `veritas_os/tests/test_evidence_bundle_cli.py`).
- Update reviewer docs to document `--json --output <path>` usage, failure-result persistence, write-failure semantics, and guidance about interpreting saved JSON with out-of-band key provenance. (docs updated: `docs/en/validation/evidence-bundle-verification-json-contract.md`, `docs/en/validation/evidence-bundle-reviewer-checklist.md`, and `docs/en/validation/sample-evidence-bundle-verification-output.md`).

### Testing
- Lint/type checks: `ruff check` passed for the modified files under a compatible interpreter. 
- Syntax checks: `python3 -m py_compile` succeeded for `veritas_os/cli/evidence_bundle.py`, the modified tests, and the docs-check script. 
- Docs guard: `scripts/quality/check_evidence_bundle_reviewer_docs.py` passed and verified the updated documentation links and safety language. 
- Test runs: attempting to run `pytest` was blocked by environment constraints and missing dependencies (repository `.python-version` targets Python 3.12.12 which is not available in this environment, missing runtime dependencies such as `pydantic`, and a PyPI fetch failure during dependency sync), so the new unit tests were added but not executed here; they are self-contained and schema-validated in CI where the full test environment is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27a8bd090c8326a37ccac8bb51603a)