### PR TITLE
feat: add key provenance result validation schema

### DIFF
--- a/docs/en/validation/evidence-bundle-reviewer-checklist.md
+++ b/docs/en/validation/evidence-bundle-reviewer-checklist.md
@@ -119,7 +119,10 @@ veritas-evidence-bundle validate-key-provenance-result \
   --result key-provenance-validation.json
 ```
 
-This command validates saved report shape only. It does not re-run key
+This command validates saved report shape only. Its `--json` output has a
+dedicated Draft 2020-12 schema at
+[`schemas/trusted_public_key_provenance_result_validation_report.schema.json`](../../../schemas/trusted_public_key_provenance_result_validation_report.schema.json).
+That schema validates the validator result shape only. It does not re-run key
 provenance validation, does not re-run cryptographic verification, does not
 create trust, is not regulatory certification, and is not completed third-party
 audit approval. Add `--json --output <path>` to emit and save byte-for-byte the

--- a/docs/en/validation/evidence-bundle-verification-json-contract.md
+++ b/docs/en/validation/evidence-bundle-verification-json-contract.md
@@ -188,13 +188,16 @@ veritas-evidence-bundle validate-key-provenance-result \
   --result key-provenance-validation.json
 ```
 
-The command validates saved report shape only. It does not re-run key
+The command validates saved report shape only. Its `--json` output has a
+dedicated Draft 2020-12 schema at
+[`schemas/trusted_public_key_provenance_result_validation_report.schema.json`](../../../schemas/trusted_public_key_provenance_result_validation_report.schema.json).
+That schema validates the validator result shape only. It does not re-run key
 provenance validation, does not re-run cryptographic verification, does not
 create trust, is not regulatory certification, and is not completed third-party
 audit approval. Its JSON output uses `result_schema_valid`,
-`validated_schema_id`, `validator`, and fixed `errors`; it does not expose raw
-fingerprints, raw paths, raw exception text, raw schema validator messages, or
-raw JSON values from the saved report. Add `--json --output <path>` to save a
+`validated_schema_id`, `report_schema_id`, `validator`, and fixed `errors`; it
+does not expose raw fingerprints, raw paths, raw exception text, raw schema
+validator messages, or raw JSON values from the saved report. Add `--json --output <path>` to save a
 byte-for-byte copy of stdout JSON; parent directories are created, and
 `--output` without `--json` is rejected.
 

--- a/docs/en/validation/sample-evidence-bundle-verification-output.md
+++ b/docs/en/validation/sample-evidence-bundle-verification-output.md
@@ -255,6 +255,7 @@ Illustrative `--json` success output:
   "ok": true,
   "result_schema_valid": true,
   "validated_schema_id": "https://veritas-os.example/schemas/trusted_public_key_provenance_validation_report.schema.json",
+  "report_schema_id": "https://veritas-os.example/schemas/trusted_public_key_provenance_result_validation_report.schema.json",
   "validator": "veritas-evidence-bundle validate-key-provenance-result",
   "errors": []
 }
@@ -262,12 +263,15 @@ Illustrative `--json` success output:
 
 Add `--json --output <path>` to save byte-for-byte the same JSON emitted to
 stdout; parent directories are created, and `--output` without `--json` fails
-clearly. `validate-key-provenance-result` validates saved report shape only. It
-does not re-run key provenance validation, does not re-run cryptographic
-verification, does not create trust, is not regulatory certification, and is
-not completed third-party audit approval. Output remains privacy-safe: it does
-not expose raw fingerprints, raw paths, raw exception text, raw schema
-validator messages, or raw JSON values from the saved report.
+clearly. `validate-key-provenance-result` has a dedicated Draft 2020-12
+JSON Schema at
+[`schemas/trusted_public_key_provenance_result_validation_report.schema.json`](../../../schemas/trusted_public_key_provenance_result_validation_report.schema.json).
+That schema validates the validator result shape only. It does not re-run key
+provenance validation, does not re-run cryptographic verification, does not
+create trust, is not regulatory certification, and is not completed third-party
+audit approval. Output remains privacy-safe: it does not expose raw
+fingerprints, raw paths, raw exception text, raw schema validator messages, or
+raw JSON values from the saved report.
 
 ## Successful strict verification
 

--- a/docs/en/validation/trusted-public-key-provenance.md
+++ b/docs/en/validation/trusted-public-key-provenance.md
@@ -123,12 +123,14 @@ Trusted public key provenance validation report schema: PASS
 Add `--json` for a stable machine-readable report, and add `--output <path>`
 with `--json` to save byte-for-byte the same JSON emitted to stdout. Parent
 directories are created when needed, and `--output` without `--json` is
