### PR TITLE
feat: make validate-result --json self-describing (add report_schema_id / validated_schema_id / validator)

### DIFF
--- a/docs/en/validation/evidence-bundle-reviewer-checklist.md
+++ b/docs/en/validation/evidence-bundle-reviewer-checklist.md
@@ -67,10 +67,14 @@ CI, UI, or external audit tooling must consume a machine-readable validation
 report for the saved result file; that validation report has its own
 machine-readable schema at
 [`schemas/evidence_bundle_validation_report.schema.json`](../../../schemas/evidence_bundle_validation_report.schema.json).
-Add `--output <path>` together with `--json` to save the exact stdout
-validation report as UTF-8 audit evidence, including failure reports for
-schema-invalid or malformed saved results. The validation report schema only
-validates the report shape. It does not validate the original bundle, re-run
+The JSON validation report is self-describing: `report_schema_id` identifies
+the validation report schema, `validated_schema_id` identifies the verification
+result schema used for saved result validation, and `validator` identifies the
+emitting CLI command. Add `--output <path>` together with `--json` to save the
+exact stdout validation report as UTF-8 audit evidence, including failure
+reports for schema-invalid or malformed saved results. The validation report
+schema only validates the report shape, and its metadata fields do not prove
+authenticity or trust. It does not validate the original bundle, re-run
 file/hash integrity checks or Ed25519 signature verification, establish trusted
 key provenance, or provide regulatory certification or completed third-party
 audit approval. Preserve the out-of-band trusted-key provenance record even

--- a/docs/en/validation/evidence-bundle-verification-json-contract.md
+++ b/docs/en/validation/evidence-bundle-verification-json-contract.md
@@ -18,9 +18,16 @@ itself.
 
 Machine-readable verification result validation is pinned in the JSON Schema at
 [`schemas/evidence_bundle_verification_result.schema.json`](../../../schemas/evidence_bundle_verification_result.schema.json).
-`validate-result --json` validation reports have their own machine-readable
-JSON Schema at
+`validate-result --json` validation reports are self-describing and have
+their own machine-readable JSON Schema at
 [`schemas/evidence_bundle_validation_report.schema.json`](../../../schemas/evidence_bundle_validation_report.schema.json).
+The `report_schema_id` field identifies the validation report schema,
+`validated_schema_id` identifies the saved verification result schema used for
+saved result validation, and `validator` identifies the CLI command that
+emitted the report. These metadata fields help CI, UI, and external audit
+tools interpret the report later; they do not prove authenticity, establish
+trusted key provenance, re-run cryptographic verification, or provide
+certification.
 
 ## Saving reviewer evidence to a file
 
@@ -108,6 +115,9 @@ A schema-valid saved result emits only JSON on stdout and exits `0`:
   "ok": true,
   "schema_valid": true,
   "result_path": "evidence-bundle-verification-result.json",
