### PR TITLE
feat: add optional key_provenance metadata to Reviewer Evidence Packets

### DIFF
--- a/README.md
+++ b/README.md
@@ -2102,3 +2102,7 @@ We welcome contributions! Please see [`CONTRIBUTING.md`](CONTRIBUTING.md) for gu
 
 * Issues: [https://github.com/veritasfuji-japan/veritas_os/issues](https://github.com/veritasfuji-japan/veritas_os/issues)
 * Email: [veritas.fuji@gmail.com](mailto:veritas.fuji@gmail.com)
+
+### Reviewer Evidence Packet key provenance references
+
+Reviewer Evidence Packets may include optional Trusted Public Key Provenance validation artifact references (`trusted-public-key-provenance.json`, `key-provenance-validation.json`, and `key-provenance-result-validation.json`). These references help reviewers check public key trust provenance, but the packet does not create trust, does not re-run cryptographic verification, is not regulatory certification, and is not completed third-party audit approval. Matching fingerprints support correlation only; they are not standalone trust proof. Packet metadata references fixed artifact names and schema identifiers only, not raw fingerprints, raw local paths, exception text, schema validator messages, or externally supplied JSON values.

--- a/README_JP.md
+++ b/README_JP.md
@@ -1903,3 +1903,7 @@ Phase 2（今後）:
 
 - Issues: [https://github.com/veritasfuji-japan/veritas_os/issues](https://github.com/veritasfuji-japan/veritas_os/issues)
 - Email: [veritas.fuji@gmail.com](mailto:veritas.fuji@gmail.com)
+
+### Reviewer Evidence Packet の key provenance 参照
+
+Reviewer Evidence Packet には、Trusted Public Key Provenance validation artifact（`trusted-public-key-provenance.json`、`key-provenance-validation.json`、`key-provenance-result-validation.json`）への optional な参照を含められます。これらはレビュアーが public key trust provenance を確認するための手がかりですが、packet 自体が trust を作るものではなく、cryptographic verification を再実行するものでもありません。また regulatory certification や completed third-party audit approval ではありません。fingerprint の一致は correlation を支援するだけで、単独の trust proof ではありません。packet metadata は固定 artifact name と schema identifier のみを参照し、raw fingerprint、raw local path、exception text、schema validator message、外部 artifact 由来の raw JSON value は埋め込みません。

--- a/docs/en/demo/examples/evaluation-governance-chain-reviewer-packet-v1/reviewer-evidence-packet.generated.example.json
+++ b/docs/en/demo/examples/evaluation-governance-chain-reviewer-packet-v1/reviewer-evidence-packet.generated.example.json
@@ -737,8 +737,23 @@
     }
   ],
   "generated_at": "2026-01-01T00:00:00Z",
+  "key_provenance": {
+    "key_provenance_result_validation_report": {
+      "artifact_name": "key-provenance-result-validation.json",
+      "schema_id": "https://veritas-os.example/schemas/trusted_public_key_provenance_result_validation_report.schema.json"
+    },
+    "key_provenance_validation_report": {
+      "artifact_name": "key-provenance-validation.json",
+      "schema_id": "https://veritas-os.example/schemas/trusted_public_key_provenance_validation_report.schema.json"
+    },
+    "trusted_public_key_provenance_receipt": {
+      "artifact_name": "trusted-public-key-provenance.json",
+      "required_for_strict_signature_review": true,
+      "schema_id": "https://veritas-os.example/schemas/trusted_public_key_provenance_receipt.schema.json"
+    }
+  },
   "local_offline_only": true,
-  "packet_hash": "5daaabfc86ef1af7dbfc9c9362979231c9881f4d4fd07b54a630adc8c323da49",
+  "packet_hash": "c361eb1bac6f36e751f449a1e3d5af0de439bd7f5d3602bbee6ca87ceb33c053",
   "packet_id": "reviewer-evidence-packet-saas-permission-change-v1",
   "packet_version": "v1",
   "reviewer_notes": [

--- a/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated/reviewer-evidence-packet.generated.example.json
+++ b/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated/reviewer-evidence-packet.generated.example.json
@@ -737,8 +737,23 @@
     }
   ],
   "generated_at": "2026-01-01T00:00:00Z",
