### PR TITLE
feat: add key provenance validation report schema

### DIFF
--- a/docs/en/validation/evidence-bundle-reviewer-checklist.md
+++ b/docs/en/validation/evidence-bundle-reviewer-checklist.md
@@ -100,15 +100,17 @@ result schema, checks exact fingerprint correlation, rejects
 `bundle_internal_key_used: true`, and confirms strict authenticity success
 (`signature_status: "pass"`, `signature_verified: true`, and
 `authenticity_ok: true`). Add `--json --output <path>` to emit and save the
-exact same machine-readable report, including failure reports. The public report
-exposes only booleans and fixed diagnostics: it does not echo raw fingerprint
-values, raw file paths, raw schema validator messages, or raw exception text. It
-only records fingerprint presence and correlation status because the raw
-fingerprints remain in the source receipt and verification-result artifacts.
-The command does not create trust by itself, does not re-run cryptographic
-verification, does not prove regulatory certification, and does not complete
-third-party audit approval. Matching fingerprints support correlation, not
-standalone trust.
+exact same machine-readable report, including failure reports. The JSON report
+has a dedicated Draft 2020-12 schema at
+[`schemas/trusted_public_key_provenance_validation_report.schema.json`](../../../schemas/trusted_public_key_provenance_validation_report.schema.json).
+That schema validates the report shape only; it does not re-run cryptographic
+verification, create trust, prove regulatory certification, or complete
+third-party audit approval. The public report exposes only booleans and fixed
+diagnostics: it does not echo raw fingerprint values, raw file paths, raw schema
+validator messages, or raw exception text. It only records fingerprint presence
+and correlation status because the raw fingerprints remain in the source receipt
+and verification-result artifacts. Matching fingerprints support correlation,
+not standalone trust.
 
 ## Verification order
 

--- a/docs/en/validation/evidence-bundle-verification-json-contract.md
+++ b/docs/en/validation/evidence-bundle-verification-json-contract.md
@@ -172,12 +172,13 @@ It does not echo raw fingerprint values, raw file paths, raw schema validator
 messages, or raw exception text; the raw fingerprints remain in the source
 receipt and verification-result artifacts. `--output <path>` is allowed only
 with `--json`; the saved JSON is byte-for-byte the same as stdout JSON, and
-failure reports are saved as audit evidence. This correlation report has no
-dedicated schema yet and is intentionally structured for future extension. It
-does not create trust by itself, does not re-run cryptographic verification,
-does not prove regulatory certification, and does not complete third-party
-audit approval. Matching fingerprints support correlation, not standalone
-trust.
+failure reports are saved as audit evidence. This correlation report has a
+dedicated Draft 2020-12 schema at
+[`schemas/trusted_public_key_provenance_validation_report.schema.json`](../../../schemas/trusted_public_key_provenance_validation_report.schema.json).
+The schema validates the report shape only; it does not re-run cryptographic
+verification, create trust, prove regulatory certification, or complete
+third-party audit approval. The report does not expose raw fingerprints or raw
+paths. Matching fingerprints support correlation, not standalone trust.
 
 ## Contract scope
 