+  "report_schema_id": "https://veritas-os.example/schemas/evidence_bundle_validation_report.schema.json",
+  "validated_schema_id": "https://veritas-os.example/schemas/evidence_bundle_verification_result.schema.json",
+  "validator": "veritas-evidence-bundle validate-result",
   "errors": []
 }
 ```
@@ -118,13 +128,18 @@ For malformed JSON, the path is `$` because the document cannot be parsed before
 schema validation.
 
 The validation report schema validates only the shape of the
-`validate-result --json` report (`ok`, `schema_valid`, `result_path`, and
-`errors[]` diagnostics with `path` and `message`). It does not validate the
-original Evidence Bundle, does not validate the saved verification result
-beyond recording this command outcome, does not re-run Evidence Bundle
-file/hash checks, does not re-run Ed25519 manifest signature verification,
-does not establish trusted key provenance, and is not regulatory certification
-or completed third-party audit approval. Saving a
+`validate-result --json` report (`ok`, `schema_valid`, `result_path`,
+`report_schema_id`, `validated_schema_id`, `validator`, and `errors[]`
+diagnostics with `path` and `message`). The report is self-describing:
+`report_schema_id` identifies the validation report schema,
+`validated_schema_id` identifies the verification result schema used by
+`validate-result`, and `validator` identifies the emitting CLI command. These
+fields are metadata for interpretation only. They do not validate the original
+Evidence Bundle, do not validate the saved verification result beyond recording
+this command outcome, do not prove authenticity, do not re-run Evidence Bundle
+file/hash checks, do not re-run Ed25519 manifest signature verification, do
+not establish trusted key provenance, and are not regulatory certification or
+completed third-party audit approval. Saving a
 `validate-result --json --output` report records the schema-validation outcome
 for the already-saved result file; it is not a new cryptographic verification
 run. Reviewers must still preserve out-of-band trusted public key provenance for

--- a/docs/en/validation/sample-evidence-bundle-verification-output.md
+++ b/docs/en/validation/sample-evidence-bundle-verification-output.md
@@ -102,7 +102,10 @@ veritas-evidence-bundle validate-result \
 The stdout JSON and saved UTF-8 JSON file are byte-for-byte identical. Failure
 reports for schema-invalid or malformed saved results are also written so CI,
 UI, and external audit tools can retain the failed validation outcome. The
-validation report shape is documented by
+validation report is self-describing: `report_schema_id` identifies the
+validation report schema, `validated_schema_id` identifies the verification
+result schema used for saved result validation, and `validator` identifies the
+emitting CLI command. The validation report shape is documented by
 [`schemas/evidence_bundle_validation_report.schema.json`](../../../schemas/evidence_bundle_validation_report.schema.json).
 `validate-result --output` without `--json` fails clearly.
 
@@ -113,6 +116,9 @@ Illustrative `validate-result --json` success output:
   "ok": true,
   "schema_valid": true,
   "result_path": "evidence-bundle-verification-result.json",
+  "report_schema_id": "https://veritas-os.example/schemas/evidence_bundle_validation_report.schema.json",
+  "validated_schema_id": "https://veritas-os.example/schemas/evidence_bundle_verification_result.schema.json",
+  "validator": "veritas-evidence-bundle validate-result",
   "errors": []
 }
 ```
@@ -124,6 +130,9 @@ Illustrative `validate-result --json` failure output:
   "ok": false,
   "schema_valid": false,
   "result_path": "evidence-bundle-verification-result.json",
