### PR TITLE
feat: save validate-result JSON reports (--json --output)

### DIFF
--- a/docs/en/validation/evidence-bundle-reviewer-checklist.md
+++ b/docs/en/validation/evidence-bundle-reviewer-checklist.md
@@ -64,11 +64,13 @@ veritas-evidence-bundle validate-result \
 required fields, `signature_status` enum values, and
 `public_key_fingerprint_sha256` null-or-lowercase-hex shape. Add `--json` when
 CI, UI, or external audit tooling must consume a machine-readable validation
-report for the saved result file. It does not re-run file/hash integrity checks
-or Ed25519 signature verification, does not establish trusted key provenance,
-and is not regulatory certification or completed third-party audit approval.
-Preserve the out-of-band trusted-key provenance record even when saved-result
-schema validation passes.
+report for the saved result file. Add `--output <path>` together with `--json`
+to save the exact stdout validation report as UTF-8 audit evidence, including
+failure reports for schema-invalid or malformed saved results. It does not re-run
+file/hash integrity checks or Ed25519 signature verification, does not establish
+trusted key provenance, and is not regulatory certification or completed
+third-party audit approval. Preserve the out-of-band trusted-key provenance
+record even when saved-result schema validation passes.
 
 ## Verification order
 

--- a/docs/en/validation/evidence-bundle-verification-json-contract.md
+++ b/docs/en/validation/evidence-bundle-verification-json-contract.md
@@ -82,6 +82,22 @@ veritas-evidence-bundle validate-result \
   --json
 ```
 
+Add `--output <path>` with `--json` to save the exact same Schema validation
+report as UTF-8 audit evidence while still emitting the JSON to stdout:
+
+```bash
+veritas-evidence-bundle validate-result \
+  --result evidence-bundle-verification-result.json \
+  --json \
+  --output evidence-bundle-verification-result-validation.json
+```
+
+`validate-result --output` requires `--json`. Parent directories are created
+when needed. Schema-invalid and malformed-result failure reports are also saved,
+because failure reports are part of the audit trail. If the report cannot be
+written, the CLI exits non-zero and prints a clear write-failure diagnostic on
+stderr.
+
 A schema-valid saved result emits only JSON on stdout and exits `0`:
 
 ```json
@@ -101,10 +117,12 @@ schema validation.
 Schema validation confirms the saved result document shape only. It does not
 re-run Evidence Bundle file/hash checks, does not re-run Ed25519 manifest
 signature verification, does not establish trusted key provenance, and is not
-regulatory certification or completed third-party audit approval. Reviewers must
-still preserve out-of-band trusted public key provenance for the key represented
-by `public_key_fingerprint_sha256` before relying on any saved strict
-verification result.
+regulatory certification or completed third-party audit approval. Saving a
+`validate-result --json --output` report records the schema-validation outcome
+for the already-saved result file; it is not a new cryptographic verification
+run. Reviewers must still preserve out-of-band trusted public key provenance for
+the key represented by `public_key_fingerprint_sha256` before relying on any
+saved strict verification result.
 
 ## Contract scope
 

--- a/docs/en/validation/sample-evidence-bundle-verification-output.md
+++ b/docs/en/validation/sample-evidence-bundle-verification-output.md
@@ -89,6 +89,21 @@ veritas-evidence-bundle validate-result \
   --json
 ```
 
+To preserve that validation report as audit evidence, add `--output <path>` with
+`--json`:
+
+```bash
+veritas-evidence-bundle validate-result \
+  --result evidence-bundle-verification-result.json \
+  --json \
+  --output evidence-bundle-verification-result-validation.json
+```
+
+The stdout JSON and saved UTF-8 JSON file are byte-for-byte identical. Failure
+reports for schema-invalid or malformed saved results are also written so CI,
+UI, and external audit tools can retain the failed validation outcome.
+`validate-result --output` without `--json` fails clearly.
+
 Illustrative `validate-result --json` success output:
 
 ```json
@@ -122,7 +137,9 @@ message beginning with `malformed JSON:`.
 This schema validation confirms saved result shape only. It does not re-run
 cryptographic verification, does not establish out-of-band trusted key
 provenance, and is not regulatory certification or completed third-party audit
-approval.
+approval. A saved `validate-result --json --output` report is evidence of the
+schema-validation report for an existing result file, not evidence of a new
+Evidence Bundle verification run.
 
 ## Successful strict verification
 

--- a/veritas_os/cli/evidence_bundle.py
+++ b/veritas_os/cli/evidence_bundle.py
@@ -145,11 +145,18 @@ def _validate_verification_result_schema(
     ]
 
 
