### PR TITLE
docs: add key provenance review sample artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2106,4 +2106,11 @@ We welcome contributions! Please see [`CONTRIBUTING.md`](CONTRIBUTING.md) for gu
 
 ### Reviewer Evidence Packet key provenance references
 
+An illustrative sample artifact chain is available in
+[`samples/evidence_bundle/key_provenance_review/`](samples/evidence_bundle/key_provenance_review/).
+Use it only to inspect expected file relationships; the samples do not create
+trust, do not replace out-of-band public key trust, do not prove regulatory
+certification, and are not completed third-party audit approval. Matching
+fingerprints support correlation only, not standalone trust.
+
 Reviewer Evidence Packets may include optional Trusted Public Key Provenance validation artifact references (`trusted-public-key-provenance.json`, `key-provenance-validation.json`, and `key-provenance-result-validation.json`). Use the [Reviewer Key Provenance Walkthrough](docs/en/validation/reviewer-key-provenance-walkthrough.md) for the copyable review sequence. These references help reviewers check public key trust provenance, but the packet does not create trust, does not re-run cryptographic verification, does not replace out-of-band public key trust, is not regulatory certification, and is not completed third-party audit approval. Matching fingerprints support correlation only; they are not standalone trust proof. Reviewer Evidence Packets reference artifacts; they do not prove trust alone. Packet metadata references fixed artifact names and schema identifiers only, not raw fingerprints, raw local paths, exception text, schema validator messages, or externally supplied JSON values.

--- a/README_JP.md
+++ b/README_JP.md
@@ -129,6 +129,10 @@ VERITAS には、local/offline の SaaS permission-change governed execution dem
 
 ## Reviewer Evidence Packet v1
 
+Trusted Public Key Provenance の reviewer walkthrough 用に、illustrative sample artifact chain を
+[`samples/evidence_bundle/key_provenance_review/`](samples/evidence_bundle/key_provenance_review/)
+に追加しています。これは expected file relationship を確認するためのサンプル限定であり、trust を作成せず、out-of-band public key trust を置き換えず、規制認証を証明せず、完了済み第三者監査承認でもありません。fingerprint の一致は correlation を支援するだけで、standalone trust ではありません。
+
 VERITAS には local/offline の Reviewer Evidence Packet v1 export が追加されています。これは、SaaS permission-change governed execution demo の結果を、case outcome、AuthorityEvidence / HumanApproval summary、OutcomeReceipt summary、EvidenceChainManifest summary、EvidenceChainVerification summary、aggregate counts、reviewer notes、決定論的 packet hash を含む JSON-friendly artifact としてまとめるものです。本番導入や監査認証の証明ではなく、local/offline の review packet です。
 
 - ドキュメント: docs/en/demo/reviewer-evidence-packet.md

--- a/docs/en/validation/evidence-bundle-reviewer-checklist.md
+++ b/docs/en/validation/evidence-bundle-reviewer-checklist.md
@@ -42,6 +42,16 @@ Security boundaries:
 - Do not add private keys, real signing keys, production secrets, or unsanitized
   customer data to review notes or shared examples.
 
+## Illustrative key provenance sample
+
+For a small sample of the expected Trusted Public Key Provenance artifact chain,
+see
+[`samples/evidence_bundle/key_provenance_review/`](../../../samples/evidence_bundle/key_provenance_review/).
+The directory is illustrative only and does not create trust, replace
+out-of-band public key trust, prove regulatory certification, or represent
+completed third-party audit approval. Matching fingerprints support correlation,
+not standalone trust.
+
 ## Saving JSON reviewer evidence
 
 Reviewers can preserve a machine-readable audit trail by adding

--- a/docs/en/validation/reviewer-key-provenance-walkthrough.md
+++ b/docs/en/validation/reviewer-key-provenance-walkthrough.md
@@ -28,6 +28,16 @@ real public keys, local file paths, exception text, schema validator messages,
 private keys, production secrets, or unsanitized customer data into reviewer
 examples or packet metadata.
 