-rejected. This command validates the saved report shape only. It does not
-re-run key provenance validation, does not re-run cryptographic verification,
-does not create trust, is not regulatory certification, and is not completed
-third-party audit approval. Its public output uses fixed diagnostics and does
-not expose raw fingerprints, raw file paths, raw exception text, raw schema
-validator messages, or raw JSON values from the saved report.
+rejected. The JSON output has a dedicated Draft 2020-12 schema at
+[`schemas/trusted_public_key_provenance_result_validation_report.schema.json`](../../../schemas/trusted_public_key_provenance_result_validation_report.schema.json).
+That schema validates the validator result shape only. It does not re-run key
+provenance validation, does not re-run cryptographic verification, does not
+create trust, is not regulatory certification, and is not completed third-party
+audit approval. Its public output uses fixed diagnostics and does not expose
+raw fingerprints, raw file paths, raw exception text, raw schema validator
+messages, or raw JSON values from the saved report.
 
 The command checks that:
 

--- a/schemas/trusted_public_key_provenance_result_validation_report.schema.json
+++ b/schemas/trusted_public_key_provenance_result_validation_report.schema.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://veritas-os.example/schemas/trusted_public_key_provenance_result_validation_report.schema.json",
+  "title": "Trusted Public Key Provenance Result Validation Report",
+  "description": "Machine-readable report contract emitted by veritas-evidence-bundle validate-key-provenance-result --json. This schema validates only the validator result shape for a saved validate-key-provenance --json report. It does not re-run key provenance validation, re-run cryptographic verification, create trust, prove regulatory certification, or complete third-party audit approval. The report intentionally exposes booleans, fixed schema identifiers, and fixed diagnostics only; it does not expose raw fingerprints, raw file paths, raw exception text, raw schema validator messages, or raw JSON values from the saved report.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "result_schema_valid",
+    "validated_schema_id",
+    "report_schema_id",
+    "validator",
+    "errors"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "description": "Overall validate-key-provenance-result status. True means the saved validate-key-provenance --json report conformed to its JSON Schema."
+    },
+    "result_schema_valid": {
+      "type": "boolean",
+      "description": "True when the saved validate-key-provenance --json report conforms to the trusted public key provenance validation report schema."
+    },
+    "validated_schema_id": {
+      "type": "string",
+      "const": "https://veritas-os.example/schemas/trusted_public_key_provenance_validation_report.schema.json",
+      "description": "Identifies the saved validate-key-provenance --json report schema checked by validate-key-provenance-result."
+    },
+    "report_schema_id": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "https://veritas-os.example/schemas/trusted_public_key_provenance_result_validation_report.schema.json",
+        null
+      ],
+      "description": "Identifies this validator result schema. This metadata validates report shape only; it does not re-run key provenance validation, re-run cryptographic verification, or establish trust."
+    },
+    "validator": {
+      "type": "string",
+      "const": "veritas-evidence-bundle validate-key-provenance-result",
+      "description": "Identifies the validator command that emitted this report."
+    },
+    "errors": {
+      "type": "array",
+      "description": "Fixed public diagnostics for failed saved-report checks. Empty when ok is true.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "check",
+          "path",
+          "message"
+        ],
+        "properties": {
+          "check": {
+            "type": "string",
+            "enum": [
+              "result_readable",
+              "result_json_valid",
+              "result_schema_valid"
+            ],
+            "description": "Fixed saved-report check that failed."
+          },
+          "path": {
+            "type": "string",
+            "enum": [
+              "$"
+            ],
+            "description": "Fixed public JSONPath-like location for the failed check."
+          },
+          "message": {
+            "type": "string",
+            "enum": [
+              "result file could not be read",
+              "result file is not valid JSON",
+              "result does not satisfy schema"
+            ],
+            "description": "Fixed public diagnostic. Raw external values, raw file paths, raw fingerprints, exception text, raw schema validator messages, and raw JSON values are not permitted."
+          }
+        }
+      }
+    }
+  }
+}

--- a/veritas_os/cli/evidence_bundle.py
+++ b/veritas_os/cli/evidence_bundle.py
@@ -46,6 +46,10 @@ VALIDATE_RESULT_VALIDATOR = "veritas-evidence-bundle validate-result"
 TRUSTED_PUBLIC_KEY_PROVENANCE_VALIDATION_REPORT_SCHEMA_ID = (
     f"{SCHEMA_BASE_URL}/trusted_public_key_provenance_validation_report.schema.json"
 )
