### PR TITLE
feat: include DecisionCandidate refusal artifacts in reviewer evidence

### DIFF
--- a/docs/en/architecture/llm-to-control-plane-contract.md
+++ b/docs/en/architecture/llm-to-control-plane-contract.md
@@ -74,6 +74,8 @@ did not become an `ExecutionIntent`; it is pre-`ExecutionIntent` evidence for
 reviewer inspection of fail-closed or human-review-required outcomes. It is not
 a `BindReceipt`, does not mean execution was attempted, and does not perform
 live LLM extraction, live authority-source validation, or bind adjudication.
+Reviewer-facing packet examples for this artifact remain local/offline
+fixture-backed evidence unless a later PR explicitly integrates them.
 
 ## 5. Promotion rule
 

--- a/docs/en/demo/external-reviewer-artifact-index.md
+++ b/docs/en/demo/external-reviewer-artifact-index.md
@@ -20,6 +20,8 @@ Key local/offline reviewer-facing artifacts:
   - verifies reviewer-evidence-artifact-manifest.json against actual artifact files, hashes, and sizes
 - `docs/en/demo/fixtures/reviewer-evidence-packet-saas-permission-change-v1.json`
   - checked-in golden fixture
+- `docs/en/demo/fixtures/reviewer-evidence-packet-decision-candidate-refusal-v1.json`
+  - local/offline reviewer fixture showing a `DecisionCandidateRefusalArtifact` as pre-`ExecutionIntent` evidence; it is not a `BindReceipt`, does not imply execution was attempted, and does not wire into `/v1/decide`, TrustLog, bind adjudication, adapters, live LLM extraction, live authority-source validation, or live IAM/IdP/SaaS/bank/sanctions/customer-system integrations
 - `docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json`
   - JSON Schema contract
 - `docs/en/demo/schemas/intervention-actionability-map-v0.schema.json`

--- a/docs/en/demo/external-reviewer-quickstart.md
+++ b/docs/en/demo/external-reviewer-quickstart.md
@@ -24,6 +24,8 @@ The current review path demonstrates:
 - EvidenceChainManifest linking artifacts
 - EvidenceChainVerifier checking manifest/artifact consistency
 - Reviewer Evidence Packet packaging the result
+- optional `DecisionCandidateRefusalArtifact` reviewer evidence for local/offline
+  pre-`ExecutionIntent` candidates that fail closed or require human review
 - golden fixture, schema, and validation report checks
 
 ## Fast path
@@ -51,6 +53,13 @@ Use this 10–15 minute path for a reviewer-facing inspection:
    `scripts/demo/saas_permission_change_governed_demo.py`
 7. Optionally review Evaluation Governance artifacts, if present. These attachments are optional in v1, non-enforcing, and useful for architecture-hardening review without changing runtime admissibility.
    A synthetic example packet is available at `docs/en/demo/examples/reviewer-evidence-packet-with-evaluation-governance-v1.json`; schema validation does not require the referenced artifact files to exist.
+8. Optionally review the local/offline DecisionCandidate refusal fixture:
+   `docs/en/demo/fixtures/reviewer-evidence-packet-decision-candidate-refusal-v1.json`.
+   The refusal artifact records why a candidate did not become an
+   `ExecutionIntent`; it is not a `BindReceipt`, does not imply execution was
+   attempted, and does not perform `/v1/decide` wiring, TrustLog writes, bind
+   adjudication, adapter calls, live LLM extraction, live authority-source
+   validation, or live IAM/IdP/SaaS/bank/sanctions/customer-system integration.
 
 ## Evaluation Governance offline reviewer demo
 

