### PR TITLE
feat(cli): add JSON output for validate-result

### DIFF
--- a/docs/en/validation/evidence-bundle-reviewer-checklist.md
+++ b/docs/en/validation/evidence-bundle-reviewer-checklist.md
@@ -62,11 +62,13 @@ veritas-evidence-bundle validate-result \
 
 `validate-result` checks JSON parsing and the saved result schema, including
 required fields, `signature_status` enum values, and
-`public_key_fingerprint_sha256` null-or-lowercase-hex shape. It does not re-run
-file/hash integrity checks or Ed25519 signature verification, does not establish
-trusted key provenance, and is not regulatory certification or completed
-third-party audit approval. Preserve the out-of-band trusted-key provenance
-record even when saved-result schema validation passes.
+`public_key_fingerprint_sha256` null-or-lowercase-hex shape. Add `--json` when
+CI, UI, or external audit tooling must consume a machine-readable validation
+report for the saved result file. It does not re-run file/hash integrity checks
+or Ed25519 signature verification, does not establish trusted key provenance,
+and is not regulatory certification or completed third-party audit approval.
+Preserve the out-of-band trusted-key provenance record even when saved-result
+schema validation passes.
 
 ## Verification order
 

--- a/docs/en/validation/evidence-bundle-verification-json-contract.md
+++ b/docs/en/validation/evidence-bundle-verification-json-contract.md
@@ -73,6 +73,31 @@ missing required fields, invalid field types, invalid enum values such as
 `public_key_fingerprint_sha256` values that are not `null` or 64-character
 lowercase hexadecimal strings.
 
+For CI, UI, or external audit-tool integrations, add `--json` to make the saved
+result Schema validation outcome machine-readable on stdout:
+
+```bash
+veritas-evidence-bundle validate-result \
+  --result evidence-bundle-verification-result.json \
+  --json
+```
+
+A schema-valid saved result emits only JSON on stdout and exits `0`:
+
+```json
+{
+  "ok": true,
+  "schema_valid": true,
+  "result_path": "evidence-bundle-verification-result.json",
+  "errors": []
+}
+```
+
+Schema-invalid or malformed JSON inputs emit only JSON on stdout and exit `1`.
+Each error contains a JSONPath-like `path` and reviewer/tooling-safe `message`.
+For malformed JSON, the path is `$` because the document cannot be parsed before
+schema validation.
+
 Schema validation confirms the saved result document shape only. It does not
 re-run Evidence Bundle file/hash checks, does not re-run Ed25519 manifest
 signature verification, does not establish trusted key provenance, and is not

