### PR TITLE
feat: validate trusted key provenance in evidence CLI

### DIFF
--- a/docs/en/validation/evidence-bundle-reviewer-checklist.md
+++ b/docs/en/validation/evidence-bundle-reviewer-checklist.md
@@ -86,6 +86,25 @@ key provenance, or provide regulatory certification or completed third-party
 audit approval. Preserve the out-of-band trusted-key provenance record even
 when saved-result schema validation passes.
 
+After preserving a Trusted Public Key Provenance Receipt, validate the receipt
+and correlate it with the saved strict verification result:
+
+```bash
+veritas-evidence-bundle validate-key-provenance \
+  --receipt trusted-public-key-provenance.json \
+  --verification-result verification-result.json
+```
+
+This command validates the receipt schema, validates the saved verification
+result schema, checks exact fingerprint correlation, rejects
+`bundle_internal_key_used: true`, and confirms strict authenticity success
+(`signature_status: "pass"`, `signature_verified: true`, and
+`authenticity_ok: true`). Add `--json --output <path>` to emit and save the
+exact same machine-readable report, including failure reports. The command does
+not create trust by itself, does not re-run cryptographic verification, does
+not prove regulatory certification, and does not complete third-party audit
+approval. Matching fingerprints support correlation, not standalone trust.
+
 ## Verification order
 
 | Step | Reviewer action | PASS criterion | FAIL / follow-up criterion |

--- a/docs/en/validation/evidence-bundle-reviewer-checklist.md
+++ b/docs/en/validation/evidence-bundle-reviewer-checklist.md
@@ -100,10 +100,13 @@ result schema, checks exact fingerprint correlation, rejects
 `bundle_internal_key_used: true`, and confirms strict authenticity success
 (`signature_status: "pass"`, `signature_verified: true`, and
 `authenticity_ok: true`). Add `--json --output <path>` to emit and save the
-exact same machine-readable report, including failure reports. The command does
-not create trust by itself, does not re-run cryptographic verification, does
-not prove regulatory certification, and does not complete third-party audit
-approval. Matching fingerprints support correlation, not standalone trust.
+exact same machine-readable report, including failure reports. The report does
+not echo raw fingerprint values; it only records fingerprint presence and
+correlation status because the raw fingerprints remain in the source receipt
+and verification-result artifacts. The command does not create trust by itself,
+does not re-run cryptographic verification, does not prove regulatory
+certification, and does not complete third-party audit approval. Matching
+fingerprints support correlation, not standalone trust.
 
 ## Verification order
 

--- a/docs/en/validation/evidence-bundle-reviewer-checklist.md
+++ b/docs/en/validation/evidence-bundle-reviewer-checklist.md
@@ -101,12 +101,13 @@ result schema, checks exact fingerprint correlation, rejects
 (`signature_status: "pass"`, `signature_verified: true`, and
 `authenticity_ok: true`). Add `--json --output <path>` to emit and save the
 exact same machine-readable report, including failure reports. The report does
-not echo raw fingerprint values; it only records fingerprint presence and
-correlation status because the raw fingerprints remain in the source receipt
-and verification-result artifacts. The command does not create trust by itself,
-does not re-run cryptographic verification, does not prove regulatory
-certification, and does not complete third-party audit approval. Matching
-fingerprints support correlation, not standalone trust.
+not echo raw fingerprint values or user-provided file paths; it only records
+path-provided booleans, fingerprint presence, and correlation status because
+the raw fingerprints and paths remain in the source receipt, verification-result
+artifacts, and reviewer-controlled command history. The command does not create
+trust by itself, does not re-run cryptographic verification, does not prove
+regulatory certification, and does not complete third-party audit approval.
+Matching fingerprints support correlation, not standalone trust.
 
 ## Verification order
 

--- a/docs/en/validation/evidence-bundle-verification-json-contract.md
+++ b/docs/en/validation/evidence-bundle-verification-json-contract.md
@@ -154,6 +154,28 @@ run. Reviewers must still preserve out-of-band trusted public key provenance for
 the key represented by `public_key_fingerprint_sha256` before relying on any
 saved strict verification result.
 
+Use `validate-key-provenance` when tooling needs one command to validate the
+Trusted Public Key Provenance Receipt shape and correlate it with this saved
+verification-result contract:
+
+```bash
+veritas-evidence-bundle validate-key-provenance \
+  --receipt trusted-public-key-provenance.json \
+  --verification-result verification-result.json \
+  --json
+```
+
+The JSON report includes stable booleans for receipt schema validity,
+verification-result schema validity, fingerprint correlation,
+`bundle_internal_key_used: false`, and strict authenticity success.
+`--output <path>` is allowed only with `--json`; the saved JSON is byte-for-byte
+the same as stdout JSON, and failure reports are saved as audit evidence. This
+correlation report has no dedicated schema yet and is intentionally structured
+for future extension. It does not create trust by itself, does not re-run
+cryptographic verification, does not prove regulatory certification, and does
+not complete third-party audit approval. Matching fingerprints support
+correlation, not standalone trust.
+
 ## Contract scope
 
 The contract separates two reviewer decisions that external UI and audit tooling

--- a/docs/en/validation/evidence-bundle-verification-json-contract.md
+++ b/docs/en/validation/evidence-bundle-verification-json-contract.md
@@ -166,15 +166,17 @@ veritas-evidence-bundle validate-key-provenance \
 ```
 
 The JSON report includes stable booleans for receipt schema validity,
-verification-result schema validity, fingerprint correlation,
-`bundle_internal_key_used: false`, and strict authenticity success.
-`--output <path>` is allowed only with `--json`; the saved JSON is byte-for-byte
-the same as stdout JSON, and failure reports are saved as audit evidence. This
-correlation report has no dedicated schema yet and is intentionally structured
-for future extension. It does not create trust by itself, does not re-run
-cryptographic verification, does not prove regulatory certification, and does
-not complete third-party audit approval. Matching fingerprints support
-correlation, not standalone trust.
+verification-result schema validity, fingerprint presence, fingerprint
+correlation, `bundle_internal_key_used: false`, and strict authenticity success.
+It does not echo raw fingerprint values; those values remain in the source
+receipt and verification-result artifacts. `--output <path>` is allowed only
+with `--json`; the saved JSON is byte-for-byte the same as stdout JSON, and
+failure reports are saved as audit evidence. This correlation report has no
+dedicated schema yet and is intentionally structured for future extension. It
+does not create trust by itself, does not re-run cryptographic verification,
+does not prove regulatory certification, and does not complete third-party
+audit approval. Matching fingerprints support correlation, not standalone
+trust.
 
 ## Contract scope
 

--- a/docs/en/validation/evidence-bundle-verification-json-contract.md
+++ b/docs/en/validation/evidence-bundle-verification-json-contract.md
@@ -166,12 +166,13 @@ veritas-evidence-bundle validate-key-provenance \
 ```
 
 The JSON report includes stable booleans for receipt schema validity,
-verification-result schema validity, fingerprint presence, fingerprint
-correlation, `bundle_internal_key_used: false`, and strict authenticity success.
-It does not echo raw fingerprint values; those values remain in the source
-receipt and verification-result artifacts. `--output <path>` is allowed only
-with `--json`; the saved JSON is byte-for-byte the same as stdout JSON, and
-failure reports are saved as audit evidence. This correlation report has no
+verification-result schema validity, path presence, fingerprint presence,
+fingerprint correlation, `bundle_internal_key_used: false`, and strict
+authenticity success. It does not echo raw fingerprint values or user-provided
+file paths; those values remain in the source receipt and verification-result
+artifacts and reviewer-controlled command history. `--output <path>` is allowed
+only with `--json`; the saved JSON is byte-for-byte the same as stdout JSON,
+and failure reports are saved as audit evidence. This correlation report has no
 dedicated schema yet and is intentionally structured for future extension. It
 does not create trust by itself, does not re-run cryptographic verification,
 does not prove regulatory certification, and does not complete third-party