+## Illustrative sample artifacts
+
+A schema-valid, illustrative sample chain is available at
+[`samples/evidence_bundle/key_provenance_review/`](../../../samples/evidence_bundle/key_provenance_review/).
+Use it only to see expected file names and relationships. The samples do not
+create trust, do not replace out-of-band public key trust, do not prove
+regulatory certification, and are not completed third-party audit approval.
+Matching fingerprints in the samples support correlation only, not standalone
+trust.
+
 ## Full reviewer sequence
 
 1. Verify the Evidence Bundle strictly with a trusted public key.

--- a/docs/en/validation/trusted-public-key-provenance.md
+++ b/docs/en/validation/trusted-public-key-provenance.md
@@ -13,6 +13,18 @@ Receipt schema:
 `validate-key-provenance --json` report schema:
 [`schemas/trusted_public_key_provenance_validation_report.schema.json`](../../../schemas/trusted_public_key_provenance_validation_report.schema.json)
 
+## Illustrative sample artifacts
+
+Reviewers who want to see the expected artifact relationships can inspect the
+illustrative sample set at
+[`samples/evidence_bundle/key_provenance_review/`](../../../samples/evidence_bundle/key_provenance_review/).
+The sample set links `verification-result.json`,
+`trusted-public-key-provenance.json`, `key-provenance-validation.json`,
+`key-provenance-result-validation.json`, and `reviewer-evidence-packet.json`.
+It is illustrative only: it does not create trust, replace out-of-band public
+key trust, prove regulatory certification, or represent completed third-party
+audit approval. Matching fingerprints support correlation only.
+
 ## Why public key provenance matters
 
 Strict Evidence Bundle verification separates two questions:

--- a/samples/evidence_bundle/key_provenance_review/README.md
+++ b/samples/evidence_bundle/key_provenance_review/README.md
@@ -1,0 +1,41 @@
+# Trusted Public Key Provenance reviewer sample artifacts
+
+This directory contains an illustrative sample artifact chain for the Trusted
+Public Key Provenance reviewer walkthrough.
+
+> Illustrative sample only. Not production evidence, not regulatory
+> certification, and not completed third-party audit approval.
+
+## Artifact chain
+
+```text
+verification-result.json
+→ trusted-public-key-provenance.json
+→ key-provenance-validation.json
+→ key-provenance-result-validation.json
+→ reviewer-evidence-packet.json
+```
+
+## Files
+
+| file | purpose |
+|---|---|
+| `verification-result.json` | Illustrates the saved strict Evidence Bundle verification result under a reviewer-supplied trusted public key. |
+| `trusted-public-key-provenance.json` | Illustrates the reviewer/operator trust-channel receipt that correlates to the saved verification result fingerprint. |
+| `key-provenance-validation.json` | Illustrates the saved `validate-key-provenance --json` report showing schema and fingerprint-correlation checks. |
+| `key-provenance-result-validation.json` | Illustrates the saved `validate-key-provenance-result --json` report for the provenance-validation report. |
+| `reviewer-evidence-packet.json` | Illustrates Reviewer Evidence Packet references to the key provenance artifacts. |
+
+## Boundaries
+
+- These samples are illustrative only.
+- These samples do not create trust.
+- These samples do not replace out-of-band public key trust.
+- These samples do not prove regulatory certification.
+- These samples are not completed third-party audit approval.
+- Matching fingerprints support correlation, not standalone trust.
+- Placeholder fingerprints and hashes are synthetic-looking values used only to
+  satisfy schemas and show relationships.
+- The samples intentionally avoid real keys, real fingerprints, customer data,
+  secrets, absolute local paths, exception text, and raw schema validator
+  messages.

--- a/samples/evidence_bundle/key_provenance_review/key-provenance-result-validation.json
+++ b/samples/evidence_bundle/key_provenance_review/key-provenance-result-validation.json
@@ -1,0 +1,8 @@
+{
+  "errors": [],
+  "ok": true,
+  "report_schema_id": "https://veritas-os.example/schemas/trusted_public_key_provenance_result_validation_report.schema.json",
+  "result_schema_valid": true,
+  "validated_schema_id": "https://veritas-os.example/schemas/trusted_public_key_provenance_validation_report.schema.json",
+  "validator": "veritas-evidence-bundle validate-key-provenance-result"
+}