--- a/docs/en/demo/fixtures/reviewer-evidence-packet-decision-candidate-refusal-v1.json
+++ b/docs/en/demo/fixtures/reviewer-evidence-packet-decision-candidate-refusal-v1.json
@@ -1,0 +1,727 @@
+{
+  "aggregate_summary": {
+    "blocked_cases": 4,
+    "committed_cases": 1,
+    "failed_chains": 0,
+    "incomplete_chains": 0,
+    "indeterminate_chains": 0,
+    "local_offline_only": true,
+    "passed_cases": 5,
+    "total_cases": 5,
+    "verified_chains": 5
+  },
+  "boundary_note": "local/offline fixture only; pre-ExecutionIntent evidence; no /v1/decide wiring, live LLM extraction, live SaaS/IAM/IdP/bank/sanctions/customer-system integration, bind adjudication, BindReceipt, TrustLog append, adapter call, authority-source validation, or execution attempt",
+  "cases": [
+    {
+      "actual_outcome": "block",
+      "authority_validation_status": "fail",
+      "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+      "case_id": "missing_authority",
+      "evidence_chain_manifest_summary": {
+        "action_class": "permission_change",
+        "authority_evidence_hash": null,
+        "authority_evidence_id": null,
+        "bind_coverage_operation_id": "saas_permission_change_demo",
+        "bind_receipt_hash": null,
+        "bind_receipt_id": null,
+        "chain_status": "blocked",
+        "decision_id": "decision-saas-001",
+        "execution_intent_id": "intent-saas-001",
+        "final_outcome": "block",
+        "generated_at": "2026-04-26T00:00:00+00:00",
+        "human_approval_receipt_hash": "22c26614740e5a495beea2a46f1e8a498303e8c50d96a2f25a2a8e788d1c4547",
+        "human_approval_receipt_id": "har-saas-001",
+        "manifest_hash": "66e0d0a277ca167b9021191e721a87c19edffa954f70d671e35bfe434613db8e",
+        "manifest_id": "ecm-saas-permission-change-missing_authority",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "missing_links": [
+          "authority_evidence_hash"
+        ],
+        "observed_effects_summary": [],
+        "operation_id": "saas-permission-change-missing_authority",
+        "outcome_receipt_hash": "8f28c45ec0f7efd2f8f4cd25b02fe46450c012b10a06ed715d9ed25f899ea71f",
+        "outcome_receipt_id": "outcome-saas-permission-change-missing_authority",
+        "refusal_basis": [
+          "authority_expired_or_missing",
+          "authority_invalid",
+          "authority_missing"
+        ],
+        "requested_scope": [
+          "saas:grant_admin"
+        ],
+        "target_resource": "contractor:external.user@example.test",
+        "target_system": "mock_saas_directory"
+      },
+      "evidence_chain_verification_summary": {
+        "decision_id": "decision-saas-001",
+        "execution_intent_id": "intent-saas-001",
+        "failure_reasons": [],
+        "is_valid": true,
+        "manifest_hash_matches": true,
+        "manifest_id": "ecm-saas-permission-change-missing_authority",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "mismatched_links": [],
+        "missing_links": [
+          "authority_evidence_hash"
+        ],
+        "operation_id": "saas-permission-change-missing_authority",
+        "recomputed_manifest_hash": "66e0d0a277ca167b9021191e721a87c19edffa954f70d671e35bfe434613db8e",
+        "verification_status": "verified",
+        "verified_at": "2026-04-26T00:00:00+00:00",
+        "verified_links": [
+          "bind_coverage_operation_id",
+          "human_approval_receipt_hash",
+          "manifest_hash",
+          "outcome_receipt_hash"
+        ]
+      },
+      "expected_outcome": "block",
+      "failure_reasons": [
+        "authority_expired_or_missing",
+        "authority_invalid",
+        "authority_missing"
+      ],
+      "human_approval_summary": {
+        "approval_receipt_id": "har-saas-001",
+        "approved": true,
+        "approved_scope": [
+          "saas:grant_admin"
+        ],
+        "approver_identity": "human:manager.alex",
+        "approver_role": "engineering_manager",
+        "failure_reasons": [],
+        "receipt_hash_present": true
+      },
+      "outcome_receipt_summary": {
+        "action_class": "permission_change",
+        "bind_receipt_id": null,
+        "blocked": true,
+        "committed": false,
+        "decision_id": "decision-saas-001",
+        "escalated": false,
+        "evaluated_at": "2026-04-26T00:00:00+00:00",
+        "execution_intent_id": "intent-saas-001",
+        "failure_reasons": [
+          "authority_expired_or_missing",
+          "authority_invalid",
+          "authority_missing"
+        ],
+        "final_outcome": "block",
+        "intended_action": "grant_admin_permission",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "observed_effects": [],
+        "operation_id": "saas-permission-change-missing_authority",
+        "outcome_hash": "8f28c45ec0f7efd2f8f4cd25b02fe46450c012b10a06ed715d9ed25f899ea71f",
+        "outcome_receipt_id": "outcome-saas-permission-change-missing_authority",
+        "post_state_fingerprint": null,
+        "postcondition_status": "skipped",
+        "pre_state_fingerprint": null,
+        "requested_scope": [
+          "saas:grant_admin"
+        ],
+        "rollback_status": null,
+        "rolled_back": false,
+        "target_resource": "contractor:external.user@example.test",
+        "target_system": "mock_saas_directory"
+      },
+      "passed": true,
+      "refusal_basis": [
+        "authority_expired_or_missing",
+        "authority_invalid",
+        "authority_missing"
+      ],
+      "requested_scope": [
+        "saas:grant_admin"
+      ],
+      "reviewer_interpretation": "The local/offline fixture blocked because AuthorityEvidence was missing.",
+      "runtime_recommended_outcome": "block",
+      "target_resource": "contractor:external.user@example.test",
+      "target_system": "mock_saas_directory"
+    },
+    {
+      "actual_outcome": "block",
+      "authority_validation_status": "fail",
+      "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+      "case_id": "missing_human_approval",
+      "evidence_chain_manifest_summary": {
+        "action_class": "permission_change",
+        "authority_evidence_hash": "86bd3a69cb781db382f94e0a87e6a36aaa203d934403a23ac36e8856a9d5e940",
+        "authority_evidence_id": "aev-saas-001",
+        "bind_coverage_operation_id": "saas_permission_change_demo",
+        "bind_receipt_hash": null,
+        "bind_receipt_id": null,
+        "chain_status": "blocked",
+        "decision_id": "decision-saas-001",
+        "execution_intent_id": "intent-saas-001",
+        "final_outcome": "block",
+        "generated_at": "2026-04-26T00:00:00+00:00",
+        "human_approval_receipt_hash": null,
+        "human_approval_receipt_id": null,
+        "manifest_hash": "de5f807be0e901dc94a3968a831a30485aa059dc04722e479771199d1226477b",
+        "manifest_id": "ecm-saas-permission-change-missing_human_approval",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "missing_links": [
+          "human_approval_receipt_hash"
+        ],
+        "observed_effects_summary": [],
+        "operation_id": "saas-permission-change-missing_human_approval",
+        "outcome_receipt_hash": "9675064eed76fafddc5aae73292bba314f31a3e106f81451c4a0f3d472bf6ebd",
+        "outcome_receipt_id": "outcome-saas-permission-change-missing_human_approval",
+        "refusal_basis": [
+          "human_approval_missing"
+        ],
+        "requested_scope": [
+          "saas:grant_admin"
+        ],
+        "target_resource": "contractor:external.user@example.test",
+        "target_system": "mock_saas_directory"
+      },
+      "evidence_chain_verification_summary": {
+        "decision_id": "decision-saas-001",
+        "execution_intent_id": "intent-saas-001",
+        "failure_reasons": [],
+        "is_valid": true,
+        "manifest_hash_matches": true,
+        "manifest_id": "ecm-saas-permission-change-missing_human_approval",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "mismatched_links": [],
+        "missing_links": [
+          "human_approval_receipt_hash"
+        ],
+        "operation_id": "saas-permission-change-missing_human_approval",
+        "recomputed_manifest_hash": "de5f807be0e901dc94a3968a831a30485aa059dc04722e479771199d1226477b",
+        "verification_status": "verified",
+        "verified_at": "2026-04-26T00:00:00+00:00",
+        "verified_links": [
+          "authority_evidence_hash",
+          "bind_coverage_operation_id",
+          "manifest_hash",
+          "outcome_receipt_hash"
+        ]
+      },
+      "expected_outcome": "block",
+      "failure_reasons": [
+        "human_approval_missing"
+      ],
+      "human_approval_summary": {
+        "approval_receipt_id": null,
+        "approved": false,
+        "approved_scope": [],
+        "approver_identity": null,
+        "approver_role": null,
+        "failure_reasons": [
+          "human_approval_missing"
+        ],
+        "receipt_hash_present": false
+      },
+      "outcome_receipt_summary": {
+        "action_class": "permission_change",
+        "bind_receipt_id": null,
+        "blocked": true,
+        "committed": false,
+        "decision_id": "decision-saas-001",
+        "escalated": false,
+        "evaluated_at": "2026-04-26T00:00:00+00:00",
+        "execution_intent_id": "intent-saas-001",
+        "failure_reasons": [
+          "human_approval_missing"
+        ],
+        "final_outcome": "block",
+        "intended_action": "grant_admin_permission",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "observed_effects": [],
+        "operation_id": "saas-permission-change-missing_human_approval",
+        "outcome_hash": "9675064eed76fafddc5aae73292bba314f31a3e106f81451c4a0f3d472bf6ebd",
+        "outcome_receipt_id": "outcome-saas-permission-change-missing_human_approval",
+        "post_state_fingerprint": null,
+        "postcondition_status": "skipped",
+        "pre_state_fingerprint": null,
+        "requested_scope": [
+          "saas:grant_admin"
+        ],
+        "rollback_status": null,
+        "rolled_back": false,
+        "target_resource": "contractor:external.user@example.test",
+        "target_system": "mock_saas_directory"
+      },
+      "passed": true,
+      "refusal_basis": [
+        "human_approval_missing"
+      ],
+      "requested_scope": [
+        "saas:grant_admin"
+      ],
+      "reviewer_interpretation": "The local/offline fixture blocked because HumanApprovalReceipt was missing.",
+      "runtime_recommended_outcome": "block",
+      "target_resource": "contractor:external.user@example.test",
+      "target_system": "mock_saas_directory"
+    },
+    {
+      "actual_outcome": "block",
+      "authority_validation_status": "fail",
+      "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+      "case_id": "expired_human_approval",
+      "evidence_chain_manifest_summary": {
+        "action_class": "permission_change",
+        "authority_evidence_hash": "86bd3a69cb781db382f94e0a87e6a36aaa203d934403a23ac36e8856a9d5e940",
+        "authority_evidence_id": "aev-saas-001",
+        "bind_coverage_operation_id": "saas_permission_change_demo",
+        "bind_receipt_hash": null,
+        "bind_receipt_id": null,
+        "chain_status": "blocked",
+        "decision_id": "decision-saas-001",
+        "execution_intent_id": "intent-saas-001",
+        "final_outcome": "block",
+        "generated_at": "2026-04-26T00:00:00+00:00",
+        "human_approval_receipt_hash": null,
+        "human_approval_receipt_id": null,
+        "manifest_hash": "a01e60928b028538839d9d0709424d92d7bf164efd209adcc7cfcc768982f20a",
+        "manifest_id": "ecm-saas-permission-change-expired_human_approval",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "missing_links": [
+          "human_approval_receipt_hash"
+        ],
+        "observed_effects_summary": [],
+        "operation_id": "saas-permission-change-expired_human_approval",
+        "outcome_receipt_hash": "04f7b00e736648ed570282482a90bf453e4e8d871e26f4ca4d173467f0be92af",
+        "outcome_receipt_id": "outcome-saas-permission-change-expired_human_approval",
+        "refusal_basis": [
+          "human_approval_missing"
+        ],
+        "requested_scope": [
+          "saas:grant_admin"
+        ],
+        "target_resource": "contractor:external.user@example.test",
+        "target_system": "mock_saas_directory"
+      },
+      "evidence_chain_verification_summary": {
+        "decision_id": "decision-saas-001",
+        "execution_intent_id": "intent-saas-001",
+        "failure_reasons": [],
+        "is_valid": true,
+        "manifest_hash_matches": true,
+        "manifest_id": "ecm-saas-permission-change-expired_human_approval",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "mismatched_links": [],
+        "missing_links": [
+          "human_approval_receipt_hash"
+        ],
+        "operation_id": "saas-permission-change-expired_human_approval",
+        "recomputed_manifest_hash": "a01e60928b028538839d9d0709424d92d7bf164efd209adcc7cfcc768982f20a",
+        "verification_status": "verified",
+        "verified_at": "2026-04-26T00:00:00+00:00",
+        "verified_links": [
+          "authority_evidence_hash",
+          "bind_coverage_operation_id",
+          "manifest_hash",
+          "outcome_receipt_hash"
+        ]
+      },
+      "expected_outcome": "block",
+      "failure_reasons": [
+        "human_approval_missing"
+      ],
+      "human_approval_summary": {
+        "approval_receipt_id": null,
+        "approved": false,
+        "approved_scope": [],
+        "approver_identity": null,
+        "approver_role": null,
+        "failure_reasons": [
+          "human_approval_expired"
+        ],
+        "receipt_hash_present": false
+      },
+      "outcome_receipt_summary": {
+        "action_class": "permission_change",
+        "bind_receipt_id": null,
+        "blocked": true,
+        "committed": false,
+        "decision_id": "decision-saas-001",
+        "escalated": false,
+        "evaluated_at": "2026-04-26T00:00:00+00:00",
+        "execution_intent_id": "intent-saas-001",
+        "failure_reasons": [
+          "human_approval_missing"
+        ],
+        "final_outcome": "block",
+        "intended_action": "grant_admin_permission",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "observed_effects": [],
+        "operation_id": "saas-permission-change-expired_human_approval",
+        "outcome_hash": "04f7b00e736648ed570282482a90bf453e4e8d871e26f4ca4d173467f0be92af",
+        "outcome_receipt_id": "outcome-saas-permission-change-expired_human_approval",
+        "post_state_fingerprint": null,
+        "postcondition_status": "skipped",
+        "pre_state_fingerprint": null,
+        "requested_scope": [
+          "saas:grant_admin"
+        ],
+        "rollback_status": null,
+        "rolled_back": false,
+        "target_resource": "contractor:external.user@example.test",
+        "target_system": "mock_saas_directory"
+      },
+      "passed": true,
+      "refusal_basis": [
+        "human_approval_missing"
+      ],
+      "requested_scope": [
+        "saas:grant_admin"
+      ],
+      "reviewer_interpretation": "The local/offline fixture blocked because HumanApprovalReceipt was expired.",
+      "runtime_recommended_outcome": "block",
+      "target_resource": "contractor:external.user@example.test",
+      "target_system": "mock_saas_directory"
+    },
+    {
+      "actual_outcome": "block",
+      "authority_validation_status": "fail",
+      "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+      "case_id": "scope_mismatch",
+      "evidence_chain_manifest_summary": {
+        "action_class": "permission_change",
+        "authority_evidence_hash": "f3ef007f0aa8236117004edd91c0abd105762b8f4d02f8b2572a5988c6c0647a",
+        "authority_evidence_id": "aev-saas-001",
+        "bind_coverage_operation_id": "saas_permission_change_demo",
+        "bind_receipt_hash": null,
+        "bind_receipt_id": null,
+        "chain_status": "blocked",
+        "decision_id": "decision-saas-001",
+        "execution_intent_id": "intent-saas-001",
+        "final_outcome": "block",
+        "generated_at": "2026-04-26T00:00:00+00:00",
+        "human_approval_receipt_hash": null,
+        "human_approval_receipt_id": null,
+        "manifest_hash": "4e3785488ebac6a6e58abf0f23303ff0f7737f1899ec1618ac809432934d7484",
+        "manifest_id": "ecm-saas-permission-change-scope_mismatch",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "missing_links": [
+          "human_approval_receipt_hash"
+        ],
+        "observed_effects_summary": [],
+        "operation_id": "saas-permission-change-scope_mismatch",
+        "outcome_receipt_hash": "3fff28c56dd93ff5d7e11c71a9ed6ba134c31dc8a057810e72d24b93f2c8a54f",
+        "outcome_receipt_id": "outcome-saas-permission-change-scope_mismatch",
+        "refusal_basis": [
+          "authority_invalid",
+          "human_approval_missing"
+        ],
+        "requested_scope": [
+          "saas:grant_admin"
+        ],
+        "target_resource": "contractor:external.user@example.test",
+        "target_system": "mock_saas_directory"
+      },
+      "evidence_chain_verification_summary": {
+        "decision_id": "decision-saas-001",
+        "execution_intent_id": "intent-saas-001",
+        "failure_reasons": [],
+        "is_valid": true,
+        "manifest_hash_matches": true,
+        "manifest_id": "ecm-saas-permission-change-scope_mismatch",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "mismatched_links": [],
+        "missing_links": [
+          "human_approval_receipt_hash"
+        ],
+        "operation_id": "saas-permission-change-scope_mismatch",
+        "recomputed_manifest_hash": "4e3785488ebac6a6e58abf0f23303ff0f7737f1899ec1618ac809432934d7484",
+        "verification_status": "verified",
+        "verified_at": "2026-04-26T00:00:00+00:00",
+        "verified_links": [
+          "authority_evidence_hash",
+          "bind_coverage_operation_id",
+          "manifest_hash",
+          "outcome_receipt_hash"
+        ]
+      },
+      "expected_outcome": "block",
+      "failure_reasons": [
+        "authority_invalid",
+        "human_approval_missing"
+      ],
+      "human_approval_summary": {
+        "approval_receipt_id": null,
+        "approved": false,
+        "approved_scope": [],
+        "approver_identity": null,
+        "approver_role": null,
+        "failure_reasons": [
+          "human_approval_scope_not_granted"
+        ],
+        "receipt_hash_present": false
+      },
+      "outcome_receipt_summary": {
+        "action_class": "permission_change",
+        "bind_receipt_id": null,
+        "blocked": true,
+        "committed": false,
+        "decision_id": "decision-saas-001",
+        "escalated": false,
+        "evaluated_at": "2026-04-26T00:00:00+00:00",
+        "execution_intent_id": "intent-saas-001",
+        "failure_reasons": [
+          "authority_invalid",
+          "human_approval_missing"
+        ],
+        "final_outcome": "block",
+        "intended_action": "grant_admin_permission",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "observed_effects": [],
+        "operation_id": "saas-permission-change-scope_mismatch",
+        "outcome_hash": "3fff28c56dd93ff5d7e11c71a9ed6ba134c31dc8a057810e72d24b93f2c8a54f",
+        "outcome_receipt_id": "outcome-saas-permission-change-scope_mismatch",
+        "post_state_fingerprint": null,
+        "postcondition_status": "skipped",
+        "pre_state_fingerprint": null,
+        "requested_scope": [
+          "saas:grant_admin"
+        ],
+        "rollback_status": null,
+        "rolled_back": false,
+        "target_resource": "contractor:external.user@example.test",
+        "target_system": "mock_saas_directory"
+      },
+      "passed": true,
+      "refusal_basis": [
+        "authority_invalid",
+        "human_approval_missing"
+      ],
+      "requested_scope": [
+        "saas:grant_admin"
+      ],
+      "reviewer_interpretation": "The local/offline fixture blocked because approved authority or approval scope was insufficient.",
+      "runtime_recommended_outcome": "block",
+      "target_resource": "contractor:external.user@example.test",
+      "target_system": "mock_saas_directory"
+    },
+    {
+      "actual_outcome": "commit",
+      "authority_validation_status": "pass",
+      "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+      "case_id": "valid_authority_and_approval",
+      "evidence_chain_manifest_summary": {
+        "action_class": "permission_change",
+        "authority_evidence_hash": "6879ecdcdeded375a2e81832fe8819a698c9c5df151d7819224420f21a7a53a0",
+        "authority_evidence_id": "aev-saas-001",
+        "bind_coverage_operation_id": "saas_permission_change_demo",
+        "bind_receipt_hash": null,
+        "bind_receipt_id": null,
+        "chain_status": "complete",
+        "decision_id": "decision-saas-001",
+        "execution_intent_id": "intent-saas-001",
+        "final_outcome": "commit",
+        "generated_at": "2026-04-26T00:00:00+00:00",
+        "human_approval_receipt_hash": "22c26614740e5a495beea2a46f1e8a498303e8c50d96a2f25a2a8e788d1c4547",
+        "human_approval_receipt_id": "har-saas-001",
+        "manifest_hash": "264d650ff037717002e56642e702db0853792e256bf0b624cd5d6df2f5bc1bcb",
+        "manifest_id": "ecm-saas-permission-change-valid_authority_and_approval",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "missing_links": [],
+        "observed_effects_summary": [
+          {
+            "effect_type": "permission_grant",
+            "fixture_only": true,
+            "permission": "saas:grant_admin",
+            "target_resource": "contractor:external.user@example.test"
+          }
+        ],
+        "operation_id": "saas-permission-change-valid_authority_and_approval",
+        "outcome_receipt_hash": "e8eb969be01b97993b20283a6f0314f5e83be4d6377e879f7b3719562e5a036a",
+        "outcome_receipt_id": "outcome-saas-permission-change-valid_authority_and_approval",
+        "refusal_basis": [],
+        "requested_scope": [
+          "saas:grant_admin"
+        ],
+        "target_resource": "contractor:external.user@example.test",
+        "target_system": "mock_saas_directory"
+      },
+      "evidence_chain_verification_summary": {
+        "decision_id": "decision-saas-001",
+        "execution_intent_id": "intent-saas-001",
+        "failure_reasons": [],
+        "is_valid": true,
+        "manifest_hash_matches": true,
+        "manifest_id": "ecm-saas-permission-change-valid_authority_and_approval",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "mismatched_links": [],
+        "missing_links": [],
+        "operation_id": "saas-permission-change-valid_authority_and_approval",
+        "recomputed_manifest_hash": "264d650ff037717002e56642e702db0853792e256bf0b624cd5d6df2f5bc1bcb",
+        "verification_status": "verified",
+        "verified_at": "2026-04-26T00:00:00+00:00",
+        "verified_links": [
+          "authority_evidence_hash",
+          "bind_coverage_operation_id",
+          "human_approval_receipt_hash",
+          "manifest_hash",
+          "outcome_receipt_hash"
+        ]
+      },
+      "expected_outcome": "commit",
+      "failure_reasons": [],
+      "human_approval_summary": {
+        "approval_receipt_id": "har-saas-001",
+        "approved": true,
+        "approved_scope": [
+          "saas:grant_admin"
+        ],
+        "approver_identity": "human:manager.alex",
+        "approver_role": "engineering_manager",
+        "failure_reasons": [],
+        "receipt_hash_present": true
+      },
+      "outcome_receipt_summary": {
+        "action_class": "permission_change",
+        "bind_receipt_id": null,
+        "blocked": false,
+        "committed": true,
+        "decision_id": "decision-saas-001",
+        "escalated": false,
+        "evaluated_at": "2026-04-26T00:00:00+00:00",
+        "execution_intent_id": "intent-saas-001",
+        "failure_reasons": [],
+        "final_outcome": "commit",
+        "intended_action": "grant_admin_permission",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "observed_effects": [
+          {
+            "effect_type": "permission_grant",
+            "fixture_only": true,
+            "permission": "saas:grant_admin",
+            "target_resource": "contractor:external.user@example.test"
+          }
+        ],
+        "operation_id": "saas-permission-change-valid_authority_and_approval",
+        "outcome_hash": "e8eb969be01b97993b20283a6f0314f5e83be4d6377e879f7b3719562e5a036a",
+        "outcome_receipt_id": "outcome-saas-permission-change-valid_authority_and_approval",
+        "post_state_fingerprint": null,
+        "postcondition_status": "passed",
+        "pre_state_fingerprint": null,
+        "requested_scope": [
+          "saas:grant_admin"
+        ],
+        "rollback_status": null,
+        "rolled_back": false,
+        "target_resource": "contractor:external.user@example.test",
+        "target_system": "mock_saas_directory"
+      },
+      "passed": true,
+      "refusal_basis": [],
+      "requested_scope": [
+        "saas:grant_admin"
+      ],
+      "reviewer_interpretation": "AuthorityEvidence and HumanApprovalReceipt were sufficient for the local/offline fixture to reach a commit outcome.",
+      "runtime_recommended_outcome": "commit",
+      "target_resource": "contractor:external.user@example.test",
+      "target_system": "mock_saas_directory"
+    }
+  ],
+  "decision_candidate_refusal_artifacts": [
+    {
+      "ambiguity_flags": [],
+      "artifact_hash": "118f373281031644dc4a9c0319c9fe1c72099cb76fb3bffe40e3c4e66c859df5",
+      "artifact_id": "refusal-local-missing-target-001",
+      "artifact_type": "decision_candidate_refusal_artifact",
+      "candidate_hash": "3ac44df32f1da7469f7ab54f34445ae827b168c32acbf5b4e403f9b7ad73696a",
+      "candidate_id": "candidate-local-refusal-missing-target-001",
+      "created_at": "2026-06-13T00:00:00Z",
+      "fail_closed": true,
+      "metadata": {
+        "bind_receipt_created": false,
+        "execution_attempted": false,
+        "execution_intent_created": false,
+        "fixture_only": true,
+        "local_offline_only": true,
+        "pre_execution_intent_evidence": true,
+        "raw_natural_language_omitted": true
+      },
+      "missing_required_fields": [
+        "target_resource"
+      ],
+      "promotion_status": "REFUSED",
+      "refusal_id": "refusal-local-missing-target-001",
+      "refusal_reason_codes": [
+        "DECISION_CANDIDATE_MISSING_REQUIRED_FIELD",
+        "DECISION_CANDIDATE_RATIONALE_ONLY"
+      ],
+      "refusal_type": "FAIL_CLOSED",
+      "requires_human_review": false
+    }
+  ],
+  "demo_id": "decision-candidate-refusal-local-offline-v1",
+  "generated_at": "2026-06-13T00:00:00Z",
+  "key_provenance": {
+    "key_provenance_result_validation_report": {
+      "artifact_name": "key-provenance-result-validation.json",
+      "schema_id": "https://veritas-os.example/schemas/trusted_public_key_provenance_result_validation_report.schema.json"
+    },
+    "key_provenance_validation_report": {
+      "artifact_name": "key-provenance-validation.json",
+      "schema_id": "https://veritas-os.example/schemas/trusted_public_key_provenance_validation_report.schema.json"
+    },
+    "trusted_public_key_provenance_receipt": {
+      "artifact_name": "trusted-public-key-provenance.json",
+      "required_for_strict_signature_review": true,
+      "schema_id": "https://veritas-os.example/schemas/trusted_public_key_provenance_receipt.schema.json"
+    }
+  },
+  "local_offline_only": true,
+  "packet_hash": "dc281b854019d93aed8f42a46d7a83e144a81f5de71896a34e84a16f3e117a42",
+  "packet_id": "reviewer-evidence-packet-decision-candidate-refusal-v1",
+  "packet_version": "v1",
+  "reviewer_notes": [
+    "DecisionCandidateRefusalArtifact records why a structured candidate did not become an ExecutionIntent.",
+    "This refusal artifact is pre-ExecutionIntent reviewer evidence only; it is not a BindReceipt and does not imply execution was attempted.",
+    "The fixture omits raw natural-language LLM content and uses local/offline references only.",
+    "This is not legal advice, regulatory approval, third-party certification, live IAM/IdP/SaaS/bank/sanctions/customer-system integration, live LLM extraction, live authority-source validation, bind adjudication, or proof of attempted execution."
+  ],
+  "summary": "Local/offline reviewer packet showing a DecisionCandidateRefusalArtifact for a candidate missing target_resource before any ExecutionIntent, BindReceipt, TrustLog append, adapter call, or execution attempt.",
+  "title": "Reviewer Evidence Packet: DecisionCandidate Refusal Artifact (Local/Offline)"
+}

