### PR TITLE
Harden evidence bundle signature verification and runtime human approval validation

### DIFF
--- a/docs/en/demo/fixtures/reviewer-evidence-packet-saas-permission-change-v1.json
+++ b/docs/en/demo/fixtures/reviewer-evidence-packet-saas-permission-change-v1.json
@@ -293,7 +293,7 @@
         "generated_at": "2026-04-26T00:00:00+00:00",
         "human_approval_receipt_hash": null,
         "human_approval_receipt_id": null,
-        "manifest_hash": "a01e60928b028538839d9d0709424d92d7bf164efd209adcc7cfcc768982f20a",
+        "manifest_hash": "5fe5e0f4a5b8758f9ef550dfb5007116c3a2e8dedc6952f944e84529532ea628",
         "manifest_id": "ecm-saas-permission-change-expired_human_approval",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -304,10 +304,10 @@
         ],
         "observed_effects_summary": [],
         "operation_id": "saas-permission-change-expired_human_approval",
-        "outcome_receipt_hash": "04f7b00e736648ed570282482a90bf453e4e8d871e26f4ca4d173467f0be92af",
+        "outcome_receipt_hash": "16be694d54dd6115f03c6a466c2cbb5daa6ad3b75e5ae4967d8ae68b2c03fca6",
         "outcome_receipt_id": "outcome-saas-permission-change-expired_human_approval",
         "refusal_basis": [
-          "human_approval_missing"
+          "human_approval_expired"
         ],
         "requested_scope": [
           "saas:grant_admin"
@@ -331,7 +331,7 @@
           "human_approval_receipt_hash"
         ],
         "operation_id": "saas-permission-change-expired_human_approval",
-        "recomputed_manifest_hash": "a01e60928b028538839d9d0709424d92d7bf164efd209adcc7cfcc768982f20a",
+        "recomputed_manifest_hash": "5fe5e0f4a5b8758f9ef550dfb5007116c3a2e8dedc6952f944e84529532ea628",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -343,7 +343,7 @@
       },
       "expected_outcome": "block",
       "failure_reasons": [
-        "human_approval_missing"
+        "human_approval_expired"
       ],
       "human_approval_summary": {
         "approval_receipt_id": null,
@@ -366,7 +366,7 @@
         "evaluated_at": "2026-04-26T00:00:00+00:00",
         "execution_intent_id": "intent-saas-001",
         "failure_reasons": [
-          "human_approval_missing"
+          "human_approval_expired"
         ],
         "final_outcome": "block",
         "intended_action": "grant_admin_permission",
@@ -376,7 +376,7 @@
         },
         "observed_effects": [],
         "operation_id": "saas-permission-change-expired_human_approval",
-        "outcome_hash": "04f7b00e736648ed570282482a90bf453e4e8d871e26f4ca4d173467f0be92af",
+        "outcome_hash": "16be694d54dd6115f03c6a466c2cbb5daa6ad3b75e5ae4967d8ae68b2c03fca6",
         "outcome_receipt_id": "outcome-saas-permission-change-expired_human_approval",
         "post_state_fingerprint": null,
         "postcondition_status": "skipped",
@@ -391,7 +391,7 @@
       },
       "passed": true,
       "refusal_basis": [
-        "human_approval_missing"
+        "human_approval_expired"
       ],
       "requested_scope": [
         "saas:grant_admin"
@@ -420,7 +420,7 @@
         "generated_at": "2026-04-26T00:00:00+00:00",
         "human_approval_receipt_hash": null,
         "human_approval_receipt_id": null,
-        "manifest_hash": "4e3785488ebac6a6e58abf0f23303ff0f7737f1899ec1618ac809432934d7484",
+        "manifest_hash": "3b46df974ec6ff40375387ba377546be1c04a277db90535d3570d577206ab7d3",
         "manifest_id": "ecm-saas-permission-change-scope_mismatch",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -431,11 +431,11 @@
         ],
         "observed_effects_summary": [],
         "operation_id": "saas-permission-change-scope_mismatch",
-        "outcome_receipt_hash": "3fff28c56dd93ff5d7e11c71a9ed6ba134c31dc8a057810e72d24b93f2c8a54f",
+        "outcome_receipt_hash": "06087675fc8f2a2cac67f624004a538e24cfe715b03e63d8f625f6aaecfe12ad",
         "outcome_receipt_id": "outcome-saas-permission-change-scope_mismatch",
         "refusal_basis": [
           "authority_invalid",
-          "human_approval_missing"
+          "human_approval_scope_not_granted"
         ],
         "requested_scope": [
           "saas:grant_admin"
@@ -459,7 +459,7 @@
           "human_approval_receipt_hash"
         ],
         "operation_id": "saas-permission-change-scope_mismatch",
-        "recomputed_manifest_hash": "4e3785488ebac6a6e58abf0f23303ff0f7737f1899ec1618ac809432934d7484",
+        "recomputed_manifest_hash": "3b46df974ec6ff40375387ba377546be1c04a277db90535d3570d577206ab7d3",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -472,7 +472,7 @@
       "expected_outcome": "block",
       "failure_reasons": [
         "authority_invalid",
-        "human_approval_missing"
+        "human_approval_scope_not_granted"
       ],
       "human_approval_summary": {
         "approval_receipt_id": null,
@@ -496,7 +496,7 @@
         "execution_intent_id": "intent-saas-001",
         "failure_reasons": [
           "authority_invalid",
-          "human_approval_missing"
+          "human_approval_scope_not_granted"
         ],
         "final_outcome": "block",
         "intended_action": "grant_admin_permission",
@@ -506,7 +506,7 @@
         },
         "observed_effects": [],
         "operation_id": "saas-permission-change-scope_mismatch",
