### PR TITLE
feat(evidence-bundle): add `validate-result` CLI to schema-validate saved verification JSON

### DIFF
--- a/docs/en/validation/evidence-bundle-reviewer-checklist.md
+++ b/docs/en/validation/evidence-bundle-reviewer-checklist.md
@@ -53,6 +53,21 @@ approval. Interpret the saved JSON with the out-of-band trusted public key
 handoff record; `public_key_fingerprint_sha256` helps correlate the saved result
 with that key provenance record, but does not itself establish trust.
 
+To validate only the saved result shape later, run:
+
+```bash
+veritas-evidence-bundle validate-result \
+  --result evidence-bundle-verification-result.json
+```
+
+`validate-result` checks JSON parsing and the saved result schema, including
+required fields, `signature_status` enum values, and
+`public_key_fingerprint_sha256` null-or-lowercase-hex shape. It does not re-run
+file/hash integrity checks or Ed25519 signature verification, does not establish
+trusted key provenance, and is not regulatory certification or completed
+third-party audit approval. Preserve the out-of-band trusted-key provenance
+record even when saved-result schema validation passes.
+
 ## Verification order
 
 | Step | Reviewer action | PASS criterion | FAIL / follow-up criterion |

--- a/docs/en/validation/evidence-bundle-verification-json-contract.md
+++ b/docs/en/validation/evidence-bundle-verification-json-contract.md
@@ -50,6 +50,37 @@ with the reviewer/operator key handoff record, but the fingerprint does not by
 itself establish trust and a key copied only from the bundle must not be used as
 a trust source.
 
+## Validating a saved result against the schema
+
+Use `validate-result --result <path>` to check later that a saved verification
+result JSON file still conforms to the machine-readable schema:
+
+```bash
+veritas-evidence-bundle validate-result \
+  --result evidence-bundle-verification-result.json
+```
+
+A schema-valid saved result prints:
+
+```text
+Evidence bundle verification result schema: PASS
+```
+
+A malformed or schema-invalid saved result exits non-zero, prints
+`Evidence bundle verification result schema: FAIL`, and includes diagnostics for
+missing required fields, invalid field types, invalid enum values such as
+`signature_status`, and invalid patterns such as
+`public_key_fingerprint_sha256` values that are not `null` or 64-character
+lowercase hexadecimal strings.
+
+Schema validation confirms the saved result document shape only. It does not
+re-run Evidence Bundle file/hash checks, does not re-run Ed25519 manifest
+signature verification, does not establish trusted key provenance, and is not
+regulatory certification or completed third-party audit approval. Reviewers must
+still preserve out-of-band trusted public key provenance for the key represented
+by `public_key_fingerprint_sha256` before relying on any saved strict
+verification result.
+
 ## Contract scope
 
 The contract separates two reviewer decisions that external UI and audit tooling

--- a/docs/en/validation/sample-evidence-bundle-verification-output.md
+++ b/docs/en/validation/sample-evidence-bundle-verification-output.md
@@ -59,6 +59,33 @@ Reviewers must interpret the file with out-of-band trusted public key
 provenance; `public_key_fingerprint_sha256` helps correlate the saved result
 with the key handoff record, but does not make the key trustworthy on its own.
 
+## Validating a saved JSON result shape
+
+A saved verification result can be checked later against the JSON Schema:
+
+```bash
+veritas-evidence-bundle validate-result \
+  --result evidence-bundle-verification-result.json
+```
+
+Illustrative success output:
+
+```text
+Evidence bundle verification result schema: PASS
+```
+
+Illustrative failure output:
+
+```text
+Evidence bundle verification result schema: FAIL
+  error at $['signature_status']: 'verified' is not one of ['pass', 'fail', 'missing', 'not_verified']
+```
+
+This schema validation confirms result shape only. It does not re-run
+cryptographic verification, does not establish out-of-band trusted key
+provenance, and is not regulatory certification or completed third-party audit
+approval.
+
 ## Successful strict verification
 
 Illustrative output:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
   "orjson==3.11.6",
   "PyYAML==6.0.1",
   "jinja2==3.1.6",