--- a/docs/en/validation/sample-evidence-bundle-verification-output.md
+++ b/docs/en/validation/sample-evidence-bundle-verification-output.md
@@ -212,13 +212,15 @@ veritas-evidence-bundle validate-key-provenance \
 ```
 
 The stdout JSON and saved UTF-8 JSON file are byte-for-byte identical, including
-failure reports. `--output` without `--json` fails clearly. This command
-validates receipt shape, validates saved verification-result shape, checks exact
-fingerprint correlation, rejects `bundle_internal_key_used: true`, and confirms
-strict authenticity success. It does not create trust by itself, does not re-run
-cryptographic verification, does not prove regulatory certification, and does
-not complete third-party audit approval. Matching fingerprints support
-correlation, not standalone trust.
+failure reports. `--output` without `--json` fails clearly. The report does not
+echo raw fingerprint values; raw fingerprints remain in the source receipt and
+verification-result artifacts. This command validates receipt shape, validates
+saved verification-result shape, checks exact fingerprint correlation, rejects
+`bundle_internal_key_used: true`, and confirms strict authenticity success. It
+does not create trust by itself, does not re-run cryptographic verification,
+does not prove regulatory certification, and does not complete third-party
+audit approval. Matching fingerprints support correlation, not standalone
+trust.
 
 ## Successful strict verification
 

--- a/docs/en/validation/sample-evidence-bundle-verification-output.md
+++ b/docs/en/validation/sample-evidence-bundle-verification-output.md
@@ -213,14 +213,15 @@ veritas-evidence-bundle validate-key-provenance \
 
 The stdout JSON and saved UTF-8 JSON file are byte-for-byte identical, including
 failure reports. `--output` without `--json` fails clearly. The report does not
-echo raw fingerprint values; raw fingerprints remain in the source receipt and
-verification-result artifacts. This command validates receipt shape, validates
-saved verification-result shape, checks exact fingerprint correlation, rejects
-`bundle_internal_key_used: true`, and confirms strict authenticity success. It
-does not create trust by itself, does not re-run cryptographic verification,
-does not prove regulatory certification, and does not complete third-party
-audit approval. Matching fingerprints support correlation, not standalone
-trust.
+echo raw fingerprint values or user-provided file paths; raw fingerprints and
+paths remain in the source receipt, verification-result artifacts, and
+reviewer-controlled command history. This command validates receipt shape,
+validates saved verification-result shape, checks exact fingerprint correlation,
+rejects `bundle_internal_key_used: true`, and confirms strict authenticity
+success. It does not create trust by itself, does not re-run cryptographic
+verification, does not prove regulatory certification, and does not complete
+third-party audit approval. Matching fingerprints support correlation, not
+standalone trust.
 
 ## Successful strict verification
 

--- a/docs/en/validation/sample-evidence-bundle-verification-output.md
+++ b/docs/en/validation/sample-evidence-bundle-verification-output.md
@@ -167,6 +167,59 @@ regulatory certification or completed third-party audit approval. A saved
 report for an existing result file, not evidence of a new Evidence Bundle
 verification run.
 
+## Validating trusted public key provenance correlation
+
+After strict verification and receipt preservation, reviewers can validate the
+receipt shape and correlate its fingerprint with the saved verification result:
+
+```bash
+veritas-evidence-bundle validate-key-provenance \
+  --receipt trusted-public-key-provenance.json \
+  --verification-result verification-result.json
+```
+
+Illustrative success output:
+
+```text
+Trusted public key provenance validation: PASS
+Receipt schema: PASS
+Verification result schema: PASS
+Fingerprint correlation: PASS
+Bundle-internal key used: PASS
+Strict authenticity result: PASS
+```
+
+Illustrative failure output:
+
+```text
+Trusted public key provenance validation: FAIL
+Receipt schema: PASS
+Verification result schema: PASS
+Fingerprint correlation: FAIL
+Bundle-internal key used: PASS
+Strict authenticity result: PASS
+  error [fingerprint_correlation_ok] at $['public_key_fingerprint_sha256']: receipt and verification result public key fingerprints do not match
+```
+
+For machine-readable output and saved audit evidence, use `--json --output`:
+
+```bash
+veritas-evidence-bundle validate-key-provenance \
+  --receipt trusted-public-key-provenance.json \
+  --verification-result verification-result.json \
+  --json \
+  --output key-provenance-validation.json
+```
+
+The stdout JSON and saved UTF-8 JSON file are byte-for-byte identical, including
+failure reports. `--output` without `--json` fails clearly. This command
+validates receipt shape, validates saved verification-result shape, checks exact
+fingerprint correlation, rejects `bundle_internal_key_used: true`, and confirms
+strict authenticity success. It does not create trust by itself, does not re-run
+cryptographic verification, does not prove regulatory certification, and does
+not complete third-party audit approval. Matching fingerprints support
+correlation, not standalone trust.
+
 ## Successful strict verification
 
 Illustrative output:

--- a/docs/en/validation/trusted-public-key-provenance.md
+++ b/docs/en/validation/trusted-public-key-provenance.md
@@ -82,7 +82,11 @@ Strict authenticity result: PASS
 For CI, UI, or audit-tool ingestion, add `--json`. Add `--output <path>` with
 `--json` to save the exact same JSON report that is emitted to stdout; failure
 reports are saved too, and parent directories are created when needed.
-`--output` without `--json` is rejected.
+`--output` without `--json` is rejected. To avoid echoing externally supplied
+key material in logs, the CLI report does not print raw fingerprint values; it
+only reports whether receipt and verification-result fingerprints are present
+and whether correlation passed. The raw fingerprints remain preserved in the
+source receipt and verification-result artifacts.
 
 ```bash
 veritas-evidence-bundle validate-key-provenance \
@@ -103,12 +107,14 @@ The command checks that:
 - the saved result reports strict authenticity success: `signature_status:
   "pass"`, `signature_verified: true`, and `authenticity_ok: true`.
 
-This command validates receipt shape and fingerprint correlation only. It does
-not create trust by itself, does not re-run cryptographic verification, does
-not prove regulatory certification, and does not complete third-party audit
-approval. Matching fingerprints support correlation between a saved strict
-verification result and a reviewer/operator provenance record; they are not
-standalone trust.
+This command validates receipt shape and fingerprint correlation only. The CLI
+report intentionally does not echo raw fingerprint values; use the original
+receipt and verification-result artifacts when a reviewer must inspect exact
+fingerprints. It does not create trust by itself, does not re-run cryptographic
+verification, does not prove regulatory certification, and does not complete
+third-party audit approval. Matching fingerprints support correlation between a
+saved strict verification result and a reviewer/operator provenance record;
+they are not standalone trust.
 
 ## Fingerprint comparison
 

--- a/docs/en/validation/trusted-public-key-provenance.md
+++ b/docs/en/validation/trusted-public-key-provenance.md
@@ -56,6 +56,60 @@ verification run and the out-of-band trust record. It is not regulatory
 certification and is not completed third-party audit approval. It is not
 standalone proof that the original Evidence Bundle is authentic.
 