--- a/docs/en/validation/sample-evidence-bundle-verification-output.md
+++ b/docs/en/validation/sample-evidence-bundle-verification-output.md
@@ -212,16 +212,18 @@ veritas-evidence-bundle validate-key-provenance \
 ```
 
 The stdout JSON and saved UTF-8 JSON file are byte-for-byte identical, including
-failure reports. `--output` without `--json` fails clearly. The public report
-does not echo raw fingerprint values, raw file paths, raw schema validator
-messages, or raw exception text; raw fingerprints remain in the source receipt
-and verification-result artifacts. This command validates receipt shape,
-validates saved verification-result shape, checks exact fingerprint correlation,
-rejects `bundle_internal_key_used: true`, and confirms strict authenticity
-success. It does not create trust by itself, does not re-run cryptographic
-verification, does not prove regulatory certification, and does not complete
-third-party audit approval. Matching fingerprints support correlation, not
-standalone trust.
+failure reports. `--output` without `--json` fails clearly. The JSON report has
+a dedicated Draft 2020-12 schema at
+[`schemas/trusted_public_key_provenance_validation_report.schema.json`](../../../schemas/trusted_public_key_provenance_validation_report.schema.json).
+That schema validates the report shape only; it does not re-run cryptographic
+verification, create trust, prove regulatory certification, or complete
+third-party audit approval. The public report does not echo raw fingerprint
+values, raw file paths, raw schema validator messages, or raw exception text;
+raw fingerprints remain in the source receipt and verification-result artifacts.
+This command validates receipt shape, validates saved verification-result shape,
+checks exact fingerprint correlation, rejects `bundle_internal_key_used: true`,
+and confirms strict authenticity success. Matching fingerprints support
+correlation, not standalone trust.
 
 ## Successful strict verification
 

--- a/docs/en/validation/trusted-public-key-provenance.md
+++ b/docs/en/validation/trusted-public-key-provenance.md
@@ -5,8 +5,11 @@ trusted the Ed25519 public key used during strict Evidence Bundle verification.
 It complements `verification-result.json`; it is not generated from the
 Evidence Bundle alone and it does not replace cryptographic verification.
 
-Schema:
+Receipt schema:
 [`schemas/trusted_public_key_provenance_receipt.schema.json`](../../../schemas/trusted_public_key_provenance_receipt.schema.json)
+
+`validate-key-provenance --json` report schema:
+[`schemas/trusted_public_key_provenance_validation_report.schema.json`](../../../schemas/trusted_public_key_provenance_validation_report.schema.json)
 
 ## Why public key provenance matters
 
@@ -79,9 +82,14 @@ Bundle-internal key used: PASS
 Strict authenticity result: PASS
 ```
 
-For CI, UI, or audit-tool ingestion, add `--json`. Add `--output <path>` with
-`--json` to save the exact same JSON report that is emitted to stdout; failure
-reports are saved too, and parent directories are created when needed.
+For CI, UI, or audit-tool ingestion, add `--json`. The JSON report has a
+dedicated Draft 2020-12 schema at
+[`schemas/trusted_public_key_provenance_validation_report.schema.json`](../../../schemas/trusted_public_key_provenance_validation_report.schema.json).
+That schema validates the report shape only; it does not re-run cryptographic
+verification, create trust, prove regulatory certification, or complete
+third-party audit approval. Add `--output <path>` with `--json` to save the
+exact same JSON report that is emitted to stdout; failure reports are saved too,
+and parent directories are created when needed.
 `--output` without `--json` is rejected. To avoid echoing externally supplied
 key material or local environment details in logs, the public CLI report exposes
 only booleans and fixed diagnostics. It does not print raw fingerprint values,

