### PR TITLE
Add Trusted Public Key Provenance Receipt schema and reviewer docs

### DIFF
--- a/docs/en/validation/evidence-bundle-reviewer-checklist.md
+++ b/docs/en/validation/evidence-bundle-reviewer-checklist.md
@@ -10,6 +10,9 @@ Use it with the strict CLI path in
 and the example transcripts in
 [Sample Evidence Bundle Verification Output](sample-evidence-bundle-verification-output.md)
 and the [Evidence Bundle Verification JSON Contract](evidence-bundle-verification-json-contract.md).
+Use the [Trusted Public Key Provenance Receipt](trusted-public-key-provenance.md)
+to preserve the reviewer/operator trust basis for the public key used in
+strict verification.
 
 ## Scope and non-certification boundary
 
@@ -24,10 +27,13 @@ Security boundaries:
 - A public key included only inside the bundle is not trusted by itself.
 - The `public_key_fingerprint_sha256` JSON field records which public key
   material was used for verification; it is key-provenance evidence, not a trust
-  proof.
+  proof. Strict verification requires trusted public key provenance before a
+  reviewer relies on authenticity.
 - The trusted Ed25519 public key must be obtained outside the bundle through an
   approved out-of-band reviewer/operator trust channel, and reviewers should
-  record and compare that out-of-band key fingerprint in their review notes.
+  preserve a Trusted Public Key Provenance Receipt for that key. Matching
+  `public_key_fingerprint_sha256` values support correlation between the
+  verification result and the provenance receipt; they are not certification.
 - The `--json` result contract supports reviewer-facing verification and UI
   integration, but it does not certify regulatory compliance or audit approval.
 - Do not add private keys, real signing keys, production secrets, or unsanitized
@@ -101,9 +107,9 @@ Record `ACCEPT` only when all of the following are true:
 - `File/hash integrity: PASS` is present in the strict verification output.
 - `Manifest signature: PASS` is present in the same strict verification output.
 - The trusted Ed25519 public key was obtained outside the bundle, its
-  provenance is documented by the reviewer, and its out-of-band SHA-256
-  fingerprint matches `public_key_fingerprint_sha256` in the strict `--json`
-  result.
+  provenance is documented by the reviewer in a Trusted Public Key
+  Provenance Receipt, and its out-of-band SHA-256 fingerprint matches
+  `public_key_fingerprint_sha256` in the strict `--json` result.
 - `acceptance_checklist.json` has no blocking failures.
 - Expected artifacts for the bundle type and review objective are present.
 - Any non-blocking notes in `verification_report.json` have been reviewed and
@@ -150,5 +156,7 @@ key, the bundle is not reviewer-facing verified evidence.
   [Sample Evidence Bundle Verification Output](sample-evidence-bundle-verification-output.md)
 - Stable `--json` field semantics for reviewer/UI consumers:
   [Evidence Bundle Verification JSON Contract](evidence-bundle-verification-json-contract.md)
+- Trusted public key provenance receipt and fingerprint correlation:
+  [Trusted Public Key Provenance Receipt](trusted-public-key-provenance.md)
 - Bundle contents and delivery policy:
   [External Audit Readiness Pack](external-audit-readiness.md)

--- a/docs/en/validation/evidence-bundle-verification-json-contract.md
+++ b/docs/en/validation/evidence-bundle-verification-json-contract.md
@@ -1,5 +1,13 @@
 # Evidence Bundle Verification JSON Contract
 