+TRUSTED_PUBLIC_KEY_PROVENANCE_RESULT_VALIDATION_REPORT_SCHEMA_ID = (
+    f"{SCHEMA_BASE_URL}/"
+    "trusted_public_key_provenance_result_validation_report.schema.json"
+)
 VALIDATE_KEY_PROVENANCE_VALIDATOR = "veritas-evidence-bundle validate-key-provenance"
 VALIDATE_KEY_PROVENANCE_RESULT_VALIDATOR = (
     "veritas-evidence-bundle validate-key-provenance-result"
@@ -546,6 +550,9 @@ def _validate_key_provenance_result_status(
         "result_schema_valid": result_schema_valid,
         "validated_schema_id": (
             TRUSTED_PUBLIC_KEY_PROVENANCE_VALIDATION_REPORT_SCHEMA_ID
+        ),
+        "report_schema_id": (
+            TRUSTED_PUBLIC_KEY_PROVENANCE_RESULT_VALIDATION_REPORT_SCHEMA_ID
         ),
         "validator": VALIDATE_KEY_PROVENANCE_RESULT_VALIDATOR,
         "errors": _key_provenance_result_report_errors(

--- a/veritas_os/tests/test_trusted_public_key_provenance_cli.py
+++ b/veritas_os/tests/test_trusted_public_key_provenance_cli.py
@@ -21,6 +21,15 @@ REPORT_SCHEMA_PATH = (
     / "schemas"
     / "trusted_public_key_provenance_validation_report.schema.json"
 )
+RESULT_VALIDATION_REPORT_SCHEMA_ID = (
+    "https://veritas-os.example/schemas/"
+    "trusted_public_key_provenance_result_validation_report.schema.json"
+)
+RESULT_VALIDATION_REPORT_SCHEMA_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "schemas"
+    / "trusted_public_key_provenance_result_validation_report.schema.json"
+)
 
 
 def _valid_receipt_payload() -> dict[str, Any]:
@@ -68,7 +77,6 @@ def _write_valid_inputs(tmp_path: Path) -> tuple[Path, Path]:
     return receipt_path, verification_result_path
 
 
-
 def _report_schema_validator() -> jsonschema.Draft202012Validator:
     """Return the validate-key-provenance report schema validator."""
     schema = json.loads(REPORT_SCHEMA_PATH.read_text(encoding="utf-8"))
@@ -80,6 +88,25 @@ def _assert_report_matches_schema(report: dict[str, Any]) -> None:
     """Assert a validate-key-provenance JSON report matches its schema."""
     _report_schema_validator().validate(report)
     assert report["report_schema_id"] == REPORT_SCHEMA_ID
+
+
+def _result_validation_report_schema_validator() -> (
+    jsonschema.Draft202012Validator
+):
+    """Return the validate-key-provenance-result report schema validator."""
+    schema = json.loads(
+        RESULT_VALIDATION_REPORT_SCHEMA_PATH.read_text(encoding="utf-8")
+    )
+    jsonschema.Draft202012Validator.check_schema(schema)
+    return jsonschema.Draft202012Validator(schema)
+
+
+def _assert_result_validation_report_matches_schema(
+    report: dict[str, Any],
+) -> None:
+    """Assert validate-key-provenance-result JSON matches its schema."""
+    _result_validation_report_schema_validator().validate(report)
+    assert report["report_schema_id"] == RESULT_VALIDATION_REPORT_SCHEMA_ID
 
 
 def _run_json_report(
@@ -775,7 +802,6 @@ def test_validate_key_provenance_result_invalid_saved_report_fails(
     assert "result does not satisfy schema" in output
     _assert_key_provenance_result_output_is_safe(output, result_path)
 
-
 def test_validate_key_provenance_result_malformed_json_fails_safely(
     tmp_path,
     capsys,
@@ -843,11 +869,95 @@ def test_validate_key_provenance_result_json_emits_stable_report(
         "ok": True,
         "result_schema_valid": True,
         "validated_schema_id": REPORT_SCHEMA_ID,
+        "report_schema_id": RESULT_VALIDATION_REPORT_SCHEMA_ID,
         "validator": "veritas-evidence-bundle validate-key-provenance-result",
         "errors": [],
     }
+    _assert_result_validation_report_matches_schema(report)
     assert output.endswith("\n")
     _assert_key_provenance_result_output_is_safe(output, result_path)
+
+
+def test_validate_key_provenance_result_malformed_json_report_matches_schema(
+    tmp_path,
+    capsys,
+) -> None:
+    """Malformed saved JSON failure output matches the result schema."""
+    result_path = tmp_path / "malformed-key-provenance-validation.json"
+    result_path.write_text('{"raw_saved_value": ', encoding="utf-8")
+
+    exit_code, report, stdout, stderr = _run_key_provenance_result_json(
+        result_path,
+        capsys,
+    )
+
+    assert exit_code == 1
+    assert stderr == ""
+    assert report["errors"] == [
+        {
+            "check": "result_json_valid",
+            "path": "$",
+            "message": "result file is not valid JSON",
+        }
+    ]
+    _assert_result_validation_report_matches_schema(report)
+    _assert_key_provenance_result_output_is_safe(stdout, result_path)
+
+
+def test_validate_key_provenance_result_missing_file_report_matches_schema(
+    tmp_path,
+    capsys,
+) -> None:
+    """Missing saved report failure output matches the result schema."""
+    result_path = tmp_path / "missing-key-provenance-validation.json"
+
+    exit_code, report, stdout, stderr = _run_key_provenance_result_json(
+        result_path,
+        capsys,
+    )
+
+    assert exit_code == 2
+    assert stderr == ""
+    assert report["errors"] == [
+        {
+            "check": "result_readable",
+            "path": "$",
+            "message": "result file could not be read",
+        }
+    ]
+    _assert_result_validation_report_matches_schema(report)
+    _assert_key_provenance_result_output_is_safe(stdout, result_path)
+
+
+def test_validate_key_provenance_result_invalid_saved_report_matches_schema(
+    tmp_path,
+    capsys,
+) -> None:
+    """Schema-invalid saved report failure output matches result schema."""
+    result_path = _write_valid_key_provenance_validation_report(tmp_path)
+    invalid_report = _valid_key_provenance_validation_report()
+    invalid_report["receipt_schema_valid"] = "raw-json-value"
+    invalid_report["unexpected_raw_value"] = "do-not-echo-this-json-value"
+    _write_json(result_path, invalid_report)
+
+    exit_code, report, stdout, stderr = _run_key_provenance_result_json(
+        result_path,
+        capsys,
+    )
+
+    assert exit_code == 1
+    assert stderr == ""
+    assert report["errors"] == [
+        {
+            "check": "result_schema_valid",
+            "path": "$",
+            "message": "result does not satisfy schema",
+        }
+    ]
+    _assert_result_validation_report_matches_schema(report)
+    _assert_key_provenance_result_output_is_safe(stdout, result_path)
+    assert "raw-json-value" not in stdout
+    assert "do-not-echo-this-json-value" not in stdout
 
 
 def test_validate_key_provenance_result_json_output_matches_stdout(
@@ -869,6 +979,7 @@ def test_validate_key_provenance_result_json_output_matches_stdout(
     assert stderr == ""
     assert report["ok"] is True
     assert output_path.read_text(encoding="utf-8") == stdout
+    _assert_result_validation_report_matches_schema(report)
     _assert_key_provenance_result_output_is_safe(stdout, result_path, output_path)
 
 
@@ -929,6 +1040,7 @@ def test_validate_key_provenance_result_failure_json_is_privacy_safe(
             "message": "result does not satisfy schema",
         }
     ]
+    _assert_result_validation_report_matches_schema(report)
     _assert_key_provenance_result_output_is_safe(stdout, result_path)
 
 


### PR DESCRIPTION
### Motivation
- Stabilize the machine-readable output of `validate-key-provenance-result --json` with a dedicated Draft 2020-12 JSON Schema so downstream CI/UI/audit tooling can validate the validator result shape.
- Prevent accidental leakage of user-controlled or sensitive values by limiting emitted fields to booleans, fixed schema identifiers, a fixed `validator` string, and enumerated diagnostics.
- Add automated coverage to assert that success and common failure modes emit schema-conformant, privacy-safe outputs.
- Note: changes touch CLI reporting and docs only and should be reviewed for privacy/security concerns around emitted diagnostics.

### Description
- Add new schema `schemas/trusted_public_key_provenance_result_validation_report.schema.json` (Draft 2020-12) with required fields `ok`, `result_schema_valid`, `validated_schema_id`, `report_schema_id`, `validator`, and `errors`, `additionalProperties: false`, and enum-constrained diagnostics to forbid raw paths, fingerprints, exception text, validator messages, or saved JSON values.
- Introduce `TRUSTED_PUBLIC_KEY_PROVENANCE_RESULT_VALIDATION_REPORT_SCHEMA_ID` in `veritas_os/cli/evidence_bundle.py` and include it as `report_schema_id` in the `validate-key-provenance-result --json` output.
- Update `veritas_os/tests/test_trusted_public_key_provenance_cli.py` with schema-validator helpers and new tests asserting that success, malformed JSON, missing-file, and schema-invalid saved-report outputs conform to the new result schema and do not echo raw sensitive values, and assert stdout/file parity for `--json --output`.
- Update docs and sample output in `docs/en/validation/*` to reference the new result schema and describe the validator-result-only scope and non-trust/non-certification boundaries.

### Testing
- Ran `ruff check veritas_os/cli/evidence_bundle.py veritas_os/tests/test_trusted_public_key_provenance_cli.py` and it succeeded.
- Ran `python3 -m compileall` on modified modules and `python3 -m json.tool` to validate the new schema JSON and both succeeded.
- Attempted `pytest -q veritas_os/tests/test_trusted_public_key_provenance_cli.py` but the environment lacked required dependencies (`pydantic`/package install) and network access prevented dependency install, so unit tests could not be executed here; test code was added and should pass in CI where dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28ee8982a88326891e9a46478946c8)