+  "key_provenance": {
+    "key_provenance_result_validation_report": {
+      "artifact_name": "key-provenance-result-validation.json",
+      "schema_id": "https://veritas-os.example/schemas/trusted_public_key_provenance_result_validation_report.schema.json"
+    },
+    "key_provenance_validation_report": {
+      "artifact_name": "key-provenance-validation.json",
+      "schema_id": "https://veritas-os.example/schemas/trusted_public_key_provenance_validation_report.schema.json"
+    },
+    "trusted_public_key_provenance_receipt": {
+      "artifact_name": "trusted-public-key-provenance.json",
+      "required_for_strict_signature_review": true,
+      "schema_id": "https://veritas-os.example/schemas/trusted_public_key_provenance_receipt.schema.json"
+    }
+  },
   "local_offline_only": true,
-  "packet_hash": "425af2062d031478088d0194daaf18462ce6c982e9db9d59598b28f9da0a852b",
+  "packet_hash": "ad718ce6e4068acc538e0f48c126e517c2f0f8285e96e324c03717e233b09641",
   "packet_id": "reviewer-evidence-packet-saas-permission-change-v1",
   "packet_version": "v1",
   "reviewer_notes": [

--- a/docs/en/demo/fixtures/reviewer-evidence-packet-saas-permission-change-v1.json
+++ b/docs/en/demo/fixtures/reviewer-evidence-packet-saas-permission-change-v1.json
@@ -665,8 +665,23 @@
   ],
   "demo_id": "saas_permission_change_governed_execution_v1",
   "generated_at": "2026-04-26T00:00:00+00:00",
+  "key_provenance": {
+    "key_provenance_result_validation_report": {
+      "artifact_name": "key-provenance-result-validation.json",
+      "schema_id": "https://veritas-os.example/schemas/trusted_public_key_provenance_result_validation_report.schema.json"
+    },
+    "key_provenance_validation_report": {
+      "artifact_name": "key-provenance-validation.json",
+      "schema_id": "https://veritas-os.example/schemas/trusted_public_key_provenance_validation_report.schema.json"
+    },
+    "trusted_public_key_provenance_receipt": {
+      "artifact_name": "trusted-public-key-provenance.json",
+      "required_for_strict_signature_review": true,
+      "schema_id": "https://veritas-os.example/schemas/trusted_public_key_provenance_receipt.schema.json"
+    }
+  },
   "local_offline_only": true,