--- a/docs/en/validation/sample-evidence-bundle-verification-output.md
+++ b/docs/en/validation/sample-evidence-bundle-verification-output.md
@@ -81,7 +81,45 @@ Evidence bundle verification result schema: FAIL
   error at $['signature_status']: 'verified' is not one of ['pass', 'fail', 'missing', 'not_verified']
 ```
 
-This schema validation confirms result shape only. It does not re-run
+For machine-readable saved-result Schema validation, add `--json`:
+
+```bash
+veritas-evidence-bundle validate-result \
+  --result evidence-bundle-verification-result.json \
+  --json
+```
+
+Illustrative `validate-result --json` success output:
+
+```json
+{
+  "ok": true,
+  "schema_valid": true,
+  "result_path": "evidence-bundle-verification-result.json",
+  "errors": []
+}
+```
+
+Illustrative `validate-result --json` failure output:
+
+```json
+{
+  "ok": false,
+  "schema_valid": false,
+  "result_path": "evidence-bundle-verification-result.json",
+  "errors": [
+    {
+      "path": "$['signature_status']",
+      "message": "'verified' is not one of ['pass', 'fail', 'missing', 'not_verified']"
+    }
+  ]
+}
+```
+
+Malformed JSON is also returned as structured JSON with `path` set to `$` and a
+message beginning with `malformed JSON:`.
+
+This schema validation confirms saved result shape only. It does not re-run
 cryptographic verification, does not establish out-of-band trusted key
 provenance, and is not regulatory certification or completed third-party audit
 approval.

--- a/veritas_os/cli/evidence_bundle.py
+++ b/veritas_os/cli/evidence_bundle.py
@@ -82,15 +82,17 @@ def _public_key_fingerprint_sha256(public_key_path: Optional[Path]) -> Optional[
     return hashlib.sha256(public_key_bytes).hexdigest()
 
 
-def _format_json_schema_error(error: jsonschema.ValidationError) -> str:
-    """Format a JSON Schema validation error for CLI diagnostics."""
+def _json_schema_error_path(error: jsonschema.ValidationError) -> str:
+    """Return a JSONPath-like location for a JSON Schema validation error."""
     path = "$"
     if error.absolute_path:
         path += "".join(f"[{item!r}]" for item in error.absolute_path)
-    return f"error at {path}: {error.message}"
+    return path
 
 
-def _validate_verification_result_schema(result_path: Path) -> list[str]:
+def _validate_verification_result_schema(
+    result_path: Path,
+) -> list[dict[str, str]]:
     """Validate a saved Evidence Bundle verification result JSON file.
 
     The validation is intentionally limited to the saved result document shape.
@@ -100,14 +102,24 @@ def _validate_verification_result_schema(result_path: Path) -> list[str]:
     try:
         raw_result = result_path.read_text(encoding="utf-8")
     except OSError as exc:
-        return [f"failed to read result file {result_path}: {exc}"]
+        return [
+            {
+                "path": "$",
+                "message": f"failed to read result file {result_path}: {exc}",
+            }
+        ]
 
     try:
         result = json.loads(raw_result)
     except json.JSONDecodeError as exc:
         return [
-            "malformed JSON: "
-            f"line {exc.lineno}, column {exc.colno}: {exc.msg}"
+            {
+                "path": "$",
+                "message": (
+                    "malformed JSON: "
+                    f"line {exc.lineno}, column {exc.colno}: {exc.msg}"
+                ),
+            }
         ]
 
     try:
@@ -115,26 +127,48 @@ def _validate_verification_result_schema(result_path: Path) -> list[str]:
             VERIFICATION_RESULT_SCHEMA_PATH.read_text(encoding="utf-8")
         )
     except (OSError, json.JSONDecodeError) as exc:
-        return [f"failed to load verification result schema: {exc}"]
+        return [
+            {
+                "path": "$",
+                "message": f"failed to load verification result schema: {exc}",
+            }
+        ]
 
     validator = jsonschema.Draft202012Validator(schema)
     errors = sorted(
         validator.iter_errors(result),
         key=lambda error: (list(error.absolute_path), error.message),
     )
-    return [_format_json_schema_error(error) for error in errors]
+    return [
+        {"path": _json_schema_error_path(error), "message": error.message}
+        for error in errors
+    ]
 
 
-def _run_validate_result(result_path: Path) -> int:
-    """Run saved verification result JSON Schema validation and print status."""
+def _run_validate_result(result_path: Path, *, json_output: bool = False) -> int:
+    """Run saved verification result JSON Schema validation and print status.
+
+    When ``json_output`` is true, stdout is limited to a machine-readable
+    validation report for CI, UI, and external audit-tool integrations.
+    """
     errors = _validate_verification_result_schema(result_path)
+    output = {
+        "ok": not errors,
+        "schema_valid": not errors,
+        "result_path": str(result_path),
+        "errors": errors,
+    }
+    if json_output:
+        print(json.dumps(output, indent=2, ensure_ascii=False))
+        return 0 if output["ok"] else 1
+
     if not errors:
         print("Evidence bundle verification result schema: PASS")
         return 0
 
     print("Evidence bundle verification result schema: FAIL")
     for error in errors:
-        print(f"  {error}")
+        print(f"  error at {error['path']}: {error['message']}")
     return 1
 
 
@@ -209,6 +243,11 @@ def build_parser() -> argparse.ArgumentParser:
         type=Path,
         help="Saved JSON result file from verify --json --output",
     )
+    validate.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a machine-readable validation report as JSON",
+    )
 
     return parser
 
@@ -249,7 +288,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         return 0
 
     if args.command == "validate-result":
-        return _run_validate_result(args.result)
+        return _run_validate_result(args.result, json_output=args.json)
 
     if args.output is not None and not args.json:
         parser.error("verify --output requires --json")

--- a/veritas_os/tests/test_evidence_bundle_cli.py
+++ b/veritas_os/tests/test_evidence_bundle_cli.py
@@ -1086,3 +1086,126 @@ def test_evidence_bundle_cli_validate_result_malformed_json_fails_clearly(
     assert exit_code == 1
     assert "Evidence bundle verification result schema: FAIL" in output
     assert "malformed JSON: line 1" in output
+
+
+def test_evidence_bundle_cli_validate_result_valid_saved_result_json_passes(
+    tmp_path,
+    capsys,
+) -> None:
+    """validate-result --json emits a machine-readable success report."""
+    from veritas_os.cli.evidence_bundle import main
+
+    result_path = tmp_path / "valid-result.json"
+    _write_result_payload(result_path, _valid_verification_result_payload())
+
+    exit_code = main(["validate-result", "--result", str(result_path), "--json"])
+    output = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert output == {
+        "ok": True,
+        "schema_valid": True,
+        "result_path": str(result_path),
+        "errors": [],
+    }
+
+
+def test_evidence_bundle_cli_validate_result_missing_required_field_json_fails(
+    tmp_path,
+    capsys,
+) -> None:
+    """validate-result --json reports missing required fields structurally."""
+    from veritas_os.cli.evidence_bundle import main
+
+    result_path = tmp_path / "missing-field-result.json"
+    payload = _valid_verification_result_payload()
+    del payload["signature_verified"]
+    _write_result_payload(result_path, payload)
+
+    exit_code = main(["validate-result", "--result", str(result_path), "--json"])
+    output = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    assert output["ok"] is False
+    assert output["schema_valid"] is False
+    assert output["result_path"] == str(result_path)
+    assert output["errors"] == [
+        {
+            "path": "$",
+            "message": "'signature_verified' is a required property",
+        }
+    ]
+
+
+def test_evidence_bundle_cli_validate_result_invalid_signature_status_json_fails(
+    tmp_path,
+    capsys,
+) -> None:
+    """validate-result --json reports invalid signature_status paths."""
+    from veritas_os.cli.evidence_bundle import main
+
+    result_path = tmp_path / "invalid-status-result.json"
+    payload = _valid_verification_result_payload()
+    payload["signature_status"] = "verified"
+    _write_result_payload(result_path, payload)
+
+    exit_code = main(["validate-result", "--result", str(result_path), "--json"])
+    output = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    assert output["ok"] is False
+    assert output["schema_valid"] is False
+    assert output["errors"][0]["path"] == "$['signature_status']"
+    assert "'verified' is not one of" in output["errors"][0]["message"]
+
+
+def test_evidence_bundle_cli_validate_result_invalid_fingerprint_json_fails(
+    tmp_path,
+    capsys,
+) -> None:
+    """validate-result --json reports invalid fingerprint paths."""
+    from veritas_os.cli.evidence_bundle import main
+
+    result_path = tmp_path / "invalid-fingerprint-result.json"
+    payload = _valid_verification_result_payload()
+    payload["public_key_fingerprint_sha256"] = "A" * 64
+    _write_result_payload(result_path, payload)
+
+    exit_code = main(["validate-result", "--result", str(result_path), "--json"])
+    output = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    assert output["ok"] is False
+    assert output["schema_valid"] is False
+    assert output["errors"][0]["path"] == "$['public_key_fingerprint_sha256']"
+    assert "does not match '^[0-9a-f]{64}$'" in output["errors"][0]["message"]
+
+
+def test_evidence_bundle_cli_validate_result_malformed_json_json_fails(
+    tmp_path,
+    capsys,
+) -> None:
+    """validate-result --json reports malformed JSON as structured output."""
+    from veritas_os.cli.evidence_bundle import main
+
+    result_path = tmp_path / "malformed-result.json"
+    result_path.write_text('{"ok": true,', encoding="utf-8")
+
+    exit_code = main(["validate-result", "--result", str(result_path), "--json"])
+    output = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    assert output == {
+        "ok": False,
+        "schema_valid": False,
+        "result_path": str(result_path),
+        "errors": [
+            {
+                "path": "$",
+                "message": (
+                    "malformed JSON: line 1, column 13: "
+                    "Expecting property name enclosed in double quotes"
+                ),
+            }
+        ],
+    }


### PR DESCRIPTION
### Motivation

- Provide a machine-readable `validate-result --json` output so CI, UIs, and external audit tooling can consume saved Evidence Bundle verification result schema validation programmatically.
- Keep the existing human-oriented PASS/FAIL CLI output unchanged when `--json` is not specified and preserve the current exit-code semantics.

### Description

- Add a `--json` flag to the `validate-result` subcommand and thread it into `_run_validate_result` so `validate-result --json` emits only a structured JSON validation report to stdout.
- Change schema diagnostics to return structured error objects with a JSONPath-like `path` and a reviewer/tooling-safe `message` by introducing `_json_schema_error_path` and returning `list[dict[str,str]]` from `_validate_verification_result_schema`.
- When `--json` is supplied the CLI prints a JSON object with top-level fields `ok`, `schema_valid`, `result_path`, and `errors`; when omitted the existing human-readable PASS/FAIL text and diagnostics remain unchanged.
- Add focused tests for `validate-result --json` covering valid result, missing required field, invalid `signature_status`, invalid `public_key_fingerprint_sha256`, and malformed JSON, and update docs in `docs/en/validation/*` to document `--json` behaviors and caveats (not a cryptographic re-check, not trust-provenance, not certification).
- Preserve exit codes: schema-valid -> exit code `0`; schema-invalid / malformed JSON / read failure -> exit code `1`.

### Testing

- Compiled the modified modules with `python -m py_compile` which succeeded for `veritas_os/cli/evidence_bundle.py` and the updated tests file.
- Ran static checks with `ruff` which completed with no reported issues for the changed files.
- Performed `git diff --check` (no whitespace/merge markers) and updated relevant docs to describe the new `--json` behavior.
- Attempted to run the new tests with `pytest` but execution was blocked in this environment due to missing test dependencies (e.g., `pydantic`) and network dependency resolution failures; the new tests are present and ready to run in CI where dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27d27102dc8326884d0d662cc41a5c)