### PR TITLE
Add `validate-key-provenance` CLI command with docs and tests

### DIFF
--- a/docs/en/validation/evidence-bundle-reviewer-checklist.md
+++ b/docs/en/validation/evidence-bundle-reviewer-checklist.md
@@ -86,6 +86,30 @@ key provenance, or provide regulatory certification or completed third-party
 audit approval. Preserve the out-of-band trusted-key provenance record even
 when saved-result schema validation passes.
 
+After preserving a Trusted Public Key Provenance Receipt, validate the receipt
+and correlate it with the saved strict verification result:
+
+```bash
+veritas-evidence-bundle validate-key-provenance \
+  --receipt trusted-public-key-provenance.json \
+  --verification-result verification-result.json
+```
+
+This command validates the receipt schema, validates the saved verification
+result schema, checks exact fingerprint correlation, rejects
+`bundle_internal_key_used: true`, and confirms strict authenticity success
+(`signature_status: "pass"`, `signature_verified: true`, and
+`authenticity_ok: true`). Add `--json --output <path>` to emit and save the
+exact same machine-readable report, including failure reports. The public report
+exposes only booleans and fixed diagnostics: it does not echo raw fingerprint
+values, raw file paths, raw schema validator messages, or raw exception text. It
+only records fingerprint presence and correlation status because the raw
+fingerprints remain in the source receipt and verification-result artifacts.
+The command does not create trust by itself, does not re-run cryptographic
+verification, does not prove regulatory certification, and does not complete
+third-party audit approval. Matching fingerprints support correlation, not
+standalone trust.
+
 ## Verification order
 
 | Step | Reviewer action | PASS criterion | FAIL / follow-up criterion |

--- a/docs/en/validation/evidence-bundle-verification-json-contract.md
+++ b/docs/en/validation/evidence-bundle-verification-json-contract.md
@@ -154,6 +154,31 @@ run. Reviewers must still preserve out-of-band trusted public key provenance for
 the key represented by `public_key_fingerprint_sha256` before relying on any
 saved strict verification result.
 
+Use `validate-key-provenance` when tooling needs one command to validate the
+Trusted Public Key Provenance Receipt shape and correlate it with this saved
+verification-result contract:
+
+```bash
+veritas-evidence-bundle validate-key-provenance \
+  --receipt trusted-public-key-provenance.json \
+  --verification-result verification-result.json \
+  --json
+```
+
+The JSON report includes stable booleans for receipt schema validity,
+verification-result schema validity, fingerprint presence, fingerprint
+correlation, `bundle_internal_key_used: false`, and strict authenticity success.
+It does not echo raw fingerprint values, raw file paths, raw schema validator
+messages, or raw exception text; the raw fingerprints remain in the source
+receipt and verification-result artifacts. `--output <path>` is allowed only
+with `--json`; the saved JSON is byte-for-byte the same as stdout JSON, and
+failure reports are saved as audit evidence. This correlation report has no
+dedicated schema yet and is intentionally structured for future extension. It
+does not create trust by itself, does not re-run cryptographic verification,
+does not prove regulatory certification, and does not complete third-party
+audit approval. Matching fingerprints support correlation, not standalone
+trust.
+
 ## Contract scope
 
 The contract separates two reviewer decisions that external UI and audit tooling

--- a/docs/en/validation/sample-evidence-bundle-verification-output.md
+++ b/docs/en/validation/sample-evidence-bundle-verification-output.md
@@ -167,6 +167,62 @@ regulatory certification or completed third-party audit approval. A saved
 report for an existing result file, not evidence of a new Evidence Bundle
 verification run.
 
+## Validating trusted public key provenance correlation
+
+After strict verification and receipt preservation, reviewers can validate the
+receipt shape and correlate its fingerprint with the saved verification result:
+
+```bash
+veritas-evidence-bundle validate-key-provenance \
+  --receipt trusted-public-key-provenance.json \
+  --verification-result verification-result.json
+```
+
+Illustrative success output:
+
+```text
+Trusted public key provenance validation: PASS
+Receipt schema: PASS
+Verification result schema: PASS
+Fingerprint correlation: PASS
+Bundle-internal key used: PASS
+Strict authenticity result: PASS
+```
+
+Illustrative failure output:
+
+```text
+Trusted public key provenance validation: FAIL
+Receipt schema: PASS
+Verification result schema: PASS
+Fingerprint correlation: FAIL
+Bundle-internal key used: PASS
+Strict authenticity result: PASS
+  error [fingerprint_correlation_ok] at $['public_key_fingerprint_sha256']: receipt and verification result public key fingerprints do not match
+```
+
+For machine-readable output and saved audit evidence, use `--json --output`:
+
+```bash
+veritas-evidence-bundle validate-key-provenance \
+  --receipt trusted-public-key-provenance.json \
+  --verification-result verification-result.json \
+  --json \
+  --output key-provenance-validation.json
+```
+
+The stdout JSON and saved UTF-8 JSON file are byte-for-byte identical, including
+failure reports. `--output` without `--json` fails clearly. The public report
+does not echo raw fingerprint values, raw file paths, raw schema validator
+messages, or raw exception text; raw fingerprints remain in the source receipt
+and verification-result artifacts. This command validates receipt shape,
+validates saved verification-result shape, checks exact fingerprint correlation,
+rejects `bundle_internal_key_used: true`, and confirms strict authenticity
+success. It does not create trust by itself, does not re-run cryptographic
+verification, does not prove regulatory certification, and does not complete
+third-party audit approval. Matching fingerprints support correlation, not
+standalone trust.
+
 ## Successful strict verification
 
 Illustrative output:

--- a/docs/en/validation/trusted-public-key-provenance.md
+++ b/docs/en/validation/trusted-public-key-provenance.md
@@ -56,6 +56,69 @@ verification run and the out-of-band trust record. It is not regulatory
 certification and is not completed third-party audit approval. It is not
 standalone proof that the original Evidence Bundle is authentic.
 
+## CLI validation
+
+Use `validate-key-provenance` to validate the receipt shape, validate the saved
+Evidence Bundle verification result shape, and correlate the two saved
+fingerprints:
+
+```bash
+veritas-evidence-bundle validate-key-provenance \
+  --receipt trusted-public-key-provenance.json \
+  --verification-result verification-result.json
+```
+
+Successful human-readable output reports each check explicitly:
+
+```text
+Trusted public key provenance validation: PASS
+Receipt schema: PASS
+Verification result schema: PASS
+Fingerprint correlation: PASS
+Bundle-internal key used: PASS
+Strict authenticity result: PASS
+```
+
+For CI, UI, or audit-tool ingestion, add `--json`. Add `--output <path>` with
+`--json` to save the exact same JSON report that is emitted to stdout; failure
+reports are saved too, and parent directories are created when needed.
+`--output` without `--json` is rejected. To avoid echoing externally supplied
+key material or local environment details in logs, the public CLI report exposes
+only booleans and fixed diagnostics. It does not print raw fingerprint values,
+raw file paths, raw schema validator messages, or raw exception text; it only
+reports whether receipt and verification-result fingerprints are present and
+whether correlation passed. The raw fingerprints remain preserved in the source
+receipt and verification-result artifacts.
+
+```bash
+veritas-evidence-bundle validate-key-provenance \
+  --receipt trusted-public-key-provenance.json \
+  --verification-result verification-result.json \
+  --json \
+  --output key-provenance-validation.json
+```
+
+The command checks that:
+
+- `--receipt` conforms to
+  `schemas/trusted_public_key_provenance_receipt.schema.json`;
+- `--verification-result` conforms to
+  `schemas/evidence_bundle_verification_result.schema.json`;
+- both `public_key_fingerprint_sha256` values match exactly;
+- the receipt has `bundle_internal_key_used: false`; and
+- the saved result reports strict authenticity success: `signature_status:
+  "pass"`, `signature_verified: true`, and `authenticity_ok: true`.
+
+This command validates receipt shape and fingerprint correlation only. The CLI
+report intentionally does not echo raw fingerprint values, raw file paths, raw
+schema validator messages, or raw exception text; use the original receipt and
+verification-result artifacts when a reviewer must inspect exact fingerprints.
+It does not create trust by itself, does not re-run cryptographic verification,
+does not prove regulatory certification, and does not complete third-party
+audit approval. Matching fingerprints support correlation between a saved
+strict verification result and a reviewer/operator provenance record; they are
+not standalone trust.
+
 ## Fingerprint comparison
 
 Compare these fields exactly:

--- a/veritas_os/cli/evidence_bundle.py
+++ b/veritas_os/cli/evidence_bundle.py
@@ -357,6 +357,10 @@ def _key_provenance_public_report(
     status: KeyProvenanceValidationStatus,
 ) -> dict[str, Any]:
     """Build public validate-key-provenance JSON from fixed fields only."""