+For reviewer/operator key trust records, pair this contract with the
+[Trusted Public Key Provenance Receipt](trusted-public-key-provenance.md).
+Strict verification requires trusted public key provenance before reviewers
+rely on authenticity. The `public_key_fingerprint_sha256` field records key
+material evidence; it is not trust proof. Matching fingerprints support
+correlation between `verification-result.json` and the provenance receipt,
+not regulatory certification or completed third-party audit approval.
+
 This page documents the reviewer-facing JSON result contract emitted by:
 
 ```bash
@@ -342,10 +350,11 @@ reviewer-facing verified evidence.
 - Treat `authenticity_ok: false` as “authenticity not established,” even when
   `hash_integrity_ok: true`.
 - Display `errors` as blocking reviewer actions and `warnings` as review notes.
-- Record `public_key_fingerprint_sha256` with the reviewer/operator key handoff
-  notes as key-provenance evidence.
+- Record `public_key_fingerprint_sha256` with the reviewer/operator Trusted
+  Public Key Provenance Receipt as key-material evidence.
 - Never trust a key because its fingerprint matches a value copied from the
   bundle or its adjacent artifacts; fingerprint matching is only useful after the
   reviewer obtained the key through an out-of-band trust channel.
 - Record trusted public key provenance outside the bundle before relying on
-  `signature_verified: true`.
+  `signature_verified: true`, preferably using the
+  [Trusted Public Key Provenance Receipt](trusted-public-key-provenance.md).

--- a/docs/en/validation/sample-evidence-bundle-verification-output.md
+++ b/docs/en/validation/sample-evidence-bundle-verification-output.md
@@ -1,5 +1,12 @@
 # Sample Evidence Bundle Verification Output
 
+These examples should be read with the
+[Trusted Public Key Provenance Receipt](trusted-public-key-provenance.md).
+Strict verification requires reviewer/operator provenance for the public key;
+`public_key_fingerprint_sha256` records key material evidence, not trust
+proof. Matching fingerprints support correlation and do not certify the
+bundle or complete a third-party audit.
+
 This page is a reviewer-facing sample transcript for Evidence Bundle strict
 verification. All command output below is **illustrative output** for external
 auditors and design partners to preview the expected CLI shape before handling a
@@ -56,8 +63,11 @@ saved verification result is reviewer evidence, including for failed
 verification attempts such as missing public keys or wrong public keys. It is
 not regulatory certification and is not completed third-party audit approval.
 Reviewers must interpret the file with out-of-band trusted public key
-provenance; `public_key_fingerprint_sha256` helps correlate the saved result
-with the key handoff record, but does not make the key trustworthy on its own.
+provenance, preserved in a Trusted Public Key Provenance Receipt;
+`public_key_fingerprint_sha256` helps correlate the saved result with the
+key handoff receipt, but does not make the key trustworthy on its own. A
+public key copied only from the Evidence Bundle must not be trusted by
+itself.
 
 ## Validating a saved JSON result shape
 

--- a/docs/en/validation/technical-proof-pack.md
+++ b/docs/en/validation/technical-proof-pack.md
@@ -62,6 +62,7 @@ Start here for the completed reviewer path:
 - [Evidence Bundle Signature Verification Demo](evidence-bundle-signature-verification.md)
 - [Sample Evidence Bundle Verification Output](sample-evidence-bundle-verification-output.md)
 - [Evidence Bundle Verification JSON Contract](evidence-bundle-verification-json-contract.md)
+- [Trusted Public Key Provenance Receipt](trusted-public-key-provenance.md)
 - [External Audit Readiness Pack](external-audit-readiness.md)
 
 Boundaries:
@@ -70,7 +71,12 @@ Boundaries:
 - It is not regulatory certification.
 - It is not completed third-party audit approval.
 - Trusted public keys must come from an out-of-band reviewer/operator trust
-  channel.
+  channel, and reviewers should preserve a Trusted Public Key Provenance
+  Receipt.
+- `public_key_fingerprint_sha256` is key material evidence, not trust proof;
+  matching fingerprints support correlation, not certification.
+- A public key copied only from inside the Evidence Bundle is not trusted by
+  itself.
 
 ---
 

--- a/docs/en/validation/trusted-public-key-provenance.md
+++ b/docs/en/validation/trusted-public-key-provenance.md
@@ -53,8 +53,8 @@ strict verification artifacts when relying on Evidence Bundle authenticity:
 
 A matching fingerprint supports correlation between the cryptographic
 verification run and the out-of-band trust record. It is not regulatory
-certification, completed third-party audit approval, or standalone proof that
-the original Evidence Bundle is authentic.
+certification and is not completed third-party audit approval. It is not
+standalone proof that the original Evidence Bundle is authentic.
 
 ## Fingerprint comparison
 
@@ -110,5 +110,6 @@ Reject or request a corrected handoff when any of the following occur:
 
 The receipt records reviewer/operator provenance for trusted Ed25519 public key
 material. It does not re-run cryptographic verification, does not prove that the
-original Evidence Bundle is authentic by itself, and is not regulatory
-certification or completed third-party audit approval.
+original Evidence Bundle is authentic by itself. This receipt is not
+regulatory certification. This receipt is not completed third-party audit
+approval.

--- a/docs/en/validation/trusted-public-key-provenance.md
+++ b/docs/en/validation/trusted-public-key-provenance.md
@@ -1,0 +1,114 @@
+# Trusted Public Key Provenance Receipt
+
+The Trusted Public Key Provenance Receipt records why a reviewer or operator
+trusted the Ed25519 public key used during strict Evidence Bundle verification.
+It complements `verification-result.json`; it is not generated from the
+Evidence Bundle alone and it does not replace cryptographic verification.
+
+Schema:
+[`schemas/trusted_public_key_provenance_receipt.schema.json`](../../../schemas/trusted_public_key_provenance_receipt.schema.json)
+
+## Why public key provenance matters
+
+Strict Evidence Bundle verification separates two questions:
+
+1. **Which key material was used?** The verifier records this as
+   `public_key_fingerprint_sha256`.
+2. **Why was that key trusted?** The reviewer must establish this through an
+   out-of-band reviewer/operator process such as an operator handoff,
+   reviewer vault, signed release, KMS/certificate process, or offline key
+   ceremony.
+
+A matching signature under an untrusted key does not establish reviewer-facing
+authenticity. A public key copied only from the Evidence Bundle, or from
+bundle-adjacent material without an independent trust process, is not trusted by
+itself.
+
+## Public key fingerprint versus trust
+
+`public_key_fingerprint_sha256` is key-material evidence. It records the
+SHA-256 lowercase hexadecimal fingerprint of the public key bytes supplied to
+strict verification.
+
+The fingerprint is not a trust proof. It helps reviewers correlate the saved
+verification result with an independent provenance receipt. Trust comes from the
+reviewer/operator trust channel recorded in the receipt, not from the bundle or
+fingerprint alone.
+
+## How reviewers should use the receipt
+
+Reviewers should preserve a Trusted Public Key Provenance Receipt next to the
+strict verification artifacts when relying on Evidence Bundle authenticity:
+
+1. Obtain the Ed25519 public key outside the Evidence Bundle through an
+   approved reviewer/operator trust channel.
+2. Record a receipt with the key fingerprint, trust channel, received timestamp,
+   approving identity, approval reference, and reviewer notes.
+3. Run strict verification with the trusted public key and save JSON output:
+   `veritas-evidence-bundle verify --require-signature --json --output
+   verification-result.json`.
+4. Compare the fingerprint in `verification-result.json` with the fingerprint in
+   the Trusted Public Key Provenance Receipt.
+5. Preserve both files as review evidence.
+
+A matching fingerprint supports correlation between the cryptographic
+verification run and the out-of-band trust record. It is not regulatory
+certification, completed third-party audit approval, or standalone proof that
+the original Evidence Bundle is authentic.
+
+## Fingerprint comparison
+
+Compare these fields exactly:
+
+- `verification-result.json.public_key_fingerprint_sha256`
+- `trusted_public_key_provenance_receipt.public_key_fingerprint_sha256`
+
+Both values must be 64-character lowercase hexadecimal SHA-256 fingerprints.
+If the values differ, the verification result used different key material than
+the trusted provenance receipt records. Treat that as a reject condition until a
+corrected handoff or corrected verification result is available.
+
+## Bundle-internal keys are not enough
+
+A key stored only inside the Evidence Bundle can help identify what the bundle
+claims, but it cannot establish why a reviewer should trust the bundle. The
+provenance receipt therefore requires `bundle_internal_key_used` to be `false`.
+If the only available key material came from inside the bundle, do not accept the
+bundle as reviewer-facing verified evidence.
+
+## Example valid receipt
+
+```json
+{
+  "receipt_type": "trusted_public_key_provenance",
+  "algorithm": "Ed25519",
+  "public_key_fingerprint_sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  "trust_channel": "operator_handoff",
+  "received_at": "2026-06-09T00:00:00Z",
+  "approved_by": "reviewer@example.com",
+  "approval_reference": "ticket-or-vault-reference",
+  "notes": "Public key received from out-of-band reviewer/operator trust channel.",
+  "bundle_internal_key_used": false
+}
+```
+
+## Example reject conditions
+
+Reject or request a corrected handoff when any of the following occur:
+
+- The public key is copied only from the Evidence Bundle.
+- `bundle_internal_key_used` is `true` or missing.
+- The receipt fingerprint does not match
+  `verification-result.json.public_key_fingerprint_sha256`.
+- `trust_channel` is unknown and not recorded as `other` with clear notes and an
+  approval reference.
+- The receipt is missing `approved_by`, `approval_reference`, or reviewer notes.
+- Strict verification did not produce `signature_status: "pass"`,
+  `signature_verified: true`, and `authenticity_ok: true` under the trusted key.
+
+## Boundary
+
+The receipt records reviewer/operator provenance for trusted Ed25519 public key
+material. It does not re-run cryptographic verification, does not prove that the
+original Evidence Bundle is authentic by itself, and is not regulatory
+certification or completed third-party audit approval.

--- a/schemas/trusted_public_key_provenance_receipt.schema.json
+++ b/schemas/trusted_public_key_provenance_receipt.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://veritas-os.example/schemas/trusted_public_key_provenance_receipt.schema.json",
   "title": "Trusted Public Key Provenance Receipt",
-  "description": "This receipt records reviewer/operator provenance for a trusted Ed25519 public key. It helps reviewers correlate public_key_fingerprint_sha256 in verification results with an out-of-band trust record. It is not generated from the Evidence Bundle alone. A public key copied only from the Evidence Bundle is not trusted by itself; Evidence Bundle alone is not enough. This receipt does not re-run cryptographic verification. This receipt does not prove that the original Evidence Bundle is authentic by itself. This receipt is not regulatory certification or completed third-party audit approval.",
+  "description": "This receipt records reviewer/operator provenance for a trusted Ed25519 public key. It helps reviewers correlate public_key_fingerprint_sha256 in verification results with an out-of-band trust record. It is not generated from the Evidence Bundle alone. A public key copied only from the Evidence Bundle is not trusted by itself; Evidence Bundle alone is not enough. This receipt does not re-run cryptographic verification. This receipt does not prove that the original Evidence Bundle is authentic by itself. This receipt is not regulatory certification. This receipt is not completed third-party audit approval.",
   "type": "object",
   "additionalProperties": false,
   "required": [

--- a/schemas/trusted_public_key_provenance_receipt.schema.json
+++ b/schemas/trusted_public_key_provenance_receipt.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://veritas-os.example/schemas/trusted_public_key_provenance_receipt.schema.json",
+  "title": "Trusted Public Key Provenance Receipt",
+  "description": "This receipt records reviewer/operator provenance for a trusted Ed25519 public key. It helps reviewers correlate public_key_fingerprint_sha256 in verification results with an out-of-band trust record. It is not generated from the Evidence Bundle alone. A public key copied only from the Evidence Bundle is not trusted by itself; Evidence Bundle alone is not enough. This receipt does not re-run cryptographic verification. This receipt does not prove that the original Evidence Bundle is authentic by itself. This receipt is not regulatory certification or completed third-party audit approval.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "receipt_type",
+    "algorithm",
+    "public_key_fingerprint_sha256",
+    "trust_channel",
+    "received_at",
+    "approved_by",
+    "approval_reference",
+    "notes",
+    "bundle_internal_key_used"
+  ],
+  "properties": {
+    "receipt_type": {
+      "type": "string",
+      "const": "trusted_public_key_provenance",
+      "description": "Receipt discriminator for trusted public key provenance records."
+    },
+    "algorithm": {
+      "type": "string",
+      "const": "Ed25519",
+      "description": "Public key algorithm. Evidence Bundle strict signature verification currently expects a trusted Ed25519 public key."
+    },
+    "public_key_fingerprint_sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$",
+      "description": "SHA-256 lowercase hexadecimal fingerprint of the trusted public key bytes as recorded through the reviewer/operator trust channel. This supports correlation with verification-result.json public_key_fingerprint_sha256; it is not trust proof by itself."
+    },
+    "trust_channel": {
+      "type": "string",
+      "enum": [
+        "operator_handoff",
+        "reviewer_vault",
+        "signed_release",
+        "kms_or_certificate_process",
+        "offline_key_ceremony",
+        "other"
+      ],
+      "description": "Reviewer/operator channel used to establish why this public key material was trusted. Use other only when notes and approval_reference identify the actual trust process."
+    },
+    "received_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "UTC timestamp when the reviewer/operator received or confirmed the trusted public key material."
+    },
+    "approved_by": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Reviewer, operator, or approving identity that accepted this public key as trusted for the Evidence Bundle review."
+    },
+    "approval_reference": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Ticket, vault entry, signed release note, KMS/certificate record, ceremony record, or equivalent reference for the trust decision."
+    },
+    "notes": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable provenance notes. Do not include private keys, secrets, or unsanitized customer data."
+    },
+    "bundle_internal_key_used": {
+      "type": "boolean",
+      "const": false,
+      "description": "Must be false. Public key material copied only from inside the Evidence Bundle is not trusted by itself and must not be used as the provenance basis for this receipt."
+    }
+  }
+}

--- a/veritas_os/tests/test_trusted_public_key_provenance_schema.py
+++ b/veritas_os/tests/test_trusted_public_key_provenance_schema.py
@@ -1,0 +1,123 @@
+"""Tests for the trusted public key provenance receipt schema."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator, FormatChecker
+
+
+SCHEMA_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "schemas"
+    / "trusted_public_key_provenance_receipt.schema.json"
+)
+VALID_FINGERPRINT = "0123456789abcdef" * 4
+
+
+def _load_schema() -> dict[str, Any]:
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def _valid_receipt() -> dict[str, Any]:
+    return {
+        "receipt_type": "trusted_public_key_provenance",
+        "algorithm": "Ed25519",
+        "public_key_fingerprint_sha256": VALID_FINGERPRINT,
+        "trust_channel": "operator_handoff",
+        "received_at": "2026-06-09T00:00:00Z",
+        "approved_by": "reviewer@example.com",
+        "approval_reference": "ticket-or-vault-reference",
+        "notes": "Public key received from out-of-band trust record.",
+        "bundle_internal_key_used": False,
+    }
+
+
+def _validator() -> Draft202012Validator:
+    return Draft202012Validator(_load_schema(), format_checker=FormatChecker())
+
+
+def _messages_for(receipt: dict[str, Any]) -> list[str]:
+    return [error.message for error in _validator().iter_errors(receipt)]
+
+
+def test_schema_loads_and_is_valid_draft_2020_12() -> None:
+    schema = _load_schema()
+
+    Draft202012Validator.check_schema(schema)
+    assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+
+
+def test_valid_receipt_matches_schema() -> None:
+    _validator().validate(_valid_receipt())
+
+
+def test_required_fields_are_enforced() -> None:
+    for field in _load_schema()["required"]:
+        receipt = _valid_receipt()
+        receipt.pop(field)
+
+        messages = _messages_for(receipt)
+
+        assert any(field in message and "required" in message for message in messages)
+
+
+def test_public_key_fingerprint_must_be_64_lowercase_hex() -> None:
+    invalid_values = [
+        "0123456789abcdef" * 3,
+        "0123456789abcdef" * 4 + "00",
+        "0123456789ABCDEF" * 4,
+        "g" * 64,
+    ]
+
+    for value in invalid_values:
+        receipt = _valid_receipt()
+        receipt["public_key_fingerprint_sha256"] = value
+
+        messages = _messages_for(receipt)
+
+        assert any("does not match" in message for message in messages)
+
+
+def test_algorithm_requires_ed25519() -> None:
+    receipt = _valid_receipt()
+    receipt["algorithm"] = "RSA"
+
+    messages = _messages_for(receipt)
+
+    assert any("Ed25519" in message for message in messages)
+
+
+def test_trust_channel_enum_rejects_unknown_values_unless_other() -> None:
+    receipt = _valid_receipt()
+    receipt["trust_channel"] = "chat_message"
+
+    messages = _messages_for(receipt)
+
+    assert any("not one of" in message for message in messages)
+
+    receipt["trust_channel"] = "other"
+    _validator().validate(receipt)
+
+
+def test_bundle_internal_key_use_is_rejected() -> None:
+    receipt = _valid_receipt()
+    receipt["bundle_internal_key_used"] = True
+
+    messages = _messages_for(receipt)
+
+    assert any("False was expected" in message for message in messages)
+
+
+def test_schema_description_documents_security_boundaries() -> None:
+    description = _load_schema()["description"]
+
+    expected_phrases = [
+        "out-of-band trust record",
+        "Evidence Bundle alone is not enough",
+        "not regulatory certification",
+        "not completed third-party audit approval",
+    ]
+    for phrase in expected_phrases:
+        assert phrase in description


### PR DESCRIPTION
### Motivation

- Reviewers need a machine-readable way to record why an Ed25519 public key was trusted for Evidence Bundle verification, because `public_key_fingerprint_sha256` records key material but not trust provenance. 
- Add an auditable receipt schema and reviewer guidance to make the boundary between key material evidence and out-of-band trust explicit. 

### Description

- Add a Draft 2020-12 JSON Schema `schemas/trusted_public_key_provenance_receipt.schema.json` that requires `receipt_type`, `algorithm` (const `Ed25519`), `public_key_fingerprint_sha256` (64 lowercase hex), `trust_channel` (enum), `received_at`, `approved_by`, `approval_reference`, `notes`, and `bundle_internal_key_used` (must be `false`).
- Add reviewer documentation `docs/en/validation/trusted-public-key-provenance.md` that explains why provenance matters, how to compare `verification-result.json.public_key_fingerprint_sha256` with the receipt, example valid receipt, and reject conditions. 
- Update existing validation docs to reference and link the new receipt: `evidence-bundle-reviewer-checklist.md`, `evidence-bundle-verification-json-contract.md`, `sample-evidence-bundle-verification-output.md`, and `technical-proof-pack.md` to clarify that fingerprint matching is correlation, not trust proof. 
- Add schema tests `veritas_os/tests/test_trusted_public_key_provenance_schema.py` that assert schema loads as Draft 2020-12, required fields are enforced, fingerprint pattern, `Ed25519` enforcement, `trust_channel` enum behavior (including `other`), `bundle_internal_key_used` rejection, and presence of security-boundary wording. 
- No CLI behavior was changed in this PR; CLI generation/consumption changes are planned for a follow-up.

### Testing

- The new JSON Schema was syntactically validated with `python3 -m json.tool schemas/trusted_public_key_provenance_receipt.schema.json` and basic schema properties were sanity-checked via a short Python assertion script, and those checks passed. 
- The new test module was byte-checked by compiling with `python3 -m py_compile veritas_os/tests/test_trusted_public_key_provenance_schema.py` and that succeeded. 
- An attempt to run the tests with `pytest` in this container was blocked by the environment: the pinned `3.12.12` interpreter was unavailable and `uv` could not fetch dependencies due to a network tunnel error, so full `pytest` execution was not performed here and is expected to run in CI. 
- The added tests are included and will be executed by CI (where the correct interpreter and dependencies are available).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a280b0b8a008326a6eb0fd24744f57f)