### PR TITLE
feat(cli): add validate-key-provenance-result to validate saved key-provenance reports

### DIFF
--- a/docs/en/validation/evidence-bundle-reviewer-checklist.md
+++ b/docs/en/validation/evidence-bundle-reviewer-checklist.md
@@ -112,6 +112,22 @@ and correlation status because the raw fingerprints remain in the source receipt
 and verification-result artifacts. Matching fingerprints support correlation,
 not standalone trust.
 
+To validate the saved `validate-key-provenance --json` report shape later, run:
+
+```bash
+veritas-evidence-bundle validate-key-provenance-result \
+  --result key-provenance-validation.json
+```
+
+This command validates saved report shape only. It does not re-run key
+provenance validation, does not re-run cryptographic verification, does not
+create trust, is not regulatory certification, and is not completed third-party
+audit approval. Add `--json --output <path>` to emit and save byte-for-byte the
+same fixed-diagnostic JSON report; parent directories are created and
+`--output` without `--json` is rejected. The output does not expose raw
+fingerprints, raw file paths, raw exception text, raw schema validator messages,
+or raw JSON values from the saved report.
+
 ## Verification order
 
 | Step | Reviewer action | PASS criterion | FAIL / follow-up criterion |

--- a/docs/en/validation/evidence-bundle-verification-json-contract.md
+++ b/docs/en/validation/evidence-bundle-verification-json-contract.md
@@ -180,6 +180,24 @@ verification, create trust, prove regulatory certification, or complete
 third-party audit approval. The report does not expose raw fingerprints or raw
 paths. Matching fingerprints support correlation, not standalone trust.
 
+Use `validate-key-provenance-result` to validate a saved
+`validate-key-provenance --json` report against that report schema:
+
+```bash
+veritas-evidence-bundle validate-key-provenance-result \
+  --result key-provenance-validation.json
+```
+
+The command validates saved report shape only. It does not re-run key
+provenance validation, does not re-run cryptographic verification, does not
+create trust, is not regulatory certification, and is not completed third-party
+audit approval. Its JSON output uses `result_schema_valid`,
+`validated_schema_id`, `validator`, and fixed `errors`; it does not expose raw
+fingerprints, raw paths, raw exception text, raw schema validator messages, or
+raw JSON values from the saved report. Add `--json --output <path>` to save a
+byte-for-byte copy of stdout JSON; parent directories are created, and
+`--output` without `--json` is rejected.
+
 ## Contract scope
 
 The contract separates two reviewer decisions that external UI and audit tooling

--- a/docs/en/validation/sample-evidence-bundle-verification-output.md
+++ b/docs/en/validation/sample-evidence-bundle-verification-output.md
@@ -225,6 +225,50 @@ checks exact fingerprint correlation, rejects `bundle_internal_key_used: true`,
 and confirms strict authenticity success. Matching fingerprints support
 correlation, not standalone trust.
 
+## Validating a saved key provenance validation report shape
+
+Saved `validate-key-provenance --json` reports can be checked against their
+Draft 2020-12 schema without re-running provenance or cryptographic checks:
+
+```bash
+veritas-evidence-bundle validate-key-provenance-result \
+  --result key-provenance-validation.json
+```
+
+Illustrative success output:
+
+```text
+Trusted public key provenance validation report schema: PASS
+```
+
+Illustrative failure output:
+
+```text
+Trusted public key provenance validation report schema: FAIL
+  error [result_schema_valid]: result does not satisfy schema
+```
+
+Illustrative `--json` success output:
+
+```json
+{
+  "ok": true,
+  "result_schema_valid": true,
+  "validated_schema_id": "https://veritas-os.example/schemas/trusted_public_key_provenance_validation_report.schema.json",
+  "validator": "veritas-evidence-bundle validate-key-provenance-result",
+  "errors": []
+}
+```
+
+Add `--json --output <path>` to save byte-for-byte the same JSON emitted to
+stdout; parent directories are created, and `--output` without `--json` fails
+clearly. `validate-key-provenance-result` validates saved report shape only. It
+does not re-run key provenance validation, does not re-run cryptographic
+verification, does not create trust, is not regulatory certification, and is
+not completed third-party audit approval. Output remains privacy-safe: it does
+not expose raw fingerprints, raw paths, raw exception text, raw schema
+validator messages, or raw JSON values from the saved report.
+
 ## Successful strict verification
 
 Illustrative output:

