### PR TITLE
ci: validate key provenance review samples

### DIFF
--- a/.github/workflows/reviewer-evidence-packet-validation.yml
+++ b/.github/workflows/reviewer-evidence-packet-validation.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Check Reviewer Evidence Packet fixture
         run: python3 scripts/demo/check_reviewer_evidence_packet_fixture.py
 
+      - name: Validate key provenance reviewer samples
+        run: python3 scripts/quality/check_key_provenance_review_samples.py
+
       - name: Export current Reviewer Evidence Packet
         run: >
           python3 scripts/demo/export_reviewer_evidence_packet.py

--- a/README.md
+++ b/README.md
@@ -2111,6 +2111,10 @@ An illustrative sample artifact chain is available in
 Use it only to inspect expected file relationships; the samples do not create
 trust, do not replace out-of-band public key trust, do not prove regulatory
 certification, and are not completed third-party audit approval. Matching
-fingerprints support correlation only, not standalone trust.
+fingerprints support correlation only, not standalone trust. CI validates the
+sample artifact chain for structure, JSON Schema conformance, fixed artifact
+references, and forbidden sensitive/raw diagnostic patterns only; CI validation
+does not create trust, replace out-of-band public key trust, prove regulatory
+certification, or indicate completed third-party audit approval.
 
 Reviewer Evidence Packets may include optional Trusted Public Key Provenance validation artifact references (`trusted-public-key-provenance.json`, `key-provenance-validation.json`, and `key-provenance-result-validation.json`). Use the [Reviewer Key Provenance Walkthrough](docs/en/validation/reviewer-key-provenance-walkthrough.md) for the copyable review sequence. These references help reviewers check public key trust provenance, but the packet does not create trust, does not re-run cryptographic verification, does not replace out-of-band public key trust, is not regulatory certification, and is not completed third-party audit approval. Matching fingerprints support correlation only; they are not standalone trust proof. Reviewer Evidence Packets reference artifacts; they do not prove trust alone. Packet metadata references fixed artifact names and schema identifiers only, not raw fingerprints, raw local paths, exception text, schema validator messages, or externally supplied JSON values.

--- a/README_JP.md
+++ b/README_JP.md
@@ -384,6 +384,7 @@ Authority Evidence と Audit Log の違いは明確です。
 - **AML/KYC Governance Template Contract**: [`docs/ja/guides/financial-governance-templates.md`](docs/ja/guides/financial-governance-templates.md)（英語正本あり）
 - **External Audit / Evidence Bundle Readiness**: [`docs/ja/validation/external-audit-readiness.md`](docs/ja/validation/external-audit-readiness.md)（英語正本あり）
 - **Reviewer Key Provenance Walkthrough（英語正本）**: [`docs/en/validation/reviewer-key-provenance-walkthrough.md`](docs/en/validation/reviewer-key-provenance-walkthrough.md)
+  - `samples/evidence_bundle/key_provenance_review/` の illustrative sample chain は CI で JSON Schema conformance、固定 artifact reference、禁止された sensitive/raw diagnostic pattern のみを検証します。この CI validation は trust を作成せず、out-of-band public key trust を置き換えず、regulatory certification や completed third-party audit approval を示しません。
 - **External Technical Proof Pack（review/pilot/DD/audit）**: [`docs/ja/validation/technical-proof-pack.md`](docs/ja/validation/technical-proof-pack.md)（英語正本あり）
 - **AML/KYC Short Positioning（customer / operator / investor）**: [`docs/ja/positioning/aml-kyc-beachhead-short-positioning.md`](docs/ja/positioning/aml-kyc-beachhead-short-positioning.md)（英語正本あり）
 - **GitHub**: https://github.com/veritasfuji-japan/veritas_os

--- a/docs/en/validation/reviewer-key-provenance-walkthrough.md
+++ b/docs/en/validation/reviewer-key-provenance-walkthrough.md
@@ -36,6 +36,9 @@ Use it only to see expected file names and relationships. The samples do not
 create trust, do not replace out-of-band public key trust, do not prove
 regulatory certification, and are not completed third-party audit approval.
 Matching fingerprints in the samples support correlation only, not standalone