--- a/samples/evidence_bundle/key_provenance_review/key-provenance-validation.json
+++ b/samples/evidence_bundle/key_provenance_review/key-provenance-validation.json
@@ -1,0 +1,16 @@
+{
+  "bundle_internal_key_used_ok": true,
+  "errors": [],
+  "fingerprint_correlation_ok": true,
+  "ok": true,
+  "receipt_public_key_fingerprint_present": true,
+  "receipt_schema_id": "https://veritas-os.example/schemas/trusted_public_key_provenance_receipt.schema.json",
+  "receipt_schema_valid": true,
+  "report_schema_id": "https://veritas-os.example/schemas/trusted_public_key_provenance_validation_report.schema.json",
+  "sample_notice": "Illustrative sample only. Not production evidence, not regulatory certification, and not completed third-party audit approval.",
+  "strict_authenticity_ok": true,
+  "validator": "veritas-evidence-bundle validate-key-provenance",
+  "verification_result_public_key_fingerprint_present": true,
+  "verification_result_schema_id": "https://veritas-os.example/schemas/evidence_bundle_verification_result.schema.json",
+  "verification_result_schema_valid": true
+}

--- a/samples/evidence_bundle/key_provenance_review/reviewer-evidence-packet.json
+++ b/samples/evidence_bundle/key_provenance_review/reviewer-evidence-packet.json
@@ -1,0 +1,160 @@
+{
+  "aggregate_summary": {
+    "blocked_cases": 0,
+    "committed_cases": 1,
+    "failed_chains": 0,
+    "incomplete_chains": 0,
+    "indeterminate_chains": 0,
+    "local_offline_only": true,
+    "passed_cases": 1,
+    "total_cases": 1,
+    "verified_chains": 1
+  },
+  "boundary_note": "Illustrative sample only. Not production evidence, not regulatory certification, and not completed third-party audit approval. The packet references artifacts for reviewer navigation only; it does not create trust, replace out-of-band public key trust, or prove certification.",
+  "cases": [
+    {
+      "actual_outcome": "commit",
+      "authority_validation_status": "sample_authority_present",
+      "boundary_note": "Illustrative local/offline case summary only; not production evidence or audit approval.",
+      "case_id": "sample_key_provenance_review",
+      "evidence_chain_manifest_summary": {
+        "action_class": "sample.review",
+        "authority_evidence_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "authority_evidence_id": "sample-authority-evidence",
+        "bind_coverage_operation_id": "sample-operation",
+        "bind_receipt_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "bind_receipt_id": "sample-bind-receipt",
+        "chain_status": "complete",
+        "decision_id": "sample-decision",
+        "execution_intent_id": "sample-execution-intent",
+        "final_outcome": "commit",
+        "generated_at": "2026-01-15T12:05:00Z",
+        "human_approval_receipt_hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "human_approval_receipt_id": "sample-human-approval",
+        "manifest_hash": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+        "manifest_id": "sample-evidence-chain-manifest",
+        "metadata": {
+          "sample_context": "key provenance reviewer walkthrough"
+        },
+        "missing_links": [],
+        "observed_effects_summary": [
+          {
+            "effect": "sample reference packet assembled"
+          }
+        ],
+        "operation_id": "sample-operation",
+        "outcome_receipt_hash": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        "outcome_receipt_id": "sample-outcome-receipt",
+        "refusal_basis": [],
+        "requested_scope": [
+          "sample:review"
+        ],
+        "target_resource": "sample-evidence-bundle",
+        "target_system": "sample-review-system"
+      },
+      "evidence_chain_verification_summary": {
+        "decision_id": "sample-decision",
+        "execution_intent_id": "sample-execution-intent",
+        "failure_reasons": [],
+        "is_valid": true,
+        "manifest_hash_matches": true,
+        "manifest_id": "sample-evidence-chain-manifest",
+        "metadata": {
+          "sample_context": "key provenance reviewer walkthrough"
+        },
+        "mismatched_links": [],
+        "missing_links": [],
+        "operation_id": "sample-operation",
+        "recomputed_manifest_hash": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+        "verification_status": "verified",
+        "verified_at": "2026-01-15T12:06:00Z",
+        "verified_links": [
+          "authority_evidence",
+          "human_approval_receipt",
+          "bind_receipt",
+          "outcome_receipt"
+        ]
+      },
+      "expected_outcome": "Reviewer can follow illustrative key provenance artifact references.",
+      "failure_reasons": [],
+      "human_approval_summary": {
+        "approval_receipt_id": "sample-human-approval",
+        "approved": true,
+        "approved_scope": [
+          "sample:review"
+        ],
+        "approver_identity": "sample-reviewer",
+        "approver_role": "sample-review-role",
+        "failure_reasons": [],
+        "receipt_hash_present": true
+      },
+      "outcome_receipt_summary": {
+        "action_class": "sample.review",
+        "blocked": false,
+        "committed": true,
+        "decision_id": "sample-decision",
+        "escalated": false,
+        "evaluated_at": "2026-01-15T12:04:00Z",
+        "execution_intent_id": "sample-execution-intent",
+        "failure_reasons": [],
+        "final_outcome": "commit",
+        "intended_action": "assemble illustrative reviewer evidence packet",
+        "metadata": {
+          "sample_context": "key provenance reviewer walkthrough"
+        },
+        "observed_effects": [
+          {
+            "effect": "sample artifacts referenced"
+          }
+        ],
+        "operation_id": "sample-operation",
+        "outcome_hash": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        "outcome_receipt_id": "sample-outcome-receipt",
+        "postcondition_status": "passed",
+        "requested_scope": [
+          "sample:review"
+        ],
+        "rolled_back": false,
+        "target_resource": "sample-evidence-bundle",
+        "target_system": "sample-review-system"
+      },
+      "passed": true,
+      "refusal_basis": [],
+      "requested_scope": [
+        "sample:review"
+      ],
+      "reviewer_interpretation": "The packet points to the key provenance artifacts; reviewers still need independent public key trust.",
+      "runtime_recommended_outcome": "sample_commit_eligible",
+      "target_resource": "sample-evidence-bundle",
+      "target_system": "sample-review-system"
+    }
+  ],
+  "demo_id": "sample-key-provenance-review",
+  "generated_at": "2026-01-15T12:07:00Z",
+  "key_provenance": {
+    "key_provenance_result_validation_report": {
+      "artifact_name": "key-provenance-result-validation.json",
+      "schema_id": "https://veritas-os.example/schemas/trusted_public_key_provenance_result_validation_report.schema.json"
+    },
+    "key_provenance_validation_report": {
+      "artifact_name": "key-provenance-validation.json",
+      "schema_id": "https://veritas-os.example/schemas/trusted_public_key_provenance_validation_report.schema.json"
+    },
+    "trusted_public_key_provenance_receipt": {
+      "artifact_name": "trusted-public-key-provenance.json",
+      "required_for_strict_signature_review": true,
+      "schema_id": "https://veritas-os.example/schemas/trusted_public_key_provenance_receipt.schema.json"
+    }
+  },
+  "local_offline_only": true,
+  "packet_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "packet_id": "reviewer-evidence-packet-saas-permission-change-v1",
+  "packet_version": "v1",
+  "reviewer_notes": [
+    "Illustrative sample only. Not production evidence, not regulatory certification, and not completed third-party audit approval.",
+    "This sample demonstrates verification-result.json to trusted-public-key-provenance.json to key-provenance-validation.json to key-provenance-result-validation.json to reviewer-evidence-packet.json relationships.",
+    "Samples do not create trust, do not replace out-of-band public key trust, and matching fingerprints support correlation only."
+  ],
+  "summary": "Illustrative sample packet showing key provenance artifact references for reviewer walkthroughs.",
+  "title": "Illustrative Trusted Public Key Provenance Reviewer Evidence Packet"
+}