-  "packet_hash": "c69551bc5fff66657ff8b00461bcedf2f998a171ada570064a48badab2c047d4",
+  "packet_hash": "497f9a8c97cf58f7be0658458e5f65f3cef285773fdc30c18341f1126390257f",
   "packet_id": "reviewer-evidence-packet-saas-permission-change-v1",
   "packet_version": "v1",
   "reviewer_notes": [

--- a/docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json
+++ b/docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json
@@ -74,6 +74,9 @@
       "items": {
         "$ref": "#/$defs/evaluation_governance_artifact"
       }
+    },
+    "key_provenance": {
+      "$ref": "#/$defs/key_provenance"
     }
   },
   "$defs": {
@@ -656,6 +659,110 @@
         },
         "required_for_review": {
           "type": "boolean"
+        }
+      }
+    },
+    "artifact_name": {
+      "type": "string",
+      "enum": [
+        "trusted-public-key-provenance.json",
+        "key-provenance-validation.json",
+        "key-provenance-result-validation.json"
+      ]
+    },
+    "key_provenance_schema_id": {
+      "type": "string",
+      "enum": [
+        "https://veritas-os.example/schemas/trusted_public_key_provenance_receipt.schema.json",
+        "https://veritas-os.example/schemas/trusted_public_key_provenance_validation_report.schema.json",
+        "https://veritas-os.example/schemas/trusted_public_key_provenance_result_validation_report.schema.json"
+      ]
+    },
+    "key_provenance_artifact_reference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "artifact_name",
+        "schema_id"
+      ],
+      "properties": {
+        "artifact_name": {
+          "$ref": "#/$defs/artifact_name"
+        },
+        "schema_id": {
+          "$ref": "#/$defs/key_provenance_schema_id"
+        }
+      }
+    },
+    "trusted_public_key_provenance_receipt_reference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "artifact_name",
+        "schema_id",
+        "required_for_strict_signature_review"
+      ],
+      "properties": {
+        "artifact_name": {
+          "const": "trusted-public-key-provenance.json"
+        },
+        "schema_id": {
+          "const": "https://veritas-os.example/schemas/trusted_public_key_provenance_receipt.schema.json"
+        },
+        "required_for_strict_signature_review": {
+          "const": true
+        }
+      }
+    },
+    "key_provenance_validation_report_reference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "artifact_name",
+        "schema_id"
+      ],
+      "properties": {
+        "artifact_name": {
+          "const": "key-provenance-validation.json"
+        },
+        "schema_id": {
+          "const": "https://veritas-os.example/schemas/trusted_public_key_provenance_validation_report.schema.json"
+        }
+      }
+    },
+    "key_provenance_result_validation_report_reference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "artifact_name",
+        "schema_id"
+      ],
+      "properties": {
+        "artifact_name": {
+          "const": "key-provenance-result-validation.json"
+        },
+        "schema_id": {
+          "const": "https://veritas-os.example/schemas/trusted_public_key_provenance_result_validation_report.schema.json"
+        }
+      }
+    },
+    "key_provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "trusted_public_key_provenance_receipt",
+        "key_provenance_validation_report",
+        "key_provenance_result_validation_report"
+      ],
+      "properties": {
+        "trusted_public_key_provenance_receipt": {
+          "$ref": "#/$defs/trusted_public_key_provenance_receipt_reference"
+        },
+        "key_provenance_validation_report": {
+          "$ref": "#/$defs/key_provenance_validation_report_reference"
+        },
+        "key_provenance_result_validation_report": {
+          "$ref": "#/$defs/key_provenance_result_validation_report_reference"
         }
       }
     }

--- a/docs/en/validation/evidence-bundle-reviewer-checklist.md
+++ b/docs/en/validation/evidence-bundle-reviewer-checklist.md
@@ -205,3 +205,15 @@ key, the bundle is not reviewer-facing verified evidence.
   [Trusted Public Key Provenance Receipt](trusted-public-key-provenance.md)
 - Bundle contents and delivery policy:
   [External Audit Readiness Pack](external-audit-readiness.md)
+
+## Reviewer Evidence Packet key provenance references
+
+Reviewer Evidence Packets may include an optional `key_provenance` metadata section that references the Trusted Public Key Provenance validation artifacts by fixed artifact name and schema identifier:
+
+- `trusted-public-key-provenance.json`
+- `key-provenance-validation.json`
+- `key-provenance-result-validation.json`
+
+These references help reviewers locate the artifacts used to check public key trust provenance for strict Evidence Bundle signature review. The packet does not create trust by itself, does not re-run cryptographic verification, and does not replace the out-of-band reviewer/operator trust channel. Matching fingerprints support correlation between the verification result and the Trusted Public Key Provenance Receipt; matching fingerprints are not standalone trust proof.
+
+Reviewer Evidence Packet metadata must not embed raw public key fingerprints, raw local file paths, raw exception text, raw schema validator messages, or raw JSON values copied from externally supplied artifacts. It should reference only the stable artifact names and schema identifiers above. The packet is not regulatory certification and is not completed third-party audit approval.

--- a/docs/en/validation/evidence-bundle-verification-json-contract.md
+++ b/docs/en/validation/evidence-bundle-verification-json-contract.md
@@ -405,3 +405,15 @@ reviewer-facing verified evidence.
 - Record trusted public key provenance outside the bundle before relying on
   `signature_verified: true`, preferably using the
   [Trusted Public Key Provenance Receipt](trusted-public-key-provenance.md).
