### PR TITLE
docs: surface LLM-to-Control-Plane flow for reviewers

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,30 @@ Boundary:
 - This is not third-party certification.
 - Fixture-backed PoC evidence should not be presented as live bank-side integration.
 
+
+## LLM-to-Control-Plane Boundary
+
+VERITAS does not ask an LLM to govern itself. LLM or agent output is treated as a proposal. Before it can become an executable governance input, it must cross a structured control-plane boundary:
+
+```mermaid
+flowchart TD
+    A[LLM / Agent Proposal] --> B[DecisionCandidate]
+    B --> C[Normalize]
+    C --> D[Validate]
+    D -->|Incomplete or ambiguous| E[DecisionCandidateRefusalArtifact]
+    D -->|Valid and complete| F[ExecutionIntent]
+    E --> G[Reviewer Evidence Packet]
+    F --> H[Bind Adjudication]
+```
+
+If the candidate is incomplete, ambiguous, missing required authority or human approval context, or relies only on natural-language rationale, it is not promoted to `ExecutionIntent`. It may instead become a `DecisionCandidateRefusalArtifact`, which records why the candidate was refused or sent to human review.
+
+This artifact is pre-`ExecutionIntent` reviewer evidence. It is not a `BindReceipt`, does not imply execution was attempted, and does not perform live LLM extraction, live authority-source validation, or bind adjudication. It is not legal advice, regulatory approval, third-party certification, or a claim of live IAM, IdP, SaaS, bank, sanctions, or customer-system integration.
+
+- [LLM-to-Control-Plane Contract](docs/en/architecture/llm-to-control-plane-contract.md)
+- [DecisionCandidate refusal fixture](docs/en/demo/fixtures/reviewer-evidence-packet-decision-candidate-refusal-v1.json)
+- [External Reviewer Quickstart v1](docs/en/demo/external-reviewer-quickstart.md)
+
 ## Evaluation Governance reviewer artifacts
 
 VERITAS includes a reviewer-facing Evaluation Governance artifact chain for inspecting how authority, evaluator definition, evaluation receipts, outcome deltas, evaluator drift, trajectory movement, and legitimacy-impacting changes can be represented for external review.

--- a/README_JP.md
+++ b/README_JP.md
@@ -66,6 +66,30 @@ VERITAS OS は **Decision Governance and Bind-Boundary Control Plane for AI Agen
 - 第三者認証ではありません。
 - fixture ベースの PoC 証跡は、実銀行統合の証明として提示してはいけません。
 
+
+## LLMと制御プレーンの責任分界
+
+VERITASは、LLMに自己監査や最終判断を任せる設計ではありません。LLMやエージェントの出力は、まず「提案」として扱われます。実行可能なガバナンス入力になる前に、構造化された制御プレーン境界を通過します。
+
+```mermaid
+flowchart TD
+    A[LLM / Agent Proposal] --> B[DecisionCandidate]
+    B --> C[Normalize]
+    C --> D[Validate]
+    D -->|Incomplete or ambiguous| E[DecisionCandidateRefusalArtifact]
+    D -->|Valid and complete| F[ExecutionIntent]
+    E --> G[Reviewer Evidence Packet]
+    F --> H[Bind Adjudication]
+```
+
+候補が不完全、曖昧、必要な権限情報や人間承認情報を欠く、または自然言語の理由だけに依存している場合、その候補は `ExecutionIntent` へ昇格されません。その場合、`DecisionCandidateRefusalArtifact` として「なぜ `ExecutionIntent` にならなかったのか」を記録できます。
+
+これは pre-`ExecutionIntent` のレビュアー向け証拠であり、`BindReceipt` ではありません。実行が試行されたことも意味せず、live LLM extraction、live authority-source validation、bind adjudication も行いません。法的助言、規制当局の承認、第三者認証、または live IAM / IdP / SaaS / bank / sanctions / customer-system integration の主張でもありません。
+
+- [LLMと制御プレーンの責任分界](docs/ja/architecture/llm-to-control-plane-contract.md)
+- [DecisionCandidate refusal fixture](docs/en/demo/fixtures/reviewer-evidence-packet-decision-candidate-refusal-v1.json)
+- [External Reviewer Quickstart v1](docs/en/demo/external-reviewer-quickstart.md)
+
 ## Evaluation Governance レビュアー向け成果物
 
 VERITASには、authority、評価関数の定義、Evaluation Receipt、outcome delta、評価drift、trajectory movement、legitimacyに影響し得る変更を外部レビュー可能にするための Evaluation Governance artifact chain が含まれています。

--- a/docs/en/demo/external-reviewer-artifact-index.md
+++ b/docs/en/demo/external-reviewer-artifact-index.md
@@ -21,7 +21,9 @@ Key local/offline reviewer-facing artifacts:
 - `docs/en/demo/fixtures/reviewer-evidence-packet-saas-permission-change-v1.json`
   - checked-in golden fixture
 - `docs/en/demo/fixtures/reviewer-evidence-packet-decision-candidate-refusal-v1.json`
