### PR TITLE
feat: add `validate-review-result` CLI to validate reviewer handoff review-result artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2123,6 +2123,15 @@ indicate completed third-party audit approval. The reviewer result records what
 was checked and a decision of `ACCEPT`, `REJECT`, or `NEEDS_FOLLOW_UP`; it is
 not certification by itself, not regulatory approval, not completed
 third-party audit approval, and not cryptographic truth by itself. Reviewer
-decisions depend on reviewer scope and out-of-band public key trust context.
+decisions depend on reviewer scope and out-of-band public key trust context. Use
+`veritas-evidence-bundle validate-review-result --result
+reviewer-handoff-review-result.json --json --output
+reviewer-review-result-validation.json` to validate the saved review result
+artifact, its schema conformance, acknowledgement structure, required artifact
+references, decision value, and forbidden sensitive/raw diagnostic patterns. The
+command records and checks review-result structure only: it does not create
+trust, does not replace out-of-band public key trust, does not prove regulatory
+certification, is not completed third-party audit approval, and does not
+establish cryptographic truth by itself.
 
 Reviewer Evidence Packets may include optional Trusted Public Key Provenance validation artifact references (`trusted-public-key-provenance.json`, `key-provenance-validation.json`, and `key-provenance-result-validation.json`). Use the [Reviewer Key Provenance Walkthrough](docs/en/validation/reviewer-key-provenance-walkthrough.md) for the copyable review sequence and the [Reviewer Handoff Guide](docs/en/validation/reviewer-handoff-guide.md) for what to send, what to verify, and what not to infer. These references help reviewers check public key trust provenance, but the packet does not create trust, does not re-run cryptographic verification, does not replace out-of-band public key trust, is not regulatory certification, and is not completed third-party audit approval. Matching fingerprints support correlation only; they are not standalone trust proof. Reviewer Evidence Packets reference artifacts; they do not prove trust alone. Packet metadata references fixed artifact names and schema identifiers only, not raw fingerprints, raw local paths, exception text, schema validator messages, or externally supplied JSON values.

--- a/README_JP.md
+++ b/README_JP.md
@@ -385,7 +385,21 @@ Authority Evidence と Audit Log の違いは明確です。
 - **External Audit / Evidence Bundle Readiness**: [`docs/ja/validation/external-audit-readiness.md`](docs/ja/validation/external-audit-readiness.md)（英語正本あり）
 - **Reviewer Key Provenance Walkthrough（英語正本）**: [`docs/en/validation/reviewer-key-provenance-walkthrough.md`](docs/en/validation/reviewer-key-provenance-walkthrough.md)
 - **Reviewer Handoff Guide（英語正本）**: [`docs/en/validation/reviewer-handoff-guide.md`](docs/en/validation/reviewer-handoff-guide.md)
-  - `samples/evidence_bundle/key_provenance_review/` の illustrative sample chain には `sample-artifact-manifest.json` と `reviewer-handoff-review-result.json` が含まれます。CI は JSON Schema conformance、固定 artifact reference、manifest、artifact hash、禁止された sensitive/raw diagnostic pattern を検証します。Reviewer Review Result は確認内容と `ACCEPT` / `REJECT` / `NEEDS_FOLLOW_UP` の decision を記録しますが、単独の certification、regulatory approval、completed third-party audit approval、cryptographic truth ではありません。hash matching は sample integrity を支援するだけで standalone trust ではありません。この CI validation は trust を作成せず、out-of-band public key trust を置き換えず、regulatory certification や completed third-party audit approval を示しません。
+  - `samples/evidence_bundle/key_provenance_review/` の illustrative sample chain には
+    `sample-artifact-manifest.json` と `reviewer-handoff-review-result.json` が含まれます。CI は
+    JSON Schema conformance、固定 artifact reference、manifest、artifact hash、禁止された
+    sensitive/raw diagnostic pattern を検証します。Reviewer Review Result は確認内容と
+    `ACCEPT` / `REJECT` / `NEEDS_FOLLOW_UP` の decision を記録しますが、単独の
+    certification、regulatory approval、completed third-party audit approval、cryptographic truth
+    ではありません。hash matching は sample integrity を支援するだけで standalone trust ではありません。
+    この CI validation は trust を作成せず、out-of-band public key trust を置き換えず、
+    regulatory certification や completed third-party audit approval を示しません。
+    `veritas-evidence-bundle validate-review-result --result reviewer-handoff-review-result.json --json --output reviewer-review-result-validation.json`
+    は、保存済み review result artifact の schema、acknowledgement structure、required artifact
+    reference、decision、禁止された sensitive/raw diagnostic pattern を検証します。この command は
+    review-result structure を記録・検査するだけで、trust を作成せず、out-of-band public key trust
+    を置き換えず、regulatory certification を証明せず、completed third-party audit approval
+    ではなく、それ単独で cryptographic truth を証明しません。
 - **External Technical Proof Pack（review/pilot/DD/audit）**: [`docs/ja/validation/technical-proof-pack.md`](docs/ja/validation/technical-proof-pack.md)（英語正本あり）
 - **AML/KYC Short Positioning（customer / operator / investor）**: [`docs/ja/positioning/aml-kyc-beachhead-short-positioning.md`](docs/ja/positioning/aml-kyc-beachhead-short-positioning.md)（英語正本あり）
 - **GitHub**: https://github.com/veritasfuji-japan/veritas_os