+    # The public validate-key-provenance report must remain boolean-only and
+    # must not include raw fingerprints, file paths, exception text, schema
+    # validator messages, or JSON values loaded from reviewer-controlled
+    # artifacts.
     return {
         "ok": status.ok,
         "receipt_schema_valid": status.receipt_schema_valid,
@@ -430,6 +434,11 @@ def _run_validate_key_provenance(
                     file=sys.stderr,
                 )
                 return 2
+        # lgtm [py/clear-text-logging-sensitive-data] The public
+        # validate-key-provenance JSON report is rebuilt from booleans, fixed
+        # identifiers, and fixed diagnostics only; raw fingerprints, file
+        # paths, exception text, schema validator messages, and JSON values
+        # loaded from reviewer-controlled artifacts are intentionally omitted.
         print(output_json)
         return 0 if status.ok else 1
 

--- a/veritas_os/cli/evidence_bundle.py
+++ b/veritas_os/cli/evidence_bundle.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 import os
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional
 
@@ -38,12 +39,47 @@ VERIFICATION_RESULT_SCHEMA_ID = (
 VALIDATION_REPORT_SCHEMA_ID = (
     f"{SCHEMA_BASE_URL}/evidence_bundle_validation_report.schema.json"
 )
+TRUSTED_PUBLIC_KEY_PROVENANCE_RECEIPT_SCHEMA_ID = (
+    f"{SCHEMA_BASE_URL}/trusted_public_key_provenance_receipt.schema.json"
+)
 VALIDATE_RESULT_VALIDATOR = "veritas-evidence-bundle validate-result"
+VALIDATE_KEY_PROVENANCE_VALIDATOR = "veritas-evidence-bundle validate-key-provenance"
 VERIFICATION_RESULT_SCHEMA_PATH = (
     Path(__file__).resolve().parents[2]
     / "schemas"
     / "evidence_bundle_verification_result.schema.json"
 )
+TRUSTED_PUBLIC_KEY_PROVENANCE_RECEIPT_SCHEMA_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "schemas"
+    / "trusted_public_key_provenance_receipt.schema.json"
+)
+
+
+@dataclass(frozen=True)
+class KeyProvenanceValidationStatus:
+    """Internal validate-key-provenance status without raw input values."""
+
+    receipt_schema_valid: bool
+    verification_result_schema_valid: bool
+    fingerprint_correlation_ok: bool
+    bundle_internal_key_used_ok: bool
+    strict_authenticity_ok: bool
+    receipt_path_provided: bool
+    verification_result_path_provided: bool
+    receipt_public_key_fingerprint_present: bool
+    verification_result_public_key_fingerprint_present: bool
+
+    @property
+    def ok(self) -> bool:
+        """Return whether all trusted key provenance checks passed."""
+        return (
+            self.receipt_schema_valid
+            and self.verification_result_schema_valid
+            and self.fingerprint_correlation_ok
+            and self.bundle_internal_key_used_ok
+            and self.strict_authenticity_ok
+        )
 
 
 def _is_fail_closed_posture() -> bool:
@@ -124,16 +160,13 @@ def _validate_verification_result_schema(
             {
                 "path": "$",
                 "message": (
-                    "malformed JSON: "
-                    f"line {exc.lineno}, column {exc.colno}: {exc.msg}"
+                    f"malformed JSON: line {exc.lineno}, column {exc.colno}: {exc.msg}"
                 ),
             }
         ]
 
     try:
-        schema = json.loads(
-            VERIFICATION_RESULT_SCHEMA_PATH.read_text(encoding="utf-8")
-        )
+        schema = json.loads(VERIFICATION_RESULT_SCHEMA_PATH.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
         return [
             {
@@ -151,6 +184,269 @@ def _validate_verification_result_schema(
         {"path": _json_schema_error_path(error), "message": error.message}
         for error in errors
     ]
+
+
+def _load_json_document(document_path: Path) -> tuple[Any, bool]:
+    """Load JSON for internal validation without exposing diagnostics."""
+    try:
+        raw_document = document_path.read_text(encoding="utf-8")
+    except OSError:
+        return None, False
+
+    try:
+        return json.loads(raw_document), True
+    except json.JSONDecodeError:
+        return None, False
+
+
+def _load_schema(schema_path: Path) -> tuple[Any, bool]:
+    """Load a JSON Schema for internal boolean validation."""
+    try:
+        return json.loads(schema_path.read_text(encoding="utf-8")), True
+    except (OSError, json.JSONDecodeError):
+        return None, False
+
+
+def _json_schema_valid(instance: Any, schema_path: Path) -> bool:
+    """Return only whether an instance satisfies a repository JSON Schema."""
+    schema, loaded = _load_schema(schema_path)
+    if not loaded:
+        return False
+
+    validator = jsonschema.Draft202012Validator(schema)
+    return not any(validator.iter_errors(instance))
+
+
+def _strict_authenticity_ok(verification_result: Any) -> bool:
+    """Return whether a verification result reports strict authenticity success."""
+    if not isinstance(verification_result, dict):
+        return False
+    return (
+        verification_result.get("signature_status") == "pass"
+        and verification_result.get("signature_verified") is True
+        and verification_result.get("authenticity_ok") is True
+    )
+
+
+def _load_and_check_json_schema(
+    document_path: Path,
+    schema_path: Path,
+) -> tuple[Any, bool]:
+    """Load JSON and return only schema validity for public reporting.
+
+    The loaded document may contain externally supplied key material. Callers
+    must not expose it directly; this helper returns only the document for
+    internal boolean checks and a boolean schema status for public output.
+    """
+    document, loaded = _load_json_document(document_path)
+    if not loaded:
+        return document, False
+    return document, _json_schema_valid(document, schema_path)
+
+
+def _build_key_provenance_status(
+    receipt_path: Path,
+    verification_result_path: Path,
+) -> KeyProvenanceValidationStatus:
+    """Validate trusted key provenance and return booleans only.
+
+    This function may inspect externally supplied JSON documents internally, but
+    it does not return raw JSON values, raw fingerprints, raw file paths, raw
+    exception text, or raw JSON Schema validator messages. Public CLI output is
+    built separately from this boolean-only status to avoid clear-text logging
+    of sensitive or secret-like input values.
+    """
+    receipt, receipt_schema_valid = _load_and_check_json_schema(
+        receipt_path,
+        TRUSTED_PUBLIC_KEY_PROVENANCE_RECEIPT_SCHEMA_PATH,
+    )
+    verification_result, verification_result_schema_valid = _load_and_check_json_schema(
+        verification_result_path,
+        VERIFICATION_RESULT_SCHEMA_PATH,
+    )
+
+    receipt_fingerprint = None
+    if isinstance(receipt, dict):
+        receipt_fingerprint = receipt.get("public_key_fingerprint_sha256")
+    verification_fingerprint = None
+    if isinstance(verification_result, dict):
+        verification_fingerprint = verification_result.get(
+            "public_key_fingerprint_sha256"
+        )
+
+    receipt_fingerprint_present = isinstance(receipt_fingerprint, str)
+    verification_fingerprint_present = isinstance(verification_fingerprint, str)
+    fingerprint_correlation_ok = (
+        receipt_fingerprint_present
+        and verification_fingerprint_present
+        and receipt_fingerprint == verification_fingerprint
+    )
+    bundle_internal_key_used_ok = (
+        isinstance(receipt, dict) and receipt.get("bundle_internal_key_used") is False
+    )
+
+    return KeyProvenanceValidationStatus(
+        receipt_schema_valid=receipt_schema_valid,
+        verification_result_schema_valid=verification_result_schema_valid,
+        fingerprint_correlation_ok=fingerprint_correlation_ok,
+        bundle_internal_key_used_ok=bundle_internal_key_used_ok,
+        strict_authenticity_ok=_strict_authenticity_ok(verification_result),
+        receipt_path_provided=receipt_path is not None,
+        verification_result_path_provided=verification_result_path is not None,
+        receipt_public_key_fingerprint_present=receipt_fingerprint_present,
+        verification_result_public_key_fingerprint_present=(
+            verification_fingerprint_present
+        ),
+    )
+
+
+def _key_provenance_public_errors(
+    status: KeyProvenanceValidationStatus,
+) -> list[dict[str, str]]:
+    """Build fixed public diagnostics from boolean validation status."""
+    errors: list[dict[str, str]] = []
+    if not status.receipt_schema_valid:
+        errors.append(
+            {
+                "check": "receipt_schema_valid",
+                "path": "$",
+                "message": "receipt does not satisfy schema",
+            }
+        )
+    if not status.verification_result_schema_valid:
+        errors.append(
+            {
+                "check": "verification_result_schema_valid",
+                "path": "$",
+                "message": "verification result does not satisfy schema",
+            }
+        )
+    if not status.fingerprint_correlation_ok:
+        errors.append(
+            {
+                "check": "fingerprint_correlation_ok",
+                "path": "$['public_key_fingerprint_sha256']",
+                "message": (
+                    "receipt and verification result public key fingerprints "
+                    "do not match"
+                ),
+            }
+        )
+    if not status.bundle_internal_key_used_ok:
+        errors.append(
+            {
+                "check": "bundle_internal_key_used_ok",
+                "path": "$['bundle_internal_key_used']",
+                "message": "receipt bundle_internal_key_used must be false",
+            }
+        )
+    if not status.strict_authenticity_ok:
+        errors.append(
+            {
+                "check": "strict_authenticity_ok",
+                "path": "$",
+                "message": (
+                    "verification result must report strict authenticity success"
+                ),
+            }
+        )
+    return errors
+
+
+def _key_provenance_public_report(
+    status: KeyProvenanceValidationStatus,
+) -> dict[str, Any]:
+    """Build public validate-key-provenance JSON from fixed fields only."""
+    return {
+        "ok": status.ok,
+        "receipt_schema_valid": status.receipt_schema_valid,
+        "verification_result_schema_valid": (status.verification_result_schema_valid),
+        "fingerprint_correlation_ok": status.fingerprint_correlation_ok,
+        "bundle_internal_key_used_ok": status.bundle_internal_key_used_ok,
+        "strict_authenticity_ok": status.strict_authenticity_ok,
+        "receipt_path_provided": status.receipt_path_provided,
+        "verification_result_path_provided": (status.verification_result_path_provided),
+        "receipt_public_key_fingerprint_present": (
+            status.receipt_public_key_fingerprint_present
+        ),
+        "verification_result_public_key_fingerprint_present": (
+            status.verification_result_public_key_fingerprint_present
+        ),
+        "report_schema_id": None,
+        "receipt_schema_id": TRUSTED_PUBLIC_KEY_PROVENANCE_RECEIPT_SCHEMA_ID,
+        "verification_result_schema_id": VERIFICATION_RESULT_SCHEMA_ID,
+        "validator": VALIDATE_KEY_PROVENANCE_VALIDATOR,
+        "errors": _key_provenance_public_errors(status),
+    }
+
+
+def _print_key_provenance_human_errors(
+    status: KeyProvenanceValidationStatus,
+) -> None:
+    """Print fixed human diagnostics without interpolating input-derived data."""
+    if not status.receipt_schema_valid:
+        print("  error [receipt_schema_valid]: receipt does not satisfy schema")
+    if not status.verification_result_schema_valid:
+        print(
+            "  error [verification_result_schema_valid]: "
+            "verification result does not satisfy schema"
+        )
+    if not status.fingerprint_correlation_ok:
+        print(
+            "  error [fingerprint_correlation_ok]: "
+            "receipt and verification result public key fingerprints do not match"
+        )
+    if not status.bundle_internal_key_used_ok:
+        print(
+            "  error [bundle_internal_key_used_ok]: "
+            "receipt bundle_internal_key_used must be false"
+        )
+    if not status.strict_authenticity_ok:
+        print(
+            "  error [strict_authenticity_ok]: "
+            "verification result must report strict authenticity success"
+        )
+
+
+def _run_validate_key_provenance(
+    receipt_path: Path,
+    verification_result_path: Path,
+    *,
+    json_output: bool = False,
+    output_path: Optional[Path] = None,
+) -> int:
+    """Run trusted public key provenance receipt validation."""
+    status = _build_key_provenance_status(receipt_path, verification_result_path)
+    report = _key_provenance_public_report(status)
+    if json_output:
+        output_json = json.dumps(report, indent=2, ensure_ascii=False)
+        if output_path is not None:
+            try:
+                output_path.parent.mkdir(parents=True, exist_ok=True)
+                output_path.write_text(output_json + "\n", encoding="utf-8")
+            except OSError:
+                print(
+                    "error: failed to write key provenance validation report",
+                    file=sys.stderr,
+                )
+                return 2
+        print(output_json)
+        return 0 if status.ok else 1
+
+    overall_status = "PASS" if status.ok else "FAIL"
+    print(f"Trusted public key provenance validation: {overall_status}")
+    labels = [
+        ("Receipt schema", status.receipt_schema_valid),
+        ("Verification result schema", status.verification_result_schema_valid),
+        ("Fingerprint correlation", status.fingerprint_correlation_ok),
+        ("Bundle-internal key used", status.bundle_internal_key_used_ok),
+        ("Strict authenticity result", status.strict_authenticity_ok),
+    ]
+    for label, passed in labels:
+        check_status = "PASS" if passed else "FAIL"
+        print(f"{label}: {check_status}")
+    _print_key_provenance_human_errors(status)
+    return 0 if status.ok else 1
 
 
 def _run_validate_result(
@@ -187,8 +483,7 @@ def _run_validate_result(
                 output_path.write_text(output_json + "\n", encoding="utf-8")
             except OSError as exc:
                 print(
-                    "error: failed to write validation report "
-                    f"to {output_path}: {exc}",
+                    f"error: failed to write validation report to {output_path}: {exc}",
                     file=sys.stderr,
                 )
                 return 2
@@ -223,11 +518,15 @@ def _write_verification_result(output_path: Path, result: Dict[str, Any]) -> Non
 
 def build_parser() -> argparse.ArgumentParser:
     """Build argparse parser for evidence bundle CLI."""
-    parser = argparse.ArgumentParser(description="Generate/verify VERITAS evidence bundles")
+    parser = argparse.ArgumentParser(
+        description="Generate/verify VERITAS evidence bundles"
+    )
     sub = parser.add_subparsers(dest="command", required=True)
 
     gen = sub.add_parser("generate", help="Generate evidence bundle")
-    gen.add_argument("--bundle-type", required=True, choices=["decision", "incident", "release"])
+    gen.add_argument(
+        "--bundle-type", required=True, choices=["decision", "incident", "release"]
+    )
     gen.add_argument("--witness-ledger", required=True, type=Path)
     gen.add_argument("--output-dir", required=True, type=Path)
     gen.add_argument("--request-id", action="append", dest="request_ids")
@@ -290,6 +589,39 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
 
+    key_provenance = sub.add_parser(
+        "validate-key-provenance",
+        help=(
+            "Validate trusted public key provenance and correlate it with a "
+            "saved strict verification result"
+        ),
+    )
+    key_provenance.add_argument(
+        "--receipt",
+        required=True,
+        type=Path,
+        help="Trusted Public Key Provenance Receipt JSON file",
+    )
+    key_provenance.add_argument(
+        "--verification-result",
+        required=True,
+        type=Path,
+        help="Saved JSON result file from verify --json --output",
+    )
+    key_provenance.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a machine-readable key provenance validation report as JSON",
+    )
+    key_provenance.add_argument(
+        "--output",
+        type=Path,
+        help=(
+            "Write the JSON key provenance validation report to this UTF-8 "
+            "file. Requires --json and does not suppress stdout JSON."
+        ),
+    )
+
     return parser
 
 
@@ -334,6 +666,17 @@ def main(argv: Optional[list[str]] = None) -> int:
             return 2
         return _run_validate_result(
             args.result,
+            json_output=args.json,
+            output_path=args.output,
+        )
+
+    if args.command == "validate-key-provenance":
+        if args.output is not None and not args.json:
+            parser.error("validate-key-provenance --output requires --json")
+            return 2
+        return _run_validate_key_provenance(
+            args.receipt,
+            args.verification_result,
             json_output=args.json,
             output_path=args.output,
         )

--- a/veritas_os/tests/test_trusted_public_key_provenance_cli.py
+++ b/veritas_os/tests/test_trusted_public_key_provenance_cli.py
@@ -1,0 +1,438 @@
+"""Tests for trusted public key provenance CLI validation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+FINGERPRINT = "a" * 64
+MISMATCHED_FINGERPRINT = "b" * 64
+
+
+def _valid_receipt_payload() -> dict[str, Any]:
+    """Return a schema-valid Trusted Public Key Provenance Receipt."""
+    return {
+        "receipt_type": "trusted_public_key_provenance",
+        "algorithm": "Ed25519",
+        "public_key_fingerprint_sha256": FINGERPRINT,
+        "trust_channel": "reviewer_vault",
+        "received_at": "2026-06-09T00:00:00Z",
+        "approved_by": "external-reviewer@example.com",
+        "approval_reference": "vault://trusted/veritas/evidence-key",
+        "notes": "Key fingerprint confirmed through reviewer vault record.",
+        "bundle_internal_key_used": False,
+    }
+
+
+def _valid_verification_result_payload() -> dict[str, Any]:
+    """Return a schema-valid strict authenticity verification result."""
+    return {
+        "ok": True,
+        "tampered": False,
+        "hash_integrity_ok": True,
+        "signature_status": "pass",
+        "signature_verified": True,
+        "authenticity_ok": True,
+        "authenticity_failure": None,
+        "public_key_fingerprint_sha256": FINGERPRINT,
+        "errors": [],
+        "warnings": [],
+    }
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Write a compact UTF-8 JSON fixture."""
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _write_valid_inputs(tmp_path: Path) -> tuple[Path, Path]:
+    """Write valid receipt and verification result fixtures."""
+    receipt_path = tmp_path / "trusted-public-key-provenance.json"
+    verification_result_path = tmp_path / "verification-result.json"
+    _write_json(receipt_path, _valid_receipt_payload())
+    _write_json(verification_result_path, _valid_verification_result_payload())
+    return receipt_path, verification_result_path
+
+
+def test_validate_key_provenance_valid_inputs_pass(tmp_path, capsys) -> None:
+    """Valid receipt and strict result with matching fingerprint pass."""
+    from veritas_os.cli.evidence_bundle import main
+
+    receipt_path, verification_result_path = _write_valid_inputs(tmp_path)
+
+    exit_code = main(
+        [
+            "validate-key-provenance",
+            "--receipt",
+            str(receipt_path),
+            "--verification-result",
+            str(verification_result_path),
+        ]
+    )
+    output = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "Trusted public key provenance validation: PASS" in output
+    assert "Receipt schema: PASS" in output
+    assert "Verification result schema: PASS" in output
+    assert "Fingerprint correlation: PASS" in output
+    assert "Bundle-internal key used: PASS" in output
+    assert "Strict authenticity result: PASS" in output
+    assert FINGERPRINT not in output
+    assert str(receipt_path) not in output
+    assert str(verification_result_path) not in output
+
+
+def test_validate_key_provenance_fingerprint_mismatch_fails(tmp_path, capsys) -> None:
+    """Fingerprint mismatch fails correlation without hiding schema success."""
+    from veritas_os.cli.evidence_bundle import main
+
+    receipt_path, verification_result_path = _write_valid_inputs(tmp_path)
+    verification_result = _valid_verification_result_payload()
+    verification_result["public_key_fingerprint_sha256"] = MISMATCHED_FINGERPRINT
+    _write_json(verification_result_path, verification_result)
+
+    exit_code = main(
+        [
+            "validate-key-provenance",
+            "--receipt",
+            str(receipt_path),
+            "--verification-result",
+            str(verification_result_path),
+        ]
+    )
+    output = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "Trusted public key provenance validation: FAIL" in output
+    assert "Receipt schema: PASS" in output
+    assert "Verification result schema: PASS" in output
+    assert "Fingerprint correlation: FAIL" in output
+    assert FINGERPRINT not in output
+    assert MISMATCHED_FINGERPRINT not in output
+    assert str(receipt_path) not in output
+    assert str(verification_result_path) not in output
+
+
+def test_validate_key_provenance_receipt_schema_invalid_fails(tmp_path, capsys) -> None:
+    """Receipt schema failures are reported as validation failures."""
+    from veritas_os.cli.evidence_bundle import main
+
+    receipt_path, verification_result_path = _write_valid_inputs(tmp_path)
+    receipt = _valid_receipt_payload()
+    receipt.pop("approved_by")
+    _write_json(receipt_path, receipt)
+
+    exit_code = main(
+        [
+            "validate-key-provenance",
+            "--receipt",
+            str(receipt_path),
+            "--verification-result",
+            str(verification_result_path),
+        ]
+    )
+    output = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "Receipt schema: FAIL" in output
+    assert "receipt does not satisfy schema" in output
+    assert "value does not satisfy schema at this path" not in output
+    assert "'approved_by' is a required property" not in output
+    assert str(receipt_path) not in output
+
+
+def test_validate_key_provenance_verification_result_schema_invalid_fails(
+    tmp_path,
+    capsys,
+) -> None:
+    """Verification result schema failures are reported as validation failures."""
+    from veritas_os.cli.evidence_bundle import main
+
+    receipt_path, verification_result_path = _write_valid_inputs(tmp_path)
+    verification_result = _valid_verification_result_payload()
+    verification_result["signature_status"] = "verified"
+    _write_json(verification_result_path, verification_result)
+
+    exit_code = main(
+        [
+            "validate-key-provenance",
+            "--receipt",
+            str(receipt_path),
+            "--verification-result",
+            str(verification_result_path),
+        ]
+    )
+    output = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "Verification result schema: FAIL" in output
+    assert "verification result does not satisfy schema" in output
+    assert "value does not satisfy schema at this path" not in output
+    assert "'verified' is not one of" not in output
+    assert str(verification_result_path) not in output
+
+
+def test_validate_key_provenance_bundle_internal_key_used_true_fails(
+    tmp_path,
+    capsys,
+) -> None:
+    """A receipt based on bundle-internal key material is rejected."""
+    from veritas_os.cli.evidence_bundle import main
+
+    receipt_path, verification_result_path = _write_valid_inputs(tmp_path)
+    receipt = _valid_receipt_payload()
+    receipt["bundle_internal_key_used"] = True
+    _write_json(receipt_path, receipt)
+
+    exit_code = main(
+        [
+            "validate-key-provenance",
+            "--receipt",
+            str(receipt_path),
+            "--verification-result",
+            str(verification_result_path),
+        ]
+    )
+    output = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "Bundle-internal key used: FAIL" in output
+    assert "receipt bundle_internal_key_used must be false" in output
+
+
+def test_validate_key_provenance_authenticity_false_fails(tmp_path, capsys) -> None:
+    """Strict authenticity must be true in the verification result."""
+    from veritas_os.cli.evidence_bundle import main
+
+    receipt_path, verification_result_path = _write_valid_inputs(tmp_path)
+    verification_result = _valid_verification_result_payload()
+    verification_result["ok"] = False
+    verification_result["authenticity_ok"] = False
+    verification_result["authenticity_failure"] = "signature_verification_failed"
+    _write_json(verification_result_path, verification_result)
+
+    exit_code = main(
+        [
+            "validate-key-provenance",
+            "--receipt",
+            str(receipt_path),
+            "--verification-result",
+            str(verification_result_path),
+        ]
+    )
+    output = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "Strict authenticity result: FAIL" in output
+
+
+def test_validate_key_provenance_json_output_stable_fields(tmp_path, capsys) -> None:
+    """--json output contains stable provenance validation fields."""
+    from veritas_os.cli.evidence_bundle import main
+
+    receipt_path, verification_result_path = _write_valid_inputs(tmp_path)
+
+    exit_code = main(
+        [
+            "validate-key-provenance",
+            "--receipt",
+            str(receipt_path),
+            "--verification-result",
+            str(verification_result_path),
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert output["ok"] is True
+    assert output["receipt_schema_valid"] is True
+    assert output["verification_result_schema_valid"] is True
+    assert output["fingerprint_correlation_ok"] is True
+    assert output["bundle_internal_key_used_ok"] is True
+    assert output["strict_authenticity_ok"] is True
+    assert output["receipt_path_provided"] is True
+    assert output["verification_result_path_provided"] is True
+    assert "receipt_path" not in output
+    assert "verification_result_path" not in output
+    assert output["receipt_public_key_fingerprint_present"] is True
+    assert output["verification_result_public_key_fingerprint_present"] is True
+    assert "receipt_public_key_fingerprint_sha256" not in output
+    assert "verification_result_public_key_fingerprint_sha256" not in output
+    output_json = json.dumps(output)
+    assert FINGERPRINT not in output_json
+    assert str(receipt_path) not in output_json
+    assert str(verification_result_path) not in output_json
+    assert output["errors"] == []
+
+
+def test_validate_key_provenance_json_invalid_schema_uses_fixed_errors(
+    tmp_path,
+    capsys,
+) -> None:
+    """--json schema failures expose only fixed public diagnostics."""
+    from veritas_os.cli.evidence_bundle import main
+
+    receipt_path, verification_result_path = _write_valid_inputs(tmp_path)
+    receipt = _valid_receipt_payload()
+    receipt.pop("approved_by")
+    _write_json(receipt_path, receipt)
+    verification_result = _valid_verification_result_payload()
+    verification_result["signature_status"] = "verified"
+    _write_json(verification_result_path, verification_result)
+
+    exit_code = main(
+        [
+            "validate-key-provenance",
+            "--receipt",
+            str(receipt_path),
+            "--verification-result",
+            str(verification_result_path),
+            "--json",
+        ]
+    )
+    output_text = capsys.readouterr().out
+    output = json.loads(output_text)
+    messages = {error["message"] for error in output["errors"]}
+
+    assert exit_code == 1
+    assert output["receipt_schema_valid"] is False
+    assert output["verification_result_schema_valid"] is False
+    assert "receipt does not satisfy schema" in messages
+    assert "verification result does not satisfy schema" in messages
+    assert "'approved_by' is a required property" not in output_text
+    assert "'verified' is not one of" not in output_text
+    assert "value does not satisfy schema at this path" not in output_text
+    assert FINGERPRINT not in output_text
+    assert str(receipt_path) not in output_text
+    assert str(verification_result_path) not in output_text
+
+
+def test_validate_key_provenance_json_missing_file_hides_exception_text(
+    tmp_path,
+    capsys,
+) -> None:
+    """--json missing-file failures do not expose paths or exception text."""
+    from veritas_os.cli.evidence_bundle import main
+
+    receipt_path = tmp_path / "missing-secret-receipt.json"
+    verification_result_path = tmp_path / "verification-result.json"
+    _write_json(verification_result_path, _valid_verification_result_payload())
+
+    exit_code = main(
+        [
+            "validate-key-provenance",
+            "--receipt",
+            str(receipt_path),
+            "--verification-result",
+            str(verification_result_path),
+            "--json",
+        ]
+    )
+    output_text = capsys.readouterr().out
+    output = json.loads(output_text)
+
+    assert exit_code == 1
+    assert output["receipt_schema_valid"] is False
+    assert output["receipt_path_provided"] is True
+    assert "receipt does not satisfy schema" in {
+        error["message"] for error in output["errors"]
+    }
+    assert str(receipt_path) not in output_text
+    assert str(verification_result_path) not in output_text
+    assert "No such file" not in output_text
+    assert "Errno" not in output_text
+
+
+def test_validate_key_provenance_json_output_file_matches_stdout(
+    tmp_path,
+    capsys,
+) -> None:
+    """--json --output saves the exact stdout JSON report."""
+    from veritas_os.cli.evidence_bundle import main
+
+    receipt_path, verification_result_path = _write_valid_inputs(tmp_path)
+    output_path = tmp_path / "reports" / "key-provenance-validation.json"
+
+    exit_code = main(
+        [
+            "validate-key-provenance",
+            "--receipt",
+            str(receipt_path),
+            "--verification-result",
+            str(verification_result_path),
+            "--json",
+            "--output",
+            str(output_path),
+        ]
+    )
+    stdout = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert output_path.read_text(encoding="utf-8") == stdout
+    assert json.loads(stdout)["ok"] is True
+
+
+def test_validate_key_provenance_output_without_json_fails_clearly(
+    tmp_path,
+    capsys,
+) -> None:
+    """--output without --json fails before running validation."""
+    from veritas_os.cli.evidence_bundle import main
+
+    receipt_path, verification_result_path = _write_valid_inputs(tmp_path)
+
+    with pytest.raises(SystemExit) as excinfo:
+        main(
+            [
+                "validate-key-provenance",
+                "--receipt",
+                str(receipt_path),
+                "--verification-result",
+                str(verification_result_path),
+                "--output",
+                str(tmp_path / "report.json"),
+            ]
+        )
+
+    assert excinfo.value.code == 2
+    stderr = capsys.readouterr().err
+    assert "validate-key-provenance --output requires --json" in stderr
+
+
+def test_validate_key_provenance_output_write_failure_is_clear(
+    tmp_path,
+    capsys,
+) -> None:
+    """--json --output write failures exit non-zero with clear stderr."""
+    from veritas_os.cli.evidence_bundle import main
+
+    receipt_path, verification_result_path = _write_valid_inputs(tmp_path)
+    output_path = tmp_path / "existing-directory"
+    output_path.mkdir()
+
+    exit_code = main(
+        [
+            "validate-key-provenance",
+            "--receipt",
+            str(receipt_path),
+            "--verification-result",
+            str(verification_result_path),
+            "--json",
+            "--output",
+            str(output_path),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert captured.out == ""
+    assert captured.err.strip() == (
+        "error: failed to write key provenance validation report"
+    )
+    assert str(output_path) not in captured.err

--- a/veritas_os/tests/test_trusted_public_key_provenance_cli.py
+++ b/veritas_os/tests/test_trusted_public_key_provenance_cli.py
@@ -376,6 +376,10 @@ def test_validate_key_provenance_json_output_file_matches_stdout(
     assert exit_code == 0
     assert output_path.read_text(encoding="utf-8") == stdout
     assert json.loads(stdout)["ok"] is True
+    assert str(output_path) not in stdout
+    assert str(receipt_path) not in stdout
+    assert str(verification_result_path) not in stdout
+    assert FINGERPRINT not in stdout
 
 
 def test_validate_key_provenance_output_without_json_fails_clearly(


### PR DESCRIPTION
### Motivation

- Provide a dedicated CLI command to validate Trusted Public Key Provenance Receipts and correlate them with saved strict verification results without exposing raw fingerprint or path values.

### Description

- Add `validate-key-provenance` subcommand to the evidence bundle CLI that validates receipt and verification-result schema conformance and checks fingerprint correlation and strict authenticity, implemented in `veritas_os/cli/evidence_bundle.py`.
- Introduce `KeyProvenanceValidationStatus` dataclass and helper functions (`_load_json_document`, `_load_schema`, `_json_schema_valid`, `_strict_authenticity_ok`, `_build_key_provenance_status`, `_key_provenance_public_report`, `_key_provenance_public_errors`, `_print_key_provenance_human_errors`, and `_run_validate_key_provenance`) to perform boolean-only checks and produce public reports that intentionally omit raw fingerprints, file paths, and exception text.
- Add schema identifiers and schema path constants for the trusted receipt, wire the new command into `build_parser()` and `main()`, and ensure `--output` requires `--json` and writes byte-for-byte identical JSON when used.
- Update documentation files (`trusted-public-key-provenance.md`, `evidence-bundle-reviewer-checklist.md`, `evidence-bundle-verification-json-contract.md`, and `sample-evidence-bundle-verification-output.md`) to document usage, examples, and limitations of `validate-key-provenance`.

### Testing

- Add comprehensive unit tests in `veritas_os/tests/test_trusted_public_key_provenance_cli.py` covering success, fingerprint mismatch, schema failures, bundle-internal key rejection, authenticity failures, JSON output shape, missing-file handling, and `--output` behavior.
- Run the new test module with `pytest veritas_os/tests/test_trusted_public_key_provenance_cli.py` and confirm all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a281a43e0308326a79fa54099849fbb)