### PR TITLE
Add JSON Schema for validate-result --json reports and update tests/docs

### DIFF
--- a/docs/en/validation/evidence-bundle-reviewer-checklist.md
+++ b/docs/en/validation/evidence-bundle-reviewer-checklist.md
@@ -64,13 +64,17 @@ veritas-evidence-bundle validate-result \
 required fields, `signature_status` enum values, and
 `public_key_fingerprint_sha256` null-or-lowercase-hex shape. Add `--json` when
 CI, UI, or external audit tooling must consume a machine-readable validation
-report for the saved result file. Add `--output <path>` together with `--json`
-to save the exact stdout validation report as UTF-8 audit evidence, including
-failure reports for schema-invalid or malformed saved results. It does not re-run
-file/hash integrity checks or Ed25519 signature verification, does not establish
-trusted key provenance, and is not regulatory certification or completed
-third-party audit approval. Preserve the out-of-band trusted-key provenance
-record even when saved-result schema validation passes.
+report for the saved result file; that validation report has its own
+machine-readable schema at
+[`schemas/evidence_bundle_validation_report.schema.json`](../../../schemas/evidence_bundle_validation_report.schema.json).
+Add `--output <path>` together with `--json` to save the exact stdout
+validation report as UTF-8 audit evidence, including failure reports for
+schema-invalid or malformed saved results. The validation report schema only
+validates the report shape. It does not validate the original bundle, re-run
+file/hash integrity checks or Ed25519 signature verification, establish trusted
+key provenance, or provide regulatory certification or completed third-party
+audit approval. Preserve the out-of-band trusted-key provenance record even
+when saved-result schema validation passes.
 
 ## Verification order
 

--- a/docs/en/validation/evidence-bundle-verification-json-contract.md
+++ b/docs/en/validation/evidence-bundle-verification-json-contract.md
@@ -16,8 +16,11 @@ Trusted public keys must come from an out-of-band reviewer/operator trust
 channel; a public key copied only from the Evidence Bundle is not trusted by
 itself.
 
-Machine-readable validation is pinned in the JSON Schema at
+Machine-readable verification result validation is pinned in the JSON Schema at
 [`schemas/evidence_bundle_verification_result.schema.json`](../../../schemas/evidence_bundle_verification_result.schema.json).
+`validate-result --json` validation reports have their own machine-readable
+JSON Schema at
+[`schemas/evidence_bundle_validation_report.schema.json`](../../../schemas/evidence_bundle_validation_report.schema.json).
 
 ## Saving reviewer evidence to a file
 
@@ -114,10 +117,14 @@ Each error contains a JSONPath-like `path` and reviewer/tooling-safe `message`.
 For malformed JSON, the path is `$` because the document cannot be parsed before
 schema validation.
 
-Schema validation confirms the saved result document shape only. It does not
-re-run Evidence Bundle file/hash checks, does not re-run Ed25519 manifest
-signature verification, does not establish trusted key provenance, and is not
-regulatory certification or completed third-party audit approval. Saving a
+The validation report schema validates only the shape of the
+`validate-result --json` report (`ok`, `schema_valid`, `result_path`, and
+`errors[]` diagnostics with `path` and `message`). It does not validate the
+original Evidence Bundle, does not validate the saved verification result
+beyond recording this command outcome, does not re-run Evidence Bundle
+file/hash checks, does not re-run Ed25519 manifest signature verification,
+does not establish trusted key provenance, and is not regulatory certification
+or completed third-party audit approval. Saving a
 `validate-result --json --output` report records the schema-validation outcome
 for the already-saved result file; it is not a new cryptographic verification
 run. Reviewers must still preserve out-of-band trusted public key provenance for