--- a/docs/en/validation/evidence-bundle-reviewer-checklist.md
+++ b/docs/en/validation/evidence-bundle-reviewer-checklist.md
@@ -153,6 +153,23 @@ same fixed-diagnostic JSON report; parent directories are created and
 fingerprints, raw file paths, raw exception text, raw schema validator messages,
 or raw JSON values from the saved report.
 
+To validate the saved Reviewer Review Result artifact, run:
+
+```bash
+veritas-evidence-bundle validate-review-result \
+  --result reviewer-handoff-review-result.json \
+  --json \
+  --output reviewer-review-result-validation.json
+```
+
+`validate-review-result` validates the saved review result artifact, including
+schema conformance, acknowledgement structure, required artifact references,
+decision values, and forbidden sensitive/raw diagnostic patterns. It records and
+checks review-result structure only: it does not create trust, does not replace
+out-of-band public key trust, does not prove regulatory certification, is not
+completed third-party audit approval, and does not establish cryptographic truth
+by itself. Its public output is boolean-only with fixed diagnostics.
+
 ## Verification order
 
 | Step | Reviewer action | PASS criterion | FAIL / follow-up criterion |
@@ -165,7 +182,7 @@ or raw JSON values from the saved report.
 | 6 | Inspect `acceptance_checklist.json`. | The checklist exists and has no blocking failures for the submitted bundle profile. | The checklist is missing, malformed, incomplete, or contains any blocking failure. |
 | 7 | Inspect `verification_report.json`. | The report exists and is consistent with the strict verification result and expected bundle scope. | The report is missing, malformed, stale, inconsistent with CLI output, or reports unresolved errors. |
 | 8 | Confirm no missing expected artifacts. | Required artifacts for the bundle type and review objective are present, including expected manifest, witness, report, acceptance, and profile-specific files. | Expected artifacts are absent, empty, renamed without explanation, or inconsistent with the handoff metadata. |
-| 9 | Record reviewer result in `reviewer-handoff-review-result.json`: `ACCEPT`, `REJECT`, or `NEEDS_FOLLOW_UP`. | The final result records artifacts checked, command output, key provenance, limitation acknowledgements, reviewer scope, out-of-band trust context, and reviewer rationale. | The result is ambiguous, lacks key provenance, lacks CLI evidence, lacks limitation acknowledgements, or does not explain unresolved follow-up. |
+| 9 | Record reviewer result in `reviewer-handoff-review-result.json`: `ACCEPT`, `REJECT`, or `NEEDS_FOLLOW_UP`, then run `veritas-evidence-bundle validate-review-result --result reviewer-handoff-review-result.json`. | The final result records artifacts checked, command output, key provenance, limitation acknowledgements, reviewer scope, out-of-band trust context, and reviewer rationale; the validator reports schema-valid structure and acknowledged limitations. | The result is ambiguous, lacks key provenance, lacks CLI evidence, lacks limitation acknowledgements, fails review-result validation, or does not explain unresolved follow-up. |
 
 ## Required ACCEPT criteria
 