-  - local/offline reviewer fixture showing a `DecisionCandidateRefusalArtifact` as pre-`ExecutionIntent` evidence; it is not a `BindReceipt`, does not imply execution was attempted, and does not wire into `/v1/decide`, TrustLog, bind adjudication, adapters, live LLM extraction, live authority-source validation, or live IAM/IdP/SaaS/bank/sanctions/customer-system integrations
+  - local/offline fixture-backed reviewer evidence showing a `DecisionCandidateRefusalArtifact` as pre-`ExecutionIntent` evidence for LLM/agent proposals that fail closed or require human review
+  - useful for reviewing why a `DecisionCandidate` was refused before promotion; it is not a `BindReceipt`, does not imply execution was attempted, and does not imply legal advice, regulatory approval, or third-party certification
+  - does not wire into `/v1/decide`, perform bind adjudication, write to TrustLog, call adapters, perform live LLM extraction, perform live authority-source validation, or claim live IAM/IdP/SaaS/bank/sanctions/customer-system integration
 - `docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json`
   - JSON Schema contract
 - `docs/en/demo/schemas/intervention-actionability-map-v0.schema.json`

--- a/docs/en/demo/external-reviewer-quickstart.md
+++ b/docs/en/demo/external-reviewer-quickstart.md
@@ -28,6 +28,24 @@ The current review path demonstrates:
   pre-`ExecutionIntent` candidates that fail closed or require human review
 - golden fixture, schema, and validation report checks
 
+
+## LLM-to-Control-Plane boundary checklist
+
+Reviewers can inspect the LLM-to-Control-Plane boundary through:
+
+- the architecture note: `docs/en/architecture/llm-to-control-plane-contract.md`
+- the `DecisionCandidateRefusalArtifact` fixture: `docs/en/demo/fixtures/reviewer-evidence-packet-decision-candidate-refusal-v1.json`
+- the reviewer packet schema: `docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json`
+
+Reviewer interpretation:
+
+- A refused `DecisionCandidate` did not become an `ExecutionIntent`.
+- A refusal artifact explains why promotion failed or human review was required.
+- A refusal artifact is not a `BindReceipt`.
+- It does not imply execution was attempted.
+- It does not perform live LLM extraction, live authority-source validation, bind adjudication, TrustLog writes, adapter calls, or live IAM/IdP/SaaS/bank/sanctions/customer-system integration.
+- It is not legal advice, regulatory approval, or third-party certification.
+
 ## Fast path
 
 Use this 10–15 minute path for a reviewer-facing inspection:


### PR DESCRIPTION
### Motivation

- Make the newly implemented LLM-to-Control-Plane boundary visible on the main reviewer path so external reviewers can understand the proposal → decision promotion flow quickly. 
- Keep the change documentation-first, small, and explicit about non-claims and offline/fixture boundaries without touching runtime, API, or schemas.

### Description

- Added a concise `LLM-to-Control-Plane Boundary` section to `README.md` with a Mermaid flowchart showing: `LLM / agent proposal → DecisionCandidate → normalize → validate → DecisionCandidateRefusalArtifact or ExecutionIntent → reviewer evidence packet` and links to detailed docs. 
- Added the same short explanation in Japanese to `README_JP.md` (`LLMと制御プレーンの責任分界`) preserving explicit non-claims about execution, live validation, bind adjudication, and integrations. 
- Updated `docs/en/demo/external-reviewer-quickstart.md` to include a compact checklist for inspecting the boundary and reviewer interpretation notes linking the architecture contract, the refusal fixture, and the packet schema. 
- Clarified the `DecisionCandidateRefusalArtifact` entry in `docs/en/demo/external-reviewer-artifact-index.md` to emphasize it is local/offline pre-`ExecutionIntent` evidence for fail-closed or human-review-required proposals and does not imply execution or bind receipts. 
- This is a documentation-only change; no runtime behavior, `/v1/decide` wiring, schema shape changes, live LLM extraction, authority validation, bind adjudication, TrustLog writes, or adapter calls were introduced.

### Testing

- Ran `python3 scripts/quality/check_bilingual_docs.py` and the check completed successfully (`[check-bilingual-docs] all checks passed`).
- Ran `python3 scripts/demo/validate_reviewer_evidence_packet.py` and it produced a pass validation report (`"status": "pass"` and generated packet matched the golden fixture). 
- Encountered a local `pyenv` version mismatch when invoking `python` directly, but using `python3` (and `PYENV_VERSION=3.12.13` where needed) allowed the doc validation and packet validation scripts to run and pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d040dbf4c8326a90f47b6882b3884)