+
+## Reviewer Evidence Packet key provenance references
+
+Reviewer Evidence Packets may include an optional `key_provenance` metadata section that references the Trusted Public Key Provenance validation artifacts by fixed artifact name and schema identifier:
+
+- `trusted-public-key-provenance.json`
+- `key-provenance-validation.json`
+- `key-provenance-result-validation.json`
+
+These references help reviewers locate the artifacts used to check public key trust provenance for strict Evidence Bundle signature review. The packet does not create trust by itself, does not re-run cryptographic verification, and does not replace the out-of-band reviewer/operator trust channel. Matching fingerprints support correlation between the verification result and the Trusted Public Key Provenance Receipt; matching fingerprints are not standalone trust proof.
+
+Reviewer Evidence Packet metadata must not embed raw public key fingerprints, raw local file paths, raw exception text, raw schema validator messages, or raw JSON values copied from externally supplied artifacts. It should reference only the stable artifact names and schema identifiers above. The packet is not regulatory certification and is not completed third-party audit approval.

--- a/docs/en/validation/technical-proof-pack.md
+++ b/docs/en/validation/technical-proof-pack.md
@@ -102,3 +102,15 @@ If you are an external reviewer, start with:
 2. `implemented-vs-pending-boundary.md` (boundary control)
 3. `external-reviewer-checklist.md` (evidence verification flow)
 4. `evidence-bundle-reviewer-checklist.md` (Evidence Bundle verification)
+
+## Reviewer Evidence Packet key provenance references
+
+Reviewer Evidence Packets may include an optional `key_provenance` metadata section that references the Trusted Public Key Provenance validation artifacts by fixed artifact name and schema identifier:
+
+- `trusted-public-key-provenance.json`
+- `key-provenance-validation.json`
+- `key-provenance-result-validation.json`
+
+These references help reviewers locate the artifacts used to check public key trust provenance for strict Evidence Bundle signature review. The packet does not create trust by itself, does not re-run cryptographic verification, and does not replace the out-of-band reviewer/operator trust channel. Matching fingerprints support correlation between the verification result and the Trusted Public Key Provenance Receipt; matching fingerprints are not standalone trust proof.
+
+Reviewer Evidence Packet metadata must not embed raw public key fingerprints, raw local file paths, raw exception text, raw schema validator messages, or raw JSON values copied from externally supplied artifacts. It should reference only the stable artifact names and schema identifiers above. The packet is not regulatory certification and is not completed third-party audit approval.

--- a/docs/en/validation/trusted-public-key-provenance.md
+++ b/docs/en/validation/trusted-public-key-provenance.md
@@ -210,3 +210,15 @@ material. It does not re-run cryptographic verification, does not prove that the
 original Evidence Bundle is authentic by itself. This receipt is not
 regulatory certification. This receipt is not completed third-party audit
 approval.
+
+## Reviewer Evidence Packet key provenance references
+
+Reviewer Evidence Packets may include an optional `key_provenance` metadata section that references the Trusted Public Key Provenance validation artifacts by fixed artifact name and schema identifier:
+
+- `trusted-public-key-provenance.json`
+- `key-provenance-validation.json`
+- `key-provenance-result-validation.json`
+
+These references help reviewers locate the artifacts used to check public key trust provenance for strict Evidence Bundle signature review. The packet does not create trust by itself, does not re-run cryptographic verification, and does not replace the out-of-band reviewer/operator trust channel. Matching fingerprints support correlation between the verification result and the Trusted Public Key Provenance Receipt; matching fingerprints are not standalone trust proof.
+
+Reviewer Evidence Packet metadata must not embed raw public key fingerprints, raw local file paths, raw exception text, raw schema validator messages, or raw JSON values copied from externally supplied artifacts. It should reference only the stable artifact names and schema identifiers above. The packet is not regulatory certification and is not completed third-party audit approval.