--- a/docs/en/validation/sample-evidence-bundle-verification-output.md
+++ b/docs/en/validation/sample-evidence-bundle-verification-output.md
@@ -101,7 +101,9 @@ veritas-evidence-bundle validate-result \
 
 The stdout JSON and saved UTF-8 JSON file are byte-for-byte identical. Failure
 reports for schema-invalid or malformed saved results are also written so CI,
-UI, and external audit tools can retain the failed validation outcome.
+UI, and external audit tools can retain the failed validation outcome. The
+validation report shape is documented by
+[`schemas/evidence_bundle_validation_report.schema.json`](../../../schemas/evidence_bundle_validation_report.schema.json).
 `validate-result --output` without `--json` fails clearly.
 
 Illustrative `validate-result --json` success output:
@@ -134,12 +136,15 @@ Illustrative `validate-result --json` failure output:
 Malformed JSON is also returned as structured JSON with `path` set to `$` and a
 message beginning with `malformed JSON:`.
 
-This schema validation confirms saved result shape only. It does not re-run
-cryptographic verification, does not establish out-of-band trusted key
-provenance, and is not regulatory certification or completed third-party audit
-approval. A saved `validate-result --json --output` report is evidence of the
-schema-validation report for an existing result file, not evidence of a new
-Evidence Bundle verification run.
+The saved-result schema validation confirms saved verification result shape
+only. The separate validation report schema validates only the
+`validate-result --json` report shape. Neither schema validates the original
+Evidence Bundle, re-runs file/hash integrity checks, re-runs Ed25519 signature
+verification, establishes out-of-band trusted key provenance, or provides
+regulatory certification or completed third-party audit approval. A saved
+`validate-result --json --output` report is evidence of the schema-validation
+report for an existing result file, not evidence of a new Evidence Bundle
+verification run.
 
 ## Successful strict verification
 

--- a/schemas/evidence_bundle_validation_report.schema.json
+++ b/schemas/evidence_bundle_validation_report.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://veritas-os.example/schemas/evidence_bundle_validation_report.schema.json",
+  "title": "Evidence Bundle Validation Report",
+  "description": "This schema describes the machine-readable report emitted by veritas-evidence-bundle validate-result --json. It validates the validation report shape only. It does not validate the original Evidence Bundle. It does not re-run file/hash integrity checks. It does not re-run Ed25519 signature verification. It does not establish trusted key provenance. It is not regulatory certification or completed third-party audit approval.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "ok",
+    "schema_valid",
+    "result_path",
+    "errors"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "description": "Overall validation report result. True means the saved verification result document was parsed and matched the saved-result JSON Schema."
+    },
+    "schema_valid": {
+      "type": "boolean",
+      "description": "True when the saved verification result document conforms to the saved-result JSON Schema."
+    },
+    "result_path": {
+      "type": "string",
+      "description": "Path to the saved Evidence Bundle verification result JSON file that validate-result checked."
+    },
+    "errors": {
+      "type": "array",
+      "description": "Schema or JSON parsing diagnostics for the saved verification result file. Empty when schema_valid is true.",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "path",
+          "message"
+        ],
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "JSONPath-like location for the validation diagnostic, or $ for document-level and malformed JSON errors."
+          },
+          "message": {
+            "type": "string",
+            "description": "Reviewer/tooling-safe diagnostic message for the validation error."
+          }
+        }
+      }
+    }
+  }
+}

--- a/veritas_os/tests/test_evidence_bundle_cli.py
+++ b/veritas_os/tests/test_evidence_bundle_cli.py
@@ -15,6 +15,9 @@ from veritas_os.audit import trustlog_signed
 
 
 SCHEMA_PATH = Path("schemas/evidence_bundle_verification_result.schema.json")