--- a/schemas/trusted_public_key_provenance_validation_report.schema.json
+++ b/schemas/trusted_public_key_provenance_validation_report.schema.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://veritas-os.example/schemas/trusted_public_key_provenance_validation_report.schema.json",
+  "title": "Trusted Public Key Provenance Validation Report",
+  "description": "Machine-readable report contract emitted by veritas-evidence-bundle validate-key-provenance --json. This schema validates the report shape only. It does not re-run cryptographic verification, create trust, prove regulatory certification, or complete third-party audit approval. The report intentionally exposes booleans and fixed diagnostics only; it does not expose raw fingerprints, raw file paths, raw exception text, raw schema validator messages, or raw JSON values.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "ok",
+    "receipt_schema_valid",
+    "verification_result_schema_valid",
+    "fingerprint_correlation_ok",
+    "bundle_internal_key_used_ok",
+    "strict_authenticity_ok",
+    "receipt_public_key_fingerprint_present",
+    "verification_result_public_key_fingerprint_present",
+    "report_schema_id",
+    "receipt_schema_id",
+    "verification_result_schema_id",
+    "validator",
+    "errors"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "description": "Overall validate-key-provenance result. True means the receipt and saved verification result schemas passed, fingerprints correlated, bundle_internal_key_used was false, and strict authenticity succeeded."
+    },
+    "receipt_schema_valid": {
+      "type": "boolean",
+      "description": "True when the Trusted Public Key Provenance Receipt conforms to its JSON Schema."
+    },
+    "verification_result_schema_valid": {
+      "type": "boolean",
+      "description": "True when the saved Evidence Bundle verification result conforms to its JSON Schema."
+    },
+    "fingerprint_correlation_ok": {
+      "type": "boolean",
+      "description": "True when both inputs contain public key fingerprint fields and those internal values match. The raw values are not emitted in this report."
+    },
+    "bundle_internal_key_used_ok": {
+      "type": "boolean",
+      "description": "True when the receipt reports bundle_internal_key_used as false."
+    },
+    "strict_authenticity_ok": {
+      "type": "boolean",
+      "description": "True when the saved verification result reports strict authenticity success."
+    },
+    "receipt_public_key_fingerprint_present": {
+      "type": "boolean",
+      "description": "True when the receipt contains a public key fingerprint field. The raw fingerprint is not emitted."
+    },
+    "verification_result_public_key_fingerprint_present": {
+      "type": "boolean",
+      "description": "True when the saved verification result contains a public key fingerprint field. The raw fingerprint is not emitted."
+    },
+    "report_schema_id": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Identifies this validation report schema. This metadata validates report shape only; it does not re-run cryptographic verification or establish trust.",
+      "enum": [
+        "https://veritas-os.example/schemas/trusted_public_key_provenance_validation_report.schema.json",
+        null
+      ]
+    },
+    "receipt_schema_id": {
+      "type": "string",
+      "const": "https://veritas-os.example/schemas/trusted_public_key_provenance_receipt.schema.json",
+      "description": "Identifies the Trusted Public Key Provenance Receipt schema used by validate-key-provenance."
+    },
+    "verification_result_schema_id": {
+      "type": "string",
+      "const": "https://veritas-os.example/schemas/evidence_bundle_verification_result.schema.json",
+      "description": "Identifies the saved Evidence Bundle verification result schema used by validate-key-provenance."
+    },
+    "validator": {
+      "type": "string",
+      "const": "veritas-evidence-bundle validate-key-provenance",
+      "description": "Identifies the validator command that emitted this report."
+    },
+    "errors": {
+      "type": "array",
+      "description": "Fixed public diagnostics for failed checks. Empty when ok is true.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "check",
+          "path",
+          "message"
+        ],
+        "properties": {
+          "check": {
+            "type": "string",
+            "enum": [
+              "receipt_schema_valid",
+              "verification_result_schema_valid",
+              "fingerprint_correlation_ok",
+              "bundle_internal_key_used_ok",
+              "strict_authenticity_ok"
+            ],
+            "description": "Boolean check that failed."
+          },
+          "path": {
+            "type": "string",
+            "enum": [
+              "$",
+              "$['public_key_fingerprint_sha256']",
+              "$['bundle_internal_key_used']"
+            ],
+            "description": "Fixed public JSONPath-like location for the failed check."
+          },
+          "message": {
+            "type": "string",
+            "enum": [
+              "receipt does not satisfy schema",
+              "verification result does not satisfy schema",
+              "receipt and verification result public key fingerprints do not match",
+              "receipt bundle_internal_key_used must be false",
+              "verification result must report strict authenticity success"
+            ],
+            "description": "Fixed public diagnostic. Raw external values and raw validator messages are not permitted."
+          }
+        }
+      }
+    }
+  }
+}

--- a/veritas_os/cli/evidence_bundle.py
+++ b/veritas_os/cli/evidence_bundle.py
@@ -43,6 +43,9 @@ TRUSTED_PUBLIC_KEY_PROVENANCE_RECEIPT_SCHEMA_ID = (
     f"{SCHEMA_BASE_URL}/trusted_public_key_provenance_receipt.schema.json"
 )
 VALIDATE_RESULT_VALIDATOR = "veritas-evidence-bundle validate-result"