-def _run_validate_result(result_path: Path, *, json_output: bool = False) -> int:
+def _run_validate_result(
+    result_path: Path,
+    *,
+    json_output: bool = False,
+    output_path: Optional[Path] = None,
+) -> int:
     """Run saved verification result JSON Schema validation and print status.
 
     When ``json_output`` is true, stdout is limited to a machine-readable
-    validation report for CI, UI, and external audit-tool integrations.
+    validation report for CI, UI, and external audit-tool integrations. When
+    ``output_path`` is supplied, the exact stdout JSON report is also written
+    as UTF-8 audit evidence, including schema validation failure reports.
     """
     errors = _validate_verification_result_schema(result_path)
     output = {
@@ -159,7 +166,19 @@ def _run_validate_result(result_path: Path, *, json_output: bool = False) -> int
         "errors": errors,
     }
     if json_output:
-        print(json.dumps(output, indent=2, ensure_ascii=False))
+        output_json = json.dumps(output, indent=2, ensure_ascii=False)
+        if output_path is not None:
+            try:
+                output_path.parent.mkdir(parents=True, exist_ok=True)
+                output_path.write_text(output_json + "\n", encoding="utf-8")
+            except OSError as exc:
+                print(
+                    "error: failed to write validation report "
+                    f"to {output_path}: {exc}",
+                    file=sys.stderr,
+                )
+                return 2
+        print(output_json)
         return 0 if output["ok"] else 1
 
     if not errors:
@@ -248,6 +267,14 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Emit a machine-readable validation report as JSON",
     )
+    validate.add_argument(
+        "--output",
+        type=Path,
+        help=(
+            "Write the JSON validation report to this UTF-8 file. "
+            "Requires --json and does not suppress stdout JSON."
+        ),
+    )
 
     return parser
 
@@ -288,7 +315,14 @@ def main(argv: Optional[list[str]] = None) -> int:
         return 0
 
     if args.command == "validate-result":
-        return _run_validate_result(args.result, json_output=args.json)
+        if args.output is not None and not args.json:
+            parser.error("validate-result --output requires --json")
+            return 2
+        return _run_validate_result(
+            args.result,
+            json_output=args.json,
+            output_path=args.output,
+        )
 
     if args.output is not None and not args.json:
         parser.error("verify --output requires --json")

--- a/veritas_os/tests/test_evidence_bundle_cli.py
+++ b/veritas_os/tests/test_evidence_bundle_cli.py
@@ -1209,3 +1209,170 @@ def test_evidence_bundle_cli_validate_result_malformed_json_json_fails(
             }
         ],
     }
