### PR TITLE
docs: define LLM-to-Control-Plane contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ For a concise business-facing overview, see [Enterprise Value Brief](docs/en/pos
 13. [External Reviewer Quickstart v1](docs/en/demo/external-reviewer-quickstart.md)
 14. [External Reviewer Artifact Index v1](docs/en/demo/external-reviewer-artifact-index.md)
 15. Bind Coverage Registry v1 (local/offline): docs/en/architecture/bind-coverage-registry.md
+16. LLM-to-Control-Plane Contract: docs/en/architecture/llm-to-control-plane-contract.md
+    - 日本語補助版: docs/ja/architecture/llm-to-control-plane-contract.md
 
 Boundary:
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -56,6 +56,8 @@ VERITAS OS は **Decision Governance and Bind-Boundary Control Plane for AI Agen
 13. [External Reviewer Quickstart v1](docs/en/demo/external-reviewer-quickstart.md)
 14. [External Reviewer Artifact Index v1](docs/en/demo/external-reviewer-artifact-index.md)
 15. Bind Coverage Registry v1（local/offline）: docs/en/architecture/bind-coverage-registry.md
+16. LLM-to-Control-Plane Contract（LLMと制御プレーンの責任分界）: docs/ja/architecture/llm-to-control-plane-contract.md
+    - English: docs/en/architecture/llm-to-control-plane-contract.md
 
 境界条件:
 

--- a/docs/en/architecture/llm-to-control-plane-contract.md
+++ b/docs/en/architecture/llm-to-control-plane-contract.md
@@ -1,0 +1,122 @@
+# LLM-to-Control-Plane Contract
+
+## 1. Purpose
+
+This document defines the contract boundary between LLM-generated outputs and the non-LLM governance components in VERITAS.
+
+VERITAS treats LLMs as candidate generators, not final governance authorities. An LLM may propose an action, summarize context, or provide candidate reasoning, but VERITAS does not rely on LLM self-auditing and does not ask the LLM to govern itself.
+
+Before an execution candidate can become an `ExecutionIntent`, VERITAS requires structured, inspectable, policy-relevant fields that can be evaluated by the external VERITAS control plane.
+
+## 2. Problem
+
+LLM outputs and governance control planes have different operating models:
+
+- LLMs often produce natural language, ambiguous reasoning, or multiple possible actions.
+- Non-LLM governance components require structured, typed, policy-relevant data.
+- If this boundary is not explicit, external reviewers may reasonably worry that VERITAS is still relying on LLM interpretation.
+- Natural language should not be treated as directly executable governance input.
+
+The purpose of this contract is to make the pre-`ExecutionIntent` boundary explicit. LLM output must be converted into a structured decision candidate, validated, and either rejected, sent to human review, or promoted into an `ExecutionIntent` for downstream bind adjudication.
+
+## 3. Contract flow
+
+```mermaid
+flowchart TD
+    A[LLM Output / Proposed Action] --> B[DecisionCandidate]
+    B --> C[Schema Validation]
+    C --> D{Valid, complete, and unambiguous?}
+    D -->|No| E[Fail-Closed Refusal or Human Review]
+    D -->|Yes| F[ExecutionIntent]
+    F --> G[Bind Adjudication]
+    G --> H{Allow / Block / Escalate}
+    H --> I[BindReceipt]
+    I --> J[Evidence Chain / Reviewer Packet]
+```
+
+The key boundary is between unstructured LLM output and the structured `DecisionCandidate`. The LLM may inform the candidate, but the non-LLM control plane validates whether the candidate is complete, unambiguous, and eligible for promotion.
+
+## 4. Candidate fields
+
+`DecisionCandidate` is a proposed v1 conceptual structure. This PR documents the contract only; it does not add a runtime schema or change API behavior.
+
+A conceptual `DecisionCandidate` should include fields such as:
+
+- `candidate_id`
+- `source_model`
+- `source_trace_ref`
+- `candidate_type`
+- `action_type`
+- `actor_identity`
+- `target_system`
+- `target_resource`
+- `intended_action`
+- `required_authority`
+- `required_human_approval`
+- `risk_level`
+- `evidence_refs`
+- `policy_context_refs`
+- `ambiguity_flags`
+- `missing_required_fields`
+- `candidate_rationale_ref`
+
+The rationale may be useful for reviewer context, but it is not a substitute for structured fields. A candidate that only contains natural-language reasoning is not sufficient for non-LLM governance evaluation.
+
+## 5. Promotion rule
+
+A `DecisionCandidate` may become an `ExecutionIntent` only when all of the following are true:
+
+- Required fields are present.
+- Target system and target resource are explicit.
+- Intended action is explicit.
+- Actor identity is explicit or resolvable.
+- Required authority and approval requirements are represented.
+- Ambiguity flags are empty or explicitly resolved.
+- Missing required fields are empty.
+- Policy-relevant fields are typed enough for non-LLM evaluation.
+
+Promotion is not a statement that execution is allowed. Promotion only means the candidate is structured enough to enter downstream bind adjudication.
+
+## 6. Fail-closed rule
+
+A candidate must not be promoted to `ExecutionIntent` when any of the following are true:
+
+- Required fields are missing.
+- The action is ambiguous.
+- Target resource is unclear.
+- Actor identity is unknown.
+- Authority requirements cannot be determined.
+- Human approval requirement is unclear.
+- Risk classification is indeterminate for a regulated or high-impact action.
+- The candidate depends only on natural-language rationale without structured fields.
+
+In these cases, the correct outcome is one of:
+
+- fail-closed refusal;
+- `human_review_required`; or
+- reconstruction of the candidate from clearer structured input.
+
+## 7. Relationship to existing VERITAS components
+
+This contract connects to existing VERITAS governance artifacts and checks as follows:
+
+- `ExecutionIntent` remains the downstream execution attempt descriptor.
+- `DecisionCandidate` is the pre-`ExecutionIntent` candidate contract.
+- `BindReceipt` records the bind adjudication result and supporting decision evidence.
+- `BindAdapterContract` defines how effect-bearing adapters expose bind-relevant operation metadata.
+- Authority Evidence supplies structured evidence about whether the actor has required authority.
+- Human Approval Receipt supplies structured evidence about required human approval.
+- Risk, Constraint, and Drift checks evaluate policy-relevant properties after the candidate has been structured enough for non-LLM evaluation.
+- Evidence Chain Manifest and Evidence Chain Verification connect governance artifacts into an auditable local/offline chain.
+- Reviewer Evidence Packet packages selected evidence for external inspection.
+
+Bind does not manufacture legitimacy. Invalid, ambiguous, or incomplete candidates should not be made bind-eligible merely because an LLM produced plausible language or rationale.
+
+## 8. Boundary and limitations
+
+- This is not legal advice.
+- This is not regulatory approval.
+- This is not third-party certification.
+- This does not claim live IAM, IdP, SaaS, bank, sanctions, or customer-system integration.
+- This PR documents the contract; it does not implement production-grade LLM extraction, enterprise workflow integration, or live authority-source validation.
+- Fixture-backed or local/offline evidence must not be presented as live production integration.

--- a/docs/ja/architecture/llm-to-control-plane-contract.md
+++ b/docs/ja/architecture/llm-to-control-plane-contract.md
@@ -1,0 +1,122 @@
+# LLM-to-Control-Plane Contract（LLMと制御プレーンの責任分界）
+
+## 1. 目的
+
+この文書は、LLM が生成する出力と、VERITAS の非 LLM ガバナンスコンポーネントとの境界契約を定義します。
+
+VERITAS における LLM は、最終判断者ではなく候補生成者です。LLM は行動案、文脈の要約、候補となる理由付けを提示できますが、VERITAS は LLM に自己監査させる仕組みではありません。最終的な実行前ガバナンス判断は、LLM の外側にある VERITAS の制御プレーンが担います。
+
+実行候補が `ExecutionIntent` になる前に、VERITAS は構造化され、検査可能で、ポリシー評価に必要なフィールドを要求します。
+
+## 2. 問題
+
+LLM 出力とガバナンス制御プレーンには、次のようなインピーダンスミスマッチがあります。
+
+- LLM は自然言語、曖昧な理由付け、複数の可能な行動を出力しがちです。
+- 非 LLM のガバナンスコンポーネントは、構造化され、型付けされ、ポリシーに関係するデータを必要とします。
+- この境界が明示されていないと、外部レビュアーは VERITAS が依然として LLM の解釈に依存しているのではないかと懸念できます。
+- 自然言語をそのまま実行可能なガバナンス入力として扱ってはいけません。
+
+この契約の目的は、`ExecutionIntent` より前の境界を明確にすることです。LLM 出力は `DecisionCandidate` として構造化され、検証され、拒否、人間レビュー、または `ExecutionIntent` への昇格のいずれかに進みます。
+
+## 3. 契約フロー
+
+```mermaid
+flowchart TD
+    A[LLM Output / Proposed Action] --> B[DecisionCandidate]
+    B --> C[Schema Validation]
+    C --> D{Valid, complete, and unambiguous?}
+    D -->|No| E[Fail-Closed Refusal or Human Review]
+    D -->|Yes| F[ExecutionIntent]
+    F --> G[Bind Adjudication]
+    G --> H{Allow / Block / Escalate}
+    H --> I[BindReceipt]
+    I --> J[Evidence Chain / Reviewer Packet]
+```
+
+重要な境界は、非構造の LLM 出力と、構造化された `DecisionCandidate` の間にあります。LLM は候補作成に情報を与えることはできますが、その候補が完全で、曖昧でなく、昇格可能かどうかは非 LLM の制御プレーンが検証します。
+
+## 4. 候補フィールド
+
+`DecisionCandidate` は v1 の概念的な構造案です。この PR は契約を文書化するだけであり、ランタイムスキーマや API 挙動は変更しません。
+
+概念的な `DecisionCandidate` には、次のようなフィールドを含めます。
+
+- `candidate_id`
+- `source_model`
+- `source_trace_ref`
+- `candidate_type`
+- `action_type`
+- `actor_identity`
+- `target_system`
+- `target_resource`
+- `intended_action`
+- `required_authority`
+- `required_human_approval`
+- `risk_level`
+- `evidence_refs`
+- `policy_context_refs`
+- `ambiguity_flags`
+- `missing_required_fields`
+- `candidate_rationale_ref`
+
+理由付けはレビュアーの文脈理解には役立ちますが、構造化フィールドの代替にはなりません。自然言語の理由だけに依存する候補は、非 LLM ガバナンス評価の入力として十分ではありません。
+
+## 5. 昇格ルール
+
+`DecisionCandidate` は、次の条件をすべて満たす場合にのみ `ExecutionIntent` へ昇格できます。
+
+- 必須フィールドが存在する。
+- 対象システムと対象リソースが明示されている。
+- 意図された行動が明示されている。
+- 行為者の identity が明示されている、または解決可能である。
+- 必要な権限と人間承認の要件が表現されている。
+- `ambiguity_flags` が空、または明示的に解決済みである。
+- `missing_required_fields` が空である。
+- ポリシーに関係するフィールドが、非 LLM 評価に十分な程度に型付けされている。
+
+昇格は、実行を許可するという意味ではありません。昇格は、その候補が downstream の bind adjudication に入れる程度に構造化されている、という意味だけです。
+
+## 6. Fail-closed ルール
+
+次のいずれかに該当する候補は、`ExecutionIntent` に昇格してはいけません。
+
+- 必須フィールドが不足している。
+- 行動が曖昧である。
+- 対象リソースが不明確である。
+- 行為者 identity が不明である。
+- 権限要件を判断できない。
+- 人間承認の要否が不明確である。
+- 規制対象または高影響アクションについて、リスク分類が不定である。
+- 構造化フィールドではなく自然言語の理由付けだけに依存している。
+
+この場合の正しい結果は、次のいずれかです。
+
+- fail-closed refusal;
+- `human_review_required`; または
+- より明確な構造化入力から候補を再構築すること。
+
+## 7. 既存の VERITAS コンポーネントとの関係
+
+この契約は、既存の VERITAS ガバナンス成果物やチェックと次のようにつながります。
+
+- `ExecutionIntent` は downstream の実行試行記述子のままです。
+- `DecisionCandidate` は `ExecutionIntent` より前の候補契約です。
+- `BindReceipt` は bind adjudication の結果と関連する判断証跡を記録します。
+- `BindAdapterContract` は effect-bearing adapter が bind に必要な操作メタデータを公開する方法を定義します。
+- Authority Evidence は、行為者が必要な権限を持つかどうかの構造化証拠を提供します。
+- Human Approval Receipt は、必要な人間承認に関する構造化証拠を提供します。
+- Risk / Constraint / Drift checks は、候補が非 LLM 評価に十分な形へ構造化された後で、ポリシー関連の性質を評価します。
+- Evidence Chain Manifest / Verification は、ガバナンス成果物を監査可能な local/offline chain として接続します。
+- Reviewer Evidence Packet は、外部レビュー向けに選択された証跡をまとめます。
+
+Bind は legitimacy を作り出すものではありません。LLM がもっともらしい自然言語や理由付けを出しただけで、無効、曖昧、または不完全な候補を bind 対象にしてはいけません。
+
+## 8. 境界と制限
+
+- これは法的助言ではありません。
+- これは規制当局による承認ではありません。
+- これは第三者認証ではありません。
+- 本番の IAM、IdP、SaaS、銀行、制裁リスト、顧客システムとのライブ統合を主張しません。
+- この PR は設計契約の文書化であり、本番グレードの LLM 抽出、企業ワークフロー統合、外部権限ソースのライブ検証を実装するものではありません。
+- fixture-backed または local/offline の証跡を、本番ライブ統合として提示してはいけません。


### PR DESCRIPTION
### Motivation

- Make the pre-`ExecutionIntent` boundary explicit by documenting how LLM-generated proposals must be converted into structured, inspectable decision candidates before any governance or execution attempt. 
- Clarify that LLMs are candidate generators, not final governance authorities, and that VERITAS does not rely on LLM self-auditing. 
- Provide reviewer-facing guidance to avoid treating natural-language output as directly executable governance input and to enforce fail-closed behavior for ambiguous or incomplete candidates.

### Description

- Added an English architecture note at `docs/en/architecture/llm-to-control-plane-contract.md` that defines the contract flow (LLM output → `DecisionCandidate` → schema validation → fail-closed/human review or promote to `ExecutionIntent` → bind adjudication → `BindReceipt` / Evidence Chain), including a Mermaid flowchart. 
- Added a Japanese support document at `docs/ja/architecture/llm-to-control-plane-contract.md` that conveys the same concepts in natural Japanese and reproduces the boundary, promotion, and fail-closed rules. 
- Linked the new documents from the README navigation in `README.md` and `README_JP.md`, and emphasized that this is documentation-only with explicit boundary and limitation language (no runtime/API/schema/source-folder changes and no claims of live integrations or regulatory approval). 

### Testing

- Ran the bilingual documentation validator with `python scripts/quality/check_bilingual_docs.py`, which completed successfully. 
- Ran basic Markdown/link/format checks (`git diff --check` / repository link validation as part of docs checks), which found no issues. 
- Confirmed the change is documentation-only and did not modify runtime code, API schemas, or move source folders.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2cd84020908326be33be7dd7aad391)