+  "report_schema_id": "https://veritas-os.example/schemas/evidence_bundle_validation_report.schema.json",
+  "validated_schema_id": "https://veritas-os.example/schemas/evidence_bundle_verification_result.schema.json",
+  "validator": "veritas-evidence-bundle validate-result",
   "errors": [
     {
       "path": "$['signature_status']",
@@ -138,7 +147,9 @@ message beginning with `malformed JSON:`.
 
 The saved-result schema validation confirms saved verification result shape
 only. The separate validation report schema validates only the
-`validate-result --json` report shape. Neither schema validates the original
+`validate-result --json` report shape. Its `report_schema_id`,
+`validated_schema_id`, and `validator` fields are metadata for interpretation;
+they do not prove authenticity or trust. Neither schema validates the original
 Evidence Bundle, re-runs file/hash integrity checks, re-runs Ed25519 signature
 verification, establishes out-of-band trusted key provenance, or provides
 regulatory certification or completed third-party audit approval. A saved

--- a/schemas/evidence_bundle_validation_report.schema.json
+++ b/schemas/evidence_bundle_validation_report.schema.json
@@ -2,13 +2,16 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://veritas-os.example/schemas/evidence_bundle_validation_report.schema.json",
   "title": "Evidence Bundle Validation Report",
-  "description": "This schema describes the machine-readable report emitted by veritas-evidence-bundle validate-result --json. It validates the validation report shape only. It does not validate the original Evidence Bundle. It does not re-run file/hash integrity checks. It does not re-run Ed25519 signature verification. It does not establish trusted key provenance. It is not regulatory certification or completed third-party audit approval.",
+  "description": "This schema describes the machine-readable, self-describing report emitted by veritas-evidence-bundle validate-result --json. It validates the validation report shape only. report_schema_id identifies the schema for the validation report shape. validated_schema_id identifies the saved verification result schema used by validate-result. These fields are metadata for interpretation. They do not re-run cryptographic verification. They do not re-run file/hash integrity checks. They do not establish trusted key provenance. They are not regulatory certification or completed third-party audit approval.",
   "type": "object",
   "additionalProperties": true,
   "required": [
     "ok",
     "schema_valid",
     "result_path",
+    "report_schema_id",
+    "validated_schema_id",
+    "validator",
     "errors"
   ],
   "properties": {
@@ -23,6 +26,18 @@
     "result_path": {
       "type": "string",
       "description": "Path to the saved Evidence Bundle verification result JSON file that validate-result checked."
+    },
+    "report_schema_id": {
+      "type": "string",
+      "description": "Identifies the schema for the validation report shape. This field is metadata for interpretation only; it does not re-run cryptographic verification, establish trusted key provenance, or represent regulatory certification or completed third-party audit approval."
+    },
+    "validated_schema_id": {
+      "type": "string",
+      "description": "Identifies the saved verification result schema used by validate-result. This field is metadata for interpretation only; it does not re-run cryptographic verification, establish trusted key provenance, or represent regulatory certification or completed third-party audit approval."
+    },
+    "validator": {
+      "type": "string",
+      "description": "Identifies the validator command that emitted this validation report. This field is metadata for interpretation only; it does not establish trusted key provenance or completed third-party audit approval."
     },
     "errors": {
       "type": "array",

--- a/veritas_os/cli/evidence_bundle.py
+++ b/veritas_os/cli/evidence_bundle.py
@@ -31,6 +31,14 @@ def _parse_key_value_pairs(values: Optional[list[str]]) -> Dict[str, str]:
 
 
 SECURE_POSTURES = {"secure", "prod"}
+SCHEMA_BASE_URL = "https://veritas-os.example/schemas"
+VERIFICATION_RESULT_SCHEMA_ID = (
+    f"{SCHEMA_BASE_URL}/evidence_bundle_verification_result.schema.json"
+)
+VALIDATION_REPORT_SCHEMA_ID = (
+    f"{SCHEMA_BASE_URL}/evidence_bundle_validation_report.schema.json"
+)
+VALIDATE_RESULT_VALIDATOR = "veritas-evidence-bundle validate-result"
 VERIFICATION_RESULT_SCHEMA_PATH = (
     Path(__file__).resolve().parents[2]
     / "schemas"
@@ -156,13 +164,19 @@ def _run_validate_result(
     When ``json_output`` is true, stdout is limited to a machine-readable
     validation report for CI, UI, and external audit-tool integrations. When
     ``output_path`` is supplied, the exact stdout JSON report is also written
-    as UTF-8 audit evidence, including schema validation failure reports.
+    as UTF-8 audit evidence, including schema validation failure reports. The
+    JSON report includes schema metadata fields for later interpretation; those
+    fields do not re-run cryptographic verification or establish trusted key
+    provenance.
     """
     errors = _validate_verification_result_schema(result_path)
     output = {
         "ok": not errors,
         "schema_valid": not errors,
         "result_path": str(result_path),
+        "report_schema_id": VALIDATION_REPORT_SCHEMA_ID,
+        "validated_schema_id": VERIFICATION_RESULT_SCHEMA_ID,
+        "validator": VALIDATE_RESULT_VALIDATOR,
         "errors": errors,
     }
     if json_output:

--- a/veritas_os/tests/test_evidence_bundle_cli.py
+++ b/veritas_os/tests/test_evidence_bundle_cli.py
@@ -678,25 +678,22 @@ def test_verify_bundle_signature_failure_reports_authenticity_failure(
     tmp_path,
     monkeypatch,
 ) -> None:
-    """A validly encoded wrong Ed25519 signature is classified as verification failure."""
+    """Wrong-key Ed25519 verification returns failure, not verifier error."""
     from veritas_os.audit.verify_bundle import verify_evidence_bundle
-    from veritas_os.security.signing import verify_payload_signature
-
-    bundle_dir, _private_key, public_key = _signed_bundle(tmp_path, monkeypatch)
-    manifest_path = bundle_dir / "manifest.json"
-    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    manifest["manifest_signature"] = base64.urlsafe_b64encode(
-        b"\x00" * 64
-    ).decode("ascii")
-    manifest_path.write_text(
-        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
+    from veritas_os.security.signing import (
+        store_keypair,
+        verify_payload_signature,
     )
+
+    bundle_dir, _private_key, _public_key = _signed_bundle(tmp_path, monkeypatch)
+    wrong_private_key = tmp_path / "wrong_verify_keys" / "priv.key"
+    wrong_public_key = tmp_path / "wrong_verify_keys" / "pub.key"
+    store_keypair(wrong_private_key, wrong_public_key)
 
     result = verify_evidence_bundle(
         bundle_dir,
         verify_signature_fn=lambda payload_hash, signature_b64: (
-            verify_payload_signature(payload_hash, signature_b64, public_key)
+            verify_payload_signature(payload_hash, signature_b64, wrong_public_key)
         ),
         require_signature=True,
     )
@@ -707,11 +704,39 @@ def test_verify_bundle_signature_failure_reports_authenticity_failure(
     assert result["authenticity_failure"] == "signature_verification_failed"
 
 
+def test_verify_bundle_signature_verifier_error_reports_authenticity_error(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    """Verifier exceptions are classified separately from signature mismatch."""
+    from veritas_os.audit.verify_bundle import verify_evidence_bundle
+
+    def raise_verifier_error(_payload_hash: str, _signature_b64: str) -> bool:
+        raise RuntimeError("verifier backend unavailable")
+
+    bundle_dir, _private_key, _public_key = _signed_bundle(tmp_path, monkeypatch)
+
+    result = verify_evidence_bundle(
+        bundle_dir,
+        verify_signature_fn=raise_verifier_error,
+        require_signature=True,
+    )
+
+    assert result["ok"] is False
+    assert result["hash_integrity_ok"] is True
+    assert result["authenticity_ok"] is False
+    assert result["authenticity_failure"] == "signature_verification_error"
+    assert any(
+        error.startswith("Manifest signature verification error")
+        for error in result["errors"]
+    )
+
+
 def test_verify_bundle_malformed_signature_reports_authenticity_error(
     tmp_path,
     monkeypatch,
 ) -> None:
-    """Malformed manifest_signature is classified separately from signature mismatch."""
+    """Malformed manifest_signature is classified separately from mismatch."""
     from veritas_os.audit.verify_bundle import verify_evidence_bundle
     from veritas_os.security.signing import verify_payload_signature
 

--- a/veritas_os/tests/test_evidence_bundle_cli.py
+++ b/veritas_os/tests/test_evidence_bundle_cli.py
@@ -123,10 +123,9 @@ def test_evidence_bundle_validation_report_schema_contract() -> None:
     assert error_schema["properties"]["path"]["type"] == "string"
     assert error_schema["properties"]["message"]["type"] == "string"
     description = schema["description"]
-    assert (
-        "machine-readable report emitted by "
-        "veritas-evidence-bundle validate-result --json"
-    ) in description
+    assert "machine-readable" in description
+    assert "self-describing report emitted by" in description
+    assert "veritas-evidence-bundle validate-result --json" in description
     assert "validates the validation report shape only" in description
     assert "report_schema_id identifies the schema" in description
     assert (
@@ -134,9 +133,9 @@ def test_evidence_bundle_validation_report_schema_contract() -> None:
         in description
     )
     assert "metadata for interpretation" in description
-    assert "does not re-run cryptographic verification" in description
-    assert "does not re-run file/hash integrity checks" in description
-    assert "does not establish trusted key provenance" in description
+    assert "not re-run cryptographic verification" in description
+    assert "not re-run file/hash integrity checks" in description
+    assert "not establish trusted key provenance" in description
     assert "not regulatory certification" in description
 
     _assert_validation_report_schema(

--- a/veritas_os/tests/test_evidence_bundle_cli.py
+++ b/veritas_os/tests/test_evidence_bundle_cli.py
@@ -18,6 +18,20 @@ SCHEMA_PATH = Path("schemas/evidence_bundle_verification_result.schema.json")
 VALIDATION_REPORT_SCHEMA_PATH = Path(
     "schemas/evidence_bundle_validation_report.schema.json"
 )
+REPORT_SCHEMA_ID = (
+    "https://veritas-os.example/schemas/"
+    "evidence_bundle_validation_report.schema.json"
+)
+VALIDATED_SCHEMA_ID = (
+    "https://veritas-os.example/schemas/"
+    "evidence_bundle_verification_result.schema.json"
+)
+VALIDATOR = "veritas-evidence-bundle validate-result"
+VALIDATION_REPORT_METADATA = {
+    "report_schema_id": REPORT_SCHEMA_ID,
+    "validated_schema_id": VALIDATED_SCHEMA_ID,
+    "validator": VALIDATOR,
+}
 CONTRACT_JSON_FIELDS = {
     "ok",
     "tampered",
@@ -49,6 +63,13 @@ def _assert_validation_report_schema(output: dict[str, Any]) -> None:
     schema = _load_validation_report_schema()
     jsonschema.Draft202012Validator.check_schema(schema)
     jsonschema.Draft202012Validator(schema).validate(output)
+
+
+def _assert_validation_report_metadata(output: dict[str, Any]) -> None:
+    """Assert validate-result reports include self-describing metadata."""
+    assert output["report_schema_id"] == REPORT_SCHEMA_ID
+    assert output["validated_schema_id"] == VALIDATED_SCHEMA_ID
+    assert output["validator"] == VALIDATOR
 
 
 def _assert_contract_fields(output: dict[str, Any]) -> None:
@@ -86,11 +107,17 @@ def test_evidence_bundle_validation_report_schema_contract() -> None:
         "ok",
         "schema_valid",
         "result_path",
+        "report_schema_id",
+        "validated_schema_id",
+        "validator",
         "errors",
     }
     assert schema["properties"]["ok"]["type"] == "boolean"
     assert schema["properties"]["schema_valid"]["type"] == "boolean"
     assert schema["properties"]["result_path"]["type"] == "string"
+    assert schema["properties"]["report_schema_id"]["type"] == "string"
+    assert schema["properties"]["validated_schema_id"]["type"] == "string"
+    assert schema["properties"]["validator"]["type"] == "string"
     error_schema = schema["properties"]["errors"]["items"]
     assert set(error_schema["required"]) == {"path", "message"}
     assert error_schema["properties"]["path"]["type"] == "string"
@@ -101,9 +128,14 @@ def test_evidence_bundle_validation_report_schema_contract() -> None:
         "veritas-evidence-bundle validate-result --json"
     ) in description
     assert "validates the validation report shape only" in description
-    assert "does not validate the original Evidence Bundle" in description
+    assert "report_schema_id identifies the schema" in description
+    assert (
+        "validated_schema_id identifies the saved verification result schema"
+        in description
+    )
+    assert "metadata for interpretation" in description
+    assert "does not re-run cryptographic verification" in description
     assert "does not re-run file/hash integrity checks" in description
-    assert "does not re-run Ed25519 signature verification" in description
     assert "does not establish trusted key provenance" in description
     assert "not regulatory certification" in description
 
@@ -112,6 +144,7 @@ def test_evidence_bundle_validation_report_schema_contract() -> None:
             "ok": False,
             "schema_valid": False,
             "result_path": "verification-result.json",
+            **VALIDATION_REPORT_METADATA,
             "errors": [
                 {
                     "path": "$['signature_status']",
@@ -1163,11 +1196,13 @@ def test_evidence_bundle_cli_validate_result_valid_saved_result_json_passes(
     output = json.loads(capsys.readouterr().out)
 
     _assert_validation_report_schema(output)
+    _assert_validation_report_metadata(output)
     assert exit_code == 0
     assert output == {
         "ok": True,
         "schema_valid": True,
         "result_path": str(result_path),
+        **VALIDATION_REPORT_METADATA,
         "errors": [],
     }
 
@@ -1188,6 +1223,7 @@ def test_evidence_bundle_cli_validate_result_missing_required_field_json_fails(
     output = json.loads(capsys.readouterr().out)
 
     _assert_validation_report_schema(output)
+    _assert_validation_report_metadata(output)
     assert exit_code == 1
     assert output["ok"] is False
     assert output["schema_valid"] is False
@@ -1216,6 +1252,7 @@ def test_evidence_bundle_cli_validate_result_invalid_signature_status_json_fails
     output = json.loads(capsys.readouterr().out)
 
     _assert_validation_report_schema(output)
+    _assert_validation_report_metadata(output)
     assert exit_code == 1
     assert output["ok"] is False
     assert output["schema_valid"] is False
@@ -1239,6 +1276,7 @@ def test_evidence_bundle_cli_validate_result_invalid_fingerprint_json_fails(
     output = json.loads(capsys.readouterr().out)
 
     _assert_validation_report_schema(output)
+    _assert_validation_report_metadata(output)
     assert exit_code == 1
     assert output["ok"] is False
     assert output["schema_valid"] is False
@@ -1260,11 +1298,13 @@ def test_evidence_bundle_cli_validate_result_malformed_json_json_fails(
     output = json.loads(capsys.readouterr().out)
 
     _assert_validation_report_schema(output)
+    _assert_validation_report_metadata(output)
     assert exit_code == 1
     assert output == {
         "ok": False,
         "schema_valid": False,
         "result_path": str(result_path),
+        **VALIDATION_REPORT_METADATA,
         "errors": [
             {
                 "path": "$",
@@ -1314,11 +1354,13 @@ def test_evidence_bundle_cli_validate_result_json_output_valid_matches_stdout(
     )
 
     _assert_validation_report_schema(output)
+    _assert_validation_report_metadata(output)
     assert exit_code == 0
     assert output == {
         "ok": True,
         "schema_valid": True,
         "result_path": str(result_path),
+        **VALIDATION_REPORT_METADATA,
         "errors": [],
     }
 
@@ -1352,6 +1394,7 @@ def test_evidence_bundle_cli_validate_result_json_output_invalid_matches_stdout(
     )
 
     _assert_validation_report_schema(output)
+    _assert_validation_report_metadata(output)
     assert exit_code == 1
     assert output["ok"] is False
     assert output["schema_valid"] is False
@@ -1386,6 +1429,7 @@ def test_evidence_bundle_cli_validate_result_json_output_malformed_matches_stdou
     )
 
     _assert_validation_report_schema(output)
+    _assert_validation_report_metadata(output)
     assert exit_code == 1
     assert output["ok"] is False
     assert output["schema_valid"] is False


### PR DESCRIPTION
### Motivation
- Make `validate-result --json` output self-describing so CI, UI, and external audit tooling can unambiguously interpret which validation-report schema and which verification-result schema were used, and which validator emitted the report.

### Description
- Add `report_schema_id`, `validated_schema_id`, and `validator` to the machine-readable `validate-result --json` output and include constants for those identifiers in `veritas_os/cli/evidence_bundle.py`.
- Update `schemas/evidence_bundle_validation_report.schema.json` to require the three metadata fields as strings and expand the schema description to state these are interpretation metadata that do not re-run cryptographic verification or establish trusted key provenance.
- Update `veritas_os/tests/test_evidence_bundle_cli.py` to assert the metadata are present for valid/invalid/malformed/saved reports and to validate the updated report schema contract.
- Update documentation in `docs/en/validation/*` (contract, sample output, reviewer checklist) to describe the self-describing report fields and clarify their interpretation boundaries (they do not prove authenticity, re-run verification, or provide certification).

### Testing
- Ran Python static checks: `python -m py_compile veritas_os/cli/evidence_bundle.py veritas_os/tests/test_evidence_bundle_cli.py`, which succeeded. 
- Validated the updated JSON Schema with `python -m json.tool schemas/evidence_bundle_validation_report.schema.json` and a small Python assertion script that confirmed the added metadata fields are `required` and of type `string`; both checks passed.  
- Updated unit tests in `veritas_os/tests/test_evidence_bundle_cli.py` to assert metadata presence for success, failure, malformed, and saved-report cases; these tests were modified but full `pytest` execution could not be completed in this environment due to missing project dependencies (`pydantic`) and inability to provision dependencies (PyPI access failed), so automated pytest results are pending in CI.  
- Manual `git diff --check` and JSON/schema sanity checks were performed and passed; CI run (full `pytest`) should validate end-to-end behavior in the project environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27fac8a5188326a38673b86306453a)