+TRUSTED_PUBLIC_KEY_PROVENANCE_VALIDATION_REPORT_SCHEMA_ID = (
+    f"{SCHEMA_BASE_URL}/trusted_public_key_provenance_validation_report.schema.json"
+)
 VALIDATE_KEY_PROVENANCE_VALIDATOR = "veritas-evidence-bundle validate-key-provenance"
 VERIFICATION_RESULT_SCHEMA_PATH = (
     Path(__file__).resolve().parents[2]
@@ -372,7 +375,9 @@ def _key_provenance_public_report(
         "verification_result_public_key_fingerprint_present": (
             status.verification_result_public_key_fingerprint_present
         ),
-        "report_schema_id": None,
+        "report_schema_id": (
+            TRUSTED_PUBLIC_KEY_PROVENANCE_VALIDATION_REPORT_SCHEMA_ID
+        ),
         "receipt_schema_id": TRUSTED_PUBLIC_KEY_PROVENANCE_RECEIPT_SCHEMA_ID,
         "verification_result_schema_id": VERIFICATION_RESULT_SCHEMA_ID,
         "validator": VALIDATE_KEY_PROVENANCE_VALIDATOR,

--- a/veritas_os/tests/test_trusted_public_key_provenance_cli.py
+++ b/veritas_os/tests/test_trusted_public_key_provenance_cli.py
@@ -6,11 +6,21 @@ import json
 from pathlib import Path
 from typing import Any
 
+import jsonschema
 import pytest
 
 
 FINGERPRINT = "a" * 64
 MISMATCHED_FINGERPRINT = "b" * 64
+REPORT_SCHEMA_ID = (
+    "https://veritas-os.example/schemas/"
+    "trusted_public_key_provenance_validation_report.schema.json"
+)
+REPORT_SCHEMA_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "schemas"
+    / "trusted_public_key_provenance_validation_report.schema.json"
+)
 
 
 def _valid_receipt_payload() -> dict[str, Any]:
@@ -56,6 +66,75 @@ def _write_valid_inputs(tmp_path: Path) -> tuple[Path, Path]:
     _write_json(receipt_path, _valid_receipt_payload())
     _write_json(verification_result_path, _valid_verification_result_payload())
     return receipt_path, verification_result_path
+
+
+
+def _report_schema_validator() -> jsonschema.Draft202012Validator:
+    """Return the validate-key-provenance report schema validator."""
+    schema = json.loads(REPORT_SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.Draft202012Validator.check_schema(schema)
+    return jsonschema.Draft202012Validator(schema)
+
+
+def _assert_report_matches_schema(report: dict[str, Any]) -> None:
+    """Assert a validate-key-provenance JSON report matches its schema."""
+    _report_schema_validator().validate(report)
+    assert report["report_schema_id"] == REPORT_SCHEMA_ID
+
+
+def _run_json_report(
+    tmp_path: Path,
+    capsys,
+    *,
+    receipt_payload: dict[str, Any] | None = None,
+    verification_result_payload: dict[str, Any] | None = None,
+) -> tuple[int, dict[str, Any], str, Path, Path]:
+    """Run validate-key-provenance --json against supplied fixtures."""
+    from veritas_os.cli.evidence_bundle import main
+
+    receipt_path, verification_result_path = _write_valid_inputs(tmp_path)
+    if receipt_payload is not None:
+        _write_json(receipt_path, receipt_payload)
+    if verification_result_payload is not None:
+        _write_json(verification_result_path, verification_result_payload)
+
+    exit_code = main(
+        [
+            "validate-key-provenance",
+            "--receipt",
+            str(receipt_path),
+            "--verification-result",
+            str(verification_result_path),
+            "--json",
+        ]
+    )
+    output_text = capsys.readouterr().out
+    return (
+        exit_code,
+        json.loads(output_text),
+        output_text,
+        receipt_path,
+        verification_result_path,
+    )
+
+
+def _assert_report_hides_raw_inputs(
+    output_text: str,
+    receipt_path: Path,
+    verification_result_path: Path,
+) -> None:
+    """Assert public reports omit raw fingerprints, paths, and internals."""
+    assert FINGERPRINT not in output_text
+    assert MISMATCHED_FINGERPRINT not in output_text
+    assert str(receipt_path) not in output_text
+    assert str(verification_result_path) not in output_text
+    assert "No such file" not in output_text
+    assert "Errno" not in output_text
+    assert "Traceback" not in output_text
+    assert "ValidationError" not in output_text
+    assert "is a required property" not in output_text
+    assert "is not one of" not in output_text
+    assert "value does not satisfy schema at this path" not in output_text
 
 
 def test_validate_key_provenance_valid_inputs_pass(tmp_path, capsys) -> None:
@@ -251,6 +330,7 @@ def test_validate_key_provenance_json_output_stable_fields(tmp_path, capsys) -> 
 
     assert exit_code == 0
     assert output["ok"] is True
+    _assert_report_matches_schema(output)
     assert output["receipt_schema_valid"] is True
     assert output["verification_result_schema_valid"] is True
     assert output["fingerprint_correlation_ok"] is True
@@ -375,8 +455,127 @@ def test_validate_key_provenance_json_output_file_matches_stdout(
 
     assert exit_code == 0
     assert output_path.read_text(encoding="utf-8") == stdout
-    assert json.loads(stdout)["ok"] is True
+    saved_report = json.loads(stdout)
+    assert saved_report["ok"] is True
+    _assert_report_matches_schema(saved_report)
     assert str(output_path) not in stdout
+
+
+def test_validate_key_provenance_json_success_validates_against_schema(
+    tmp_path,
+    capsys,
+) -> None:
+    """Successful --json report validates against the report schema."""
+    exit_code, report, output_text, receipt_path, result_path = _run_json_report(
+        tmp_path,
+        capsys,
+    )
+
+    assert exit_code == 0
+    _assert_report_matches_schema(report)
+    _assert_report_hides_raw_inputs(output_text, receipt_path, result_path)
+
+
+def test_validate_key_provenance_json_fingerprint_mismatch_validates_schema(
+    tmp_path,
+    capsys,
+) -> None:
+    """Fingerprint mismatch --json report validates against the schema."""
+    verification_result = _valid_verification_result_payload()
+    verification_result["public_key_fingerprint_sha256"] = MISMATCHED_FINGERPRINT
+
+    exit_code, report, output_text, receipt_path, result_path = _run_json_report(
+        tmp_path,
+        capsys,
+        verification_result_payload=verification_result,
+    )
+
+    assert exit_code == 1
+    assert report["fingerprint_correlation_ok"] is False
+    _assert_report_matches_schema(report)
+    _assert_report_hides_raw_inputs(output_text, receipt_path, result_path)
+
+
+def test_validate_key_provenance_json_receipt_schema_failure_validates_schema(
+    tmp_path,
+    capsys,
+) -> None:
+    """Receipt schema failure --json report validates against the schema."""
+    receipt = _valid_receipt_payload()
+    receipt.pop("approved_by")
+
+    exit_code, report, output_text, receipt_path, result_path = _run_json_report(
+        tmp_path,
+        capsys,
+        receipt_payload=receipt,
+    )
+
+    assert exit_code == 1
+    assert report["receipt_schema_valid"] is False
+    _assert_report_matches_schema(report)
+    _assert_report_hides_raw_inputs(output_text, receipt_path, result_path)
+
+
+def test_validate_key_provenance_json_result_schema_failure_validates_schema(
+    tmp_path,
+    capsys,
+) -> None:
+    """Verification-result schema failure report validates against schema."""
+    verification_result = _valid_verification_result_payload()
+    verification_result["signature_status"] = "verified"
+
+    exit_code, report, output_text, receipt_path, result_path = _run_json_report(
+        tmp_path,
+        capsys,
+        verification_result_payload=verification_result,
+    )
+
+    assert exit_code == 1
+    assert report["verification_result_schema_valid"] is False
+    _assert_report_matches_schema(report)
+    _assert_report_hides_raw_inputs(output_text, receipt_path, result_path)
+
+
+def test_validate_key_provenance_json_bundle_internal_key_failure_validates_schema(
+    tmp_path,
+    capsys,
+) -> None:
+    """bundle_internal_key_used true report validates against schema."""
+    receipt = _valid_receipt_payload()
+    receipt["bundle_internal_key_used"] = True
+
+    exit_code, report, output_text, receipt_path, result_path = _run_json_report(
+        tmp_path,
+        capsys,
+        receipt_payload=receipt,
+    )
+
+    assert exit_code == 1
+    assert report["bundle_internal_key_used_ok"] is False
+    _assert_report_matches_schema(report)
+    _assert_report_hides_raw_inputs(output_text, receipt_path, result_path)
+
+
+def test_validate_key_provenance_json_strict_authenticity_failure_validates_schema(
+    tmp_path,
+    capsys,
+) -> None:
+    """Strict authenticity failure report validates against schema."""
+    verification_result = _valid_verification_result_payload()
+    verification_result["ok"] = False
+    verification_result["authenticity_ok"] = False
+    verification_result["authenticity_failure"] = "signature_verification_failed"
+
+    exit_code, report, output_text, receipt_path, result_path = _run_json_report(
+        tmp_path,
+        capsys,
+        verification_result_payload=verification_result,
+    )
+
+    assert exit_code == 1
+    assert report["strict_authenticity_ok"] is False
+    _assert_report_matches_schema(report)
+    _assert_report_hides_raw_inputs(output_text, receipt_path, result_path)
 
 
 def test_validate_key_provenance_output_without_json_fails_clearly(


### PR DESCRIPTION
### Motivation
- Stabilize the machine-readable contract for `validate-key-provenance --json` reports so downstream CI, UI, and audit tooling can reliably validate the report shape. 
- Ensure the public JSON report remains privacy-safe by exposing only booleans and fixed diagnostics and intentionally not echoing raw fingerprints, file paths, exception text, or raw schema validator messages.

### Description
- Add a Draft 2020-12 JSON Schema at `schemas/trusted_public_key_provenance_validation_report.schema.json` with the suggested `$id` `https://veritas-os.example/schemas/trusted_public_key_provenance_validation_report.schema.json` and the required fields, fixed `validator` value, and constrained `errors[]` shape and enums. 
- Populate the CLI JSON report `report_schema_id` for `validate-key-provenance` with the new report schema ID via `TRUSTED_PUBLIC_KEY_PROVENANCE_VALIDATION_REPORT_SCHEMA_ID` and ensure the validator field is `"veritas-evidence-bundle validate-key-provenance"`. 
- Expand `veritas_os/tests/test_trusted_public_key_provenance_cli.py` to add schema-driven assertions, helpers that validate emitted reports against the new schema, tests for success and each failure mode (fingerprint mismatch, receipt schema failure, verification-result schema failure, `bundle_internal_key_used: true`, strict-authenticity failure), saved-output parity, and privacy checks that assert no raw fingerprints/paths/exceptions are present. 
- Update validation documentation (`docs/en/validation/*.md`) to reference the new schema, explain the report-shape-only scope, and reiterate that the schema does not create trust or re-run cryptographic verification.

### Testing
- `python -m py_compile veritas_os/cli/evidence_bundle.py veritas_os/tests/test_trusted_public_key_provenance_cli.py` succeeded, verifying syntax of modified modules. 
- `python -m json.tool schemas/trusted_public_key_provenance_validation_report.schema.json` succeeded, confirming the schema is valid JSON. 
- `git diff --check` reported no whitespace/format issues. 
- Running the full `pytest` in this environment was blocked: attempts to run `pytest` were prevented by missing local dependency `pydantic` and an environment/network failure when the test runner attempted to fetch `psycopg` from PyPI, so the new tests were added and syntax-checked but not executed to completion here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28dfd070f48326aadb2d3765819eab)