-        "outcome_hash": "3fff28c56dd93ff5d7e11c71a9ed6ba134c31dc8a057810e72d24b93f2c8a54f",
+        "outcome_hash": "06087675fc8f2a2cac67f624004a538e24cfe715b03e63d8f625f6aaecfe12ad",
         "outcome_receipt_id": "outcome-saas-permission-change-scope_mismatch",
         "post_state_fingerprint": null,
         "postcondition_status": "skipped",
@@ -522,7 +522,7 @@
       "passed": true,
       "refusal_basis": [
         "authority_invalid",
-        "human_approval_missing"
+        "human_approval_scope_not_granted"
       ],
       "requested_scope": [
         "saas:grant_admin"
@@ -681,7 +681,7 @@
     }
   },
   "local_offline_only": true,
-  "packet_hash": "497f9a8c97cf58f7be0658458e5f65f3cef285773fdc30c18341f1126390257f",
+  "packet_hash": "e5b79db2479426be446ebe100d3e7c025c8a6f3613b03d949bebbac11565f70e",
   "packet_id": "reviewer-evidence-packet-saas-permission-change-v1",
   "packet_version": "v1",
   "reviewer_notes": [

--- a/tests/governance/test_human_approval_receipt.py
+++ b/tests/governance/test_human_approval_receipt.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
+import pytest
+
 from veritas_os.governance.action_contracts import ActionClassContract
 from veritas_os.governance.authority_evidence import AuthorityEvidence, VerificationResult
 from veritas_os.governance.human_approval_receipt import (
@@ -278,3 +280,118 @@ def test_human_approval_state_uses_finalized_receipt_hash() -> None:
 
     assert state["approved"] is True
     assert state["receipt_hash"] == finalized.receipt_hash
+
+
+def test_raw_approved_dict_without_receipt_hash_fails_closed() -> None:
+    """Runtime authority cannot trust a self-asserted approval dict."""
+    result = RuntimeAuthorityValidator().validate(
+        action_contract=_contract(),
+        authority_evidence=_authority(),
+        requested_scope=["ledger:debit"],
+        required_evidence_metadata={"kyc_status": {"present": True, "fresh": True}},
+        policy_snapshot_id="policy-001",
+        actor_identity="operator:alice",
+        human_approval_state={"approved": True},
+        bind_context_metadata={"session_id": "bind-001"},
+        now=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    assert result.status == "fail"
+    assert result.recommended_outcome == "block"
+    assert "human_approval_receipt_missing" in result.reason_summary
+
+
+def test_raw_approved_dict_with_untrusted_receipt_hash_fails_closed() -> None:
+    """Receipt-shaped dicts must include validated receipt state metadata."""
+    result = RuntimeAuthorityValidator().validate(
+        action_contract=_contract(),
+        authority_evidence=_authority(),
+        requested_scope=["ledger:debit"],
+        required_evidence_metadata={"kyc_status": {"present": True, "fresh": True}},
+        policy_snapshot_id="policy-001",
+        actor_identity="operator:alice",
+        human_approval_state={
+            "approved": True,
+            "approval_receipt_id": "har-001",
+            "receipt_hash": "0" * 64,
+            "validated_at": "2026-05-10T00:00:00+00:00",
+        },
+        bind_context_metadata={"session_id": "bind-001"},
+        now=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    assert result.status == "fail"
+    assert "human_approval_receipt_missing" in result.reason_summary
+
+
+@pytest.mark.parametrize(
+    ("receipt_overrides", "requested_scope", "action_class", "policy_snapshot_id", "reason"),
+    [
+        (
+            {"expires_at": "2026-04-01T00:00:00+00:00"},
+            ["ledger:debit"],
+            "wire_transfer",
+            "policy-001",
+            "human_approval_expired",
+        ),
+        (
+            {"signature_verified": False},
+            ["ledger:debit"],
+            "wire_transfer",
+            "policy-001",
+            "human_approval_signature_unverified",
+        ),
+        (
+            {"approved_scope": ["ledger:credit"]},
+            ["ledger:debit"],
+            "wire_transfer",
+            "policy-001",
+            "human_approval_scope_not_granted",
+        ),
+        (
+            {"policy_snapshot_id": "policy-other"},
+            ["ledger:debit"],
+            "wire_transfer",
+            "policy-001",
+            "human_approval_policy_snapshot_mismatch",
+        ),
+        (
+            {"approved_action_class": "other_action"},
+            ["ledger:debit"],
+            "wire_transfer",
+            "policy-001",
+            "human_approval_action_class_mismatch",
+        ),
+    ],
+)
+def test_runtime_authority_blocks_invalid_human_approval_receipt_state(
+    receipt_overrides: dict[str, object],
+    requested_scope: list[str],
+    action_class: str,
+    policy_snapshot_id: str,
+    reason: str,
+) -> None:
+    """Runtime authority propagates fail-closed receipt validation reasons."""
+    approval_state = build_human_approval_state(
+        _receipt(**receipt_overrides),
+        requested_scope=requested_scope,
+        action_class=action_class,
+        policy_snapshot_id=policy_snapshot_id,
+        now=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    result = RuntimeAuthorityValidator().validate(
+        action_contract=_contract(),
+        authority_evidence=_authority(),
+        requested_scope=["ledger:debit"],
+        required_evidence_metadata={"kyc_status": {"present": True, "fresh": True}},
+        policy_snapshot_id="policy-001",
+        actor_identity="operator:alice",
+        human_approval_state=approval_state,
+        bind_context_metadata={"session_id": "bind-001"},
+        now=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    assert result.status == "fail"
+    assert result.recommended_outcome == "block"
+    assert reason in result.reason_summary

--- a/tests/governance/test_human_approval_receipt.py
+++ b/tests/governance/test_human_approval_receipt.py
@@ -312,8 +312,12 @@ def test_raw_approved_dict_with_untrusted_receipt_hash_fails_closed() -> None:
         actor_identity="operator:alice",
         human_approval_state={
             "approved": True,
+            "approval_state_source": "validated_human_approval_receipt",
             "approval_receipt_id": "har-001",
             "receipt_hash": "0" * 64,
+            "approved_scope": ["ledger:debit"],
+            "approved_action_class": "wire_transfer",
+            "policy_snapshot_id": "policy-001",
             "validated_at": "2026-05-10T00:00:00+00:00",
         },
         bind_context_metadata={"session_id": "bind-001"},
@@ -322,6 +326,60 @@ def test_raw_approved_dict_with_untrusted_receipt_hash_fails_closed() -> None:
 
     assert result.status == "fail"
     assert "human_approval_receipt_missing" in result.reason_summary
+
+
+def test_tampered_receipt_hash_in_built_state_fails_closed() -> None:
+    """Runtime authority rejects receipt-derived state with tampered hash."""
+    approval_state = build_human_approval_state(
+        _receipt(),
+        requested_scope=["ledger:debit"],
+        action_class="wire_transfer",
+        policy_snapshot_id="policy-001",
+        now=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+    approval_state["receipt_hash"] = "f" * 64
+
+    result = RuntimeAuthorityValidator().validate(
+        action_contract=_contract(),
+        authority_evidence=_authority(),
+        requested_scope=["ledger:debit"],
+        required_evidence_metadata={"kyc_status": {"present": True, "fresh": True}},
+        policy_snapshot_id="policy-001",
+        actor_identity="operator:alice",
+        human_approval_state=approval_state,
+        bind_context_metadata={"session_id": "bind-001"},
+        now=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    assert result.status == "fail"
+    assert "human_approval_validation_hash_mismatch" in result.reason_summary
+
+
+def test_tampered_approved_scope_in_built_state_fails_closed() -> None:
+    """Runtime authority rejects receipt-derived state with tampered scope."""
+    approval_state = build_human_approval_state(
+        _receipt(),
+        requested_scope=["ledger:debit"],
+        action_class="wire_transfer",
+        policy_snapshot_id="policy-001",
+        now=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+    approval_state["approved_scope"] = ["ledger:mint"]
+
+    result = RuntimeAuthorityValidator().validate(
+        action_contract=_contract(),
+        authority_evidence=_authority(),
+        requested_scope=["ledger:debit"],
+        required_evidence_metadata={"kyc_status": {"present": True, "fresh": True}},
+        policy_snapshot_id="policy-001",
+        actor_identity="operator:alice",
+        human_approval_state=approval_state,
+        bind_context_metadata={"session_id": "bind-001"},
+        now=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    assert result.status == "fail"
+    assert "human_approval_validation_hash_mismatch" in result.reason_summary
 
 
 @pytest.mark.parametrize(

--- a/veritas_os/audit/evidence_bundle.py
+++ b/veritas_os/audit/evidence_bundle.py
@@ -256,7 +256,10 @@ def _build_bundle_readme(
         f"- Run: {_REVIEWER_VERIFY_COMMAND}",
         "- Obtain the trusted public key from the reviewer/operator trust channel;",
         "  do not trust a public key only because it is included in this bundle.",
-        "- Inspect verification_report.json for chain and signature status.",
+        "- Verification is only cryptographically complete when a trusted public key",
+        "  verifier is supplied and --require-signature is used.",
+        "- Inspect verification_report.json for chain and signature status;",
+        "  integrity-only reports are not signature-verified.",
         "",
     ]
     return "\n".join(lines)
@@ -280,6 +283,8 @@ def _build_ui_delivery_hook(
         "requires_trusted_public_key": True,
         "signature_required_in_postures": _SIGNATURE_REQUIRED_POSTURES,
         "verification_scope": _VERIFICATION_SCOPE,
+        "verification_requires_trusted_public_key": True,
+        "verification_requires_require_signature_flag": True,
     }
 
 
@@ -453,6 +458,7 @@ def generate_evidence_bundle(
     incident_metadata: Optional[Dict[str, Any]] = None,
     signer_fn: Optional[Callable[[str], str]] = None,
     signer_metadata: Optional[Dict[str, Any]] = None,
+    verify_signature_fn: Optional[Callable[[Dict[str, Any]], bool]] = None,
     decision_record_profile: str = "minimum",
     bundle_id: Optional[str] = None,
     created_by: str = "veritas_os",
@@ -471,6 +477,9 @@ def generate_evidence_bundle(
         incident_metadata: Optional incident metadata.
         signer_fn: Optional callable that signs a payload hash and returns base64.
         signer_metadata: Optional signer metadata dict.
+        verify_signature_fn: Optional trusted signature verifier for witness entries.
+            When omitted, bundle verification is limited to integrity checks and
+            cannot report cryptographic signature verification as passed.
         decision_record_profile: Contract profile used for decision_record.json.
         bundle_id: Optional explicit bundle ID (default: auto-generated UUIDv7).
         created_by: Creator identifier.
@@ -490,6 +499,14 @@ def generate_evidence_bundle(
 
     if not bundle_id:
         bundle_id = _uuid7()
+
+    posture = os.getenv("VERITAS_POSTURE", "dev").strip().lower()
+    signature_required = posture in _SIGNATURE_REQUIRED_POSTURES
+    if signature_required and verify_signature_fn is None:
+        raise ValueError(
+            "Signature verification is required for secure/prod evidence bundle "
+            "generation; provide verify_signature_fn."
+        )
 
     # Load and filter entries
     all_entries = _load_witness_entries(witness_ledger_path)
@@ -586,17 +603,30 @@ def generate_evidence_bundle(
         written_files.append("release_provenance.json")
 
     verify_result: Dict[str, Any] = {}
-    # Run verification and include report
+    # Run verification and include report. Never substitute a permissive/no-op
+    # verifier: signature_ok may only pass when a trusted verifier runs.
     try:
         from veritas_os.audit.trustlog_verify import verify_witness_ledger
 
-        def _noop_verify(_entry: Dict[str, Any]) -> bool:
-            return True  # Signature verification is optional in bundle context
-
+        signature_performed = verify_signature_fn is not None
         verify_result = verify_witness_ledger(
             entries=entries,
-            verify_signature_fn=_noop_verify,
+            verify_signature_fn=verify_signature_fn,
         )
+        limitations = [] if signature_performed else ["signature_verifier_not_provided"]
+        verify_result.update(
+            {
+                "verification_mode": (
+                    "signature_and_integrity" if signature_performed else "integrity_only"
+                ),
+                "signature_verification_performed": signature_performed,
+                "signature_verification_required": signature_required,
+                "verification_limitations": limitations,
+            }
+        )
+        if not signature_performed:
+            verify_result["signature_ok"] = False
+            verify_result["ok"] = False
         _write_json_file(bundle_dir, "verification_report.json", verify_result)
         written_files.append("verification_report.json")
     except Exception as exc:  # noqa: BLE001

--- a/veritas_os/audit/evidence_bundle.py
+++ b/veritas_os/audit/evidence_bundle.py
@@ -187,6 +187,7 @@ def _build_acceptance_checklist(
     written_files: Sequence[str],
     *,
     decision_record_profile: str,
+    verification_report: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Build acceptance checklist used for external audit submission gating."""
     written = set(written_files)
@@ -207,10 +208,19 @@ def _build_acceptance_checklist(
         },
         {
             "id": "verification_report_present",
-            "title": "Verification report included",
+            "title": "Verification report included and passing",
             "required": True,
-            "status": "pass" if "verification_report.json" in written else "fail",
+            "status": (
+                "pass"
+                if "verification_report.json" in written
+                and bool((verification_report or {}).get("ok"))
+                else "fail"
+            ),
             "evidence": ["verification_report.json"],
+            "details": {
+                "report_ok": bool((verification_report or {}).get("ok")),
+                "verification_mode": (verification_report or {}).get("verification_mode"),
+            },
         },
         {
             "id": "decision_record_contract",
@@ -630,7 +640,33 @@ def generate_evidence_bundle(
         _write_json_file(bundle_dir, "verification_report.json", verify_result)
         written_files.append("verification_report.json")
     except Exception as exc:  # noqa: BLE001
-        _logger.warning("Bundle verification skipped: %s", exc)
+        stable_error = exc.__class__.__name__
+        if signature_required:
+            raise ValueError(
+                f"Evidence bundle verification failed: {stable_error}"
+            ) from exc
+        _logger.warning("Bundle verification failed: %s", exc)
+        verify_result = {
+            "ledger": "witness",
+            "total_entries": len(entries),
+            "valid_entries": 0,
+            "invalid_entries": len(entries),
+            "chain_ok": False,
+            "signature_ok": False,
+            "linkage_ok": False,
+            "mirror_ok": False,
+            "last_hash": None,
+            "detailed_errors": [],
+            "verification_notes": [],
+            "ok": False,
+            "signature_verification_performed": verify_signature_fn is not None,
+            "signature_verification_required": signature_required,
+            "verification_mode": "verification_failed",
+            "verification_error": stable_error,
+            "verification_limitations": ["verification_exception"],
+        }
+        _write_json_file(bundle_dir, "verification_report.json", verify_result)
+        written_files.append("verification_report.json")
 
     if bundle_type == "decision":
         decision_entry = entries[0]
@@ -652,6 +688,7 @@ def generate_evidence_bundle(
         bundle_type,
         tuple(sorted(written_files)),
         decision_record_profile=decision_record_profile,
+        verification_report=verify_result,
     )
     _write_json_file(bundle_dir, "acceptance_checklist.json", acceptance_checklist)
     written_files.append("acceptance_checklist.json")

--- a/veritas_os/governance/human_approval_receipt.py
+++ b/veritas_os/governance/human_approval_receipt.py
@@ -12,6 +12,8 @@ from typing import Any, Literal
 
 from veritas_os.security.hash import sha256_of_canonical_json
 
+HUMAN_APPROVAL_STATE_SOURCE = "validated_human_approval_receipt"
+
 ApprovalResult = Literal["approved", "denied", "expired", "indeterminate"]
 
 
@@ -153,16 +155,33 @@ def build_human_approval_state(
 
     finalized_receipt = with_receipt_hash(receipt)
 
-    return {
+    state = {
         "approved": True,
-        "approval_state_source": "validated_human_approval_receipt",
+        "approval_state_source": HUMAN_APPROVAL_STATE_SOURCE,
         "approval_receipt_id": finalized_receipt.approval_receipt_id,
         "approver_identity": finalized_receipt.approver_identity,
         "approver_role": finalized_receipt.approver_role,
         "approved_scope": sorted(str(scope) for scope in finalized_receipt.approved_scope),
+        "approved_action_class": finalized_receipt.approved_action_class,
+        "policy_snapshot_id": finalized_receipt.policy_snapshot_id,
         "receipt_hash": finalized_receipt.receipt_hash,
         "validated_at": evaluated_at.isoformat(),
     }
+    state["approval_validation_hash"] = human_approval_state_validation_hash(state)
+    return state
+
+
+def human_approval_state_validation_hash(state: dict[str, Any]) -> str:
+    """Hash receipt-derived approval validation metadata for tamper detection."""
+    payload = {
+        "approval_receipt_id": state.get("approval_receipt_id"),
+        "receipt_hash": state.get("receipt_hash"),
+        "approved_scope": sorted(str(scope) for scope in state.get("approved_scope", [])),
+        "policy_snapshot_id": state.get("policy_snapshot_id"),
+        "approved_action_class": state.get("approved_action_class"),
+        "validated_at": state.get("validated_at"),
+    }
+    return sha256_of_canonical_json(payload)
 
 
 def _parse_iso_datetime(value: str) -> datetime | None:

--- a/veritas_os/governance/human_approval_receipt.py
+++ b/veritas_os/governance/human_approval_receipt.py
@@ -155,6 +155,7 @@ def build_human_approval_state(
 
     return {
         "approved": True,
+        "approval_state_source": "validated_human_approval_receipt",
         "approval_receipt_id": finalized_receipt.approval_receipt_id,
         "approver_identity": finalized_receipt.approver_identity,
         "approver_role": finalized_receipt.approver_role,

--- a/veritas_os/governance/runtime_authority.py
+++ b/veritas_os/governance/runtime_authority.py
@@ -14,6 +14,8 @@ from veritas_os.governance.authority_evidence import (
 )
 from veritas_os.governance.predicates import PredicateResult
 
+_HUMAN_APPROVAL_STATE_SOURCE = "validated_human_approval_receipt"
+
 RuntimeValidationStatus = Literal["pass", "fail"]
 RecommendedOutcome = Literal["commit", "block", "escalate", "refuse"]
 KNOWN_PREDICATE_TYPES = {
@@ -262,18 +264,16 @@ class RuntimeAuthorityValidator:
             )
 
             needs_approval = self._requires_human_approval(action_contract)
-            approved = bool(human_approval_state.get("approved"))
-            human_approval_ok = (not needs_approval) or approved
+            approval_ok, approval_reason = self._validated_human_approval_state(
+                human_approval_state
+            )
+            human_approval_ok = (not needs_approval) or approval_ok
             predicates.append(
                 self._predicate(
                     predicate_id="p-human-approval-present",
                     predicate_type="human_approval_present",
                     status="pass" if human_approval_ok else "missing",
-                    reason=(
-                        "human_approval_present"
-                        if human_approval_ok
-                        else "human_approval_missing"
-                    ),
+                    reason="human_approval_present" if human_approval_ok else approval_reason,
                     evaluated_at=evaluated_at,
                 )
             )
@@ -357,6 +357,42 @@ class RuntimeAuthorityValidator:
             escalation_basis=escalation_basis,
             reason_summary=summary,
         )
+
+    def _validated_human_approval_state(
+        self,
+        human_approval_state: dict[str, Any],
+    ) -> tuple[bool, str]:
+        """Accept only approval state derived from HumanApprovalReceipt validation.
+
+        Compatibility with raw dictionaries is fail-closed: callers may still
+        pass a dict, but ``{"approved": True}`` is not sufficient unless the
+        state carries receipt-derived validation metadata from
+        ``build_human_approval_state``.
+        """
+        if not bool(human_approval_state.get("approved")):
+            reasons = human_approval_state.get("failure_reasons")
+            if isinstance(reasons, list) and reasons:
+                return False, str(sorted(str(reason) for reason in reasons)[0])
+            return False, "human_approval_missing"
+
+        if (
+            human_approval_state.get("approval_state_source")
+            != _HUMAN_APPROVAL_STATE_SOURCE
+        ):
+            return False, "human_approval_receipt_missing"
+
+        required_fields = ("approval_receipt_id", "receipt_hash", "validated_at")
+        if not all(
+            str(human_approval_state.get(field) or "").strip()
+            for field in required_fields
+        ):
+            return False, "human_approval_receipt_missing"
+
+        failure_reasons = human_approval_state.get("failure_reasons")
+        if failure_reasons:
+            return False, "human_approval_receipt_invalid"
+
+        return True, "human_approval_present"
 
     def _stale_should_escalate(self, action_contract: ActionClassContract | None) -> bool:
         if not action_contract:

--- a/veritas_os/governance/runtime_authority.py
+++ b/veritas_os/governance/runtime_authority.py
@@ -12,9 +12,13 @@ from veritas_os.governance.authority_evidence import (
     VerificationResult,
     is_expired,
 )
+from veritas_os.governance.human_approval_receipt import (
+    HUMAN_APPROVAL_STATE_SOURCE,
+    HumanApprovalReceipt,
+    build_human_approval_state,
+    human_approval_state_validation_hash,
+)
 from veritas_os.governance.predicates import PredicateResult
-
-_HUMAN_APPROVAL_STATE_SOURCE = "validated_human_approval_receipt"
 
 RuntimeValidationStatus = Literal["pass", "fail"]
 RecommendedOutcome = Literal["commit", "block", "escalate", "refuse"]
@@ -66,12 +70,21 @@ class RuntimeAuthorityValidator:
         required_evidence_metadata: dict[str, Any],
         policy_snapshot_id: str | None,
         actor_identity: str | None,
-        human_approval_state: dict[str, Any],
-        bind_context_metadata: dict[str, Any],
+        human_approval_state: dict[str, Any] | None = None,
+        human_approval_receipt: HumanApprovalReceipt | None = None,
+        bind_context_metadata: dict[str, Any] | None = None,
         now: datetime | None = None,
     ) -> RuntimeAuthorityValidationResult:
-        """Validate runtime authority with explicit deterministic predicates."""
+        """Validate runtime authority with explicit deterministic predicates.
+
+        Human approval is authoritative only when provided as a
+        ``HumanApprovalReceipt`` or as a tamper-evident state produced by
+        ``build_human_approval_state``. Raw compatibility dictionaries are
+        accepted only as fail-closed/non-approved inputs.
+        """
         evaluated_at = (now or datetime.now(UTC)).isoformat()
+        human_approval_state = human_approval_state or {}
+        bind_context_metadata = bind_context_metadata or {}
         predicates: list[PredicateResult] = []
 
         try:
@@ -264,8 +277,13 @@ class RuntimeAuthorityValidator:
             )
 
             needs_approval = self._requires_human_approval(action_contract)
-            approval_ok, approval_reason = self._validated_human_approval_state(
-                human_approval_state
+            approval_ok, approval_reason = self._validated_human_approval(
+                human_approval_state=human_approval_state,
+                human_approval_receipt=human_approval_receipt,
+                requested_scope=requested_scope,
+                action_contract=action_contract,
+                policy_snapshot_id=policy_snapshot_id,
+                now=now,
             )
             human_approval_ok = (not needs_approval) or approval_ok
             predicates.append(
@@ -358,6 +376,29 @@ class RuntimeAuthorityValidator:
             reason_summary=summary,
         )
 
+    def _validated_human_approval(
+        self,
+        *,
+        human_approval_state: dict[str, Any],
+        human_approval_receipt: HumanApprovalReceipt | None,
+        requested_scope: list[str],
+        action_contract: ActionClassContract | None,
+        policy_snapshot_id: str | None,
+        now: datetime | None,
+    ) -> tuple[bool, str]:
+        """Validate human approval from a receipt before compatibility state."""
+        if human_approval_receipt is not None:
+            receipt_state = build_human_approval_state(
+                human_approval_receipt,
+                requested_scope=requested_scope,
+                action_class=action_contract.action_class if action_contract else None,
+                policy_snapshot_id=policy_snapshot_id,
+                now=now,
+            )
+            return self._validated_human_approval_state(receipt_state)
+
+        return self._validated_human_approval_state(human_approval_state)
+
     def _validated_human_approval_state(
         self,
         human_approval_state: dict[str, Any],
@@ -377,16 +418,29 @@ class RuntimeAuthorityValidator:
 
         if (
             human_approval_state.get("approval_state_source")
-            != _HUMAN_APPROVAL_STATE_SOURCE
+            != HUMAN_APPROVAL_STATE_SOURCE
         ):
             return False, "human_approval_receipt_missing"
 
-        required_fields = ("approval_receipt_id", "receipt_hash", "validated_at")
+        required_fields = (
+            "approval_receipt_id",
+            "receipt_hash",
+            "approved_action_class",
+            "policy_snapshot_id",
+            "validated_at",
+            "approval_validation_hash",
+        )
         if not all(
             str(human_approval_state.get(field) or "").strip()
             for field in required_fields
         ):
             return False, "human_approval_receipt_missing"
+        if not isinstance(human_approval_state.get("approved_scope"), list):
+            return False, "human_approval_receipt_missing"
+
+        expected_hash = human_approval_state_validation_hash(human_approval_state)
+        if human_approval_state.get("approval_validation_hash") != expected_hash:
+            return False, "human_approval_validation_hash_mismatch"
 
         failure_reasons = human_approval_state.get("failure_reasons")
         if failure_reasons:

--- a/veritas_os/tests/test_evidence_bundle_cli.py
+++ b/veritas_os/tests/test_evidence_bundle_cli.py
@@ -975,6 +975,36 @@ def test_evidence_bundle_cli_require_signature_rejects_unsigned_bundle(
     assert exit_code == 1
 
 
+def test_evidence_bundle_generation_dev_without_verifier_is_integrity_only(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    """Dev/test bundle generation writes an integrity-only failed report."""
+    from veritas_os.audit.evidence_bundle import generate_evidence_bundle
+
+    monkeypatch.setenv("VERITAS_POSTURE", "dev")
+    log_path = tmp_path / "trustlog.jsonl"
+    private_key = tmp_path / "keys" / "priv.key"
+    public_key = tmp_path / "keys" / "pub.key"
+    monkeypatch.setattr(trustlog_signed, "SIGNED_TRUSTLOG_JSONL", log_path)
+    monkeypatch.setattr(trustlog_signed, "PRIVATE_KEY_PATH", private_key)
+    monkeypatch.setattr(trustlog_signed, "PUBLIC_KEY_PATH", public_key)
+    trustlog_signed.append_signed_decision({"request_id": "dev-integrity-only"})
+
+    result = generate_evidence_bundle(
+        bundle_type="decision",
+        witness_ledger_path=log_path,
+        output_dir=tmp_path / "bundles",
+    )
+
+    report_path = Path(result["bundle_dir"]) / "verification_report.json"
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["verification_mode"] == "integrity_only"
+    assert report["signature_verification_performed"] is False
+    assert report["ok"] is False
+    assert report["signature_ok"] is False
+
+
 @pytest.mark.parametrize("posture", ["secure", "prod"])
 def test_evidence_bundle_cli_secure_or_prod_posture_rejects_unsigned_bundle(
     tmp_path,
@@ -983,7 +1013,6 @@ def test_evidence_bundle_cli_secure_or_prod_posture_rejects_unsigned_bundle(
 ) -> None:
     """VERITAS_POSTURE=secure/prod requires manifest signature verification."""
     from veritas_os.audit.evidence_bundle import generate_evidence_bundle
-    from veritas_os.cli.evidence_bundle import main
 
     monkeypatch.setenv("VERITAS_POSTURE", posture)
     log_path = tmp_path / "trustlog.jsonl"
@@ -993,15 +1022,13 @@ def test_evidence_bundle_cli_secure_or_prod_posture_rejects_unsigned_bundle(
     monkeypatch.setattr(trustlog_signed, "PRIVATE_KEY_PATH", private_key)
     monkeypatch.setattr(trustlog_signed, "PUBLIC_KEY_PATH", public_key)
     trustlog_signed.append_signed_decision({"request_id": "secure-unsigned"})
-    result = generate_evidence_bundle(
-        bundle_type="decision",
-        witness_ledger_path=log_path,
-        output_dir=tmp_path / "bundles",
-    )
 
-    exit_code = main(["verify", "--bundle-dir", result["bundle_dir"]])
-
-    assert exit_code == 1
+    with pytest.raises(ValueError, match="Signature verification is required"):
+        generate_evidence_bundle(
+            bundle_type="decision",
+            witness_ledger_path=log_path,
+            output_dir=tmp_path / "bundles",
+        )
 
 
 def test_evidence_bundle_cli_secure_unsigned_json_contract(
@@ -1009,11 +1036,11 @@ def test_evidence_bundle_cli_secure_unsigned_json_contract(
     monkeypatch,
     capsys,
 ) -> None:
-    """Secure posture --json reports unsigned bundles as authenticity failures."""
+    """Dev posture --json can still require signatures for contract checks."""
     from veritas_os.audit.evidence_bundle import generate_evidence_bundle
     from veritas_os.cli.evidence_bundle import main
 
-    monkeypatch.setenv("VERITAS_POSTURE", "secure")
+    monkeypatch.setenv("VERITAS_POSTURE", "dev")
     log_path = tmp_path / "trustlog.jsonl"
     private_key = tmp_path / "keys" / "priv.key"
     public_key = tmp_path / "keys" / "pub.key"
@@ -1027,7 +1054,15 @@ def test_evidence_bundle_cli_secure_unsigned_json_contract(
         output_dir=tmp_path / "bundles",
     )
 
-    exit_code = main(["verify", "--bundle-dir", result["bundle_dir"], "--json"])
+    exit_code = main(
+        [
+            "verify",
+            "--bundle-dir",
+            result["bundle_dir"],
+            "--require-signature",
+            "--json",
+        ]
+    )
     output = json.loads(capsys.readouterr().out)
 
     assert exit_code == 1

--- a/veritas_os/tests/test_external_audit_readiness.py
+++ b/veritas_os/tests/test_external_audit_readiness.py
@@ -783,6 +783,75 @@ class TestEvidenceBundleVerification:
                 request_ids=["r-secure-requires-verifier"],
             )
 
+    def test_bundle_secure_posture_raises_when_verifier_raises(
+        self,
+        _trustlog_env,
+        monkeypatch,
+    ):
+        """Secure/prod bundle generation fails closed on verification exceptions."""
+        env = _trustlog_env
+        trustlog_signed.append_signed_decision(
+            {"request_id": "r-secure-verifier-raises", "decision": "allow"}
+        )
+        monkeypatch.setenv("VERITAS_POSTURE", "secure")
+
+        from veritas_os.audit.evidence_bundle import generate_evidence_bundle
+
+        def raising_verifier(_entry):
+            raise RuntimeError("boom with unstable detail")
+
+        with pytest.raises(ValueError, match="Evidence bundle verification failed"):
+            generate_evidence_bundle(
+                bundle_type="decision",
+                witness_ledger_path=env["log_path"],
+                output_dir=env["tmp_path"] / "bundles",
+                request_ids=["r-secure-verifier-raises"],
+                verify_signature_fn=raising_verifier,
+            )
+
+    def test_bundle_dev_posture_writes_failed_report_when_verifier_raises(
+        self,
+        _trustlog_env,
+        monkeypatch,
+    ):
+        """Dev/test bundle generation writes a failed report on exceptions."""
+        env = _trustlog_env
+        trustlog_signed.append_signed_decision(
+            {"request_id": "r-dev-verifier-raises", "decision": "allow"}
+        )
+        monkeypatch.setenv("VERITAS_POSTURE", "dev")
+
+        from veritas_os.audit.evidence_bundle import generate_evidence_bundle
+
+        def raising_verifier(_entry):
+            raise RuntimeError("boom with unstable detail")
+
+        result = generate_evidence_bundle(
+            bundle_type="decision",
+            witness_ledger_path=env["log_path"],
+            output_dir=env["tmp_path"] / "bundles",
+            request_ids=["r-dev-verifier-raises"],
+            verify_signature_fn=raising_verifier,
+        )
+
+        bundle_dir = Path(result["bundle_dir"])
+        report_path = bundle_dir / "verification_report.json"
+        assert report_path.exists()
+        report = json.loads(report_path.read_text())
+        assert report["ok"] is False
+        assert report["signature_ok"] is False
+        assert report["signature_verification_performed"] is True
+        assert report["verification_mode"] == "verification_failed"
+        assert report["verification_error"] == "RuntimeError"
+        assert report["verification_limitations"] == ["verification_exception"]
+
+        checklist = json.loads((bundle_dir / "acceptance_checklist.json").read_text())
+        verification_item = next(
+            item for item in checklist["items"] if item["id"] == "verification_report_present"
+        )
+        assert verification_item["status"] == "fail"
+        assert verification_item["details"]["report_ok"] is False
+
     def test_bundle_signature_verifier_result_controls_report(self, _trustlog_env):
         """Provided verifier results must drive signature_ok and ok."""
         env = _trustlog_env

--- a/veritas_os/tests/test_external_audit_readiness.py
+++ b/veritas_os/tests/test_external_audit_readiness.py
@@ -734,6 +734,94 @@ class TestEvidenceBundleVerification:
         assert verify_result["tampered"] is True
         assert any("Hash mismatch" in e for e in verify_result["errors"])
 
+    def test_bundle_without_signature_verifier_reports_integrity_only(
+        self,
+        _trustlog_env,
+    ):
+        """Bundle generation must not self-report signature verification."""
+        env = _trustlog_env
+        trustlog_signed.append_signed_decision(
+            {"request_id": "r-integrity-only", "decision": "allow"}
+        )
+
+        from veritas_os.audit.evidence_bundle import generate_evidence_bundle
+
+        result = generate_evidence_bundle(
+            bundle_type="decision",
+            witness_ledger_path=env["log_path"],
+            output_dir=env["tmp_path"] / "bundles",
+            request_ids=["r-integrity-only"],
+        )
+
+        report = json.loads(
+            (Path(result["bundle_dir"]) / "verification_report.json").read_text()
+        )
+        assert report["verification_mode"] == "integrity_only"
+        assert report["signature_verification_performed"] is False
+        assert report["signature_ok"] is False
+        assert "signature_verifier_not_provided" in report["verification_limitations"]
+
+    def test_bundle_secure_posture_requires_signature_verifier(
+        self,
+        _trustlog_env,
+        monkeypatch,
+    ):
+        """Secure/prod evidence bundles fail closed without a verifier."""
+        env = _trustlog_env
+        trustlog_signed.append_signed_decision(
+            {"request_id": "r-secure-requires-verifier", "decision": "allow"}
+        )
+        monkeypatch.setenv("VERITAS_POSTURE", "secure")
+
+        from veritas_os.audit.evidence_bundle import generate_evidence_bundle
+
+        with pytest.raises(ValueError, match="Signature verification is required"):
+            generate_evidence_bundle(
+                bundle_type="decision",
+                witness_ledger_path=env["log_path"],
+                output_dir=env["tmp_path"] / "bundles",
+                request_ids=["r-secure-requires-verifier"],
+            )
+
+    def test_bundle_signature_verifier_result_controls_report(self, _trustlog_env):
+        """Provided verifier results must drive signature_ok and ok."""
+        env = _trustlog_env
+        trustlog_signed.append_signed_decision(
+            {"request_id": "r-verifier-true", "decision": "allow"}
+        )
+        trustlog_signed.append_signed_decision(
+            {"request_id": "r-verifier-false", "decision": "allow"}
+        )
+
+        from veritas_os.audit.evidence_bundle import generate_evidence_bundle
+
+        true_result = generate_evidence_bundle(
+            bundle_type="decision",
+            witness_ledger_path=env["log_path"],
+            output_dir=env["tmp_path"] / "bundles",
+            request_ids=["r-verifier-true"],
+            verify_signature_fn=lambda _entry: True,
+        )
+        true_report = json.loads(
+            (Path(true_result["bundle_dir"]) / "verification_report.json").read_text()
+        )
+        assert true_report["signature_verification_performed"] is True
+        assert true_report["signature_ok"] is True
+
+        false_result = generate_evidence_bundle(
+            bundle_type="decision",
+            witness_ledger_path=env["log_path"],
+            output_dir=env["tmp_path"] / "bundles",
+            request_ids=["r-verifier-false"],
+            verify_signature_fn=lambda _entry: False,
+        )
+        false_report = json.loads(
+            (Path(false_result["bundle_dir"]) / "verification_report.json").read_text()
+        )
+        assert false_report["signature_verification_performed"] is True
+        assert false_report["signature_ok"] is False
+        assert false_report["ok"] is False
+
     def test_detect_missing_file(self, _trustlog_env):
         """Verification detects deleted file from bundle."""
         env = _trustlog_env


### PR DESCRIPTION
### Motivation
- Prevent evidence bundles from claiming signatures were verified when a permissive/no-op verifier was used, and ensure secure/posture modes fail closed when a verifier is required. 
- Prevent runtime authority from trusting self-asserted `{"approved": true}` dicts without a validated `HumanApprovalReceipt` provenance.

### Description
- Added explicit `verify_signature_fn: Optional[Callable[[Dict[str, Any]], bool]]` parameter to `generate_evidence_bundle()` and removed the previous no-op verifier path so signature verification is only reported when a real verifier is supplied. 
- Added posture-aware fail-closed behavior: when `VERITAS_POSTURE` is one of `_SIGNATURE_REQUIRED_POSTURES` (`secure`, `prod`) bundle generation raises if no verifier is provided. 
- Added machine-readable verification metadata to `verification_report.json`: `verification_mode`, `signature_verification_performed`, `signature_verification_required`, and `verification_limitations`, and ensure `signature_ok`/`ok` cannot be claimed True when verification was not actually performed. 
- Clarified README/UI hook wording to state that cryptographic verification requires a trusted public key/verifier and `--require-signature`. 
- Hardened `RuntimeAuthorityValidator` so human approval is accepted only when `human_approval_state` is derived from a validated `HumanApprovalReceipt` (via `build_human_approval_state()`), by adding `_validated_human_approval_state()` and rejecting raw self-asserted dicts with `human_approval_receipt_missing`. 
- Marked `build_human_approval_state()` output with `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d14c65b208326ab777321026c8f63)