--- a/docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json
+++ b/docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json
@@ -20,7 +20,10 @@
   ],
   "properties": {
     "packet_id": {
-      "const": "reviewer-evidence-packet-saas-permission-change-v1"
+      "enum": [
+        "reviewer-evidence-packet-saas-permission-change-v1",
+        "reviewer-evidence-packet-decision-candidate-refusal-v1"
+      ]
     },
     "packet_version": {
       "const": "v1"
@@ -73,6 +76,12 @@
       "type": "array",
       "items": {
         "$ref": "#/$defs/evaluation_governance_artifact"
+      }
+    },
+    "decision_candidate_refusal_artifacts": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/decision_candidate_refusal_artifact"
       }
     },
     "key_provenance": {
@@ -659,6 +668,102 @@
         },
         "required_for_review": {
           "type": "boolean"
+        }
+      }
+    },
+    "decision_candidate_refusal_artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "artifact_type",
+        "artifact_id",
+        "refusal_id",
+        "candidate_id",
+        "candidate_hash",
+        "refusal_type",
+        "promotion_status",
+        "refusal_reason_codes",
+        "missing_required_fields",
+        "ambiguity_flags",
+        "requires_human_review",
+        "fail_closed",
+        "artifact_hash",
+        "created_at",
+        "metadata"
+      ],
+      "properties": {
+        "artifact_type": {
+          "const": "decision_candidate_refusal_artifact"
+        },
+        "artifact_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "refusal_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "candidate_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "candidate_hash": {
+          "$ref": "#/$defs/sha256_hex"
+        },
+        "refusal_type": {
+          "enum": [
+            "FAIL_CLOSED",
+            "HUMAN_REVIEW_REQUIRED",
+            "REFUSED"
+          ]
+        },
+        "promotion_status": {
+          "enum": [
+            "REFUSED",
+            "HUMAN_REVIEW_REQUIRED"
+          ]
+        },
+        "refusal_reason_codes": {
+          "$ref": "#/$defs/string_array"
+        },
+        "missing_required_fields": {
+          "$ref": "#/$defs/string_array"
+        },
+        "ambiguity_flags": {
+          "$ref": "#/$defs/string_array"
+        },
+        "requires_human_review": {
+          "type": "boolean"
+        },
+        "fail_closed": {
+          "type": "boolean"
+        },
+        "artifact_hash": {
+          "$ref": "#/$defs/sha256_hex"
+        },
+        "created_at": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "pre_execution_intent_evidence": {
+              "const": true
+            },
+            "execution_intent_created": {
+              "const": false
+            },
+            "bind_receipt_created": {
+              "const": false
+            },
+            "execution_attempted": {
+              "const": false
+            }
+          }
         }
       }
     },

