### PR TITLE
Guard reviewer handoff quickstart command

### DIFF
--- a/.github/workflows/reviewer-evidence-packet-validation.yml
+++ b/.github/workflows/reviewer-evidence-packet-validation.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Check reviewer handoff sample regeneration
         run: python3 scripts/quality/check_reviewer_handoff_sample_regeneration.py
 
+      - name: Check reviewer handoff quickstart command
+        run: python3 scripts/quality/check_reviewer_handoff_quickstart_command.py
+
       - name: Export current Reviewer Evidence Packet
         run: >
           python3 scripts/demo/export_reviewer_evidence_packet.py

--- a/docs/en/validation/reviewer-handoff-sample-quickstart.md
+++ b/docs/en/validation/reviewer-handoff-sample-quickstart.md
@@ -61,7 +61,16 @@ JSON, and compares the regenerated reports with the repository copies. This
 keeps sample reports aligned with current CLI behavior and confirms that
 privacy-preserving diagnostics remain fixed and boolean-only.
 
-## 8. Understand trust boundaries
+## 8. Understand the quickstart command guard
+
+The package validation command in this quickstart is CI-guarded by
+`scripts/quality/check_reviewer_handoff_quickstart_command.py`. The guard checks
+that the documented command is present, runs the equivalent package validator
+without overwriting checked-in sample files, and validates the generated report
+against the public output contract. This reduces docs/CLI drift and validates
+sample command reproducibility only.
+
+## 9. Understand trust boundaries
 
 The reviewer handoff sample package validates sample structure and validation
 status only. It does not create trust, does not replace out-of-band public key

--- a/scripts/quality/check_reviewer_handoff_quickstart_command.py
+++ b/scripts/quality/check_reviewer_handoff_quickstart_command.py
@@ -153,7 +153,10 @@ def _schema_validation_failed(schema: dict[str, Any], payload: dict[str, Any]) -
     try:
         jsonschema.Draft202012Validator.check_schema(schema)
         jsonschema.Draft202012Validator(schema).validate(payload)
-    except jsonschema.exceptions.JsonSchemaException:
+    except (
+        jsonschema.exceptions.ValidationError,
+        jsonschema.exceptions.SchemaError,
+    ):
         return True
     return False
 