--- a/docs/en/validation/reviewer-handoff-guide.md
+++ b/docs/en/validation/reviewer-handoff-guide.md
@@ -65,6 +65,25 @@ veritas-evidence-bundle validate-key-provenance-result \
   --output key-provenance-result-validation.json
 ```
 
+Validate the saved Reviewer Review Result artifact:
+
+```bash
+veritas-evidence-bundle validate-review-result \
+  --result reviewer-handoff-review-result.json \
+  --json \
+  --output reviewer-review-result-validation.json
+```
+
+`validate-review-result` checks the saved review result artifact against
+[`schemas/reviewer_handoff_review_result.schema.json`](../../../schemas/reviewer_handoff_review_result.schema.json)
+and verifies the decision enum, required artifact references, required boolean
+limitation acknowledgements, and forbidden sensitive/raw diagnostic patterns.
+It records and checks review-result structure only: it does not create trust,
+does not replace out-of-band public key trust, does not prove regulatory
+certification, is not completed third-party audit approval, and does not
+establish cryptographic truth by itself. JSON output uses booleans, fixed schema
+identifiers, and fixed diagnostics only.
+
 ## What the reviewer can verify
 
 The package supports these reviewer checks:

--- a/docs/en/validation/reviewer-key-provenance-walkthrough.md
+++ b/docs/en/validation/reviewer-key-provenance-walkthrough.md
@@ -64,7 +64,9 @@ key trust.
    artifact name and schema identifier.
 9. Record or inspect `reviewer-handoff-review-result.json` with the reviewer
    decision: `ACCEPT`, `REJECT`, or `NEEDS_FOLLOW_UP`.
-10. Confirm `sample-artifact-manifest.json` lists the full illustrative sample
+10. Run `validate-review-result` to validate the saved review result artifact
+    shape and review-boundary acknowledgements.
+11. Confirm `sample-artifact-manifest.json` lists the full illustrative sample
    set and that CI/sample validation checks the listed SHA-256 digests.
 
 ## 1. Verify the Evidence Bundle strictly
@@ -151,11 +153,23 @@ copied from externally supplied artifacts.
 Use `reviewer-handoff-review-result.json` when the reviewer needs a
 machine-readable Review Result / Acceptance Record. The artifact records what
 was checked, the reviewer, reviewer scope, limitation acknowledgements, and the
-decision value: `ACCEPT`, `REJECT`, or `NEEDS_FOLLOW_UP`. It records the review
-outcome, not cryptographic truth by itself, and it is not certification,
-regulatory approval, or completed third-party audit approval. A reviewer
-decision depends on the reviewer's scope and out-of-band public key trust
-context.
+decision value: `ACCEPT`, `REJECT`, or `NEEDS_FOLLOW_UP`. Validate the saved
+artifact with:
+
+```bash
+veritas-evidence-bundle validate-review-result \
+  --result reviewer-handoff-review-result.json \
+  --json \
+  --output reviewer-review-result-validation.json
+```
+
+`validate-review-result` validates schema conformance, acknowledgement
+structure, required artifact references, and forbidden sensitive/raw diagnostic
+patterns. It records and checks review-result structure only: it does not create
+trust, does not replace out-of-band public key trust, does not prove regulatory
+certification, is not completed third-party audit approval, and does not
+establish cryptographic truth by itself. A reviewer decision depends on the
+reviewer's scope and out-of-band public key trust context.
 
 ## Artifact map
 
@@ -166,5 +180,5 @@ context.
 | `key-provenance-validation.json` | `veritas-evidence-bundle validate-key-provenance --json --output key-provenance-validation.json` | `veritas-evidence-bundle validate-key-provenance-result --result key-provenance-validation.json` | [`schemas/trusted_public_key_provenance_validation_report.schema.json`](../../../schemas/trusted_public_key_provenance_validation_report.schema.json) | Records receipt schema validity, verification-result schema validity, strict-authenticity checks, and fingerprint correlation status. |
 | `key-provenance-result-validation.json` | `veritas-evidence-bundle validate-key-provenance-result --json --output key-provenance-result-validation.json` | Reviewer packet review and schema-aware audit tooling | [`schemas/trusted_public_key_provenance_result_validation_report.schema.json`](../../../schemas/trusted_public_key_provenance_result_validation_report.schema.json) | Records that the saved key provenance validation report itself matches the expected result-validation report shape. |
 | `reviewer-evidence-packet.json` | Reviewer Evidence Packet export or assembly process | Reviewer packet validation/report tooling and reviewer inspection | [`docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json`](../demo/schemas/reviewer-evidence-packet-v1.schema.json) | Points reviewers to the saved artifacts; it is a navigation and evidence-packet reference, not standalone trust proof. |
-| `reviewer-handoff-review-result.json` | Reviewer review process | JSON Schema validation, CI sample validation, and reviewer inspection | [`schemas/reviewer_handoff_review_result.schema.json`](../../../schemas/reviewer_handoff_review_result.schema.json) | Records artifacts checked, limitations acknowledged, reviewer scope, and decision (`ACCEPT`, `REJECT`, or `NEEDS_FOLLOW_UP`); it records outcome, not cryptographic truth by itself. |
+| `reviewer-handoff-review-result.json` | Reviewer review process | `veritas-evidence-bundle validate-review-result --result reviewer-handoff-review-result.json` and reviewer inspection | [`schemas/reviewer_handoff_review_result.schema.json`](../../../schemas/reviewer_handoff_review_result.schema.json) | Records artifacts checked, limitations acknowledged, reviewer scope, and decision (`ACCEPT`, `REJECT`, or `NEEDS_FOLLOW_UP`); it records outcome, not cryptographic truth by itself. |
 | `sample-artifact-manifest.json` | Illustrative sample set maintenance | CI sample validation and reviewer inspection | [`schemas/trusted_public_key_provenance_review_sample_manifest.schema.json`](../../../schemas/trusted_public_key_provenance_review_sample_manifest.schema.json) | Indexes expected sample artifacts, roles, schema identifiers, and SHA-256 digests; hash matching supports sample integrity, not standalone trust. |

--- a/veritas_os/cli/evidence_bundle.py
+++ b/veritas_os/cli/evidence_bundle.py
@@ -6,6 +6,7 @@ import argparse
 import hashlib
 import json
 import os
+import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -54,6 +55,12 @@ VALIDATE_KEY_PROVENANCE_VALIDATOR = "veritas-evidence-bundle validate-key-proven
 VALIDATE_KEY_PROVENANCE_RESULT_VALIDATOR = (
     "veritas-evidence-bundle validate-key-provenance-result"
 )
+REVIEWER_HANDOFF_REVIEW_RESULT_SCHEMA_ID = (
+    f"{SCHEMA_BASE_URL}/reviewer_handoff_review_result.schema.json"
+)
+VALIDATE_REVIEW_RESULT_VALIDATOR = (
+    "veritas-evidence-bundle validate-review-result"
+)
 VERIFICATION_RESULT_SCHEMA_PATH = (
     Path(__file__).resolve().parents[2]
     / "schemas"
@@ -69,6 +76,71 @@ TRUSTED_PUBLIC_KEY_PROVENANCE_VALIDATION_REPORT_SCHEMA_PATH = (
     / "schemas"
     / "trusted_public_key_provenance_validation_report.schema.json"
 )
+REVIEWER_HANDOFF_REVIEW_RESULT_SCHEMA_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "schemas"
+    / "reviewer_handoff_review_result.schema.json"
+)
+
+
+REVIEW_RESULT_DECISIONS = {"ACCEPT", "REJECT", "NEEDS_FOLLOW_UP"}
+REVIEW_RESULT_REQUIRED_LIMITATIONS = {
+    "does_not_create_trust",
+    "does_not_replace_out_of_band_public_key_trust",
+    "not_regulatory_certification",
+    "not_completed_third_party_audit_approval",
+    "fingerprint_matching_is_correlation_not_standalone_trust",
+    "sample_hashes_support_sample_integrity_only",
+}
+REVIEW_RESULT_REQUIRED_ARTIFACTS = {
+    "verification-result.json": VERIFICATION_RESULT_SCHEMA_ID,
+    "trusted-public-key-provenance.json": (
+        TRUSTED_PUBLIC_KEY_PROVENANCE_RECEIPT_SCHEMA_ID
+    ),
+    "key-provenance-validation.json": (
+        TRUSTED_PUBLIC_KEY_PROVENANCE_VALIDATION_REPORT_SCHEMA_ID
+    ),
+    "key-provenance-result-validation.json": (
+        TRUSTED_PUBLIC_KEY_PROVENANCE_RESULT_VALIDATION_REPORT_SCHEMA_ID
+    ),
+    "reviewer-evidence-packet.json": (
+        "docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json"
+    ),
+    "sample-artifact-manifest.json": (
+        f"{SCHEMA_BASE_URL}/"
+        "trusted_public_key_provenance_review_sample_manifest.schema.json"
+    ),
+}
+REVIEW_RESULT_FORBIDDEN_PATTERNS = [
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        r"-----BEGIN [A-Z ]*(?:PUBLIC|PRIVATE) KEY-----",
+        r"\bssh-(?:rsa|ed25519)\s+[A-Za-z0-9+/=]{20,}",
+        r"\b[0-9a-f]{64}\b",
+        r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b",
+        r"\bsk_live_[0-9A-Za-z]{12,}\b",
+        r"\bxox[baprs]-[0-9A-Za-z-]{10,}\b",
+        r"\bghp_[0-9A-Za-z]{20,}\b",
+        r"\bgithub_pat_[0-9A-Za-z_]{20,}\b",
+        r"\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b",
+        r"\b(?:api[_-]?key|access[_-]?token|password|secret)\s*[:=]",
+        r"(?:^|\s)/(?:Users|home|tmp|var|workspace)/[^\s,;]*",
+        r"[A-Za-z]:\\[^\s,;]*",
+        r"Traceback \(most recent call last\)",
+        (
+            r"\b(?:FileNotFoundError|PermissionError|RuntimeError|"
+            r"ValidationError|Exception):"
+        ),
+        r"jsonschema\.exceptions",
+        r"Failed validating",
+        r"is a required property",
+        r"is not of type",
+        r"Additional properties are not allowed",
+        r"\bcustomer(?:[_ -]?data)?\b",
+        r"\bproduction(?:[_ -]?data)?\b",
+        r"[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}",
+    )
+]
 
 
 @dataclass(frozen=True)
@@ -598,6 +670,200 @@ def _run_validate_key_provenance_result(
     return exit_code
 
 
+def _contains_forbidden_review_result_pattern(value: Any) -> bool:
+    """Return whether a review result contains forbidden sensitive text.
+
+    The scan is intentionally boolean-only. Callers must not expose matched text
+    because the input may contain keys, fingerprints, local paths, exception
+    text, schema validator messages, secrets, or customer/production data.
+    """
+    if isinstance(value, str):
+        return any(
+            pattern.search(value) for pattern in REVIEW_RESULT_FORBIDDEN_PATTERNS
+        )
+    if isinstance(value, dict):
+        return any(
+            _contains_forbidden_review_result_pattern(item)
+            for pair in value.items()
+            for item in pair
+        )
+    if isinstance(value, list):
+        return any(
+            _contains_forbidden_review_result_pattern(item) for item in value
+        )
+    return False
+
+
+def _review_result_decision_valid(result: Any) -> bool:
+    """Return whether the reviewer result decision uses the allowed enum."""
+    return (
+        isinstance(result, dict)
+        and result.get("decision") in REVIEW_RESULT_DECISIONS
+    )
+
+
+def _review_result_limitations_acknowledged(result: Any) -> bool:
+    """Return whether required limitation acknowledgements are boolean true."""
+    if not isinstance(result, dict):
+        return False
+    limitations = result.get("limitations_acknowledged")
+    if not isinstance(limitations, dict):
+        return False
+    return all(
+        isinstance(limitations.get(field), bool) and limitations.get(field) is True
+        for field in REVIEW_RESULT_REQUIRED_LIMITATIONS
+    )
+
+
+def _review_result_artifacts_checked_shape_valid(result: Any) -> bool:
+    """Return whether all required artifact references are present and checked."""
+    if not isinstance(result, dict):
+        return False
+    artifacts = result.get("artifacts_checked")
+    if not isinstance(artifacts, list):
+        return False
+
+    observed: dict[str, str] = {}
+    for artifact in artifacts:
+        if not isinstance(artifact, dict):
+            return False
+        name = artifact.get("artifact_name")
+        schema_id = artifact.get("schema_id")
+        checked = artifact.get("checked")
+        if not isinstance(name, str) or not isinstance(schema_id, str):
+            return False
+        if not isinstance(checked, bool) or checked is not True:
+            return False
+        observed[name] = schema_id
+
+    return all(
+        observed.get(name) == schema_id
+        for name, schema_id in REVIEW_RESULT_REQUIRED_ARTIFACTS.items()
+    )
+
+
+def _review_result_public_errors(report: dict[str, Any]) -> list[dict[str, str]]:
+    """Build fixed diagnostics for review-result validation failures."""
+    errors: list[dict[str, str]] = []
+    checks = [
+        (
+            "result_json_valid",
+            "result file is not valid JSON or could not be read",
+            report["result_json_valid"],
+        ),
+        (
+            "result_schema_valid",
+            "review result does not satisfy schema",
+            report["result_schema_valid"],
+        ),
+        (
+            "decision_valid",
+            "decision must be ACCEPT, REJECT, or NEEDS_FOLLOW_UP",
+            report["decision_valid"],
+        ),
+        (
+            "limitations_acknowledged",
+            "required limitation acknowledgements must be boolean true",
+            report["limitations_acknowledged"],
+        ),
+        (
+            "artifacts_checked_shape_valid",
+            "required artifact references must be present and checked",
+            report["artifacts_checked_shape_valid"],
+        ),
+        (
+            "forbidden_patterns_absent",
+            "review result contains forbidden sensitive or raw diagnostic text",
+            report["forbidden_patterns_absent"],
+        ),
+    ]
+    for check, message, passed in checks:
+        if not passed:
+            errors.append({"check": check, "path": "$", "message": message})
+    return errors
+
+
+def _validate_review_result_status(result_path: Path) -> tuple[dict[str, Any], int]:
+    """Validate a saved reviewer handoff review result safely.
+
+    The validator checks JSON parsing, schema conformance, reviewer decision,
+    required artifact references, limitation acknowledgement structure, and
+    forbidden sensitive/raw diagnostic patterns. Public output is intentionally
+    limited to booleans, fixed identifiers, and fixed diagnostics; it does not
+    print raw JSON values, raw file paths, raw fingerprints, raw exceptions, raw
+    schema validator messages, secrets, or customer/production data.
+    """
+    result, result_json_valid = _load_json_document(result_path)
+    result_schema_valid = (
+        result_json_valid
+        and _json_schema_valid(result, REVIEWER_HANDOFF_REVIEW_RESULT_SCHEMA_PATH)
+    )
+    decision_valid = result_json_valid and _review_result_decision_valid(result)
+    limitations_acknowledged = (
+        result_json_valid and _review_result_limitations_acknowledged(result)
+    )
+    artifacts_checked_shape_valid = (
+        result_json_valid and _review_result_artifacts_checked_shape_valid(result)
+    )
+    forbidden_patterns_absent = (
+        result_json_valid and not _contains_forbidden_review_result_pattern(result)
+    )
+    ok = (
+        result_schema_valid
+        and decision_valid
+        and limitations_acknowledged
+        and artifacts_checked_shape_valid
+        and forbidden_patterns_absent
+    )
+    report = {
+        "ok": ok,
+        "result_schema_valid": result_schema_valid,
+        "decision_valid": decision_valid,
+        "limitations_acknowledged": limitations_acknowledged,
+        "artifacts_checked_shape_valid": artifacts_checked_shape_valid,
+        "forbidden_patterns_absent": forbidden_patterns_absent,
+        "validated_schema_id": REVIEWER_HANDOFF_REVIEW_RESULT_SCHEMA_ID,
+        "validator": VALIDATE_REVIEW_RESULT_VALIDATOR,
+        "errors": [],
+    }
+    report["errors"] = _review_result_public_errors(
+        {**report, "result_json_valid": result_json_valid}
+    )
+    return report, 0 if ok else 1
+
+
+def _run_validate_review_result(
+    result_path: Path,
+    *,
+    json_output: bool = False,
+    output_path: Optional[Path] = None,
+) -> int:
+    """Run saved reviewer handoff review result validation."""
+    output, exit_code = _validate_review_result_status(result_path)
+    if json_output:
+        output_json = json.dumps(output, indent=2, ensure_ascii=False)
+        if output_path is not None:
+            try:
+                output_path.parent.mkdir(parents=True, exist_ok=True)
+                output_path.write_text(output_json + "\n", encoding="utf-8")
+            except OSError:
+                print(
+                    "error: failed to write review result validation report",
+                    file=sys.stderr,
+                )
+                return 2
+        # codeql[py/clear-text-logging-sensitive-data]: validate-review-result
+        # emits only fixed schema identifiers, booleans, and fixed diagnostics.
+        print(output_json)
+        return exit_code
+
+    status = "PASS" if output["ok"] else "FAIL"
+    print(f"Reviewer handoff review result validation: {status}")
+    for error in output["errors"]:
+        print(f"  error [{error['check']}]: {error['message']}")
+    return exit_code
+
+
 def _run_validate_result(
     result_path: Path,
     *,
@@ -738,6 +1004,33 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
 
+    review_result = sub.add_parser(
+        "validate-review-result",
+        help=(
+            "Validate a saved reviewer handoff review result artifact "
+            "against its schema and review-boundary checks"
+        ),
+    )
+    review_result.add_argument(
+        "--result",
+        required=True,
+        type=Path,
+        help="Saved reviewer-handoff-review-result.json artifact",
+    )
+    review_result.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a machine-readable review result validation report as JSON",
+    )
+    review_result.add_argument(
+        "--output",
+        type=Path,
+        help=(
+            "Write the JSON review result validation report to this UTF-8 "
+            "file. Requires --json and does not suppress stdout JSON."
+        ),
+    )
+
     key_provenance = sub.add_parser(
         "validate-key-provenance",
         help=(
@@ -841,6 +1134,16 @@ def main(argv: Optional[list[str]] = None) -> int:
             parser.error("validate-result --output requires --json")
             return 2
         return _run_validate_result(
+            args.result,
+            json_output=args.json,
+            output_path=args.output,
+        )
+
+    if args.command == "validate-review-result":
+        if args.output is not None and not args.json:
+            parser.error("validate-review-result --output requires --json")
+            return 2
+        return _run_validate_review_result(
             args.result,
             json_output=args.json,
             output_path=args.output,

--- a/veritas_os/tests/test_evidence_bundle_cli.py
+++ b/veritas_os/tests/test_evidence_bundle_cli.py
@@ -1513,3 +1513,170 @@ def test_evidence_bundle_cli_validate_result_output_write_failure_is_clear(
     assert exit_code == 2
     assert captured.out == ""
     assert "failed to write validation report" in captured.err
+
+REVIEW_RESULT_SAMPLE_PATH = Path(
+    "samples/evidence_bundle/key_provenance_review/"
+    "reviewer-handoff-review-result.json"
+)
+REVIEW_RESULT_VALIDATED_SCHEMA_ID = (
+    "https://veritas-os.example/schemas/"
+    "reviewer_handoff_review_result.schema.json"
+)
+REVIEW_RESULT_VALIDATOR = "veritas-evidence-bundle validate-review-result"
+
+
+def _load_review_result_sample() -> dict[str, Any]:
+    """Load the placeholder reviewer handoff review result sample."""
+    return json.loads(REVIEW_RESULT_SAMPLE_PATH.read_text(encoding="utf-8"))
+
+
+def _write_review_result(tmp_path: Path, result: dict[str, Any]) -> Path:
+    """Write a reviewer handoff review result fixture for CLI tests."""
+    result_path = tmp_path / "reviewer-handoff-review-result.json"
+    result_path.write_text(json.dumps(result, indent=2), encoding="utf-8")
+    return result_path
+
+
+def _run_validate_review_result_json(result_path: Path, capsys) -> dict[str, Any]:
+    """Run validate-review-result --json and return parsed stdout."""
+    from veritas_os.cli.evidence_bundle import main
+
+    exit_code = main(
+        ["validate-review-result", "--result", str(result_path), "--json"]
+    )
+    captured = capsys.readouterr()
+    output = json.loads(captured.out)
+    assert captured.err == ""
+    if output["ok"]:
+        assert exit_code == 0
+    else:
+        assert exit_code == 1
+    return output
+
+
+def test_validate_review_result_valid_sample_passes(capsys) -> None:
+    """validate-review-result accepts the illustrative sample artifact."""
+    output = _run_validate_review_result_json(REVIEW_RESULT_SAMPLE_PATH, capsys)
+
+    assert output == {
+        "ok": True,
+        "result_schema_valid": True,
+        "decision_valid": True,
+        "limitations_acknowledged": True,
+        "artifacts_checked_shape_valid": True,
+        "forbidden_patterns_absent": True,
+        "validated_schema_id": REVIEW_RESULT_VALIDATED_SCHEMA_ID,
+        "validator": REVIEW_RESULT_VALIDATOR,
+        "errors": [],
+    }
+
+
+@pytest.mark.parametrize(
+    ("mutate", "failed_check"),
+    [
+        (
+            lambda result: result.__setitem__("decision", "APPROVED"),
+            "decision_valid",
+        ),
+        (
+            lambda result: result["limitations_acknowledged"].pop(
+                "does_not_create_trust"
+            ),
+            "limitations_acknowledged",
+        ),
+        (
+            lambda result: result["limitations_acknowledged"].__setitem__(
+                "does_not_create_trust",
+                False,
+            ),
+            "limitations_acknowledged",
+        ),
+        (
+            lambda result: result.__setitem__(
+                "artifacts_checked",
+                result["artifacts_checked"][:-1],
+            ),
+            "artifacts_checked_shape_valid",
+        ),
+        (
+            lambda result: result.__setitem__(
+                "notes",
+                "-----BEGIN PRIVATE KEY-----",
+            ),
+            "forbidden_patterns_absent",
+        ),
+        (
+            lambda result: result.__setitem__("notes", "stored under /tmp/example"),
+            "forbidden_patterns_absent",
+        ),
+        (
+            lambda result: result.__setitem__("notes", "RuntimeError: example"),
+            "forbidden_patterns_absent",
+        ),
+    ],
+)
+def test_validate_review_result_invalid_cases_fail_safely(
+    tmp_path,
+    capsys,
+    mutate,
+    failed_check: str,
+) -> None:
+    """Invalid review result cases fail with fixed diagnostics."""
+    result = _load_review_result_sample()
+    mutate(result)
+    result_path = _write_review_result(tmp_path, result)
+
+    output = _run_validate_review_result_json(result_path, capsys)
+
+    assert output["ok"] is False
+    assert output[failed_check] is False
+    assert any(error["check"] == failed_check for error in output["errors"])
+
+
+def test_validate_review_result_json_output_file_matches_stdout(tmp_path, capsys) -> None:
+    """--json --output writes the same machine-readable report as stdout."""
+    output_path = tmp_path / "reviewer-review-result-validation.json"
+
+    from veritas_os.cli.evidence_bundle import main
+
+    exit_code = main(
+        [
+            "validate-review-result",
+            "--result",
+            str(REVIEW_RESULT_SAMPLE_PATH),
+            "--json",
+            "--output",
+            str(output_path),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert captured.err == ""
+    assert json.loads(captured.out) == json.loads(
+        output_path.read_text(encoding="utf-8")
+    )
+
+
+def test_validate_review_result_diagnostics_do_not_leak_raw_values(
+    tmp_path,
+    capsys,
+) -> None:
+    """Diagnostics do not echo raw JSON values or raw paths from invalid input."""
+    raw_path = "/workspace/private/customer/path"
+    raw_value = "APPROVED_BY_CUSTOMER_PLACEHOLDER"
+    result = _load_review_result_sample()
+    result["decision"] = raw_value
+    result["notes"] = raw_path
+    result_path = _write_review_result(tmp_path, result)
+
+    from veritas_os.cli.evidence_bundle import main
+
+    exit_code = main(["validate-review-result", "--result", str(result_path)])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert raw_path not in captured.out
+    assert raw_value not in captured.out
+    assert str(result_path) not in captured.out
+    assert "Reviewer handoff review result validation: FAIL" in captured.out


### PR DESCRIPTION
### Motivation
- Provide a reviewer-facing CLI to validate saved `reviewer-handoff-review-result.json` artifacts against its JSON Schema and review-boundary expectations without leaking sensitive/raw input values. 
- Enforce reviewer decision enum, required artifact references, required boolean limitation acknowledgements, and forbid raw keys/fingerprints/paths/exceptions/secrets/customer data in review notes.

### Description
- Add `validate-review-result` subcommand to `veritas-evidence-bundle` with `--result`, `--json`, and `--output` options and `--output` gated to `--json`.
- Implement boolean-only validation helpers and safe checks in `veritas_os/cli/evidence_bundle.py`: schema loading/boolean-check wrappers, `REVIEW_RESULT_*` constants, forbidden-pattern regexes, `_contains_forbidden_review_result_pattern`, `_review_result_*` checks, `_validate_review_result_status`, and `_run_validate_review_result` that emit fixed-diagnostic JSON or human text without echoing raw inputs.
- Add tests to `veritas_os/tests/test_evidence_bundle_cli.py` exercising the sample pass case and multiple failure cases, `--json` output parity to file, and non-leakage of raw values in diagnostics.
- Update reviewer-facing docs and README files to mention the new `validate-review-result` command, its purpose, and explicit trust/certification boundaries (docs and README changes reference the command and sample usage).
- Files changed: `veritas_os/cli/evidence_bundle.py`, `veritas_os/tests/test_evidence_bundle_cli.py`, `docs/en/validation/reviewer-handoff-guide.md`, `docs/en/validation/reviewer-key-provenance-walkthrough.md`, `docs/en/validation/evidence-bundle-reviewer-checklist.md`, `README.md`, `README_JP.md`.

### Testing
- `ruff` static checks: `ruff check veritas_os/cli/evidence_bundle.py veritas_os/tests/test_evidence_bundle_cli.py` passed.
- Python compile: `/usr/bin/python3 -m py_compile veritas_os/cli/evidence_bundle.py veritas_os/tests/test_evidence_bundle_cli.py` passed.
- Ad-hoc CLI run: invoked `veritas_os.cli.evidence_bundle.main(['validate-review-result','--result', 'samples/evidence_bundle/key_provenance_review/reviewer-handoff-review-result.json','--json'])` (with a temporary `jsonschema` shim for the environment) and observed the expected JSON `ok: true` report for the sample.
- Unit test run via `pytest` was attempted but blocked by network/PyPI dependency fetch issues in the environment (virtualenv dependency resolution failed), so the newly added `pytest` cases were not executed in CI here; tests were added and validated syntactically.
- Notes: the implementation and tests were written to ensure diagnostics do not include raw file paths, raw JSON values, raw fingerprints, exception text, or raw schema validator messages; CI should run full `pytest` in a normal environment to confirm all tests pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a296d2d35648326a16a2a8d06909a9c)