--- a/docs/en/validation/trusted-public-key-provenance.md
+++ b/docs/en/validation/trusted-public-key-provenance.md
@@ -106,6 +106,30 @@ veritas-evidence-bundle validate-key-provenance \
   --output key-provenance-validation.json
 ```
 
+Saved `validate-key-provenance --json` reports can be checked later with
+`validate-key-provenance-result`:
+
+```bash
+veritas-evidence-bundle validate-key-provenance-result \
+  --result key-provenance-validation.json
+```
+
+Successful human-readable output is:
+
+```text
+Trusted public key provenance validation report schema: PASS
+```
+
+Add `--json` for a stable machine-readable report, and add `--output <path>`
+with `--json` to save byte-for-byte the same JSON emitted to stdout. Parent
+directories are created when needed, and `--output` without `--json` is
+rejected. This command validates the saved report shape only. It does not
+re-run key provenance validation, does not re-run cryptographic verification,
+does not create trust, is not regulatory certification, and is not completed
+third-party audit approval. Its public output uses fixed diagnostics and does
+not expose raw fingerprints, raw file paths, raw exception text, raw schema
+validator messages, or raw JSON values from the saved report.
+
 The command checks that:
 
 - `--receipt` conforms to

--- a/veritas_os/cli/evidence_bundle.py
+++ b/veritas_os/cli/evidence_bundle.py
@@ -47,6 +47,9 @@ TRUSTED_PUBLIC_KEY_PROVENANCE_VALIDATION_REPORT_SCHEMA_ID = (
     f"{SCHEMA_BASE_URL}/trusted_public_key_provenance_validation_report.schema.json"
 )
 VALIDATE_KEY_PROVENANCE_VALIDATOR = "veritas-evidence-bundle validate-key-provenance"
+VALIDATE_KEY_PROVENANCE_RESULT_VALIDATOR = (
+    "veritas-evidence-bundle validate-key-provenance-result"
+)
 VERIFICATION_RESULT_SCHEMA_PATH = (
     Path(__file__).resolve().parents[2]
     / "schemas"
@@ -56,6 +59,11 @@ TRUSTED_PUBLIC_KEY_PROVENANCE_RECEIPT_SCHEMA_PATH = (
     Path(__file__).resolve().parents[2]
     / "schemas"
     / "trusted_public_key_provenance_receipt.schema.json"
+)
+TRUSTED_PUBLIC_KEY_PROVENANCE_VALIDATION_REPORT_SCHEMA_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "schemas"
+    / "trusted_public_key_provenance_validation_report.schema.json"
 )
 
 
@@ -458,6 +466,131 @@ def _run_validate_key_provenance(
     return 0 if status.ok else 1
 
 
+def _key_provenance_result_report_errors(
+    *,
+    result_readable: bool,
+    result_json_valid: bool,
+    result_schema_valid: bool,
+) -> list[dict[str, str]]:
+    """Build fixed diagnostics for saved provenance report validation.
+
+    Diagnostics intentionally do not include raw file paths, exception text,
+    schema validator messages, raw fingerprints, or JSON values from the saved
+    report because saved validation reports may be externally supplied.
+    """
+    if not result_readable:
+        return [
+            {
+                "check": "result_readable",
+                "path": "$",
+                "message": "result file could not be read",
+            }
+        ]
+    if not result_json_valid:
+        return [
+            {
+                "check": "result_json_valid",
+                "path": "$",
+                "message": "result file is not valid JSON",
+            }
+        ]
+    if not result_schema_valid:
+        return [
+            {
+                "check": "result_schema_valid",
+                "path": "$",
+                "message": "result does not satisfy schema",
+            }
+        ]
+    return []
+
+
+def _validate_key_provenance_result_status(
+    result_path: Path,
+) -> tuple[dict[str, Any], int]:
+    """Validate a saved key provenance validation report shape safely.
+
+    The validator checks only the saved ``validate-key-provenance --json``
+    report against its JSON Schema. It does not re-run key provenance
+    validation, cryptographic verification, trust establishment, regulatory
+    certification, or third-party audit approval. Public output is limited to
+    booleans, fixed schema identifiers, and fixed diagnostics.
+    """
+    try:
+        raw_report = result_path.read_text(encoding="utf-8")
+    except OSError:
+        report_document = None
+        result_readable = False
+        result_json_valid = False
+        result_schema_valid = False
+        exit_code = 2
+    else:
+        result_readable = True
+        try:
+            report_document = json.loads(raw_report)
+        except json.JSONDecodeError:
+            report_document = None
+            result_json_valid = False
+            result_schema_valid = False
+            exit_code = 1
+        else:
+            result_json_valid = True
+            result_schema_valid = _json_schema_valid(
+                report_document,
+                TRUSTED_PUBLIC_KEY_PROVENANCE_VALIDATION_REPORT_SCHEMA_PATH,
+            )
+            exit_code = 0 if result_schema_valid else 1
+
+    output = {
+        "ok": result_schema_valid,
+        "result_schema_valid": result_schema_valid,
+        "validated_schema_id": (
+            TRUSTED_PUBLIC_KEY_PROVENANCE_VALIDATION_REPORT_SCHEMA_ID
+        ),
+        "validator": VALIDATE_KEY_PROVENANCE_RESULT_VALIDATOR,
+        "errors": _key_provenance_result_report_errors(
+            result_readable=result_readable,
+            result_json_valid=result_json_valid,
+            result_schema_valid=result_schema_valid,
+        ),
+    }
+    return output, exit_code
+
+
+def _run_validate_key_provenance_result(
+    result_path: Path,
+    *,
+    json_output: bool = False,
+    output_path: Optional[Path] = None,
+) -> int:
+    """Run saved key provenance validation report schema validation."""
+    output, exit_code = _validate_key_provenance_result_status(result_path)
+    if json_output:
+        output_json = json.dumps(output, indent=2, ensure_ascii=False)
+        if output_path is not None:
+            try:
+                output_path.parent.mkdir(parents=True, exist_ok=True)
+                output_path.write_text(output_json + "\n", encoding="utf-8")
+            except OSError:
+                print(
+                    "error: failed to write key provenance result validation report",
+                    file=sys.stderr,
+                )
+                return 2
+        # codeql[py/clear-text-logging-sensitive-data]: this emits only fixed
+        # schema identifiers, booleans, and fixed diagnostics; raw paths,
+        # fingerprints, exception text, schema validator messages, and saved
+        # JSON values are intentionally not emitted.
+        print(output_json)
+        return exit_code
+
+    status = "PASS" if output["ok"] else "FAIL"
+    print(f"Trusted public key provenance validation report schema: {status}")
+    for error in output["errors"]:
+        print(f"  error [{error['check']}]: {error['message']}")
+    return exit_code
+
+
 def _run_validate_result(
     result_path: Path,
     *,
@@ -631,6 +764,33 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
 
+    key_provenance_result = sub.add_parser(
+        "validate-key-provenance-result",
+        help=(
+            "Validate a saved key provenance validation report JSON file "
+            "against the schema"
+        ),
+    )
+    key_provenance_result.add_argument(
+        "--result",
+        required=True,
+        type=Path,
+        help="Saved JSON report file from validate-key-provenance --json",
+    )
+    key_provenance_result.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a machine-readable result validation report as JSON",
+    )
+    key_provenance_result.add_argument(
+        "--output",
+        type=Path,
+        help=(
+            "Write the JSON key provenance result validation report to this "
+            "UTF-8 file. Requires --json and does not suppress stdout JSON."
+        ),
+    )
+
     return parser
 
 
@@ -686,6 +846,16 @@ def main(argv: Optional[list[str]] = None) -> int:
         return _run_validate_key_provenance(
             args.receipt,
             args.verification_result,
+            json_output=args.json,
+            output_path=args.output,
+        )
+
+    if args.command == "validate-key-provenance-result":
+        if args.output is not None and not args.json:
+            parser.error("validate-key-provenance-result --output requires --json")
+            return 2
+        return _run_validate_key_provenance_result(
+            args.result,
             json_output=args.json,
             output_path=args.output,
         )

--- a/veritas_os/tests/test_trusted_public_key_provenance_cli.py
+++ b/veritas_os/tests/test_trusted_public_key_provenance_cli.py
@@ -636,3 +636,332 @@ def test_validate_key_provenance_output_write_failure_is_clear(
         "error: failed to write key provenance validation report"
     )
     assert str(output_path) not in captured.err
+
+
+def _valid_key_provenance_validation_report() -> dict[str, Any]:
+    """Return a schema-valid validate-key-provenance JSON report."""
+    return {
+        "ok": True,
+        "receipt_schema_valid": True,
+        "verification_result_schema_valid": True,
+        "fingerprint_correlation_ok": True,
+        "bundle_internal_key_used_ok": True,
+        "strict_authenticity_ok": True,
+        "receipt_path_provided": True,
+        "verification_result_path_provided": True,
+        "receipt_public_key_fingerprint_present": True,
+        "verification_result_public_key_fingerprint_present": True,
+        "report_schema_id": REPORT_SCHEMA_ID,
+        "receipt_schema_id": (
+            "https://veritas-os.example/schemas/"
+            "trusted_public_key_provenance_receipt.schema.json"
+        ),
+        "verification_result_schema_id": (
+            "https://veritas-os.example/schemas/"
+            "evidence_bundle_verification_result.schema.json"
+        ),
+        "validator": "veritas-evidence-bundle validate-key-provenance",
+        "errors": [],
+    }
+
+
+def _write_valid_key_provenance_validation_report(tmp_path: Path) -> Path:
+    """Write a valid saved key provenance validation report fixture."""
+    report_path = tmp_path / "key-provenance-validation.json"
+    _write_json(report_path, _valid_key_provenance_validation_report())
+    return report_path
+
+
+def _run_key_provenance_result_json(
+    result_path: Path,
+    capsys,
+    *extra_args: str,
+) -> tuple[int, dict[str, Any], str, str]:
+    """Run validate-key-provenance-result --json and capture output."""
+    from veritas_os.cli.evidence_bundle import main
+
+    exit_code = main(
+        [
+            "validate-key-provenance-result",
+            "--result",
+            str(result_path),
+            "--json",
+            *extra_args,
+        ]
+    )
+    captured = capsys.readouterr()
+    return exit_code, json.loads(captured.out), captured.out, captured.err
+
+
+def _assert_key_provenance_result_output_is_safe(
+    output_text: str,
+    *paths: Path,
+) -> None:
+    """Assert saved report validation output omits user-controlled details."""
+    assert FINGERPRINT not in output_text
+    assert MISMATCHED_FINGERPRINT not in output_text
+    for path in paths:
+        assert str(path) not in output_text
+    assert "No such file" not in output_text
+    assert "Errno" not in output_text
+    assert "Traceback" not in output_text
+    assert "ValidationError" not in output_text
+    assert "is a required property" not in output_text
+    assert "is not one of" not in output_text
+    assert "not of type" not in output_text
+    assert "value does not satisfy schema at this path" not in output_text
+
+
+def test_validate_key_provenance_result_valid_saved_report_passes(
+    tmp_path,
+    capsys,
+) -> None:
+    """A saved schema-valid validate-key-provenance report passes."""
+    from veritas_os.cli.evidence_bundle import main
+
+    result_path = _write_valid_key_provenance_validation_report(tmp_path)
+
+    exit_code = main(
+        [
+            "validate-key-provenance-result",
+            "--result",
+            str(result_path),
+        ]
+    )
+    output = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert (
+        "Trusted public key provenance validation report schema: PASS" in output
+    )
+    _assert_key_provenance_result_output_is_safe(output, result_path)
+
+
+def test_validate_key_provenance_result_invalid_saved_report_fails(
+    tmp_path,
+    capsys,
+) -> None:
+    """A schema-invalid saved report fails with fixed diagnostics."""
+    from veritas_os.cli.evidence_bundle import main
+
+    result_path = _write_valid_key_provenance_validation_report(tmp_path)
+    invalid_report = _valid_key_provenance_validation_report()
+    invalid_report.pop("receipt_schema_valid")
+    invalid_report["errors"] = [
+        {
+            "check": "receipt_schema_valid",
+            "path": "$",
+            "message": (
+                "raw schema message mentions "
+                f"{FINGERPRINT} and should never be echoed"
+            ),
+        }
+    ]
+    _write_json(result_path, invalid_report)
+
+    exit_code = main(
+        [
+            "validate-key-provenance-result",
+            "--result",
+            str(result_path),
+        ]
+    )
+    output = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert (
+        "Trusted public key provenance validation report schema: FAIL" in output
+    )
+    assert "result does not satisfy schema" in output
+    _assert_key_provenance_result_output_is_safe(output, result_path)
+
+
+def test_validate_key_provenance_result_malformed_json_fails_safely(
+    tmp_path,
+    capsys,
+) -> None:
+    """Malformed saved JSON fails without parse exception details."""
+    from veritas_os.cli.evidence_bundle import main
+
+    result_path = tmp_path / "malformed-key-provenance-validation.json"
+    result_path.write_text('{"public_key_fingerprint_sha256": ', encoding="utf-8")
+
+    exit_code = main(
+        [
+            "validate-key-provenance-result",
+            "--result",
+            str(result_path),
+        ]
+    )
+    output = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "Trusted public key provenance validation report schema: FAIL" in output
+    assert "result file is not valid JSON" in output
+    _assert_key_provenance_result_output_is_safe(output, result_path)
+
+
+def test_validate_key_provenance_result_missing_file_fails_safely(
+    tmp_path,
+    capsys,
+) -> None:
+    """Missing saved reports return a read-error exit code safely."""
+    from veritas_os.cli.evidence_bundle import main
+
+    result_path = tmp_path / "missing-key-provenance-validation.json"
+
+    exit_code = main(
+        [
+            "validate-key-provenance-result",
+            "--result",
+            str(result_path),
+        ]
+    )
+    output = capsys.readouterr().out
+
+    assert exit_code == 2
+    assert "Trusted public key provenance validation report schema: FAIL" in output
+    assert "result file could not be read" in output
+    _assert_key_provenance_result_output_is_safe(output, result_path)
+
+
+def test_validate_key_provenance_result_json_emits_stable_report(
+    tmp_path,
+    capsys,
+) -> None:
+    """--json emits a stable boolean-only validation report."""
+    result_path = _write_valid_key_provenance_validation_report(tmp_path)
+
+    exit_code, report, output, stderr = _run_key_provenance_result_json(
+        result_path,
+        capsys,
+    )
+
+    assert exit_code == 0
+    assert stderr == ""
+    assert report == {
+        "ok": True,
+        "result_schema_valid": True,
+        "validated_schema_id": REPORT_SCHEMA_ID,
+        "validator": "veritas-evidence-bundle validate-key-provenance-result",
+        "errors": [],
+    }
+    assert output.endswith("\n")
+    _assert_key_provenance_result_output_is_safe(output, result_path)
+
+
+def test_validate_key_provenance_result_json_output_matches_stdout(
+    tmp_path,
+    capsys,
+) -> None:
+    """--json --output writes byte-for-byte stdout-identical JSON."""
+    result_path = _write_valid_key_provenance_validation_report(tmp_path)
+    output_path = tmp_path / "nested" / "reports" / "result-validation.json"
+
+    exit_code, report, stdout, stderr = _run_key_provenance_result_json(
+        result_path,
+        capsys,
+        "--output",
+        str(output_path),
+    )
+
+    assert exit_code == 0
+    assert stderr == ""
+    assert report["ok"] is True
+    assert output_path.read_text(encoding="utf-8") == stdout
+    _assert_key_provenance_result_output_is_safe(stdout, result_path, output_path)
+
+
+def test_validate_key_provenance_result_output_without_json_fails(
+    tmp_path,
+    capsys,
+) -> None:
+    """--output without --json fails as a usage error."""
+    from veritas_os.cli.evidence_bundle import main
+
+    result_path = _write_valid_key_provenance_validation_report(tmp_path)
+
+    with pytest.raises(SystemExit) as excinfo:
+        main(
+            [
+                "validate-key-provenance-result",
+                "--result",
+                str(result_path),
+                "--output",
+                str(tmp_path / "result-validation.json"),
+            ]
+        )
+
+    captured = capsys.readouterr()
+    assert excinfo.value.code == 2
+    assert "validate-key-provenance-result --output requires --json" in captured.err
+    _assert_key_provenance_result_output_is_safe(captured.err, result_path)
+
+
+def test_validate_key_provenance_result_failure_json_is_privacy_safe(
+    tmp_path,
+    capsys,
+) -> None:
+    """Failure JSON omits paths, fingerprints, and raw validator details."""
+    result_path = _write_valid_key_provenance_validation_report(tmp_path)
+    unsafe_report = _valid_key_provenance_validation_report()
+    unsafe_report["ok"] = "true"
+    unsafe_report["errors"] = [
+        {
+            "check": "fingerprint_correlation_ok",
+            "path": "$['public_key_fingerprint_sha256']",
+            "message": f"{FINGERPRINT} is not one of allowed values",
+        }
+    ]
+    _write_json(result_path, unsafe_report)
+
+    exit_code, report, stdout, stderr = _run_key_provenance_result_json(
+        result_path,
+        capsys,
+    )
+
+    assert exit_code == 1
+    assert stderr == ""
+    assert report["errors"] == [
+        {
+            "check": "result_schema_valid",
+            "path": "$",
+            "message": "result does not satisfy schema",
+        }
+    ]
+    _assert_key_provenance_result_output_is_safe(stdout, result_path)
+
+
+def test_validate_key_provenance_result_output_write_failure_is_safe(
+    tmp_path,
+    capsys,
+) -> None:
+    """--json --output write failures omit paths and exception text."""
+    from veritas_os.cli.evidence_bundle import main
+
+    result_path = _write_valid_key_provenance_validation_report(tmp_path)
+    output_path = tmp_path / "existing-directory"
+    output_path.mkdir()
+
+    exit_code = main(
+        [
+            "validate-key-provenance-result",
+            "--result",
+            str(result_path),
+            "--json",
+            "--output",
+            str(output_path),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert captured.out == ""
+    assert captured.err.strip() == (
+        "error: failed to write key provenance result validation report"
+    )
+    _assert_key_provenance_result_output_is_safe(
+        captured.err,
+        result_path,
+        output_path,
+    )


### PR DESCRIPTION
### Motivation

- Provide a small CLI tool to validate saved `validate-key-provenance --json` reports against the new Draft 2020-12 schema so CI/UI/audit tooling can re-check saved reports without re-running provenance or crypto checks.  
- Keep output privacy-safe by emitting only booleans, fixed schema identifiers, and fixed diagnostics; avoid printing raw fingerprints, file paths, exception text, schema validator messages, or saved JSON values.  
- Security note: reviewers must verify that no raw sensitive values are emitted; the implementation intentionally uses fixed diagnostics and limited metadata to reduce data exposure risk.

### Description

- Added a new validator identifier and schema path constants: `VALIDATE_KEY_PROVENANCE_RESULT_VALIDATOR` and `TRUSTED_PUBLIC_KEY_PROVENANCE_VALIDATION_REPORT_SCHEMA_PATH` in `veritas_os/cli/evidence_bundle.py`.  
- Implemented saved-report validation helpers: `_key_provenance_result_report_errors`, `_validate_key_provenance_result_status`, and `_run_validate_key_provenance_result` to safely read a saved report, detect read/JSON/schema errors, produce fixed diagnostics, and emit either human-readable or JSON output.  
- Wired CLI parser and entrypoint: added `validate-key-provenance-result` subcommand with `--result`, `--json`, and `--output` flags and proper `--output`-only-with-`--json` enforcement in `build_parser()` and `main()`.  
- Machine-readable JSON behavior: stdout JSON is stable, `--json --output <path>` writes a byte-for-byte identical file (parent directories created), write failures return exit code `2` with a generic error message, and exit codes follow the spec (`0` valid, `1` invalid/malformed, `2` read/write/usage errors).  
- Tests and docs: added unit tests covering valid/invalid/malformed/missing reports, `--json` stability, stdout/file parity, `--output` usage errors, and privacy-safety checks in `veritas_os/tests/test_trusted_public_key_provenance_cli.py`, and updated the validation docs under `docs/en/validation/*` to document `validate-key-provenance-result` and its non-certification boundary.

### Testing

- Static checks: compiled the modified files with `python -m py_compile veritas_os/cli/evidence_bundle.py veritas_os/tests/test_trusted_public_key_provenance_cli.py` (success).  
- Linting: `ruff check veritas_os/cli/evidence_bundle.py veritas_os/tests/test_trusted_public_key_provenance_cli.py` (success).  
- Functional tests: added comprehensive pytest cases; running `pytest` in this environment was blocked by missing runtime dependencies (`pydantic` / `jsonschema`) and network-restricted dependency fetches, so the new tests are present but could not be executed here; they should pass in CI where dependencies are available.  
- Additional checks: verified CLI behavior manually for JSON generation and ensured `--output` parity and generic write-error handling in local smoke runs where the interpreter could import required modules.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28e8c13ef08326b88509f805e41309)