+
+
+def _assert_validation_report_matches_stdout(
+    output_path: Path,
+    stdout: str,
+) -> dict[str, Any]:
+    """Assert saved validate-result report bytes match stdout exactly."""
+    saved = output_path.read_text(encoding="utf-8")
+    assert saved == stdout
+    return json.loads(stdout)
+
+
+def test_evidence_bundle_cli_validate_result_json_output_valid_matches_stdout(
+    tmp_path,
+    capsys,
+) -> None:
+    """validate-result --json --output saves the success report exactly."""
+    from veritas_os.cli.evidence_bundle import main
+
+    result_path = tmp_path / "valid-result.json"
+    output_path = tmp_path / "reports" / "validation.json"
+    _write_result_payload(result_path, _valid_verification_result_payload())
+
+    exit_code = main(
+        [
+            "validate-result",
+            "--result",
+            str(result_path),
+            "--json",
+            "--output",
+            str(output_path),
+        ]
+    )
+    output = _assert_validation_report_matches_stdout(
+        output_path,
+        capsys.readouterr().out,
+    )
+
+    assert exit_code == 0
+    assert output == {
+        "ok": True,
+        "schema_valid": True,
+        "result_path": str(result_path),
+        "errors": [],
+    }
+
+
+def test_evidence_bundle_cli_validate_result_json_output_invalid_matches_stdout(
+    tmp_path,
+    capsys,
+) -> None:
+    """validate-result --json --output saves signature_status failures."""
+    from veritas_os.cli.evidence_bundle import main
+
+    result_path = tmp_path / "invalid-status-result.json"
+    output_path = tmp_path / "validation" / "invalid-status.json"
+    payload = _valid_verification_result_payload()
+    payload["signature_status"] = "verified"
+    _write_result_payload(result_path, payload)
+
+    exit_code = main(
+        [
+            "validate-result",
+            "--result",
+            str(result_path),
+            "--json",
+            "--output",
+            str(output_path),
+        ]
+    )
+    output = _assert_validation_report_matches_stdout(
+        output_path,
+        capsys.readouterr().out,
+    )
+
+    assert exit_code == 1
+    assert output["ok"] is False
+    assert output["schema_valid"] is False
+    assert output["errors"][0]["path"] == "$['signature_status']"
+    assert "'verified' is not one of" in output["errors"][0]["message"]
+
+
+def test_evidence_bundle_cli_validate_result_json_output_malformed_matches_stdout(
+    tmp_path,
+    capsys,
+) -> None:
+    """validate-result --json --output saves malformed JSON reports."""
+    from veritas_os.cli.evidence_bundle import main
+
+    result_path = tmp_path / "malformed-result.json"
+    output_path = tmp_path / "validation" / "malformed.json"
+    result_path.write_text('{"ok": true,', encoding="utf-8")
+
+    exit_code = main(
+        [
+            "validate-result",
+            "--result",
+            str(result_path),
+            "--json",
+            "--output",
+            str(output_path),
+        ]
+    )
+    output = _assert_validation_report_matches_stdout(
+        output_path,
+        capsys.readouterr().out,
+    )
+
+    assert exit_code == 1
+    assert output["ok"] is False
+    assert output["schema_valid"] is False
+    assert output["errors"][0]["path"] == "$"
+    assert "malformed JSON: line 1" in output["errors"][0]["message"]
+
+
+def test_evidence_bundle_cli_validate_result_output_requires_json(
+    tmp_path,
+    capsys,
+) -> None:
+    """validate-result --output without --json fails clearly."""
+    from veritas_os.cli.evidence_bundle import main
+
+    result_path = tmp_path / "valid-result.json"
+    _write_result_payload(result_path, _valid_verification_result_payload())
+
+    with pytest.raises(SystemExit) as excinfo:
+        main(
+            [
+                "validate-result",
+                "--result",
+                str(result_path),
+                "--output",
+                str(tmp_path / "validation.json"),
+            ]
+        )
+
+    assert excinfo.value.code == 2
+    assert "validate-result --output requires --json" in capsys.readouterr().err
+
+
+def test_evidence_bundle_cli_validate_result_output_write_failure_is_clear(
+    tmp_path,
+    capsys,
+) -> None:
+    """validate-result write failures exit non-zero with clear stderr."""
+    from veritas_os.cli.evidence_bundle import main
+
+    result_path = tmp_path / "valid-result.json"
+    output_path = tmp_path / "existing-directory"
+    _write_result_payload(result_path, _valid_verification_result_payload())
+    output_path.mkdir()
+
+    exit_code = main(
+        [
+            "validate-result",
+            "--result",
+            str(result_path),
+            "--json",
+            "--output",
+            str(output_path),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert captured.out == ""
+    assert "failed to write validation report" in captured.err


### PR DESCRIPTION
### Motivation
- Allow CI/UI/audit tooling to persist the machine-readable `validate-result --json` schema validation report as reviewer evidence so saved validation outcomes (including failures) can be retained and inspected later.
- Ensure saved validation report is byte-for-byte identical to stdout JSON and that parent directories are created automatically.
- Prevent accidental misuse by requiring `--output` only with `--json` and surface clear errors on write failures.

### Description
- Added an optional `--output <path>` argument to the `validate-result` subcommand in `veritas_os/cli/evidence_bundle.py` that is only accepted when `--json` is present. (`build_parser()` and `main()` updated.)
- Extended `_run_validate_result()` to accept `output_path: Optional[Path]` and, when `--json` is requested, write the exact same JSON emitted to stdout to the specified UTF-8 file, creating parent directories as needed and returning a clear non-zero error on write failure. (`veritas_os/cli/evidence_bundle.py`)
- Added unit tests to `veritas_os/tests/test_evidence_bundle_cli.py` that assert saved validation reports exactly match stdout for valid, invalid (`signature_status` enum failure), and malformed JSON cases, plus tests that `--output` without `--json` fails and that write failures produce a clear non-zero exit and stderr message.
- Updated docs to document `validate-result --json --output <path>` behavior and limits in `docs/en/validation/evidence-bundle-verification-json-contract.md`, `docs/en/validation/sample-evidence-bundle-verification-output.md`, and `docs/en/validation/evidence-bundle-reviewer-checklist.md` and to emphasize that saving a validation report does not re-run cryptographic verification or establish trusted key provenance.

### Testing
- Compiled impacted Python files: `python -m py_compile veritas_os/cli/evidence_bundle.py veritas_os/tests/test_evidence_bundle_cli.py` (succeeded).
- Lint checks: `ruff check veritas_os/cli/evidence_bundle.py veritas_os/tests/test_evidence_bundle_cli.py` (succeeded).
- Ran the `validate_result` test selection with `pytest` but execution in the local environment was blocked by missing runtime dependencies (`pydantic`) and PyPI fetch/connect issues, so full `pytest` execution could not complete here; the new tests are included and are ready to run in CI where dependencies are available.
- Verified `git diff --check` and fixed trailing newline; tests added and doc changes committed.

Security note: this change only records schema-validation reports for already-saved verification-result files and does not re-run cryptographic verification or establish trusted-key provenance; reviewers must maintain out-of-band public-key provenance as documented.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27d80d456483269e175ee72ec050d0)