+## CLI validation
+
+Use `validate-key-provenance` to validate the receipt shape, validate the saved
+Evidence Bundle verification result shape, and correlate the two saved
+fingerprints:
+
+```bash
+veritas-evidence-bundle validate-key-provenance \
+  --receipt trusted-public-key-provenance.json \
+  --verification-result verification-result.json
+```
+
+Successful human-readable output reports each check explicitly:
+
+```text
+Trusted public key provenance validation: PASS
+Receipt schema: PASS
+Verification result schema: PASS
+Fingerprint correlation: PASS
+Bundle-internal key used: PASS
+Strict authenticity result: PASS
+```
+
+For CI, UI, or audit-tool ingestion, add `--json`. Add `--output <path>` with
+`--json` to save the exact same JSON report that is emitted to stdout; failure
+reports are saved too, and parent directories are created when needed.
+`--output` without `--json` is rejected.
+
+```bash
+veritas-evidence-bundle validate-key-provenance \
+  --receipt trusted-public-key-provenance.json \
+  --verification-result verification-result.json \
+  --json \
+  --output key-provenance-validation.json
+```
+
+The command checks that:
+
+- `--receipt` conforms to
+  `schemas/trusted_public_key_provenance_receipt.schema.json`;
+- `--verification-result` conforms to
+  `schemas/evidence_bundle_verification_result.schema.json`;
+- both `public_key_fingerprint_sha256` values match exactly;
+- the receipt has `bundle_internal_key_used: false`; and
+- the saved result reports strict authenticity success: `signature_status:
+  "pass"`, `signature_verified: true`, and `authenticity_ok: true`.
+
+This command validates receipt shape and fingerprint correlation only. It does
+not create trust by itself, does not re-run cryptographic verification, does
+not prove regulatory certification, and does not complete third-party audit
+approval. Matching fingerprints support correlation between a saved strict
+verification result and a reviewer/operator provenance record; they are not
+standalone trust.
+
 ## Fingerprint comparison
 
 Compare these fields exactly:

--- a/docs/en/validation/trusted-public-key-provenance.md
+++ b/docs/en/validation/trusted-public-key-provenance.md
@@ -83,10 +83,12 @@ For CI, UI, or audit-tool ingestion, add `--json`. Add `--output <path>` with
 `--json` to save the exact same JSON report that is emitted to stdout; failure
 reports are saved too, and parent directories are created when needed.
 `--output` without `--json` is rejected. To avoid echoing externally supplied
-key material in logs, the CLI report does not print raw fingerprint values; it
-only reports whether receipt and verification-result fingerprints are present
-and whether correlation passed. The raw fingerprints remain preserved in the
-source receipt and verification-result artifacts.
+key material or reviewer-controlled locations in logs, the CLI report does not
+print raw fingerprint values or user-provided file paths; it only reports
+whether receipt and verification-result paths were provided, whether
+fingerprints are present, and whether correlation passed. The raw fingerprints
+and paths remain preserved in the source receipt and verification-result
+artifacts and reviewer-controlled command history.
 
 ```bash
 veritas-evidence-bundle validate-key-provenance \
@@ -108,13 +110,14 @@ The command checks that:
   "pass"`, `signature_verified: true`, and `authenticity_ok: true`.
 
 This command validates receipt shape and fingerprint correlation only. The CLI
-report intentionally does not echo raw fingerprint values; use the original
-receipt and verification-result artifacts when a reviewer must inspect exact
-fingerprints. It does not create trust by itself, does not re-run cryptographic
-verification, does not prove regulatory certification, and does not complete
-third-party audit approval. Matching fingerprints support correlation between a
-saved strict verification result and a reviewer/operator provenance record;
-they are not standalone trust.
+report intentionally does not echo raw fingerprint values or user-provided file
+paths; use the original receipt and verification-result artifacts when a
+reviewer must inspect exact fingerprints and source locations. It does not
+create trust by itself, does not re-run cryptographic verification, does not
+prove regulatory certification, and does not complete third-party audit
+approval. Matching fingerprints support correlation between a saved strict
+verification result and a reviewer/operator provenance record; they are not
+standalone trust.
 
 ## Fingerprint comparison
 

--- a/veritas_os/cli/evidence_bundle.py
+++ b/veritas_os/cli/evidence_bundle.py
@@ -54,6 +54,37 @@ TRUSTED_PUBLIC_KEY_PROVENANCE_RECEIPT_SCHEMA_PATH = (
     / "trusted_public_key_provenance_receipt.schema.json"
 )
 
+KEY_PROVENANCE_ERROR_CHECKS = {
+    "receipt_schema_valid",
+    "verification_result_schema_valid",
+    "fingerprint_correlation_ok",
+    "bundle_internal_key_used_ok",
+    "strict_authenticity_ok",
+    "validation",
+}
+KEY_PROVENANCE_ERROR_PATHS = {
+    "$",
+    "$['public_key_fingerprint_sha256']",
+    "$['bundle_internal_key_used']",
+    "$['authenticity_ok']",
+    "$['signature_status']",
+    "$['signature_verified']",
+}
+KEY_PROVENANCE_ERROR_MESSAGES = {
+    "failed to read receipt file",
+    "failed to read verification result file",
+    "failed to load receipt schema",
+    "failed to load verification result schema",
+    "malformed JSON",
+    "value does not satisfy schema at this path",
+    "receipt and verification result public key fingerprints do not match",
+    "receipt bundle_internal_key_used must be false",
+    (
+        "verification result must report signature_status pass, "
+        "signature_verified true, and authenticity_ok true"
+    ),
+}
+
 
 def _is_fail_closed_posture() -> bool:
     """Return whether evidence-bundle verification must fail closed."""