+trust. CI validates the illustrative sample chain for JSON Schema conformance,
+fixed artifact references, and forbidden sensitive/raw diagnostic patterns only;
+that CI validation does not create trust or replace out-of-band public key
 trust.
 
 ## Full reviewer sequence

--- a/scripts/quality/check_key_provenance_review_samples.py
+++ b/scripts/quality/check_key_provenance_review_samples.py
@@ -1,0 +1,449 @@
+#!/usr/bin/env python3
+"""Validate Trusted Public Key Provenance reviewer sample artifacts.
+
+The samples under ``samples/evidence_bundle/key_provenance_review`` are
+illustrative reviewer-facing artifacts. This gate keeps that sample chain
+schema-valid, internally linked, and free of obvious sensitive/raw diagnostic
+content that would be unsafe to copy into public documentation.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import subprocess
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SAMPLE_DIR = REPO_ROOT / "samples/evidence_bundle/key_provenance_review"
+WALKTHROUGH_PATH = (
+    REPO_ROOT / "docs/en/validation/reviewer-key-provenance-walkthrough.md"
+)
+AJV_MODULE_PATH = REPO_ROOT / "node_modules/.pnpm/ajv@6.14.0/node_modules/ajv"
+
+EVIDENCE_BUNDLE_VERIFICATION_RESULT_SCHEMA_ID = (
+    "https://veritas-os.example/schemas/"
+    "evidence_bundle_verification_result.schema.json"
+)
+TRUSTED_PUBLIC_KEY_PROVENANCE_RECEIPT_SCHEMA_ID = (
+    "https://veritas-os.example/schemas/"
+    "trusted_public_key_provenance_receipt.schema.json"
+)
+TRUSTED_PUBLIC_KEY_PROVENANCE_VALIDATION_REPORT_SCHEMA_ID = (
+    "https://veritas-os.example/schemas/"
+    "trusted_public_key_provenance_validation_report.schema.json"
+)
+TRUSTED_PUBLIC_KEY_PROVENANCE_RESULT_VALIDATION_REPORT_SCHEMA_ID = (
+    "https://veritas-os.example/schemas/"
+    "trusted_public_key_provenance_result_validation_report.schema.json"
+)
+
+SAMPLE_SCHEMA_CASES = {
+    "verification-result.json": (
+        REPO_ROOT / "schemas/evidence_bundle_verification_result.schema.json"
+    ),
+    "trusted-public-key-provenance.json": (
+        REPO_ROOT / "schemas/trusted_public_key_provenance_receipt.schema.json"
+    ),
+    "key-provenance-validation.json": (
+        REPO_ROOT
+        / "schemas/trusted_public_key_provenance_validation_report.schema.json"
+    ),
+    "key-provenance-result-validation.json": (
+        REPO_ROOT
+        / "schemas/"
+        "trusted_public_key_provenance_result_validation_report.schema.json"
+    ),
+    "reviewer-evidence-packet.json": (
+        REPO_ROOT
+        / "docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json"
+    ),
+}
+
+EXPECTED_ARTIFACT_CHAIN = (
+    "verification-result.json",
+    "trusted-public-key-provenance.json",
+    "key-provenance-validation.json",
+    "key-provenance-result-validation.json",
+    "reviewer-evidence-packet.json",
+)
+
+EXPECTED_KEY_PROVENANCE_REFERENCES = {
+    "trusted_public_key_provenance_receipt": {
+        "artifact_name": "trusted-public-key-provenance.json",
+        "required_for_strict_signature_review": True,
+        "schema_id": TRUSTED_PUBLIC_KEY_PROVENANCE_RECEIPT_SCHEMA_ID,
+    },
+    "key_provenance_validation_report": {
+        "artifact_name": "key-provenance-validation.json",
+        "schema_id": TRUSTED_PUBLIC_KEY_PROVENANCE_VALIDATION_REPORT_SCHEMA_ID,
+    },
+    "key_provenance_result_validation_report": {
+        "artifact_name": "key-provenance-result-validation.json",
+        "schema_id": TRUSTED_PUBLIC_KEY_PROVENANCE_RESULT_VALIDATION_REPORT_SCHEMA_ID,
+    },
+}
+
+SAFETY_PATTERNS = {
+    "raw private key": (
+        re.compile(r"-----BEGIN (?:OPENSSH |RSA |EC |DSA )?PRIVATE KEY-----"),
+        re.compile(r"-----BEGIN ENCRYPTED PRIVATE KEY-----"),
+    ),
+    "real secret or credential": (
+        re.compile(r"AKIA[0-9A-Z]{16}"),
+        re.compile(r"ASIA[0-9A-Z]{16}"),
+        re.compile(r"sk_live_[0-9A-Za-z]{12,}"),
+        re.compile(r"xox[baprs]-[0-9A-Za-z-]{10,}"),
+        re.compile(r"ghp_[0-9A-Za-z]{20,}"),
+        re.compile(r"github_pat_[0-9A-Za-z_]{20,}"),
+        re.compile(r"eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+"),
+        re.compile(
+            r"(?i)\b(?:api[_-]?key|access[_-]?token|password|secret)\b"
+            r"\s*[:=]\s*['\"]?(?!sample|example|placeholder|synthetic)"
+            r"[A-Za-z0-9_./+=-]{8,}"
+        ),
+    ),
+    "absolute local path": (
+        re.compile(r"(?<![A-Za-z0-9])(?:/(?:Users|home|tmp|var|workspace)/)"),
+        re.compile(r"(?<![A-Za-z0-9])[A-Za-z]:\\"),
+    ),
+    "exception traceback or raw exception text": (
+        re.compile(r"Traceback \(most recent call last\)"),
+        re.compile(r"\b(?:FileNotFoundError|PermissionError|RuntimeError):"),
+        re.compile(r"\b(?:Exception|ValidationError):"),
+        re.compile(r"jsonschema\.exceptions"),
+    ),
+    "raw schema validator message": (
+        re.compile(r"\bis not of type\b"),
+        re.compile(r"\bis a required property\b"),
+        re.compile(r"Additional properties are not allowed"),
+        re.compile(r"Failed validating"),
+        re.compile(r"\bdoes not match\b"),
+    ),
+    "obvious production or customer data": (
+        re.compile(r"\b\d{3}-\d{2}-\d{4}\b"),
+        re.compile(r"\b(?:\d{4}[ -]){3}\d{4}\b"),
+        re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.I),
+        re.compile(r"\bcustomer[_ -]?(?!data\b)[A-Za-z0-9-]{4,}\b", re.I),
+    ),
+    "raw external value outside sample placeholders": (
+        re.compile(r"https?://(?!veritas-os\.(?:example|local)\b)[^\s\"')]+"),
+        re.compile(r"-----BEGIN PUBLIC KEY-----"),
+        re.compile(r"-----BEGIN CERTIFICATE-----"),
+    ),
+}
+
+BOUNDARY_PHRASES = (
+    "Illustrative sample only",
+    "do not create trust",
+    "do not replace out-of-band public key trust",
+    "do not prove regulatory certification",
+    "not completed third-party audit approval",
+    "Matching fingerprints support correlation",
+)
+
+
+class ValidationProblem:
+    """A deterministic validation problem with path-oriented diagnostics."""
+
+    def __init__(self, path: Path, message: str) -> None:
+        self.path = path
+        self.message = message
+
+    def format(self) -> str:
+        """Return a repository-relative diagnostic string."""
+        try:
+            path_label = str(self.path.relative_to(REPO_ROOT))
+        except ValueError:
+            path_label = str(self.path)
+        return f"{path_label}: {self.message}"
+
+
+def _load_json(path: Path) -> Any:
+    """Load JSON from ``path`` and let callers convert errors to diagnostics."""
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _schema_id(schema_path: Path) -> str:
+    """Return the declared JSON Schema identifier for ``schema_path``."""
+    schema = _load_json(schema_path)
+    schema_id = schema.get("$id")
+    if not isinstance(schema_id, str):
+        return ""
+    return schema_id
+
+
+def _jsonschema_module() -> Any | None:
+    """Return the jsonschema module when available in the runtime."""
+    if importlib.util.find_spec("jsonschema") is None:
+        return None
+    import jsonschema
+
+    return jsonschema
+
+
+def _validate_with_local_ajv(artifact_path: Path, schema_path: Path) -> None:
+    """Validate with the repository-local Ajv dependency as a fallback."""
+    if not AJV_MODULE_PATH.exists():
+        raise RuntimeError("neither jsonschema nor repository-local Ajv is available")
+
+    script = """
+const fs = require('fs');
+const Ajv = require('./node_modules/.pnpm/ajv@6.14.0/node_modules/ajv');
+const schema = JSON.parse(fs.readFileSync(process.argv[1], 'utf8'));
+delete schema.$schema;
+const data = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+const ajv = new Ajv({
+  allErrors: true,
+  meta: false,
+  schemaId: 'auto',
+  unknownFormats: 'ignore',
+  validateSchema: false,
+});
+const validate = ajv.compile(schema);
+if (!validate(data)) {
+  process.stderr.write(JSON.stringify(validate.errors));
+  process.exit(1);
+}
+"""
+    subprocess.run(
+        ["node", "-e", script, str(schema_path), str(artifact_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+
+
+def _validate_against_schema(artifact_path: Path, schema_path: Path) -> None:
+    """Validate an artifact with jsonschema or the local Ajv fallback."""
+    jsonschema = _jsonschema_module()
+    if jsonschema is None:
+        _validate_with_local_ajv(artifact_path, schema_path)
+        return
+
+    payload = _load_json(artifact_path)
+    schema = _load_json(schema_path)
+    jsonschema.Draft202012Validator.check_schema(schema)
+    jsonschema.Draft202012Validator(schema).validate(payload)
+
+
+def _iter_sample_texts() -> Iterable[tuple[Path, str]]:
+    """Yield text for all checked sample artifacts, including README context."""
+    for path in sorted(SAMPLE_DIR.iterdir()):
+        if path.is_file() and path.suffix in {".json", ".md"}:
+            yield path, path.read_text(encoding="utf-8")
+
+
+def _collect_file_and_schema_problems() -> list[ValidationProblem]:
+    """Validate required files and JSON sample artifacts against schemas."""
+    problems: list[ValidationProblem] = []
+    if not SAMPLE_DIR.is_dir():
+        return [ValidationProblem(SAMPLE_DIR, "sample directory is missing")]
+
+    for artifact_name, schema_path in SAMPLE_SCHEMA_CASES.items():
+        artifact_path = SAMPLE_DIR / artifact_name
+        if not artifact_path.is_file():
+            problems.append(ValidationProblem(artifact_path, "sample file is missing"))
+            continue
+        if not schema_path.is_file():
+            problems.append(ValidationProblem(schema_path, "schema file is missing"))
+            continue
+
+        try:
+            _validate_against_schema(artifact_path, schema_path)
+        except (
+            json.JSONDecodeError,
+            RuntimeError,
+            subprocess.CalledProcessError,
+        ) as exc:
+            problems.append(
+                ValidationProblem(
+                    artifact_path,
+                    "does not validate against "
+                    f"{schema_path.relative_to(REPO_ROOT)}: {exc}",
+                )
+            )
+        except Exception as exc:  # jsonschema.ValidationError or SchemaError.
+            message = getattr(exc, "message", str(exc))
+            problems.append(
+                ValidationProblem(
+                    artifact_path,
+                    "does not validate against "
+                    f"{schema_path.relative_to(REPO_ROOT)}: {message}",
+                )
+            )
+    return problems
+
+
+def _collect_safety_problems() -> list[ValidationProblem]:
+    """Block private keys, secrets, local paths, raw errors, and customer data."""
+    problems: list[ValidationProblem] = []
+    for path, text in _iter_sample_texts():
+        for category, patterns in SAFETY_PATTERNS.items():
+            for pattern in patterns:
+                if pattern.search(text):
+                    problems.append(
+                        ValidationProblem(path, f"contains forbidden {category}")
+                    )
+                    break
+    return problems
+
+
+def _collect_boundary_problems() -> list[ValidationProblem]:
+    """Ensure samples keep precise illustrative/trust-boundary wording."""
+    combined_text = "\n".join(text for _, text in _iter_sample_texts())
+    return [
+        ValidationProblem(SAMPLE_DIR, f"missing boundary phrase: {phrase}")
+        for phrase in BOUNDARY_PHRASES
+        if phrase not in combined_text
+    ]
+
+
+def _artifact_names_from_walkthrough() -> tuple[str, ...]:
+    """Extract expected JSON artifact names from the walkthrough artifact map."""
+    text = WALKTHROUGH_PATH.read_text(encoding="utf-8")
+    return tuple(
+        artifact_name
+        for artifact_name in EXPECTED_ARTIFACT_CHAIN
+        if f"`{artifact_name}`" in text
+    )
+
+
+def _collect_chain_reference_problems() -> list[ValidationProblem]:
+    """Validate sample artifact-chain references and schema-id correlations."""
+    problems: list[ValidationProblem] = []
+    packet_path = SAMPLE_DIR / "reviewer-evidence-packet.json"
+    validation_path = SAMPLE_DIR / "key-provenance-validation.json"
+    result_validation_path = SAMPLE_DIR / "key-provenance-result-validation.json"
+    readme_path = SAMPLE_DIR / "README.md"
+
+    try:
+        packet = _load_json(packet_path)
+        validation_report = _load_json(validation_path)
+        result_validation_report = _load_json(result_validation_path)
+        readme_text = readme_path.read_text(encoding="utf-8")
+    except (FileNotFoundError, json.JSONDecodeError) as exc:
+        return [ValidationProblem(SAMPLE_DIR, f"cannot inspect chain: {exc}")]
+
+    key_provenance = packet.get("key_provenance")
+    if key_provenance != EXPECTED_KEY_PROVENANCE_REFERENCES:
+        problems.append(
+            ValidationProblem(
+                packet_path,
+                "key_provenance references do not match expected sample artifacts",
+            )
+        )
+
+    notes_text = "\n".join(str(note) for note in packet.get("reviewer_notes", []))
+    for artifact_name in EXPECTED_ARTIFACT_CHAIN:
+        if artifact_name not in notes_text and artifact_name not in readme_text:
+            problems.append(
+                ValidationProblem(
+                    packet_path,
+                    f"missing chain artifact {artifact_name}",
+                )
+            )
+
+    readme_positions = []
+    for artifact_name in EXPECTED_ARTIFACT_CHAIN:
+        try:
+            readme_positions.append(readme_text.index(artifact_name))
+        except ValueError:
+            problems.append(
+                ValidationProblem(readme_path, f"missing artifact {artifact_name}")
+            )
+    if readme_positions != sorted(readme_positions):
+        problems.append(
+            ValidationProblem(
+                readme_path,
+                "artifact chain order does not match walkthrough",
+            )
+        )
+
+    if _artifact_names_from_walkthrough() != EXPECTED_ARTIFACT_CHAIN:
+        problems.append(
+            ValidationProblem(
+                WALKTHROUGH_PATH,
+                "walkthrough artifact names do not match the sample chain",
+            )
+        )
+
+    expected_verification_schema_id = _schema_id(
+        SAMPLE_SCHEMA_CASES["verification-result.json"]
+    )
+    if (
+        validation_report.get("verification_result_schema_id")
+        != expected_verification_schema_id
+    ):
+        problems.append(
+            ValidationProblem(
+                validation_path,
+                "verification_result_schema_id does not reference "
+                "the verification result schema",
+            )
+        )
+
+    expected_validation_schema_id = _schema_id(
+        SAMPLE_SCHEMA_CASES["key-provenance-validation.json"]
+    )
+    if (
+        result_validation_report.get("validated_schema_id")
+        != expected_validation_schema_id
+    ):
+        problems.append(
+            ValidationProblem(
+                result_validation_path,
+                "validated_schema_id does not reference the validation report schema",
+            )
+        )
+
+    for key, expected in (
+        ("receipt_schema_id", TRUSTED_PUBLIC_KEY_PROVENANCE_RECEIPT_SCHEMA_ID),
+        ("report_schema_id", TRUSTED_PUBLIC_KEY_PROVENANCE_VALIDATION_REPORT_SCHEMA_ID),
+    ):
+        if validation_report.get(key) != expected:
+            problems.append(ValidationProblem(validation_path, f"unexpected {key}"))
+
+    if (
+        result_validation_report.get("report_schema_id")
+        != TRUSTED_PUBLIC_KEY_PROVENANCE_RESULT_VALIDATION_REPORT_SCHEMA_ID
+    ):
+        problems.append(
+            ValidationProblem(result_validation_path, "unexpected report_schema_id")
+        )
+
+    return problems
+
+
+def validate_key_provenance_review_samples() -> list[ValidationProblem]:
+    """Return all Trusted Public Key Provenance sample validation problems."""
+    problems: list[ValidationProblem] = []
+    problems.extend(_collect_file_and_schema_problems())
+    if problems:
+        return problems
+    problems.extend(_collect_safety_problems())
+    problems.extend(_collect_boundary_problems())
+    problems.extend(_collect_chain_reference_problems())
+    return problems
+
+
+def main() -> int:
+    """Run the Trusted Public Key Provenance sample CI gate."""
+    problems = validate_key_provenance_review_samples()
+    if not problems:
+        print("Trusted Public Key Provenance review samples validated.")
+        return 0
+
+    print("[SAMPLES] Trusted Public Key Provenance review samples are invalid:")
+    for problem in problems:
+        print(f"- {problem.format()}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/demo/test_key_provenance_review_samples_ci_gate.py
+++ b/tests/demo/test_key_provenance_review_samples_ci_gate.py
@@ -1,0 +1,18 @@
+"""CI gate coverage for Trusted Public Key Provenance sample artifacts."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_key_provenance_review_samples_ci_gate_exits_zero() -> None:
+    """Run the sample validation script exactly as CI does."""
+    result = subprocess.run(
+        [sys.executable, "scripts/quality/check_key_provenance_review_samples.py"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
### Motivation

- Ensure the illustrative Trusted Public Key Provenance sample artifact chain remains schema-valid, internally linked, and free of obvious sensitive/raw diagnostic content by adding a CI validation gate. 
- Prevent accidental inclusion of private keys, real secrets, absolute local paths, exception tracebacks, raw schema-validator messages, or obvious production/customer data in samples. 
- Keep claims precise in docs: CI checks structure and schema conformance only and does not create trust or replace out-of-band public-key trust. 

### Description

- Add a lightweight sample validator at `scripts/quality/check_key_provenance_review_samples.py` that validates these sample files: `verification-result.json`, `trusted-public-key-provenance.json`, `key-provenance-validation.json`, `key-provenance-result-validation.json`, and `reviewer-evidence-packet.json` against their corresponding schemas. 
- Implement fixed safety checks for raw private keys, common secret/credential patterns, absolute local paths, exception/traceback text, raw schema validator messages, obvious production/customer data, and non-placeholder external values; and verify artifact-chain references and schema-id correlations. 
- Use `jsonschema` when available and fall back to the repository-local Ajv (Node) runtime for schema validation as a robust CI-friendly fallback. 
- Wire the script into the existing Reviewer Evidence Packet validation workflow (`.github/workflows/reviewer-evidence-packet-validation.yml`) and add a pytest CI gate `tests/demo/test_key_provenance_review_samples_ci_gate.py` that runs the script and asserts an exit code of 0. 
- Update user-facing docs (`README.md`, `README_JP.md`, and `docs/en/validation/reviewer-key-provenance-walkthrough.md`) to explicitly state the CI validation scope and that it does not create trust or replace out-of-band key trust. 
- Note: no runtime behavior, FUJI Gate, Kernel, Planner, or MemoryOS responsibilities were changed; this is a documentation/sample CI guard only. 

### Testing

- Ran `python3 scripts/quality/check_key_provenance_review_samples.py` and observed: `Trusted Public Key Provenance review samples validated.` (exit 0). 
- Ran `PYENV_VERSION=3.12.13 python -m ruff check scripts/quality/check_key_provenance_review_samples.py tests/demo/test_key_provenance_review_samples_ci_gate.py` and received `All checks passed!`. 
- Ran `PYENV_VERSION=3.12.13 python -m pytest tests/demo/test_key_provenance_review_samples_ci_gate.py tests/demo/test_key_provenance_review_samples.py` and observed `31 passed, 1 warning` (tests passed). 
- Ran `python scripts/quality/check_evidence_bundle_reviewer_docs.py` and observed `Evidence Bundle reviewer documentation checks passed.` (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a293f2fe5748326bd84f433cb95a2a4)