--- a/scripts/quality/check_reviewer_handoff_quickstart_command.py
+++ b/scripts/quality/check_reviewer_handoff_quickstart_command.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""Guard the reviewer handoff quickstart package validation command.
+
+The reviewer handoff quickstart is reviewer-facing documentation, so this guard
+checks that the documented one-command package validation flow stays executable
+and continues to emit the public validation-report contract. The generated
+report is written to a temporary directory so checked-in sample artifacts are not
+overwritten.
+
+Diagnostics are intentionally fixed and privacy-preserving. The checker must not
+print raw command output, raw JSON values, raw artifact contents, raw file paths,
+raw fingerprints, public keys, secrets, exception text, schema validator
+messages, customer data, or production data.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, TextIO
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+QUICKSTART_PATH = (
+    REPO_ROOT / "docs/en/validation/reviewer-handoff-sample-quickstart.md"
+)
+REPORT_SCHEMA_PATH = (
+    REPO_ROOT / "schemas/reviewer_handoff_package_validation_report.schema.json"
+)
+MANIFEST_INPUT = (
+    "samples/evidence_bundle/key_provenance_review/"
+    "sample-artifact-manifest.json"
+)
+BASE_DIR_INPUT = "samples/evidence_bundle/key_provenance_review"
+OUTPUT_REPORT = "reviewer-handoff-package-validation.json"
+
+DOCUMENTED_COMMAND = (
+    "veritas-evidence-bundle validate-reviewer-handoff-package "
+    f"--manifest {MANIFEST_INPUT} "
+    f"--base-dir {BASE_DIR_INPUT} "
+    f"--json --output {OUTPUT_REPORT}"
+)
+EXPECTED_REPORT_SCHEMA_ID = (
+    "https://veritas-os.example/schemas/"
+    "reviewer_handoff_package_validation_report.schema.json"
+)
+EXPECTED_VALIDATED_SCHEMA_ID = (
+    "https://veritas-os.example/schemas/"
+    "trusted_public_key_provenance_review_sample_manifest.schema.json"
+)
+EXPECTED_VALIDATOR = "veritas-evidence-bundle validate-reviewer-handoff-package"
+REQUIRED_BOOLEAN_FIELDS = frozenset(
+    {
+        "ok",
+        "manifest_schema_valid",
+        "artifacts_present",
+        "artifact_hashes_valid",
+        "artifact_schemas_valid",
+        "artifact_relationships_valid",
+        "forbidden_patterns_absent",
+    }
+)
+EXPECTED_PUBLIC_FIELDS = frozenset(
+    {
+        *REQUIRED_BOOLEAN_FIELDS,
+        "validated_schema_id",
+        "report_schema_id",
+        "validator",
+        "errors",
+    }
+)
+
+CommandRunner = Callable[[Path], int | None]
+
+
+@dataclass(frozen=True)
+class QuickstartCommandProblem:
+    """A fixed diagnostic for one quickstart command guard problem."""
+
+    check: str
+    message: str
+
+
+def _cli_command(output_path: Path) -> list[str]:
+    """Return the module-based command equivalent to the documented CLI."""
+    return [
+        sys.executable,
+        "-m",
+        "veritas_os.cli.evidence_bundle",
+        "validate-reviewer-handoff-package",
+        "--manifest",
+        MANIFEST_INPUT,
+        "--base-dir",
+        BASE_DIR_INPUT,
+        "--json",
+        "--output",
+        str(output_path),
+    ]
+
+
+def _run_documented_equivalent(output_path: Path) -> int | None:
+    """Run the documented command equivalent while suppressing raw output."""
+    try:
+        completed = subprocess.run(
+            _cli_command(output_path),
+            cwd=REPO_ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError:  # pragma: no cover - fixed diagnostic safety net.
+        return None
+    return completed.returncode
+
+
+def _read_text(path: Path) -> str | None:
+    """Read UTF-8 text, returning ``None`` without exposing exceptions."""
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+
+def _load_json_object(path: Path) -> dict[str, Any] | None:
+    """Load a JSON object, returning ``None`` for invalid or unsafe input."""
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return payload
+
+
+def _load_schema() -> dict[str, Any] | None:
+    """Load the reviewer handoff package validation report schema."""
+    return _load_json_object(REPORT_SCHEMA_PATH)
+
+
+def _schema_validation_failed(schema: dict[str, Any], payload: dict[str, Any]) -> bool:
+    """Return whether jsonschema rejects the payload when available."""
+    if importlib.util.find_spec("jsonschema") is None:
+        return False
+
+    import jsonschema
+
+    try:
+        jsonschema.Draft202012Validator.check_schema(schema)
+        jsonschema.Draft202012Validator(schema).validate(payload)
+    except jsonschema.exceptions.JsonSchemaException:
+        return True
+    return False
+
+
+def _error_items_invalid(payload: dict[str, Any]) -> bool:
+    """Return whether generated error items violate the public schema shape."""
+    errors = payload.get("errors")
+    if not isinstance(errors, list):
+        return True
+    allowed_checks = {
+        "manifest_json_valid",
+        "manifest_schema_valid",
+        "artifacts_present",
+        "artifact_hashes_valid",
+        "artifact_schemas_valid",
+        "artifact_relationships_valid",
+        "forbidden_patterns_absent",
+    }
+    for item in errors:
+        if not isinstance(item, dict):
+            return True
+        if set(item) != {"check", "path", "message"}:
+            return True
+        if item.get("check") not in allowed_checks:
+            return True
+        if item.get("path") != "$":
+            return True
+        message = item.get("message")
+        if not isinstance(message, str) or not message:
+            return True
+    return False
+
+
+def _validate_schema_contract(
+    payload: dict[str, Any],
+) -> list[QuickstartCommandProblem]:
+    """Return fixed diagnostics for output contract violations."""
+    problems: list[QuickstartCommandProblem] = []
+    schema = _load_schema()
+    if schema is None:
+        return [
+            QuickstartCommandProblem(
+                check="report_schema_available",
+                message="report schema is unavailable",
+            )
+        ]
+
+    if _schema_validation_failed(schema, payload) or _error_items_invalid(payload):
+        problems.append(
+            QuickstartCommandProblem(
+                check="report_schema_contract",
+                message="generated report does not match the public schema contract",
+            )
+        )
+
+    public_fields = set(payload)
+    if public_fields != EXPECTED_PUBLIC_FIELDS:
+        problems.append(
+            QuickstartCommandProblem(
+                check="public_fields",
+                message="generated report public fields do not match the contract",
+            )
+        )
+
+    if payload.get("report_schema_id") != EXPECTED_REPORT_SCHEMA_ID:
+        problems.append(
+            QuickstartCommandProblem(
+                check="report_schema_id",
+                message="generated report schema identifier is not accepted",
+            )
+        )
+    if payload.get("validated_schema_id") != EXPECTED_VALIDATED_SCHEMA_ID:
+        problems.append(
+            QuickstartCommandProblem(
+                check="validated_schema_id",
+                message="generated validated schema identifier is not accepted",
+            )
+        )
+    if payload.get("validator") != EXPECTED_VALIDATOR:
+        problems.append(
+            QuickstartCommandProblem(
+                check="validator",
+                message="generated validator identifier is not accepted",
+            )
+        )
+
+    for field in sorted(REQUIRED_BOOLEAN_FIELDS):
+        if not isinstance(payload.get(field), bool):
+            problems.append(
+                QuickstartCommandProblem(
+                    check="boolean_status_fields",
+                    message="generated status fields do not match the contract",
+                )
+            )
+            break
+
+    if not isinstance(payload.get("errors"), list):
+        problems.append(
+            QuickstartCommandProblem(
+                check="errors_array",
+                message="generated errors field does not match the contract",
+            )
+        )
+
+    return problems
+
+
+def _validate_quickstart_command(
+    quickstart_path: Path,
+) -> list[QuickstartCommandProblem]:
+    """Return diagnostics when the exact documented command is absent."""
+    content = _read_text(quickstart_path)
+    if content is None:
+        return [
+            QuickstartCommandProblem(
+                check="quickstart_available",
+                message="quickstart document is unavailable",
+            )
+        ]
+    if DOCUMENTED_COMMAND not in content:
+        return [
+            QuickstartCommandProblem(
+                check="documented_command",
+                message="quickstart command does not match the guarded command",
+            )
+        ]
+    return []
+
+
+def _format_problem(problem: QuickstartCommandProblem) -> str:
+    """Return a fixed, privacy-preserving diagnostic line."""
+    return f"- {problem.check}: {problem.message}"
+
+
+def run(
+    *,
+    quickstart_path: Path = QUICKSTART_PATH,
+    command_runner: CommandRunner | None = None,
+    stream: TextIO = sys.stdout,
+) -> int:
+    """Run the quickstart command guard and write fixed diagnostics."""
+    problems = _validate_quickstart_command(quickstart_path)
+    if problems:
+        print("reviewer handoff quickstart command guard: FAIL", file=stream)
+        for problem in problems:
+            print(_format_problem(problem), file=stream)
+        return 1
+
+    runner = command_runner or _run_documented_equivalent
+    with tempfile.TemporaryDirectory(prefix="veritas-reviewer-handoff-") as temp_name:
+        output_path = Path(temp_name) / OUTPUT_REPORT
+        exit_code = runner(output_path)
+        if exit_code not in (0, 1) or not output_path.is_file():
+            problems.append(
+                QuickstartCommandProblem(
+                    check="command_execution",
+                    message="documented command did not produce a validation report",
+                )
+            )
+        else:
+            payload = _load_json_object(output_path)
+            if payload is None:
+                problems.append(
+                    QuickstartCommandProblem(
+                        check="report_json",
+                        message="generated report is not valid JSON object output",
+                    )
+                )
+            else:
+                problems.extend(_validate_schema_contract(payload))
+
+    if not problems:
+        print("reviewer handoff quickstart command guard: PASS", file=stream)
+        return 0
+
+    print("reviewer handoff quickstart command guard: FAIL", file=stream)
+    for problem in problems:
+        print(_format_problem(problem), file=stream)
+    return 1
+
+
+def main() -> int:
+    """CLI entry point for reviewer handoff quickstart command checks."""
+    return run()
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised by CI.
+    raise SystemExit(main())

--- a/veritas_os/tests/test_reviewer_handoff_quickstart_command.py
+++ b/veritas_os/tests/test_reviewer_handoff_quickstart_command.py
@@ -1,0 +1,240 @@
+"""Tests for the reviewer handoff quickstart command guard."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import shutil
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.quality.check_reviewer_handoff_quickstart_command import (
+    DOCUMENTED_COMMAND,
+    EXPECTED_VALIDATED_SCHEMA_ID,
+    EXPECTED_VALIDATOR,
+    OUTPUT_REPORT,
+    QUICKSTART_PATH,
+    REQUIRED_BOOLEAN_FIELDS,
+    _cli_command,
+    run,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SAMPLE_REPORT = (
+    REPO_ROOT
+    / "samples/evidence_bundle/key_provenance_review"
+    / "reviewer-handoff-package-validation.json"
+)
+
+
+def _load_sample_report() -> dict[str, Any]:
+    """Load the checked-in package validation report as a baseline."""
+    payload = json.loads(SAMPLE_REPORT.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Write deterministic JSON for fake command output."""
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _quickstart_copy(tmp_path: Path) -> Path:
+    """Copy the quickstart to a temporary editable path."""
+    quickstart_path = tmp_path / "quickstart.md"
+    shutil.copyfile(QUICKSTART_PATH, quickstart_path)
+    return quickstart_path
+
+
+def _run_guard(
+    quickstart_path: Path,
+    payload: dict[str, Any] | None = None,
+) -> tuple[int, str]:
+    """Run the guard with a fake command runner and capture diagnostics."""
+    stream = io.StringIO()
+
+    def fake_runner(output_path: Path) -> int:
+        _write_json(output_path, payload or _load_sample_report())
+        return 0
+
+    code = run(
+        quickstart_path=quickstart_path,
+        command_runner=fake_runner,
+        stream=stream,
+    )
+    return code, stream.getvalue()
+
+
+def test_quickstart_command_guard_uses_module_cli_invocation(tmp_path: Path) -> None:
+    """The executable guard invokes the CLI through the Python module."""
+    output_path = tmp_path / OUTPUT_REPORT
+    command = _cli_command(output_path)
+
+    assert command[:3] == [sys.executable, "-m", "veritas_os.cli.evidence_bundle"]
+    assert command[3:5] == ["validate-reviewer-handoff-package", "--manifest"]
+    assert command[-2:] == ["--output", str(output_path)]
+
+
+def test_quickstart_command_guard_accepts_current_quickstart() -> None:
+    """The current reviewer quickstart command is executable and contract-valid."""
+    if importlib.util.find_spec("jsonschema") is None:
+        pytest.skip("jsonschema is required by the evidence-bundle CLI")
+    stream = io.StringIO()
+    code = run(stream=stream)
+
+    assert code == 0
+    assert "PASS" in stream.getvalue()
+
+
+def test_quickstart_command_guard_rejects_missing_command(tmp_path: Path) -> None:
+    """A quickstart without the guarded command fails before execution."""
+    quickstart_path = tmp_path / "quickstart.md"
+    quickstart_path.write_text(
+        "# Quickstart\n\nNo guarded command here.\n",
+        encoding="utf-8",
+    )
+
+    code, output = _run_guard(quickstart_path)
+
+    assert code == 1
+    assert "documented_command" in output
+
+
+def test_quickstart_command_guard_rejects_changed_command_path(
+    tmp_path: Path,
+) -> None:
+    """Changing the documented manifest path fails the exact command guard."""
+    quickstart_path = _quickstart_copy(tmp_path)
+    content = quickstart_path.read_text(encoding="utf-8")
+    quickstart_path.write_text(
+        content.replace(
+            "samples/evidence_bundle/key_provenance_review/"
+            "sample-artifact-manifest.json",
+            "samples/evidence_bundle/key_provenance_review/changed-manifest.json",
+        ),
+        encoding="utf-8",
+    )
+
+    code, output = _run_guard(quickstart_path)
+
+    assert code == 1
+    assert "documented_command" in output
+
+
+def test_quickstart_command_guard_rejects_missing_report_schema_id(
+    tmp_path: Path,
+) -> None:
+    """Generated output without report_schema_id fails the contract guard."""
+    payload = _load_sample_report()
+    payload.pop("report_schema_id")
+
+    code, output = _run_guard(_quickstart_copy(tmp_path), payload)
+
+    assert code == 1
+    assert "report_schema_id" in output
+
+
+def test_quickstart_command_guard_rejects_wrong_validator(tmp_path: Path) -> None:
+    """Generated output with a wrong validator identifier fails."""
+    payload = _load_sample_report()
+    payload["validator"] = "placeholder-validator"
+
+    code, output = _run_guard(_quickstart_copy(tmp_path), payload)
+
+    assert code == 1
+    assert "validator" in output
+    assert EXPECTED_VALIDATOR not in output
+
+
+def test_quickstart_command_guard_rejects_wrong_validated_schema_id(
+    tmp_path: Path,
+) -> None:
+    """Generated output with a wrong validated schema identifier fails."""
+    payload = _load_sample_report()
+    payload["validated_schema_id"] = "https://veritas-os.example/schemas/changed.json"
+
+    code, output = _run_guard(_quickstart_copy(tmp_path), payload)
+
+    assert code == 1
+    assert "validated_schema_id" in output
+    assert EXPECTED_VALIDATED_SCHEMA_ID not in output
+
+
+def test_quickstart_command_guard_rejects_non_boolean_status_fields(
+    tmp_path: Path,
+) -> None:
+    """Generated output with non-boolean status fields fails."""
+    payload = _load_sample_report()
+    for field in REQUIRED_BOOLEAN_FIELDS:
+        payload[field] = "true"
+        break
+
+    code, output = _run_guard(_quickstart_copy(tmp_path), payload)
+
+    assert code == 1
+    assert "boolean_status_fields" in output
+
+
+def test_quickstart_command_guard_rejects_unknown_public_field(
+    tmp_path: Path,
+) -> None:
+    """Generated output with an unknown public field fails."""
+    payload = _load_sample_report()
+    payload["unexpected_public_field"] = True
+
+    code, output = _run_guard(_quickstart_copy(tmp_path), payload)
+
+    assert code == 1
+    assert "public_fields" in output
+    assert "unexpected_public_field" not in output
+
+
+def test_quickstart_command_guard_rejects_non_array_errors(
+    tmp_path: Path,
+) -> None:
+    """Generated output with a non-array errors field fails."""
+    payload = _load_sample_report()
+    payload["errors"] = {"message": "placeholder"}
+
+    code, output = _run_guard(_quickstart_copy(tmp_path), payload)
+
+    assert code == 1
+    assert "errors_array" in output
+
+
+def test_quickstart_command_guard_diagnostics_do_not_leak_raw_values(
+    tmp_path: Path,
+) -> None:
+    """Failure diagnostics omit raw output, paths, secrets, and validator text."""
+    quickstart_path = _quickstart_copy(tmp_path)
+    payload = _load_sample_report()
+    leak_markers = (
+        "raw-command-stdout-customer-production-data",
+        "raw-command-stderr-secret-value",
+        "raw-json-value-customer-production-data",
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        "-----BEGIN PUBLIC KEY-----",
+        "/tmp/veritas/local/absolute/path",
+        "Traceback",
+        "ValidationError",
+        "schema validator says secret detail",
+        "customer data",
+        "production data",
+    )
+    payload["validator"] = leak_markers[2]
+    payload["errors"] = [
+        {"check": "manifest_json_valid", "path": "$", "message": marker}
+        for marker in leak_markers[3:]
+    ]
+
+    code, output = _run_guard(quickstart_path, payload)
+
+    assert code == 1
+    for marker in leak_markers:
+        assert marker not in output
+    assert str(tmp_path) not in output
+    assert DOCUMENTED_COMMAND not in output


### PR DESCRIPTION
### Motivation
- Prevent documentation drift by ensuring the one-command quickstart in `docs/en/validation/reviewer-handoff-sample-quickstart.md` remains executable and emits the expected public validation-report contract. 
- Provide an automated CI-level guard that verifies the documented command is present, executable, and produces the expected public report shape without overwriting checked-in sample artifacts. 
- Maintain privacy and safety by emitting fixed, artifact-name-only diagnostics and avoiding any raw output, paths, keys, fingerprints, secrets, or exception text in diagnostics.  

### Description
- Add a new checker `scripts/quality/check_reviewer_handoff_quickstart_command.py` that looks for the exact documented quickstart command, runs the equivalent `python -m veritas_os.cli.evidence_bundle validate-reviewer-handoff-package` invocation writing its output to a temporary file, and validates the generated JSON against `schemas/reviewer_handoff_package_validation_report.schema.json` and a set of explicit public-field expectations. 
- Add tests `veritas_os/tests/test_reviewer_handoff_quickstart_command.py` that cover the success path and the failure modes requested (missing command, changed manifest path, missing/incorrect `report_schema_id`, wrong `validator`, wrong `validated_schema_id`, non-boolean status fields, unknown public fields, non-array `errors`, and diagnostics leakage checks). 
- Wire the checker into the Reviewer Evidence Packet Validation workflow in `.github/workflows/reviewer-evidence-packet-validation.yml` directly after the existing reviewer handoff sample regeneration step. 
- Update the quickstart doc `docs/en/validation/reviewer-handoff-sample-quickstart.md` to mention the CI guard and clarify that it verifies command presence, executability, and output contract only. 

### Testing
- Ran `python3 -m py_compile` on the new checker and its test module which succeeded. 
- Ran the existing docs guard `python3 scripts/quality/check_evidence_bundle_reviewer_docs.py` which passed. 
- Performed a smoke run of the new guard using a fake `command_runner` that returns the checked-in sample report, and the guard returned `PASS` (new guard logic and tests exercised). 
- Attempted to execute the real CLI path locally but the container lacked `jsonschema` (and full project deps), causing the direct execution path to fail in this environment; CI installs `veritas_os/requirements-core.txt` before running the workflow so the full execution will be validated in CI. 
- Note: `pytest` runs could not be executed end-to-end in this container due to missing test/runtime dependencies (for example `pytest`, `pydantic`) but the PR includes the test file and CI will run the test matrix and enforce coverage and dependency checks. 

Security note: the checker runs the CLI equivalent but writes output to a temporary directory and enforces fixed privacy-preserving diagnostics; reviewers should be aware that the check depends on project runtime dependencies (installed in CI) and that running the CLI locally may require sandboxing or review if executed in a production environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a39b090d48326b76d4899e5823e33)