--- a/scripts/demo/export_reviewer_evidence_packet.py
+++ b/scripts/demo/export_reviewer_evidence_packet.py
@@ -13,6 +13,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from scripts.demo.reviewer_key_provenance_metadata import key_provenance_metadata
 from scripts.demo.saas_permission_change_governed_demo import (
     BOUNDARY_NOTE,
     run_saas_permission_change_governed_demo,
@@ -22,6 +23,8 @@ from veritas_os.security.hash import sha256_of_canonical_json
 PACKET_ID = "reviewer-evidence-packet-saas-permission-change-v1"
 PACKET_VERSION = "v1"
 PACKET_TITLE = "SaaS Permission-Change Governed Execution Reviewer Evidence Packet"
+
+
 REVIEWER_NOTES = [
     "This packet is generated from a local/offline fixture demo.",
     (
@@ -166,6 +169,7 @@ def build_reviewer_evidence_packet() -> dict[str, Any]:
         "local_offline_only": True,
         "cases": cases,
         "aggregate_summary": _aggregate_summary(cases),
+        "key_provenance": key_provenance_metadata(),
         "reviewer_notes": list(REVIEWER_NOTES),
         "packet_hash": "",
     }

--- a/scripts/demo/generate_reviewer_evidence_packet_from_evaluation_governance_chain.py
+++ b/scripts/demo/generate_reviewer_evidence_packet_from_evaluation_governance_chain.py
@@ -31,6 +31,11 @@ REVIEWER_PACKET_TEMPLATE_PATH = (
     / "docs/en/demo/examples"
     / "reviewer-evidence-packet-with-evaluation-governance-v1.json"
 )
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.demo.reviewer_key_provenance_metadata import key_provenance_metadata  # noqa: E402
+
 SHA256_HEX_PATTERN = re.compile(r"^[0-9a-f]{64}$")
 
 ARTIFACT_TYPE_MAP = {
@@ -274,9 +279,7 @@ def validate_reviewer_packet(packet: dict[str, Any]) -> None:
     try:
         jsonschema.Draft202012Validator(schema).validate(packet)
     except jsonschema.ValidationError as exc:
-        raise ValueError(
-            f"Reviewer Evidence Packet schema validation failed: {exc}"
-        ) from exc
+        raise ValueError("Reviewer Evidence Packet schema validation failed") from exc
 
 
 def generate_reviewer_evidence_packet_from_chain(
@@ -315,6 +318,7 @@ def generate_reviewer_evidence_packet_from_chain(
     )
     packet["local_offline_only"] = True
     packet["evaluation_governance_artifacts"] = reviewer_artifacts
+    packet["key_provenance"] = key_provenance_metadata()
     packet["reviewer_notes"] = list(REVIEWER_NOTES)
     packet["packet_hash"] = _packet_hash(packet)
 

--- a/scripts/demo/reviewer_key_provenance_metadata.py
+++ b/scripts/demo/reviewer_key_provenance_metadata.py
@@ -1,0 +1,42 @@
+"""Fixed key provenance artifact metadata for Reviewer Evidence Packets."""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+KEY_PROVENANCE_ARTIFACTS = {
+    "trusted_public_key_provenance_receipt": {
+        "artifact_name": "trusted-public-key-provenance.json",
+        "schema_id": (
+            "https://veritas-os.example/schemas/"
+            "trusted_public_key_provenance_receipt.schema.json"
+        ),
+        "required_for_strict_signature_review": True,
+    },
+    "key_provenance_validation_report": {
+        "artifact_name": "key-provenance-validation.json",
+        "schema_id": (
+            "https://veritas-os.example/schemas/"
+            "trusted_public_key_provenance_validation_report.schema.json"
+        ),
+    },
+    "key_provenance_result_validation_report": {
+        "artifact_name": "key-provenance-result-validation.json",
+        "schema_id": (
+            "https://veritas-os.example/schemas/"
+            "trusted_public_key_provenance_result_validation_report.schema.json"
+        ),
+    },
+}
+
+
+def key_provenance_metadata() -> dict[str, Any]:
+    """Return fixed key provenance artifact references for reviewer metadata.
+
+    The metadata intentionally includes only stable artifact names and schema
+    identifiers. It does not copy public key fingerprints, local paths,
+    exception text, validator messages, or externally supplied JSON values into
+    Reviewer Evidence Packets.
+    """
+    return copy.deepcopy(KEY_PROVENANCE_ARTIFACTS)

--- a/tests/demo/test_evaluation_governance_chain_reviewer_packet.py
+++ b/tests/demo/test_evaluation_governance_chain_reviewer_packet.py
@@ -141,3 +141,89 @@ def test_unsupported_artifact_type_fails_clearly(tmp_path: Path) -> None:
             chain_manifest,
             tmp_path,
         )
+
+
+def test_schema_accepts_packet_without_key_provenance_section() -> None:
+    packet = helper.generate_reviewer_evidence_packet_from_chain(
+        helper.load_json(CHAIN_MANIFEST_PATH),
+        EXAMPLE_DIR,
+    )
+    packet.pop("key_provenance")
+
+    _validate_packet(packet)
+
+
+def test_schema_accepts_packet_with_key_provenance_section() -> None:
+    packet = helper.generate_reviewer_evidence_packet_from_chain(
+        helper.load_json(CHAIN_MANIFEST_PATH),
+        EXAMPLE_DIR,
+    )
+
+    _validate_packet(packet)
+    assert "key_provenance" in packet
+
+
+def test_key_provenance_schema_ids_match_existing_schema_ids() -> None:
+    packet = helper.generate_reviewer_evidence_packet_from_chain(
+        helper.load_json(CHAIN_MANIFEST_PATH),
+        EXAMPLE_DIR,
+    )
+    key_provenance = packet["key_provenance"]
+
+    schema_ids = {
+        name: _load_json(Path(path))["$id"]
+        for name, path in {
+            "trusted_public_key_provenance_receipt": (
+                "schemas/trusted_public_key_provenance_receipt.schema.json"
+            ),
+            "key_provenance_validation_report": (
+                "schemas/trusted_public_key_provenance_validation_report.schema.json"
+            ),
+            "key_provenance_result_validation_report": (
+                "schemas/"
+                "trusted_public_key_provenance_result_validation_report.schema.json"
+            ),
+        }.items()
+    }
+
+    for artifact_key, schema_id in schema_ids.items():
+        assert key_provenance[artifact_key]["schema_id"] == schema_id
+
+
+def test_key_provenance_metadata_uses_artifact_names_not_paths() -> None:
+    packet = helper.generate_reviewer_evidence_packet_from_chain(
+        helper.load_json(CHAIN_MANIFEST_PATH),
+        EXAMPLE_DIR,
+    )
+
+    artifact_names = [
+        entry["artifact_name"] for entry in packet["key_provenance"].values()
+    ]
+    assert artifact_names == [
+        "trusted-public-key-provenance.json",
+        "key-provenance-validation.json",
+        "key-provenance-result-validation.json",
+    ]
+    assert all("/" not in artifact_name for artifact_name in artifact_names)
+    assert all("\\\\" not in artifact_name for artifact_name in artifact_names)
+
+
+def test_key_provenance_metadata_omits_raw_sensitive_values() -> None:
+    packet = helper.generate_reviewer_evidence_packet_from_chain(
+        helper.load_json(CHAIN_MANIFEST_PATH),
+        EXAMPLE_DIR,
+    )
+    metadata_text = str(packet["key_provenance"])
+
+    blocked_fragments = [
+        "public_key_fingerprint_sha256",
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        "/tmp/",
+        "C:\\\\",
+        "Traceback",
+        "ValidationError",
+        "jsonschema.exceptions",
+        "schema validator",
+    ]
+    for fragment in blocked_fragments:
+        assert fragment not in metadata_text

--- a/tests/demo/test_reviewer_evidence_packet.py
+++ b/tests/demo/test_reviewer_evidence_packet.py
@@ -132,3 +132,51 @@ def test_no_network_or_environment_dependency_required(monkeypatch) -> None:
     monkeypatch.delenv("DATABASE_URL", raising=False)
     packet = build_reviewer_evidence_packet()
     assert packet["local_offline_only"] is True
+
+
+def test_packet_key_provenance_uses_fixed_artifact_references() -> None:
+    packet = build_reviewer_evidence_packet()
+    key_provenance = packet["key_provenance"]
+
+    assert key_provenance == {
+        "trusted_public_key_provenance_receipt": {
+            "artifact_name": "trusted-public-key-provenance.json",
+            "schema_id": (
+                "https://veritas-os.example/schemas/"
+                "trusted_public_key_provenance_receipt.schema.json"
+            ),
+            "required_for_strict_signature_review": True,
+        },
+        "key_provenance_validation_report": {
+            "artifact_name": "key-provenance-validation.json",
+            "schema_id": (
+                "https://veritas-os.example/schemas/"
+                "trusted_public_key_provenance_validation_report.schema.json"
+            ),
+        },
+        "key_provenance_result_validation_report": {
+            "artifact_name": "key-provenance-result-validation.json",
+            "schema_id": (
+                "https://veritas-os.example/schemas/"
+                "trusted_public_key_provenance_result_validation_report.schema.json"
+            ),
+        },
+    }
+
+
+def test_packet_key_provenance_metadata_omits_raw_external_values() -> None:
+    packet = build_reviewer_evidence_packet()
+    metadata_text = str(packet["key_provenance"])
+
+    blocked_fragments = [
+        "public_key_fingerprint_sha256",
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        "/tmp/",
+        "C:\\\\",
+        "Traceback",
+        "ValidationError",
+        "jsonschema.exceptions",
+        "schema validator",
+    ]
+    for fragment in blocked_fragments:
+        assert fragment not in metadata_text


### PR DESCRIPTION
### Motivation
- Surface the Trusted Public Key Provenance validation artifacts inside Reviewer Evidence Packets so reviewers can locate provenance receipts and validation reports without embedding raw sensitive values. 
- Keep the new metadata optional and backward-compatible so existing packets continue to validate when key provenance artifacts are absent. 
- Avoid leaking raw fingerprints, local paths, exception text, or validator messages in packet metadata by referencing only fixed artifact names and schema IDs. 

### Description
- Add a small helper module `scripts/demo/reviewer_key_provenance_metadata.py` that exposes `key_provenance_metadata()` which returns fixed artifact-name and schema-ID references (no raw fingerprints, paths, exceptions, or external JSON). 
- Include optional `key_provenance` into the Reviewer Evidence Packet generator `scripts/demo/export_reviewer_evidence_packet.py` and the chain-based generator `scripts/demo/generate_reviewer_evidence_packet_from_evaluation_governance_chain.py` via `key_provenance_metadata()`. 
- Extend the Reviewer Evidence Packet JSON Schema `docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json` to allow (but not require) a `key_provenance` section with strict sub-schemas that enumerate the three artifact names and pinned schema IDs. 
- Update checked-in fixtures/examples to include `key_provenance` and recompute their `packet_hash` values, add tests to validate schema-compatibility with and without `key_provenance`, to assert artifact-name-only references and that metadata omits raw sensitive/error fragments, and soften an earlier jsonschema error message to avoid leaking validator details. 
- Update reviewer docs (`docs/en/validation/*`, `README.md`, `README_JP.md`) to document that packets may reference key provenance artifacts and to reiterate that the packet does not create trust, re-run crypto verification, or constitute audit certification. 

### Testing
- Ran `PYENV_VERSION=3.12.13 python -m pytest tests/demo/test_evaluation_governance_chain_reviewer_packet.py` which passed (all tests passed). 
- Ran `PYENV_VERSION=3.12.13 python -m ruff check` on modified files which passed with no issues. 
- Ran `PYENV_VERSION=3.12.13 python -m py_compile` on the new/modified demo scripts which succeeded. 
- Executed the chain packet generator and compared generated JSON against the checked-in examples; outputs matched and recomputed `packet_hash` values validated. 
- Note: running the broader demo packet fixture tests that import deeper runtime modules was blocked in this environment due to a missing `yaml` dependency and inability to fetch PyPI packages, so a small subset of tests that depend on that environment were not executed here; the change preserves backward compatibility in the schema and generators. 

Security note: the implementation intentionally references only fixed artifact names and schema identifiers and avoids emitting or embedding raw public key fingerprints, file paths, exception text, schema validator messages, or external JSON values in packet metadata.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28f40b73dc832697cf7fb97c95fd9d)