--- a/samples/evidence_bundle/key_provenance_review/trusted-public-key-provenance.json
+++ b/samples/evidence_bundle/key_provenance_review/trusted-public-key-provenance.json
@@ -1,0 +1,11 @@
+{
+  "algorithm": "Ed25519",
+  "approval_reference": "SAMPLE-TRUST-REFERENCE-001",
+  "approved_by": "sample-reviewer",
+  "bundle_internal_key_used": false,
+  "notes": "Illustrative sample only. Not production evidence, not regulatory certification, and not completed third-party audit approval. Public key trust must come from an out-of-band reviewer/operator trust channel; matching fingerprints support correlation only.",
+  "public_key_fingerprint_sha256": "1111111111111111111111111111111111111111111111111111111111111111",
+  "receipt_type": "trusted_public_key_provenance",
+  "received_at": "2026-01-15T12:00:00Z",
+  "trust_channel": "operator_handoff"
+}

--- a/samples/evidence_bundle/key_provenance_review/verification-result.json
+++ b/samples/evidence_bundle/key_provenance_review/verification-result.json
@@ -1,0 +1,15 @@
+{
+  "authenticity_failure": null,
+  "authenticity_ok": true,
+  "errors": [],
+  "hash_integrity_ok": true,
+  "ok": true,
+  "public_key_fingerprint_sha256": "1111111111111111111111111111111111111111111111111111111111111111",
+  "sample_notice": "Illustrative sample only. Not production evidence, not regulatory certification, and not completed third-party audit approval.",
+  "signature_status": "pass",
+  "signature_verified": true,
+  "tampered": false,
+  "warnings": [
+    "Illustrative sample only; matching fingerprints support correlation, not standalone trust."
+  ]
+}