+  "jsonschema==4.23.0",
   # --- LLM integration (required) ---
   "openai==1.51.0",
   "httpx==0.27.2",
@@ -87,7 +88,6 @@ dev = [
   "pytest==9.0.3",
   "pytest-asyncio==1.3.0",
   "pytest-cov==6.0.0",
-  "jsonschema==4.23.0",
   "fastapi==0.121.0",
   "httpx==0.27.2",
   "mypy==1.13.0",

--- a/veritas_os/cli/evidence_bundle.py
+++ b/veritas_os/cli/evidence_bundle.py
@@ -10,6 +10,8 @@ import sys
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional
 
+import jsonschema
+
 from veritas_os.audit.evidence_bundle import generate_evidence_bundle
 from veritas_os.audit.verify_bundle import verify_evidence_bundle
 from veritas_os.security.signing import verify_payload_signature
@@ -29,6 +31,11 @@ def _parse_key_value_pairs(values: Optional[list[str]]) -> Dict[str, str]:
 
 
 SECURE_POSTURES = {"secure", "prod"}
+VERIFICATION_RESULT_SCHEMA_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "schemas"
+    / "evidence_bundle_verification_result.schema.json"
+)
 
 
 def _is_fail_closed_posture() -> bool:
@@ -73,6 +80,62 @@ def _public_key_fingerprint_sha256(public_key_path: Optional[Path]) -> Optional[
     except OSError:
         return None
     return hashlib.sha256(public_key_bytes).hexdigest()
+
+
+def _format_json_schema_error(error: jsonschema.ValidationError) -> str:
+    """Format a JSON Schema validation error for CLI diagnostics."""
+    path = "$"
+    if error.absolute_path:
+        path += "".join(f"[{item!r}]" for item in error.absolute_path)
+    return f"error at {path}: {error.message}"
+
+
+def _validate_verification_result_schema(result_path: Path) -> list[str]:
+    """Validate a saved Evidence Bundle verification result JSON file.
+
+    The validation is intentionally limited to the saved result document shape.
+    It does not re-run Evidence Bundle hash checks or Ed25519 signature
+    verification, and it does not establish trusted public key provenance.
+    """
+    try:
+        raw_result = result_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [f"failed to read result file {result_path}: {exc}"]
+
+    try:
+        result = json.loads(raw_result)
+    except json.JSONDecodeError as exc:
+        return [
+            "malformed JSON: "
+            f"line {exc.lineno}, column {exc.colno}: {exc.msg}"
+        ]
+
+    try:
+        schema = json.loads(
+            VERIFICATION_RESULT_SCHEMA_PATH.read_text(encoding="utf-8")
+        )
+    except (OSError, json.JSONDecodeError) as exc:
+        return [f"failed to load verification result schema: {exc}"]
+
+    validator = jsonschema.Draft202012Validator(schema)
+    errors = sorted(
+        validator.iter_errors(result),
+        key=lambda error: (list(error.absolute_path), error.message),
+    )
+    return [_format_json_schema_error(error) for error in errors]
+
+
+def _run_validate_result(result_path: Path) -> int:
+    """Run saved verification result JSON Schema validation and print status."""
+    errors = _validate_verification_result_schema(result_path)
+    if not errors:
+        print("Evidence bundle verification result schema: PASS")
+        return 0
+
+    print("Evidence bundle verification result schema: FAIL")
+    for error in errors:
+        print(f"  {error}")
+    return 1
 
 
 def _dump_json_result(result: Dict[str, Any]) -> str:
@@ -136,6 +199,17 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
 
+    validate = sub.add_parser(
+        "validate-result",
+        help="Validate a saved verification result JSON file against the schema",
+    )
+    validate.add_argument(
+        "--result",
+        required=True,
+        type=Path,
+        help="Saved JSON result file from verify --json --output",
+    )
+
     return parser
 
 
@@ -173,6 +247,9 @@ def main(argv: Optional[list[str]] = None) -> int:
             print(f"manifest_hash={result['manifest_hash']}")
             print(f"entry_count={result['entry_count']}")
         return 0
+
+    if args.command == "validate-result":
+        return _run_validate_result(args.result)
 
     if args.output is not None and not args.json:
         parser.error("verify --output requires --json")

--- a/veritas_os/requirements-core.txt
+++ b/veritas_os/requirements-core.txt
@@ -5,6 +5,7 @@ python-dotenv==1.2.2
 orjson==3.11.6
 PyYAML==6.0.1
 jinja2==3.1.6
+jsonschema==4.23.0
 openai==1.51.0
 httpx==0.27.2
 numpy==1.26.4

--- a/veritas_os/requirements.txt
+++ b/veritas_os/requirements.txt
@@ -23,6 +23,7 @@ python-dotenv==1.2.2
 orjson==3.11.6
 PyYAML==6.0.1
 jinja2==3.1.6
+jsonschema==4.23.0
 
 # --- Core: LLM Integration ---
 openai==1.51.0
@@ -68,5 +69,4 @@ alembic==1.18.4
 pytest==9.0.3
 pytest-asyncio==1.3.0
 pytest-cov==6.0.0
-jsonschema==4.23.0
 mypy==1.13.0

--- a/veritas_os/tests/test_evidence_bundle_cli.py
+++ b/veritas_os/tests/test_evidence_bundle_cli.py
@@ -968,3 +968,121 @@ def test_verify_bundle_signed_manifest_without_verifier_warns(
     assert result["signature_verified"] is False
     assert result["signature_status"] == "not_verified"
     assert any("no signature verifier" in w for w in result["warnings"])
+
+
+def _valid_verification_result_payload() -> dict[str, Any]:
+    """Return a minimal schema-valid saved verification result payload."""
+    return {
+        "ok": True,
+        "tampered": False,
+        "hash_integrity_ok": True,
+        "signature_status": "pass",
+        "signature_verified": True,
+        "authenticity_ok": True,
+        "authenticity_failure": None,
+        "public_key_fingerprint_sha256": "a" * 64,
+        "errors": [],
+        "warnings": [],
+    }
+
+
+def _write_result_payload(path: Path, payload: dict[str, Any]) -> None:
+    """Write a saved verification result fixture as UTF-8 JSON."""
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_evidence_bundle_cli_validate_result_valid_saved_result_passes(
+    tmp_path,
+    capsys,
+) -> None:
+    """validate-result accepts a saved verification result that matches schema."""
+    from veritas_os.cli.evidence_bundle import main
+
+    result_path = tmp_path / "valid-result.json"
+    _write_result_payload(result_path, _valid_verification_result_payload())
+
+    exit_code = main(["validate-result", "--result", str(result_path)])
+    output = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert output == "Evidence bundle verification result schema: PASS\n"
+
+
+def test_evidence_bundle_cli_validate_result_missing_required_field_fails(
+    tmp_path,
+    capsys,
+) -> None:
+    """validate-result reports the missing required contract field."""
+    from veritas_os.cli.evidence_bundle import main
+
+    result_path = tmp_path / "missing-field-result.json"
+    payload = _valid_verification_result_payload()
+    del payload["signature_verified"]
+    _write_result_payload(result_path, payload)
+
+    exit_code = main(["validate-result", "--result", str(result_path)])
+    output = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "Evidence bundle verification result schema: FAIL" in output
+    assert "'signature_verified' is a required property" in output
+
+
+def test_evidence_bundle_cli_validate_result_invalid_signature_status_fails(
+    tmp_path,
+    capsys,
+) -> None:
+    """validate-result reports invalid signature_status enum values."""
+    from veritas_os.cli.evidence_bundle import main
+
+    result_path = tmp_path / "invalid-status-result.json"
+    payload = _valid_verification_result_payload()
+    payload["signature_status"] = "verified"
+    _write_result_payload(result_path, payload)
+
+    exit_code = main(["validate-result", "--result", str(result_path)])
+    output = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "Evidence bundle verification result schema: FAIL" in output
+    assert "$['signature_status']" in output
+    assert "'verified' is not one of" in output
+
+
+def test_evidence_bundle_cli_validate_result_invalid_fingerprint_pattern_fails(
+    tmp_path,
+    capsys,
+) -> None:
+    """validate-result reports invalid public_key_fingerprint_sha256 patterns."""
+    from veritas_os.cli.evidence_bundle import main
+
+    result_path = tmp_path / "invalid-fingerprint-result.json"
+    payload = _valid_verification_result_payload()
+    payload["public_key_fingerprint_sha256"] = "A" * 64
+    _write_result_payload(result_path, payload)
+
+    exit_code = main(["validate-result", "--result", str(result_path)])
+    output = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "Evidence bundle verification result schema: FAIL" in output
+    assert "$['public_key_fingerprint_sha256']" in output
+    assert "does not match '^[0-9a-f]{64}$'" in output
+
+
+def test_evidence_bundle_cli_validate_result_malformed_json_fails_clearly(
+    tmp_path,
+    capsys,
+) -> None:
+    """validate-result reports malformed JSON before schema validation."""
+    from veritas_os.cli.evidence_bundle import main
+
+    result_path = tmp_path / "malformed-result.json"
+    result_path.write_text('{"ok": true,', encoding="utf-8")
+
+    exit_code = main(["validate-result", "--result", str(result_path)])
+    output = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "Evidence bundle verification result schema: FAIL" in output
+    assert "malformed JSON: line 1" in output


### PR DESCRIPTION
### Motivation
- Provide a CLI path to validate previously saved Evidence Bundle verification result JSON files against the machine-readable JSON Schema so reviewers/CI can confirm saved results still match the contract.
- Make validation focused on document shape (schema) only and avoid any attempt to re-run cryptographic or hash verification or to establish trusted key provenance.

### Description
- Add `veritas-evidence-bundle validate-result --result <path>` subcommand to `veritas_os/cli/evidence_bundle.py` that parses the saved JSON, validates it against `schemas/evidence_bundle_verification_result.schema.json` using `jsonschema`, prints `PASS`/`FAIL` and structured diagnostics, and returns exit code `0` on success or `1` on failure.
- Implement clear diagnostics formatting for `jsonschema` errors (field path + message) and JSON parse errors (line/column/msg).
- Add unit tests covering: valid saved result, missing required field, invalid `signature_status` enum, invalid `public_key_fingerprint_sha256` pattern, and malformed JSON in `veritas_os/tests/test_evidence_bundle_cli.py`.
- Update docs to document the CLI usage and clarify that schema validation only checks saved result shape and does not re-run cryptographic verification or provide regulatory/third-party audit certification in `docs/en/validation/*`.
- Move `jsonschema` into core/runtime dependency lists (`pyproject.toml`, `veritas_os/requirements*.txt`) so `validate-result` is available outside dev-only installs.

### Testing
- Successfully compiled changed modules: `python -m py_compile veritas_os/cli/evidence_bundle.py veritas_os/tests/test_evidence_bundle_cli.py` (success).
- Lint/quality checks: `ruff check` passed for the modified files (success).
- Attempted to run test suite with `pytest`, but full test execution was blocked by the local environment missing project dependencies (e.g. `pydantic`) and inability to bootstrap packages due to restricted PyPI access, so `pytest` could not be executed here (environment limitation).
- Notes: New unit tests were added and type/format checks pass under static checks; CI should run full `pytest` (with installed dependencies) to validate runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27ad801a38832691faf6722c8be6d5)