--- a/docs/ja/architecture/llm-to-control-plane-contract.md
+++ b/docs/ja/architecture/llm-to-control-plane-contract.md
@@ -74,7 +74,8 @@ flowchart TD
 または人間レビュー必須の結果をレビュアーが検査するための
 pre-`ExecutionIntent` evidence です。これは `BindReceipt` ではなく、実行が試行された
 ことを意味せず、live LLM extraction、live authority-source validation、bind
-adjudication も行いません。
+adjudication も行いません。この artifact の reviewer-facing packet の例は、後続 PR
+で明示的に統合されるまでは local/offline fixture-backed evidence のままです。
 
 ## 5. 昇格ルール
 

--- a/tests/demo/test_reviewer_evidence_packet_schema.py
+++ b/tests/demo/test_reviewer_evidence_packet_schema.py
@@ -16,6 +16,10 @@ SCHEMA_PATH = Path("docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json
 FIXTURE_PATH = Path(
     "docs/en/demo/fixtures/reviewer-evidence-packet-saas-permission-change-v1.json"
 )
+DECISION_CANDIDATE_REFUSAL_FIXTURE_PATH = Path(
+    "docs/en/demo/fixtures/"
+    "reviewer-evidence-packet-decision-candidate-refusal-v1.json"
+)
 EVALUATION_GOVERNANCE_EXAMPLE_PATH = Path(
     "docs/en/demo/examples/"
     "reviewer-evidence-packet-with-evaluation-governance-v1.json"
@@ -343,6 +347,27 @@ def test_schema_declares_core_packet_properties() -> None:
 
 def test_golden_fixture_validates_against_schema_or_fallback() -> None:
     _validate_or_fallback(_load_json(FIXTURE_PATH), _load_json(SCHEMA_PATH))
+
+
+def test_decision_candidate_refusal_fixture_validates_against_schema() -> None:
+    packet = _load_json(DECISION_CANDIDATE_REFUSAL_FIXTURE_PATH)
+    _validate_or_fallback(packet, _load_json(SCHEMA_PATH))
+
+
+def test_decision_candidate_refusal_fixture_preserves_runtime_boundary() -> None:
+    packet = _load_json(DECISION_CANDIDATE_REFUSAL_FIXTURE_PATH)
+    artifacts = packet["decision_candidate_refusal_artifacts"]
+
+    assert len(artifacts) == 1
+    artifact = artifacts[0]
+    assert artifact["artifact_type"] == "decision_candidate_refusal_artifact"
+    assert SHA256_HEX_PATTERN.fullmatch(artifact["candidate_hash"])
+    assert SHA256_HEX_PATTERN.fullmatch(artifact["artifact_hash"])
+    assert "bind_receipt_id" not in artifact
+    assert artifact["metadata"]["pre_execution_intent_evidence"] is True
+    assert artifact["metadata"]["execution_intent_created"] is False
+    assert artifact["metadata"]["bind_receipt_created"] is False
+    assert artifact["metadata"]["execution_attempted"] is False
 
 
 def test_generated_packet_validates_against_schema_or_fallback() -> None:

--- a/tests/policy/test_decision_candidate.py
+++ b/tests/policy/test_decision_candidate.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import pytest
 
+from veritas_os.audit.evidence_bundle import (
+    build_decision_candidate_refusal_evidence_entry,
+)
 from veritas_os.policy.bind_artifacts import ExecutionIntent
 from veritas_os.policy.decision_candidate import (
     DecisionCandidate,
@@ -440,3 +443,24 @@ def test_refusal_artifact_hashing_is_deterministic_with_fixed_id() -> None:
     assert hash_decision_candidate_refusal_artifact(first) == (
         hash_decision_candidate_refusal_artifact(second)
     )
+
+
+def test_refusal_artifact_evidence_entry_preserves_pre_execution_boundary() -> None:
+    artifact = try_build_decision_candidate_refusal_artifact(
+        _complete_candidate(target_resource=""),
+        created_at="2026-06-13T00:00:00Z",
+    )
+
+    assert artifact is not None
+    entry = build_decision_candidate_refusal_evidence_entry(artifact)
+
+    assert entry["artifact_type"] == "decision_candidate_refusal_artifact"
+    assert entry["candidate_hash"] == artifact.candidate_hash
+    assert entry["artifact_hash"] == hash_decision_candidate_refusal_artifact(
+        artifact
+    )
+    assert "bind_receipt_id" not in entry
+    assert entry["metadata"]["pre_execution_intent_evidence"] is True
+    assert entry["metadata"]["execution_intent_created"] is False
+    assert entry["metadata"]["bind_receipt_created"] is False
+    assert entry["metadata"]["execution_attempted"] is False

--- a/veritas_os/audit/evidence_bundle.py
+++ b/veritas_os/audit/evidence_bundle.py
@@ -32,6 +32,10 @@ from typing import Any, Callable, Dict, List, Optional, Sequence
 
 from veritas_os.audit.evidence_bundle_schema import BUNDLE_SCHEMA_VERSION, BUNDLE_TYPES
 from veritas_os.core.decision_semantics import canonicalize_public_gate_decision
+from veritas_os.policy.decision_candidate import (
+    DecisionCandidateRefusalArtifact,
+    hash_decision_candidate_refusal_artifact,
+)
 from veritas_os.security.hash import canonical_json_dumps, sha256_of_canonical_json
 
 _logger = logging.getLogger(__name__)
@@ -72,6 +76,42 @@ _VERIFICATION_SCOPE = [
     "file_hash_integrity",
     "manifest_signature_authenticity",
 ]
+
+
+def build_decision_candidate_refusal_evidence_entry(
+    artifact: DecisionCandidateRefusalArtifact,
+) -> Dict[str, Any]:
+    """Build reviewer evidence for a pre-``ExecutionIntent`` refusal artifact.
+
+    The returned descriptor is intentionally side-effect free. It records why a
+    ``DecisionCandidate`` was not promoted and does not perform bind
+    adjudication, create a ``BindReceipt``, append TrustLog entries, call
+    adapters, write files, or imply that execution was attempted.
+    """
+    artifact_hash = hash_decision_candidate_refusal_artifact(artifact)
+    return {
+        "artifact_type": "decision_candidate_refusal_artifact",
+        "artifact_id": artifact.refusal_id,
+        "refusal_id": artifact.refusal_id,
+        "candidate_id": artifact.candidate_id,
+        "candidate_hash": artifact.candidate_hash,
+        "refusal_type": artifact.refusal_type,
+        "promotion_status": artifact.promotion_status,
+        "refusal_reason_codes": list(artifact.refusal_reason_codes),
+        "missing_required_fields": list(artifact.missing_required_fields),
+        "ambiguity_flags": list(artifact.ambiguity_flags),
+        "requires_human_review": artifact.requires_human_review,
+        "fail_closed": artifact.fail_closed,
+        "artifact_hash": artifact_hash,
+        "created_at": artifact.created_at,
+        "metadata": {
+            **dict(artifact.metadata),
+            "pre_execution_intent_evidence": True,
+            "execution_intent_created": False,
+            "bind_receipt_created": False,
+            "execution_attempted": False,
+        },
+    }
 
 
 def _uuid7() -> str:


### PR DESCRIPTION
### Motivation

- Make `DecisionCandidateRefusalArtifact` discoverable to external reviewers as local/offline pre-`ExecutionIntent` evidence so refused or human-review-required candidates are inspectable without implying execution. 
- Preserve strict runtime boundaries: this is additive reviewer evidence only and must not wire into `/v1/decide`, bind adjudication, TrustLog, adapters, or live authority checks. 
- Keep the reviewer packet schema-style consistent and minimally invasive so existing tooling can validate/refence refusal artifacts. 
- Security warning: reviewer artifacts can contain sensitive signals; these fixtures and metadata are local/offline and should be treated as sensitive reviewer evidence in any downstream handling. 

### Description

- Added `build_decision_candidate_refusal_evidence_entry(...)` in `veritas_os/audit/evidence_bundle.py` to build side-effect-free reviewer descriptors for `DecisionCandidateRefusalArtifact` that include `candidate_hash`, `artifact_hash`, refusal details, and explicit pre-execution flags. 
- Extended `docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json` with an optional `decision_candidate_refusal_artifacts` array and a strict `decision_candidate_refusal_artifact` schema. 
- Added a local/offline fixture `docs/en/demo/fixtures/reviewer-evidence-packet-decision-candidate-refusal-v1.json` demonstrating a safe refusal (missing `target_resource`) and explicit non-execution metadata. 
- Updated docs to surface the new fixture and runtime boundary language in `docs/en/demo/external-reviewer-artifact-index.md`, `docs/en/demo/external-reviewer-quickstart.md`, and both English/Japanese `llm-to-control-plane-contract.md`. 
- Added focused tests: `tests/demo/test_reviewer_evidence_packet_schema.py` validates the new fixture and runtime boundary assertions, and `tests/policy/test_decision_candidate.py` checks the evidence-entry builder preserves the pre-execution boundary. 

### Testing

- Ran `python3 scripts/quality/check_bilingual_docs.py` and it passed. 
- Ran reviewer packet validation via `python3 scripts/demo/validate_reviewer_evidence_packet.py` and it passed in deterministic/fallback mode (schema validation skipped locally when `jsonschema` is unavailable). 
- Performed `python3 -m py_compile veritas_os/policy/decision_candidate.py veritas_os/audit/evidence_bundle.py tests/policy/test_decision_candidate.py` which succeeded (no syntax errors). 
- Executed deterministic JSON/fixture checks against the new fixture (local Python checks) and they passed. 
- Note: `pytest` could not be executed in the container because `pytest` is not installed locally; CI will run the full test suite including the new tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2cf7f496748326b0aad9f5f225eea1)