@@ -171,23 +202,21 @@ def _load_json_document(
     """Load a JSON document and return structured CLI validation errors."""
     try:
         raw_document = document_path.read_text(encoding="utf-8")
-    except OSError as exc:
+    except OSError:
         return None, [
             {
                 "path": "$",
-                "message": f"failed to read {label} file {document_path}: {exc}",
+                "message": f"failed to read {label} file",
             }
         ]
 
     try:
         return json.loads(raw_document), []
-    except json.JSONDecodeError as exc:
+    except json.JSONDecodeError:
         return None, [
             {
                 "path": "$",
-                "message": (
-                    f"malformed JSON: line {exc.lineno}, column {exc.colno}: {exc.msg}"
-                ),
+                "message": "malformed JSON",
             }
         ]
 
@@ -196,11 +225,11 @@ def _load_schema(schema_path: Path, label: str) -> tuple[Any, list[dict[str, str
     """Load a JSON Schema and return structured CLI validation errors."""
     try:
         return json.loads(schema_path.read_text(encoding="utf-8")), []
-    except (OSError, json.JSONDecodeError) as exc:
+    except (OSError, json.JSONDecodeError):
         return None, [
             {
                 "path": "$",
-                "message": f"failed to load {label} schema: {exc}",
+                "message": f"failed to load {label} schema",
             }
         ]
 
@@ -368,8 +397,8 @@ def _build_key_provenance_report(
         "fingerprint_correlation_ok": fingerprint_correlation_ok,
         "bundle_internal_key_used_ok": bundle_internal_key_used_ok,
         "strict_authenticity_ok": strict_authenticity,
-        "receipt_path": str(receipt_path),
-        "verification_result_path": str(verification_result_path),
+        "receipt_path_provided": True,
+        "verification_result_path_provided": True,
         "receipt_public_key_fingerprint_present": isinstance(
             receipt_fingerprint,
             str,
@@ -393,6 +422,69 @@ def _build_key_provenance_report(
     return report
 
 
+def _safe_key_provenance_error_for_output(
+    error: dict[str, str],
+) -> dict[str, str]:
+    """Return a validate-key-provenance error with only allowlisted text."""
+    check = error.get("check")
+    if check not in KEY_PROVENANCE_ERROR_CHECKS:
+        check = "validation"
+
+    path = error.get("path")
+    if path not in KEY_PROVENANCE_ERROR_PATHS:
+        path = "$"
+
+    message = error.get("message")
+    if message not in KEY_PROVENANCE_ERROR_MESSAGES:
+        message = _safe_validation_message(message or "")
+
+    return {
+        "check": check,
+        "path": path,
+        "message": message,
+    }
+
+
+def _safe_key_provenance_report_for_output(
+    report: dict[str, Any],
+) -> dict[str, Any]:
+    """Return a non-tainted validate-key-provenance report for output sinks.
+
+    The source report is derived from reviewer-controlled JSON files and CLI
+    paths. This helper explicitly rebuilds the output contract from booleans,
+    fixed schema identifiers, and sanitized error fields so stdout, saved JSON,
+    and human-readable messages do not echo raw paths, fingerprints, exception
+    text, or JSON values.
+    """
+    return {
+        "ok": bool(report["ok"]),
+        "receipt_schema_valid": bool(report["receipt_schema_valid"]),
+        "verification_result_schema_valid": bool(
+            report["verification_result_schema_valid"]
+        ),
+        "fingerprint_correlation_ok": bool(report["fingerprint_correlation_ok"]),
+        "bundle_internal_key_used_ok": bool(report["bundle_internal_key_used_ok"]),
+        "strict_authenticity_ok": bool(report["strict_authenticity_ok"]),
+        "receipt_path_provided": bool(report["receipt_path_provided"]),
+        "verification_result_path_provided": bool(
+            report["verification_result_path_provided"]
+        ),
+        "receipt_public_key_fingerprint_present": bool(
+            report["receipt_public_key_fingerprint_present"]
+        ),
+        "verification_result_public_key_fingerprint_present": bool(
+            report["verification_result_public_key_fingerprint_present"]
+        ),
+        "report_schema_id": None,
+        "receipt_schema_id": TRUSTED_PUBLIC_KEY_PROVENANCE_RECEIPT_SCHEMA_ID,
+        "verification_result_schema_id": VERIFICATION_RESULT_SCHEMA_ID,
+        "validator": VALIDATE_KEY_PROVENANCE_VALIDATOR,
+        "errors": [
+            _safe_key_provenance_error_for_output(error) for error in report["errors"]
+        ],
+    }
+
+
 def _run_validate_key_provenance(
     receipt_path: Path,
     verification_result_path: Path,
@@ -401,17 +493,17 @@ def _run_validate_key_provenance(
     output_path: Optional[Path] = None,
 ) -> int:
     """Run trusted public key provenance receipt validation."""
-    report = _build_key_provenance_report(receipt_path, verification_result_path)
+    raw_report = _build_key_provenance_report(receipt_path, verification_result_path)
+    report = _safe_key_provenance_report_for_output(raw_report)
     if json_output:
         output_json = json.dumps(report, indent=2, ensure_ascii=False)
         if output_path is not None:
             try:
                 output_path.parent.mkdir(parents=True, exist_ok=True)
                 output_path.write_text(output_json + "\n", encoding="utf-8")
-            except OSError as exc:
+            except OSError:
                 print(
-                    "error: failed to write key provenance validation report "
-                    f"to {output_path}: {exc}",
+                    "error: failed to write key provenance validation report",
                     file=sys.stderr,
                 )
                 return 2

--- a/veritas_os/cli/evidence_bundle.py
+++ b/veritas_os/cli/evidence_bundle.py
@@ -107,6 +107,11 @@ def _json_schema_error_path(error: jsonschema.ValidationError) -> str:
     return path
 
 
+def _safe_validation_message(_message: str) -> str:
+    """Return a schema validation message that never echoes input values."""
+    return "value does not satisfy schema at this path"
+
+
 def _validate_verification_result_schema(
     result_path: Path,
 ) -> list[dict[str, str]]:
@@ -216,7 +221,10 @@ def _validate_json_schema(
         key=lambda error: (list(error.absolute_path), error.message),
     )
     return [
-        {"path": _json_schema_error_path(error), "message": error.message}
+        {
+            "path": _json_schema_error_path(error),
+            "message": _safe_validation_message(error.message),
+        }
         for error in errors
     ]
 
@@ -353,7 +361,6 @@ def _build_key_provenance_report(
         and strict_authenticity
     )
 
-    verification_fingerprint_key = "verification_result_public_key_fingerprint_sha256"
     report = {
         "ok": ok,
         "receipt_schema_valid": receipt_schema_valid,
@@ -363,8 +370,14 @@ def _build_key_provenance_report(
         "strict_authenticity_ok": strict_authenticity,
         "receipt_path": str(receipt_path),
         "verification_result_path": str(verification_result_path),
-        "receipt_public_key_fingerprint_sha256": receipt_fingerprint,
-        verification_fingerprint_key: verification_fingerprint,
+        "receipt_public_key_fingerprint_present": isinstance(
+            receipt_fingerprint,
+            str,
+        ),
+        "verification_result_public_key_fingerprint_present": isinstance(
+            verification_fingerprint,
+            str,
+        ),
         "report_schema_id": None,
         "receipt_schema_id": TRUSTED_PUBLIC_KEY_PROVENANCE_RECEIPT_SCHEMA_ID,
         "verification_result_schema_id": VERIFICATION_RESULT_SCHEMA_ID,

--- a/veritas_os/cli/evidence_bundle.py
+++ b/veritas_os/cli/evidence_bundle.py
@@ -38,11 +38,20 @@ VERIFICATION_RESULT_SCHEMA_ID = (
 VALIDATION_REPORT_SCHEMA_ID = (
     f"{SCHEMA_BASE_URL}/evidence_bundle_validation_report.schema.json"
 )
+TRUSTED_PUBLIC_KEY_PROVENANCE_RECEIPT_SCHEMA_ID = (
+    f"{SCHEMA_BASE_URL}/trusted_public_key_provenance_receipt.schema.json"
+)
 VALIDATE_RESULT_VALIDATOR = "veritas-evidence-bundle validate-result"
+VALIDATE_KEY_PROVENANCE_VALIDATOR = "veritas-evidence-bundle validate-key-provenance"
 VERIFICATION_RESULT_SCHEMA_PATH = (
     Path(__file__).resolve().parents[2]
     / "schemas"
     / "evidence_bundle_verification_result.schema.json"
+)
+TRUSTED_PUBLIC_KEY_PROVENANCE_RECEIPT_SCHEMA_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "schemas"
+    / "trusted_public_key_provenance_receipt.schema.json"
 )
 
 
@@ -124,16 +133,13 @@ def _validate_verification_result_schema(
             {
                 "path": "$",
                 "message": (
-                    "malformed JSON: "
-                    f"line {exc.lineno}, column {exc.colno}: {exc.msg}"
+                    f"malformed JSON: line {exc.lineno}, column {exc.colno}: {exc.msg}"
                 ),
             }
         ]
 
     try:
-        schema = json.loads(
-            VERIFICATION_RESULT_SCHEMA_PATH.read_text(encoding="utf-8")
-        )
+        schema = json.loads(VERIFICATION_RESULT_SCHEMA_PATH.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
         return [
             {
@@ -151,6 +157,269 @@ def _validate_verification_result_schema(
         {"path": _json_schema_error_path(error), "message": error.message}
         for error in errors
     ]
+
+
+def _load_json_document(
+    document_path: Path,
+    label: str,
+) -> tuple[Any, list[dict[str, str]]]:
+    """Load a JSON document and return structured CLI validation errors."""
+    try:
+        raw_document = document_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return None, [
+            {
+                "path": "$",
+                "message": f"failed to read {label} file {document_path}: {exc}",
+            }
+        ]
+
+    try:
+        return json.loads(raw_document), []
+    except json.JSONDecodeError as exc:
+        return None, [
+            {
+                "path": "$",
+                "message": (
+                    f"malformed JSON: line {exc.lineno}, column {exc.colno}: {exc.msg}"
+                ),
+            }
+        ]
+
+
+def _load_schema(schema_path: Path, label: str) -> tuple[Any, list[dict[str, str]]]:
+    """Load a JSON Schema and return structured CLI validation errors."""
+    try:
+        return json.loads(schema_path.read_text(encoding="utf-8")), []
+    except (OSError, json.JSONDecodeError) as exc:
+        return None, [
+            {
+                "path": "$",
+                "message": f"failed to load {label} schema: {exc}",
+            }
+        ]
+
+
+def _validate_json_schema(
+    instance: Any,
+    schema_path: Path,
+    label: str,
+) -> list[dict[str, str]]:
+    """Validate a loaded JSON instance against a repository JSON Schema."""
+    schema, schema_errors = _load_schema(schema_path, label)
+    if schema_errors:
+        return schema_errors
+
+    validator = jsonschema.Draft202012Validator(schema)
+    errors = sorted(
+        validator.iter_errors(instance),
+        key=lambda error: (list(error.absolute_path), error.message),
+    )
+    return [
+        {"path": _json_schema_error_path(error), "message": error.message}
+        for error in errors
+    ]
+
+
+def _load_and_validate_json_schema(
+    document_path: Path,
+    schema_path: Path,
+    label: str,
+) -> tuple[Any, list[dict[str, str]]]:
+    """Load a JSON document and validate it against a JSON Schema."""
+    document, document_errors = _load_json_document(document_path, label)
+    if document_errors:
+        return document, document_errors
+    return document, _validate_json_schema(document, schema_path, label)
+
+
+def _strict_authenticity_ok(verification_result: Any) -> bool:
+    """Return whether a verification result reports strict authenticity success."""
+    if not isinstance(verification_result, dict):
+        return False
+    return (
+        verification_result.get("signature_status") == "pass"
+        and verification_result.get("signature_verified") is True
+        and verification_result.get("authenticity_ok") is True
+    )
+
+
+def _key_provenance_errors(
+    *,
+    receipt_errors: list[dict[str, str]],
+    verification_errors: list[dict[str, str]],
+    fingerprint_correlation_ok: bool,
+    bundle_internal_key_used_ok: bool,
+    strict_authenticity_ok: bool,
+) -> list[dict[str, str]]:
+    """Build stable validate-key-provenance JSON report errors."""
+    errors: list[dict[str, str]] = []
+    errors.extend(
+        {
+            "check": "receipt_schema_valid",
+            "path": error["path"],
+            "message": error["message"],
+        }
+        for error in receipt_errors
+    )
+    errors.extend(
+        {
+            "check": "verification_result_schema_valid",
+            "path": error["path"],
+            "message": error["message"],
+        }
+        for error in verification_errors
+    )
+    if not fingerprint_correlation_ok:
+        errors.append(
+            {
+                "check": "fingerprint_correlation_ok",
+                "path": "$['public_key_fingerprint_sha256']",
+                "message": (
+                    "receipt and verification result public key fingerprints "
+                    "do not match"
+                ),
+            }
+        )
+    if not bundle_internal_key_used_ok:
+        errors.append(
+            {
+                "check": "bundle_internal_key_used_ok",
+                "path": "$['bundle_internal_key_used']",
+                "message": "receipt bundle_internal_key_used must be false",
+            }
+        )
+    if not strict_authenticity_ok:
+        errors.append(
+            {
+                "check": "strict_authenticity_ok",
+                "path": "$",
+                "message": (
+                    "verification result must report signature_status pass, "
+                    "signature_verified true, and authenticity_ok true"
+                ),
+            }
+        )
+    return errors
+
+
+def _build_key_provenance_report(
+    receipt_path: Path,
+    verification_result_path: Path,
+) -> dict[str, Any]:
+    """Validate trusted public key provenance and fingerprint correlation.
+
+    This command validates saved JSON shapes and correlates the trusted-key
+    receipt fingerprint with an existing strict Evidence Bundle verification
+    result. It does not create trust, re-run cryptographic verification, prove
+    regulatory certification, or complete third-party audit approval.
+    """
+    receipt, receipt_errors = _load_and_validate_json_schema(
+        receipt_path,
+        TRUSTED_PUBLIC_KEY_PROVENANCE_RECEIPT_SCHEMA_PATH,
+        "receipt",
+    )
+    verification_result, verification_errors = _load_and_validate_json_schema(
+        verification_result_path,
+        VERIFICATION_RESULT_SCHEMA_PATH,
+        "verification result",
+    )
+
+    receipt_fingerprint = None
+    if isinstance(receipt, dict):
+        receipt_fingerprint = receipt.get("public_key_fingerprint_sha256")
+    verification_fingerprint = None
+    if isinstance(verification_result, dict):
+        verification_fingerprint = verification_result.get(
+            "public_key_fingerprint_sha256"
+        )
+
+    fingerprint_correlation_ok = (
+        isinstance(receipt_fingerprint, str)
+        and isinstance(verification_fingerprint, str)
+        and receipt_fingerprint == verification_fingerprint
+    )
+    bundle_internal_key_used_ok = (
+        isinstance(receipt, dict) and receipt.get("bundle_internal_key_used") is False
+    )
+    strict_authenticity = _strict_authenticity_ok(verification_result)
+    receipt_schema_valid = not receipt_errors
+    verification_result_schema_valid = not verification_errors
+    ok = (
+        receipt_schema_valid
+        and verification_result_schema_valid
+        and fingerprint_correlation_ok
+        and bundle_internal_key_used_ok
+        and strict_authenticity
+    )
+
+    verification_fingerprint_key = "verification_result_public_key_fingerprint_sha256"
+    report = {
+        "ok": ok,
+        "receipt_schema_valid": receipt_schema_valid,
+        "verification_result_schema_valid": verification_result_schema_valid,
+        "fingerprint_correlation_ok": fingerprint_correlation_ok,
+        "bundle_internal_key_used_ok": bundle_internal_key_used_ok,
+        "strict_authenticity_ok": strict_authenticity,
+        "receipt_path": str(receipt_path),
+        "verification_result_path": str(verification_result_path),
+        "receipt_public_key_fingerprint_sha256": receipt_fingerprint,
+        verification_fingerprint_key: verification_fingerprint,
+        "report_schema_id": None,
+        "receipt_schema_id": TRUSTED_PUBLIC_KEY_PROVENANCE_RECEIPT_SCHEMA_ID,
+        "verification_result_schema_id": VERIFICATION_RESULT_SCHEMA_ID,
+        "validator": VALIDATE_KEY_PROVENANCE_VALIDATOR,
+        "errors": _key_provenance_errors(
+            receipt_errors=receipt_errors,
+            verification_errors=verification_errors,
+            fingerprint_correlation_ok=fingerprint_correlation_ok,
+            bundle_internal_key_used_ok=bundle_internal_key_used_ok,
+            strict_authenticity_ok=strict_authenticity,
+        ),
+    }
+    return report
+
+
+def _run_validate_key_provenance(
+    receipt_path: Path,
+    verification_result_path: Path,
+    *,
+    json_output: bool = False,
+    output_path: Optional[Path] = None,
+) -> int:
+    """Run trusted public key provenance receipt validation."""
+    report = _build_key_provenance_report(receipt_path, verification_result_path)
+    if json_output:
+        output_json = json.dumps(report, indent=2, ensure_ascii=False)
+        if output_path is not None:
+            try:
+                output_path.parent.mkdir(parents=True, exist_ok=True)
+                output_path.write_text(output_json + "\n", encoding="utf-8")
+            except OSError as exc:
+                print(
+                    "error: failed to write key provenance validation report "
+                    f"to {output_path}: {exc}",
+                    file=sys.stderr,
+                )
+                return 2
+        print(output_json)
+        return 0 if report["ok"] else 1
+
+    status = "PASS" if report["ok"] else "FAIL"
+    print(f"Trusted public key provenance validation: {status}")
+    labels = [
+        ("Receipt schema", "receipt_schema_valid"),
+        ("Verification result schema", "verification_result_schema_valid"),
+        ("Fingerprint correlation", "fingerprint_correlation_ok"),
+        ("Bundle-internal key used", "bundle_internal_key_used_ok"),
+        ("Strict authenticity result", "strict_authenticity_ok"),
+    ]
+    for label, key in labels:
+        check_status = "PASS" if report[key] else "FAIL"
+        print(f"{label}: {check_status}")
+    for error in report["errors"]:
+        print(f"  error [{error['check']}] at {error['path']}: {error['message']}")
+    return 0 if report["ok"] else 1
 
 
 def _run_validate_result(
@@ -187,8 +456,7 @@ def _run_validate_result(
                 output_path.write_text(output_json + "\n", encoding="utf-8")
             except OSError as exc:
                 print(
-                    "error: failed to write validation report "
-                    f"to {output_path}: {exc}",
+                    f"error: failed to write validation report to {output_path}: {exc}",
                     file=sys.stderr,
                 )
                 return 2
@@ -223,11 +491,15 @@ def _write_verification_result(output_path: Path, result: Dict[str, Any]) -> Non
 
 def build_parser() -> argparse.ArgumentParser:
     """Build argparse parser for evidence bundle CLI."""
-    parser = argparse.ArgumentParser(description="Generate/verify VERITAS evidence bundles")
+    parser = argparse.ArgumentParser(
+        description="Generate/verify VERITAS evidence bundles"
+    )
     sub = parser.add_subparsers(dest="command", required=True)
 
     gen = sub.add_parser("generate", help="Generate evidence bundle")
-    gen.add_argument("--bundle-type", required=True, choices=["decision", "incident", "release"])
+    gen.add_argument(
+        "--bundle-type", required=True, choices=["decision", "incident", "release"]
+    )
     gen.add_argument("--witness-ledger", required=True, type=Path)
     gen.add_argument("--output-dir", required=True, type=Path)
     gen.add_argument("--request-id", action="append", dest="request_ids")
@@ -290,6 +562,39 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
 
+    key_provenance = sub.add_parser(
+        "validate-key-provenance",
+        help=(
+            "Validate trusted public key provenance and correlate it with a "
+            "saved strict verification result"
+        ),
+    )
+    key_provenance.add_argument(
+        "--receipt",
+        required=True,
+        type=Path,
+        help="Trusted Public Key Provenance Receipt JSON file",
+    )
+    key_provenance.add_argument(
+        "--verification-result",
+        required=True,
+        type=Path,
+        help="Saved JSON result file from verify --json --output",
+    )
+    key_provenance.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a machine-readable key provenance validation report as JSON",
+    )
+    key_provenance.add_argument(
+        "--output",
+        type=Path,
+        help=(
+            "Write the JSON key provenance validation report to this UTF-8 "
+            "file. Requires --json and does not suppress stdout JSON."
+        ),
+    )
+
     return parser
 
 
@@ -334,6 +639,17 @@ def main(argv: Optional[list[str]] = None) -> int:
             return 2
         return _run_validate_result(
             args.result,
+            json_output=args.json,
+            output_path=args.output,
+        )
+
+    if args.command == "validate-key-provenance":
+        if args.output is not None and not args.json:
+            parser.error("validate-key-provenance --output requires --json")
+            return 2
+        return _run_validate_key_provenance(
+            args.receipt,
+            args.verification_result,
             json_output=args.json,
             output_path=args.output,
         )

--- a/veritas_os/tests/test_trusted_public_key_provenance_cli.py
+++ b/veritas_os/tests/test_trusted_public_key_provenance_cli.py
@@ -1,0 +1,336 @@
+"""Tests for trusted public key provenance CLI validation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+FINGERPRINT = "a" * 64
+MISMATCHED_FINGERPRINT = "b" * 64
+
+
+def _valid_receipt_payload() -> dict[str, Any]:
+    """Return a schema-valid Trusted Public Key Provenance Receipt."""
+    return {
+        "receipt_type": "trusted_public_key_provenance",
+        "algorithm": "Ed25519",
+        "public_key_fingerprint_sha256": FINGERPRINT,
+        "trust_channel": "reviewer_vault",
+        "received_at": "2026-06-09T00:00:00Z",
+        "approved_by": "external-reviewer@example.com",
+        "approval_reference": "vault://trusted/veritas/evidence-key",
+        "notes": "Key fingerprint confirmed through reviewer vault record.",
+        "bundle_internal_key_used": False,
+    }
+
+
+def _valid_verification_result_payload() -> dict[str, Any]:
+    """Return a schema-valid strict authenticity verification result."""
+    return {
+        "ok": True,
+        "tampered": False,
+        "hash_integrity_ok": True,
+        "signature_status": "pass",
+        "signature_verified": True,
+        "authenticity_ok": True,
+        "authenticity_failure": None,
+        "public_key_fingerprint_sha256": FINGERPRINT,
+        "errors": [],
+        "warnings": [],
+    }
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Write a compact UTF-8 JSON fixture."""
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _write_valid_inputs(tmp_path: Path) -> tuple[Path, Path]:
+    """Write valid receipt and verification result fixtures."""
+    receipt_path = tmp_path / "trusted-public-key-provenance.json"
+    verification_result_path = tmp_path / "verification-result.json"
+    _write_json(receipt_path, _valid_receipt_payload())
+    _write_json(verification_result_path, _valid_verification_result_payload())
+    return receipt_path, verification_result_path
+
+
+def test_validate_key_provenance_valid_inputs_pass(tmp_path, capsys) -> None:
+    """Valid receipt and strict result with matching fingerprint pass."""
+    from veritas_os.cli.evidence_bundle import main
+
+    receipt_path, verification_result_path = _write_valid_inputs(tmp_path)
+
+    exit_code = main(
+        [
+            "validate-key-provenance",
+            "--receipt",
+            str(receipt_path),
+            "--verification-result",
+            str(verification_result_path),
+        ]
+    )
+    output = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "Trusted public key provenance validation: PASS" in output
+    assert "Receipt schema: PASS" in output
+    assert "Verification result schema: PASS" in output
+    assert "Fingerprint correlation: PASS" in output
+    assert "Bundle-internal key used: PASS" in output
+    assert "Strict authenticity result: PASS" in output
+
+
+def test_validate_key_provenance_fingerprint_mismatch_fails(tmp_path, capsys) -> None:
+    """Fingerprint mismatch fails correlation without hiding schema success."""
+    from veritas_os.cli.evidence_bundle import main
+
+    receipt_path, verification_result_path = _write_valid_inputs(tmp_path)
+    verification_result = _valid_verification_result_payload()
+    verification_result["public_key_fingerprint_sha256"] = MISMATCHED_FINGERPRINT
+    _write_json(verification_result_path, verification_result)
+
+    exit_code = main(
+        [
+            "validate-key-provenance",
+            "--receipt",
+            str(receipt_path),
+            "--verification-result",
+            str(verification_result_path),
+        ]
+    )
+    output = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "Trusted public key provenance validation: FAIL" in output
+    assert "Receipt schema: PASS" in output
+    assert "Verification result schema: PASS" in output
+    assert "Fingerprint correlation: FAIL" in output
+
+
+def test_validate_key_provenance_receipt_schema_invalid_fails(tmp_path, capsys) -> None:
+    """Receipt schema failures are reported as validation failures."""
+    from veritas_os.cli.evidence_bundle import main
+
+    receipt_path, verification_result_path = _write_valid_inputs(tmp_path)
+    receipt = _valid_receipt_payload()
+    receipt.pop("approved_by")
+    _write_json(receipt_path, receipt)
+
+    exit_code = main(
+        [
+            "validate-key-provenance",
+            "--receipt",
+            str(receipt_path),
+            "--verification-result",
+            str(verification_result_path),
+        ]
+    )
+    output = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "Receipt schema: FAIL" in output
+    assert "'approved_by' is a required property" in output
+
+
+def test_validate_key_provenance_verification_result_schema_invalid_fails(
+    tmp_path,
+    capsys,
+) -> None:
+    """Verification result schema failures are reported as validation failures."""
+    from veritas_os.cli.evidence_bundle import main
+
+    receipt_path, verification_result_path = _write_valid_inputs(tmp_path)
+    verification_result = _valid_verification_result_payload()
+    verification_result["signature_status"] = "verified"
+    _write_json(verification_result_path, verification_result)
+
+    exit_code = main(
+        [
+            "validate-key-provenance",
+            "--receipt",
+            str(receipt_path),
+            "--verification-result",
+            str(verification_result_path),
+        ]
+    )
+    output = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "Verification result schema: FAIL" in output
+    assert "'verified' is not one of" in output
+
+
+def test_validate_key_provenance_bundle_internal_key_used_true_fails(
+    tmp_path,
+    capsys,
+) -> None:
+    """A receipt based on bundle-internal key material is rejected."""
+    from veritas_os.cli.evidence_bundle import main
+
+    receipt_path, verification_result_path = _write_valid_inputs(tmp_path)
+    receipt = _valid_receipt_payload()
+    receipt["bundle_internal_key_used"] = True
+    _write_json(receipt_path, receipt)
+
+    exit_code = main(
+        [
+            "validate-key-provenance",
+            "--receipt",
+            str(receipt_path),
+            "--verification-result",
+            str(verification_result_path),
+        ]
+    )
+    output = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "Bundle-internal key used: FAIL" in output
+    assert "receipt bundle_internal_key_used must be false" in output
+
+
+def test_validate_key_provenance_authenticity_false_fails(tmp_path, capsys) -> None:
+    """Strict authenticity must be true in the verification result."""
+    from veritas_os.cli.evidence_bundle import main
+
+    receipt_path, verification_result_path = _write_valid_inputs(tmp_path)
+    verification_result = _valid_verification_result_payload()
+    verification_result["ok"] = False
+    verification_result["authenticity_ok"] = False
+    verification_result["authenticity_failure"] = "signature_verification_failed"
+    _write_json(verification_result_path, verification_result)
+
+    exit_code = main(
+        [
+            "validate-key-provenance",
+            "--receipt",
+            str(receipt_path),
+            "--verification-result",
+            str(verification_result_path),
+        ]
+    )
+    output = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "Strict authenticity result: FAIL" in output
+
+
+def test_validate_key_provenance_json_output_stable_fields(tmp_path, capsys) -> None:
+    """--json output contains stable provenance validation fields."""
+    from veritas_os.cli.evidence_bundle import main
+
+    receipt_path, verification_result_path = _write_valid_inputs(tmp_path)
+
+    exit_code = main(
+        [
+            "validate-key-provenance",
+            "--receipt",
+            str(receipt_path),
+            "--verification-result",
+            str(verification_result_path),
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert output["ok"] is True
+    assert output["receipt_schema_valid"] is True
+    assert output["verification_result_schema_valid"] is True
+    assert output["fingerprint_correlation_ok"] is True
+    assert output["bundle_internal_key_used_ok"] is True
+    assert output["strict_authenticity_ok"] is True
+    assert output["receipt_path"] == str(receipt_path)
+    assert output["verification_result_path"] == str(verification_result_path)
+    assert output["receipt_public_key_fingerprint_sha256"] == FINGERPRINT
+    assert output["verification_result_public_key_fingerprint_sha256"] == FINGERPRINT
+    assert output["errors"] == []
+
+
+def test_validate_key_provenance_json_output_file_matches_stdout(
+    tmp_path,
+    capsys,
+) -> None:
+    """--json --output saves the exact stdout JSON report."""
+    from veritas_os.cli.evidence_bundle import main
+
+    receipt_path, verification_result_path = _write_valid_inputs(tmp_path)
+    output_path = tmp_path / "reports" / "key-provenance-validation.json"
+
+    exit_code = main(
+        [
+            "validate-key-provenance",
+            "--receipt",
+            str(receipt_path),
+            "--verification-result",
+            str(verification_result_path),
+            "--json",
+            "--output",
+            str(output_path),
+        ]
+    )
+    stdout = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert output_path.read_text(encoding="utf-8") == stdout
+    assert json.loads(stdout)["ok"] is True
+
+
+def test_validate_key_provenance_output_without_json_fails_clearly(
+    tmp_path,
+    capsys,
+) -> None:
+    """--output without --json fails before running validation."""
+    from veritas_os.cli.evidence_bundle import main
+
+    receipt_path, verification_result_path = _write_valid_inputs(tmp_path)
+
+    with pytest.raises(SystemExit) as excinfo:
+        main(
+            [
+                "validate-key-provenance",
+                "--receipt",
+                str(receipt_path),
+                "--verification-result",
+                str(verification_result_path),
+                "--output",
+                str(tmp_path / "report.json"),
+            ]
+        )
+
+    assert excinfo.value.code == 2
+    stderr = capsys.readouterr().err
+    assert "validate-key-provenance --output requires --json" in stderr
+
+
+def test_validate_key_provenance_output_write_failure_is_clear(
+    tmp_path,
+    capsys,
+) -> None:
+    """--json --output write failures exit non-zero with clear stderr."""
+    from veritas_os.cli.evidence_bundle import main
+
+    receipt_path, verification_result_path = _write_valid_inputs(tmp_path)
+    output_path = tmp_path / "existing-directory"
+    output_path.mkdir()
+
+    exit_code = main(
+        [
+            "validate-key-provenance",
+            "--receipt",
+            str(receipt_path),
+            "--verification-result",
+            str(verification_result_path),
+            "--json",
+            "--output",
+            str(output_path),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert captured.out == ""
+    assert "failed to write key provenance validation report" in captured.err

--- a/veritas_os/tests/test_trusted_public_key_provenance_cli.py
+++ b/veritas_os/tests/test_trusted_public_key_provenance_cli.py
@@ -82,6 +82,8 @@ def test_validate_key_provenance_valid_inputs_pass(tmp_path, capsys) -> None:
     assert "Fingerprint correlation: PASS" in output
     assert "Bundle-internal key used: PASS" in output
     assert "Strict authenticity result: PASS" in output
+    assert str(receipt_path) not in output
+    assert str(verification_result_path) not in output
     assert FINGERPRINT not in output
 
 
@@ -110,6 +112,8 @@ def test_validate_key_provenance_fingerprint_mismatch_fails(tmp_path, capsys) ->
     assert "Receipt schema: PASS" in output
     assert "Verification result schema: PASS" in output
     assert "Fingerprint correlation: FAIL" in output
+    assert str(receipt_path) not in output
+    assert str(verification_result_path) not in output
     assert FINGERPRINT not in output
     assert MISMATCHED_FINGERPRINT not in output
 
@@ -248,13 +252,18 @@ def test_validate_key_provenance_json_output_stable_fields(tmp_path, capsys) -> 
     assert output["fingerprint_correlation_ok"] is True
     assert output["bundle_internal_key_used_ok"] is True
     assert output["strict_authenticity_ok"] is True
-    assert output["receipt_path"] == str(receipt_path)
-    assert output["verification_result_path"] == str(verification_result_path)
+    assert output["receipt_path_provided"] is True
+    assert output["verification_result_path_provided"] is True
+    assert "receipt_path" not in output
+    assert "verification_result_path" not in output
     assert output["receipt_public_key_fingerprint_present"] is True
     assert output["verification_result_public_key_fingerprint_present"] is True
     assert "receipt_public_key_fingerprint_sha256" not in output
     assert "verification_result_public_key_fingerprint_sha256" not in output
-    assert FINGERPRINT not in json.dumps(output)
+    output_json = json.dumps(output)
+    assert str(receipt_path) not in output_json
+    assert str(verification_result_path) not in output_json
+    assert FINGERPRINT not in output_json
     assert output["errors"] == []
 
 
@@ -283,8 +292,13 @@ def test_validate_key_provenance_json_output_file_matches_stdout(
     stdout = capsys.readouterr().out
 
     assert exit_code == 0
-    assert output_path.read_text(encoding="utf-8") == stdout
+    saved = output_path.read_text(encoding="utf-8")
+    assert saved == stdout
     assert json.loads(stdout)["ok"] is True
+    assert str(receipt_path) not in stdout
+    assert str(verification_result_path) not in stdout
+    assert str(output_path) not in stdout
+    assert str(output_path) not in saved
 
 
 def test_validate_key_provenance_output_without_json_fails_clearly(
@@ -342,3 +356,4 @@ def test_validate_key_provenance_output_write_failure_is_clear(
     assert exit_code == 2
     assert captured.out == ""
     assert "failed to write key provenance validation report" in captured.err
+    assert str(output_path) not in captured.err

--- a/veritas_os/tests/test_trusted_public_key_provenance_cli.py
+++ b/veritas_os/tests/test_trusted_public_key_provenance_cli.py
@@ -82,6 +82,7 @@ def test_validate_key_provenance_valid_inputs_pass(tmp_path, capsys) -> None:
     assert "Fingerprint correlation: PASS" in output
     assert "Bundle-internal key used: PASS" in output
     assert "Strict authenticity result: PASS" in output
+    assert FINGERPRINT not in output
 
 
 def test_validate_key_provenance_fingerprint_mismatch_fails(tmp_path, capsys) -> None:
@@ -109,6 +110,8 @@ def test_validate_key_provenance_fingerprint_mismatch_fails(tmp_path, capsys) ->
     assert "Receipt schema: PASS" in output
     assert "Verification result schema: PASS" in output
     assert "Fingerprint correlation: FAIL" in output
+    assert FINGERPRINT not in output
+    assert MISMATCHED_FINGERPRINT not in output
 
 
 def test_validate_key_provenance_receipt_schema_invalid_fails(tmp_path, capsys) -> None:
@@ -133,7 +136,8 @@ def test_validate_key_provenance_receipt_schema_invalid_fails(tmp_path, capsys) 
 
     assert exit_code == 1
     assert "Receipt schema: FAIL" in output
-    assert "'approved_by' is a required property" in output
+    assert "value does not satisfy schema at this path" in output
+    assert "'approved_by' is a required property" not in output
 
 
 def test_validate_key_provenance_verification_result_schema_invalid_fails(
@@ -161,7 +165,8 @@ def test_validate_key_provenance_verification_result_schema_invalid_fails(
 
     assert exit_code == 1
     assert "Verification result schema: FAIL" in output
-    assert "'verified' is not one of" in output
+    assert "value does not satisfy schema at this path" in output
+    assert "'verified' is not one of" not in output
 
 
 def test_validate_key_provenance_bundle_internal_key_used_true_fails(
@@ -245,8 +250,11 @@ def test_validate_key_provenance_json_output_stable_fields(tmp_path, capsys) -> 
     assert output["strict_authenticity_ok"] is True
     assert output["receipt_path"] == str(receipt_path)
     assert output["verification_result_path"] == str(verification_result_path)
-    assert output["receipt_public_key_fingerprint_sha256"] == FINGERPRINT
-    assert output["verification_result_public_key_fingerprint_sha256"] == FINGERPRINT
+    assert output["receipt_public_key_fingerprint_present"] is True
+    assert output["verification_result_public_key_fingerprint_present"] is True
+    assert "receipt_public_key_fingerprint_sha256" not in output
+    assert "verification_result_public_key_fingerprint_sha256" not in output
+    assert FINGERPRINT not in json.dumps(output)
     assert output["errors"] == []
 
 


### PR DESCRIPTION
### Motivation
- Provide a CLI helper to let reviewers/operators validate a Trusted Public Key Provenance Receipt and correlate it with an existing Evidence Bundle verification result so reviewers can record why a particular Ed25519 key was treated as trusted.
- Prevent accidental acceptance when receipt/result fingerprints mismatch, when the receipt is based on bundle-internal key material, or when the verification result does not show strict authenticity success.

### Description
- Add new subcommand `veritas-evidence-bundle validate-key-provenance --receipt <path> --verification-result <path>` that validates: receipt JSON shape against `schemas/trusted_public_key_provenance_receipt.schema.json`, verification-result JSON shape against `schemas/evidence_bundle_verification_result.schema.json`, exact equality of `public_key_fingerprint_sha256`, `bundle_internal_key_used == false`, and strict authenticity (`signature_status == "pass"`, `signature_verified is True`, `authenticity_ok is True`). (changes: `veritas_os/cli/evidence_bundle.py`)
- Emit both human-readable PASS/FAIL output (per-check lines) and machine-readable JSON with stable fields and `--json --output` which writes the exact stdout JSON to disk (creates parent directories, fails with clear stderr on write errors, `--output` only allowed with `--json`). (changes: `veritas_os/cli/evidence_bundle.py`)
- Add comprehensive unit tests covering success and all specified failure modes, JSON field stability, exact stdout/file JSON parity, and `--output` gating and write-failure behavior (`veritas_os/tests/test_trusted_public_key_provenance_cli.py`).
- Update reviewer-facing docs and sample output to document the command, usage examples, JSON semantics, `--json --output` behavior, and explicit trust boundaries (does not create trust, does not re-run cryptographic verification, not regulatory certification). (changes: `docs/en/validation/trusted-public-key-provenance.md`, `docs/en/validation/evidence-bundle-reviewer-checklist.md`, `docs/en/validation/evidence-bundle-verification-json-contract.md`, `docs/en/validation/sample-evidence-bundle-verification-output.md`)

### Testing
- Ran static/format checks: `ruff` checks passed and files were formatted successfully. (passed)
- Compiled modules: `python -m py_compile veritas_os/cli/evidence_bundle.py veritas_os/tests/test_trusted_public_key_provenance_cli.py` succeeded. (passed)
- Added unit tests `veritas_os/tests/test_trusted_public_key_provenance_cli.py` which exercise: valid inputs pass, fingerprint mismatch fails, receipt schema invalid fails, verification-result schema invalid fails, `bundle_internal_key_used: true` fails, authenticity failure fails, `--json` stable fields, `--json --output` file matches stdout, and `--output` without `--json` fails.
- Attempted to run pytest for the CLI test suite, but full test run was blocked by environment dependency fetch failures (PyPI/network tunnel errors), so runtime test execution is pending in CI; local static/compile checks passed.

Note: Security boundary preserved — this command validates saved JSON shapes and correlates fingerprints only and explicitly does not create trust, re-run cryptographic verification, or claim regulatory/third-party audit approval; docs were updated to emphasize that.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a281a43e0308326a79fa54099849fbb)