+VALIDATION_REPORT_SCHEMA_PATH = Path(
+    "schemas/evidence_bundle_validation_report.schema.json"
+)
 CONTRACT_JSON_FIELDS = {
     "ok",
     "tampered",
@@ -32,6 +35,20 @@ CONTRACT_JSON_FIELDS = {
 def _load_verification_result_schema() -> dict[str, Any]:
     """Load the Evidence Bundle verification result JSON Schema."""
     return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def _load_validation_report_schema() -> dict[str, Any]:
+    """Load the validate-result JSON validation report Schema."""
+    return json.loads(VALIDATION_REPORT_SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def _assert_validation_report_schema(output: dict[str, Any]) -> None:
+    """Assert validate-result --json output matches its report Schema."""
+    import jsonschema
+
+    schema = _load_validation_report_schema()
+    jsonschema.Draft202012Validator.check_schema(schema)
+    jsonschema.Draft202012Validator(schema).validate(output)
 
 
 def _assert_contract_fields(output: dict[str, Any]) -> None:
@@ -59,6 +76,50 @@ def _assert_contract_fields(output: dict[str, Any]) -> None:
     schema = _load_verification_result_schema()
     jsonschema.Draft202012Validator.check_schema(schema)
     jsonschema.Draft202012Validator(schema).validate(output)
+
+
+def test_evidence_bundle_validation_report_schema_contract() -> None:
+    """JSON Schema pins validate-result --json validation report fields."""
+    schema = _load_validation_report_schema()
+
+    assert set(schema["required"]) == {
+        "ok",
+        "schema_valid",
+        "result_path",
+        "errors",
+    }
+    assert schema["properties"]["ok"]["type"] == "boolean"
+    assert schema["properties"]["schema_valid"]["type"] == "boolean"
+    assert schema["properties"]["result_path"]["type"] == "string"
+    error_schema = schema["properties"]["errors"]["items"]
+    assert set(error_schema["required"]) == {"path", "message"}
+    assert error_schema["properties"]["path"]["type"] == "string"
+    assert error_schema["properties"]["message"]["type"] == "string"
+    description = schema["description"]
+    assert (
+        "machine-readable report emitted by "
+        "veritas-evidence-bundle validate-result --json"
+    ) in description
+    assert "validates the validation report shape only" in description
+    assert "does not validate the original Evidence Bundle" in description
+    assert "does not re-run file/hash integrity checks" in description
+    assert "does not re-run Ed25519 signature verification" in description
+    assert "does not establish trusted key provenance" in description
+    assert "not regulatory certification" in description
+
+    _assert_validation_report_schema(
+        {
+            "ok": False,
+            "schema_valid": False,
+            "result_path": "verification-result.json",
+            "errors": [
+                {
+                    "path": "$['signature_status']",
+                    "message": "'verified' is not one of allowed values",
+                }
+            ],
+        }
+    )
 
 
 def test_evidence_bundle_verification_result_schema_contract() -> None:
@@ -1101,6 +1162,7 @@ def test_evidence_bundle_cli_validate_result_valid_saved_result_json_passes(
     exit_code = main(["validate-result", "--result", str(result_path), "--json"])
     output = json.loads(capsys.readouterr().out)
 
+    _assert_validation_report_schema(output)
     assert exit_code == 0
     assert output == {
         "ok": True,
@@ -1125,6 +1187,7 @@ def test_evidence_bundle_cli_validate_result_missing_required_field_json_fails(
     exit_code = main(["validate-result", "--result", str(result_path), "--json"])
     output = json.loads(capsys.readouterr().out)
 
+    _assert_validation_report_schema(output)
     assert exit_code == 1
     assert output["ok"] is False
     assert output["schema_valid"] is False
@@ -1152,6 +1215,7 @@ def test_evidence_bundle_cli_validate_result_invalid_signature_status_json_fails
     exit_code = main(["validate-result", "--result", str(result_path), "--json"])
     output = json.loads(capsys.readouterr().out)
 
+    _assert_validation_report_schema(output)
     assert exit_code == 1
     assert output["ok"] is False
     assert output["schema_valid"] is False
@@ -1174,6 +1238,7 @@ def test_evidence_bundle_cli_validate_result_invalid_fingerprint_json_fails(
     exit_code = main(["validate-result", "--result", str(result_path), "--json"])
     output = json.loads(capsys.readouterr().out)
 
+    _assert_validation_report_schema(output)
     assert exit_code == 1
     assert output["ok"] is False
     assert output["schema_valid"] is False
@@ -1194,6 +1259,7 @@ def test_evidence_bundle_cli_validate_result_malformed_json_json_fails(
     exit_code = main(["validate-result", "--result", str(result_path), "--json"])
     output = json.loads(capsys.readouterr().out)
 
+    _assert_validation_report_schema(output)
     assert exit_code == 1
     assert output == {
         "ok": False,
@@ -1247,6 +1313,7 @@ def test_evidence_bundle_cli_validate_result_json_output_valid_matches_stdout(
         capsys.readouterr().out,
     )
 
+    _assert_validation_report_schema(output)
     assert exit_code == 0
     assert output == {
         "ok": True,
@@ -1284,6 +1351,7 @@ def test_evidence_bundle_cli_validate_result_json_output_invalid_matches_stdout(
         capsys.readouterr().out,
     )
 
+    _assert_validation_report_schema(output)
     assert exit_code == 1
     assert output["ok"] is False
     assert output["schema_valid"] is False
@@ -1317,6 +1385,7 @@ def test_evidence_bundle_cli_validate_result_json_output_malformed_matches_stdou
         capsys.readouterr().out,
     )
 
+    _assert_validation_report_schema(output)
     assert exit_code == 1
     assert output["ok"] is False
     assert output["schema_valid"] is False


### PR DESCRIPTION
### Motivation

- Provide a machine-readable JSON Schema for the validation report emitted by `veritas-evidence-bundle validate-result --json` so downstream CI, UI, and audit tooling can consume a stable contract. 
- Make explicit the boundary between (a) saved verification result schema validation and (b) cryptographic/file integrity verification or key provenance to avoid mistaken trust assumptions. 
- Ensure `validate-result --json` output (and saved `--output` reports) are schema-validated by tests without changing existing CLI verification behavior. 

### Description

- Added a new schema file `schemas/evidence_bundle_validation_report.schema.json` that requires top-level `ok`, `schema_valid`, `result_path`, and `errors` fields and enforces each `errors` item to have `path` and `message` strings; schema description documents the report boundary (does not re-run integrity/signature checks or establish key provenance). 
- Extended `veritas_os/tests/test_evidence_bundle_cli.py` with helpers and tests that validate representative `validate-result --json` success/failure/malformed outputs and `--json --output` saved reports against the new validation-report schema. 
- Updated docs to reference the new schema and to clearly state the validation-report scope and non-certification boundary in `docs/en/validation/evidence-bundle-verification-json-contract.md`, `docs/en/validation/sample-evidence-bundle-verification-output.md`, and `docs/en/validation/evidence-bundle-reviewer-checklist.md`. 
- No runtime behavior of `verify` or `validate-result` was changed; human-oriented CLI text and the previously-stable `--json` output remain byte-for-byte identical when saved with `--output`.

### Testing

- Executed JSON sanity check on the new schema with `python -m json.tool schemas/evidence_bundle_validation_report.schema.json`, which succeeded. 
- Static/compile check for the updated test file passed with `python -m py_compile veritas_os/tests/test_evidence_bundle_cli.py`. 
- Ran targeted test edits and exercised the `validate-result` test cases locally, but a full `pytest` run in this environment could not complete due to missing runtime dependencies (`pydantic` not installed / PyPI fetch errors); the new unit tests are present and are expected to run successfully in CI where dependencies are available. 

Note: this change is scope-limited to schema, tests, and docs and does not modify cryptographic verification, key handling, or trust logic; reviewers should confirm CI runs the new tests in the project test matrix before merging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27df046c088326b9a19a105a4cc558)