--- a/tests/demo/test_key_provenance_review_samples.py
+++ b/tests/demo/test_key_provenance_review_samples.py
@@ -1,0 +1,251 @@
+"""Validate illustrative Trusted Public Key Provenance review samples."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+SAMPLE_DIR = Path("samples/evidence_bundle/key_provenance_review")
+SCHEMA_CASES = [
+    (
+        "verification-result.json",
+        Path("schemas/evidence_bundle_verification_result.schema.json"),
+    ),
+    (
+        "trusted-public-key-provenance.json",
+        Path("schemas/trusted_public_key_provenance_receipt.schema.json"),
+    ),
+    (
+        "key-provenance-validation.json",
+        Path(
+            "schemas/"
+            "trusted_public_key_provenance_validation_report.schema.json"
+        ),
+    ),
+    (
+        "key-provenance-result-validation.json",
+        Path(
+            "schemas/"
+            "trusted_public_key_provenance_result_validation_report.schema.json"
+        ),
+    ),
+    (
+        "reviewer-evidence-packet.json",
+        Path("docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json"),
+    ),
+]
+EXPECTED_CHAIN = [
+    "verification-result.json",
+    "trusted-public-key-provenance.json",
+    "key-provenance-validation.json",
+    "key-provenance-result-validation.json",
+    "reviewer-evidence-packet.json",
+]
+RAW_PRIVATE_KEY_PATTERNS = [
+    "-----BEGIN PRIVATE KEY-----",
+    "-----BEGIN OPENSSH PRIVATE KEY-----",
+    "-----BEGIN RSA PRIVATE KEY-----",
+    "-----BEGIN EC PRIVATE KEY-----",
+]
+ABSOLUTE_LOCAL_PATH_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9])(?:/(?:Users|home|tmp|var|workspace)/|[A-Za-z]:\\)"
+)
+EXCEPTION_TEXT_PATTERNS = [
+    "Traceback (most recent call last)",
+    "ValidationError",
+    "jsonschema.exceptions",
+    "FileNotFoundError",
+    "PermissionError",
+    "Exception:",
+]
+AJV_MODULE_PATH = Path("node_modules/.pnpm/ajv@6.14.0/node_modules/ajv")
+SCHEMA_VALIDATOR_MESSAGE_PATTERNS = [
+    "is not of type",
+    "is a required property",
+    "Additional properties are not allowed",
+    "does not match",
+    "Failed validating",
+]
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _jsonschema_module() -> Any | None:
+    if importlib.util.find_spec("jsonschema") is None:
+        return None
+    import jsonschema
+
+    return jsonschema
+
+
+def _validate_with_local_ajv(artifact_path: Path, schema_path: Path) -> None:
+    if not AJV_MODULE_PATH.exists():
+        pytest.skip("neither jsonschema nor local Ajv is available")
+
+    script = """
+const fs = require('fs');
+const Ajv = require('./node_modules/.pnpm/ajv@6.14.0/node_modules/ajv');
+const schema = JSON.parse(fs.readFileSync(process.argv[1], 'utf8'));
+delete schema.$schema;
+const data = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+const ajv = new Ajv({
+  allErrors: true,
+  meta: false,
+  schemaId: 'auto',
+  unknownFormats: 'ignore',
+  validateSchema: false,
+});
+const validate = ajv.compile(schema);
+if (!validate(data)) {
+  process.stderr.write(JSON.stringify(validate.errors));
+  process.exit(1);
+}
+"""
+    subprocess.run(
+        ["node", "-e", script, str(schema_path), str(artifact_path)],
+        check=True,
+        text=True,
+    )
+
+
+def _sample_texts() -> dict[str, str]:
+    return {
+        path.name: path.read_text(encoding="utf-8")
+        for path in sorted(SAMPLE_DIR.iterdir())
+        if path.is_file()
+    }
+
+
+def test_key_provenance_review_sample_files_exist() -> None:
+    assert SAMPLE_DIR.is_dir()
+    for artifact_name in [*EXPECTED_CHAIN, "README.md"]:
+        assert (SAMPLE_DIR / artifact_name).is_file()
+
+
+@pytest.mark.parametrize(("artifact_name", "schema_path"), SCHEMA_CASES)
+def test_key_provenance_review_samples_validate_against_schemas(
+    artifact_name: str,
+    schema_path: Path,
+) -> None:
+    artifact_path = SAMPLE_DIR / artifact_name
+    jsonschema = _jsonschema_module()
+    if jsonschema is None:
+        _validate_with_local_ajv(artifact_path, schema_path)
+        return
+
+    payload = _load_json(artifact_path)
+    schema = _load_json(schema_path)
+
+    jsonschema.Draft202012Validator(schema).validate(payload)
+
+
+def test_key_provenance_review_sample_chain_is_referenced() -> None:
+    packet = _load_json(SAMPLE_DIR / "reviewer-evidence-packet.json")
+    key_provenance = packet["key_provenance"]
+
+    assert key_provenance["trusted_public_key_provenance_receipt"] == {
+        "artifact_name": "trusted-public-key-provenance.json",
+        "required_for_strict_signature_review": True,
+        "schema_id": (
+            "https://veritas-os.example/schemas/"
+            "trusted_public_key_provenance_receipt.schema.json"
+        ),
+    }
+    assert key_provenance["key_provenance_validation_report"] == {
+        "artifact_name": "key-provenance-validation.json",
+        "schema_id": (
+            "https://veritas-os.example/schemas/"
+            "trusted_public_key_provenance_validation_report.schema.json"
+        ),
+    }
+    assert key_provenance["key_provenance_result_validation_report"] == {
+        "artifact_name": "key-provenance-result-validation.json",
+        "schema_id": (
+            "https://veritas-os.example/schemas/"
+            "trusted_public_key_provenance_result_validation_report.schema.json"
+        ),
+    }
+
+    readme = (SAMPLE_DIR / "README.md").read_text(encoding="utf-8")
+    chain_positions = [
+        readme.index(artifact_name) for artifact_name in EXPECTED_CHAIN
+    ]
+    assert chain_positions == sorted(chain_positions)
+
+
+def test_key_provenance_review_sample_fingerprints_correlate() -> None:
+    verification_result = _load_json(SAMPLE_DIR / "verification-result.json")
+    provenance_receipt = _load_json(
+        SAMPLE_DIR / "trusted-public-key-provenance.json"
+    )
+    validation_report = _load_json(SAMPLE_DIR / "key-provenance-validation.json")
+
+    assert verification_result["public_key_fingerprint_sha256"] == (
+        provenance_receipt["public_key_fingerprint_sha256"]
+    )
+    assert validation_report["fingerprint_correlation_ok"] is True
+
+
+def test_key_provenance_review_samples_have_clear_illustrative_boundaries() -> None:
+    combined_text = "\n".join(_sample_texts().values())
+
+    assert "Illustrative sample only" in combined_text
+    assert "do not create trust" in combined_text
+    assert "do not replace out-of-band public key trust" in combined_text
+    assert "do not prove regulatory certification" in combined_text
+    assert "not completed third-party audit approval" in combined_text
+    assert "Matching fingerprints support correlation" in combined_text
+
+
+@pytest.mark.parametrize("forbidden", RAW_PRIVATE_KEY_PATTERNS)
+def test_key_provenance_review_samples_do_not_contain_raw_private_keys(
+    forbidden: str,
+) -> None:
+    for name, text in _sample_texts().items():
+        assert forbidden not in text, name
+
+
+def test_key_provenance_review_samples_do_not_contain_absolute_local_paths() -> None:
+    for name, text in _sample_texts().items():
+        assert ABSOLUTE_LOCAL_PATH_PATTERN.search(text) is None, name
+
+
+@pytest.mark.parametrize("forbidden", EXCEPTION_TEXT_PATTERNS)
+def test_key_provenance_review_samples_do_not_contain_exception_text(
+    forbidden: str,
+) -> None:
+    for name, text in _sample_texts().items():
+        assert forbidden not in text, name
+
+
+@pytest.mark.parametrize("forbidden", SCHEMA_VALIDATOR_MESSAGE_PATTERNS)
+def test_key_provenance_review_samples_do_not_contain_schema_validator_messages(
+    forbidden: str,
+) -> None:
+    for name, text in _sample_texts().items():
+        assert forbidden not in text, name
+
+
+@pytest.mark.parametrize(
+    "doc_path",
+    [
+        Path("docs/en/validation/reviewer-key-provenance-walkthrough.md"),
+        Path("docs/en/validation/trusted-public-key-provenance.md"),
+        Path("docs/en/validation/evidence-bundle-reviewer-checklist.md"),
+        Path("README.md"),
+        Path("README_JP.md"),
+    ],
+)
+def test_requested_docs_link_key_provenance_review_sample(doc_path: Path) -> None:
+    text = doc_path.read_text(encoding="utf-8")
+
+    assert "samples/evidence_bundle/key_provenance_review/" in text


### PR DESCRIPTION
### Motivation
- Provide a small, clearly illustrative sample artifact chain for the Trusted Public Key Provenance reviewer walkthrough so reviewers can inspect expected file names and relationships without using production data. 
- Make it easy to demonstrate the reviewer flow: strict verification result → provenance receipt → provenance validation → result-validation → reviewer packet. 
- Ensure samples are schema-compatible, avoid any real keys/fingerprints/paths/secrets, and surface explicit non-certification/trust boundaries. 
- Warn reviewers that these samples are illustrative only and do not create trust or replace out-of-band key provenance channels.

### Description
- Add an illustrative sample directory `samples/evidence_bundle/key_provenance_review/` containing `verification-result.json`, `trusted-public-key-provenance.json`, `key-provenance-validation.json`, `key-provenance-result-validation.json`, `reviewer-evidence-packet.json`, and a `README.md` with explicit boundaries and the artifact chain. 
- Where schema allows, include a `sample_notice` field and clear explanatory text in artifacts and the sample README; where schemas disallow extra properties the notice is placed in README and packet boundary fields. 
- Add a test `tests/demo/test_key_provenance_review_samples.py` that validates sample existence, schema conformance (uses `jsonschema` when available or a local Ajv fallback), artifact-chain references, fingerprint correlation, and absence of forbidden content such as raw private keys, absolute local paths, exception text, or raw validator messages. 
- Update documentation to link the sample directory and emphasize non-certification/trust boundaries in `docs/en/validation/reviewer-key-provenance-walkthrough.md`, `docs/en/validation/trusted-public-key-provenance.md`, `docs/en/validation/evidence-bundle-reviewer-checklist.md`, `README.md`, and `README_JP.md`.

### Testing
- Ran the new sample test: `pytest tests/demo/test_key_provenance_review_samples.py` and it passed (30 passed, 0 failed). 
- Ran related docs CI tests: `pytest tests/docs/test_reviewer_evidence_packet_ci_gate.py tests/docs/test_evidence_bundle_reviewer_docs_consistency.py` and they passed. 
- Performed lint check: `ruff` on the new test file passed. 
- Performed lightweight security/script checks (`scripts/security/check_runtime_pickle_artifacts.py`, `scripts/security/check_subprocess_shell_usage.py`, `scripts/security/check_bare_except_usage.py`) and they reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a293781349c832695a7241b99f98aa2)