### PR TITLE
Require HumanApprovalReceipt in secure/prod posture (posture-aware human approval validation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Boundary:
 
 ## Human Approval Receipt v1
 
-VERITAS now includes a local/offline Human Approval Receipt v1 artifact. It represents human approval as a deterministic, hashable, scope-bound, expiry-aware governance artifact that can be converted into the existing runtime `human_approval_state` used by bind-time validation. This does not add live IdP, SSO, IAM, KMS/HSM, e-signature, or production approval workflow integration.
+VERITAS now includes a local/offline Human Approval Receipt v1 artifact. It represents human approval as a deterministic, hashable, scope-bound, expiry-aware governance artifact. Dev/test local workflows may convert receipts into compatibility `human_approval_state` dictionaries for demos, fixtures, and migration, but `secure`/`prod` posture requires an explicit `HumanApprovalReceipt` object or a future signed approval artifact path when human approval is needed. The `approval_validation_hash` is tamper-evident metadata, not a substitute for cryptographic receipt verification. This does not add live IdP, SSO, IAM, KMS/HSM, e-signature, or production approval workflow integration.
 
 Boundary:
 

--- a/docs/en/architecture/human-approval-receipt.md
+++ b/docs/en/architecture/human-approval-receipt.md
@@ -27,6 +27,14 @@ It is designed to make approval:
   - action-class mismatch.
 - A compatibility helper that converts the receipt into the existing runtime `human_approval_state` shape.
 
+## Runtime posture trust boundary
+
+Runtime approval validation is posture-aware:
+
+- `dev` and `test` style local workflows may use receipt-derived compatibility `human_approval_state` dictionaries produced by `build_human_approval_state()` for demos, fixtures, and migration.
+- `secure` and `prod` posture require an explicit `HumanApprovalReceipt` object, or a future signed approval artifact path, when human approval is needed. Compatibility dictionaries alone are not authoritative in those postures.
+- `approval_validation_hash` is tamper-evident metadata for accidental/internal mutation detection. It is not cryptographically signed and is not a substitute for receipt verification across an external trust boundary.
+
 ## Explicit boundary (non-goals)
 
 This is local/offline v1 only.

--- a/tests/governance/test_human_approval_receipt.py
+++ b/tests/governance/test_human_approval_receipt.py
@@ -14,7 +14,10 @@ from veritas_os.governance.human_approval_receipt import (
     validate_human_approval_receipt,
     with_receipt_hash,
 )
-from veritas_os.governance.runtime_authority import RuntimeAuthorityValidator
+from veritas_os.governance.runtime_authority import (
+    RuntimeAuthorityValidationResult,
+    RuntimeAuthorityValidator,
+)
 
 
 def _receipt(**overrides: object) -> HumanApprovalReceipt:
@@ -453,3 +456,148 @@ def test_runtime_authority_blocks_invalid_human_approval_receipt_state(
     assert result.status == "fail"
     assert result.recommended_outcome == "block"
     assert reason in result.reason_summary
+
+
+def _approval_reason(result: RuntimeAuthorityValidationResult) -> str:
+    return next(
+        predicate.reason
+        for predicate in result.missing_predicates
+        if predicate.predicate_type == "human_approval_present"
+    )
+
+
+@pytest.mark.parametrize("posture", ["secure", "prod"])
+def test_strict_posture_passes_with_valid_human_approval_receipt(
+    monkeypatch: pytest.MonkeyPatch,
+    posture: str,
+) -> None:
+    monkeypatch.setenv("VERITAS_POSTURE", posture)
+    validator = RuntimeAuthorityValidator()
+
+    result = validator.validate(
+        action_contract=_contract(),
+        authority_evidence=_authority(),
+        requested_scope=["ledger:debit"],
+        required_evidence_metadata={"kyc_status": {"present": True, "fresh": True}},
+        policy_snapshot_id="policy-001",
+        actor_identity="operator:alice",
+        human_approval_receipt=_receipt(),
+        bind_context_metadata={"session_id": "bind-001"},
+        now=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    assert result.status == "pass"
+    assert result.recommended_outcome == "commit"
+
+
+@pytest.mark.parametrize("posture", ["secure", "prod"])
+def test_strict_posture_rejects_compatibility_state_without_receipt(
+    monkeypatch: pytest.MonkeyPatch,
+    posture: str,
+) -> None:
+    monkeypatch.setenv("VERITAS_POSTURE", posture)
+    validator = RuntimeAuthorityValidator()
+    approval_state = build_human_approval_state(
+        _receipt(),
+        requested_scope=["ledger:debit"],
+        action_class="wire_transfer",
+        policy_snapshot_id="policy-001",
+        now=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    result = validator.validate(
+        action_contract=_contract(),
+        authority_evidence=_authority(),
+        requested_scope=["ledger:debit"],
+        required_evidence_metadata={"kyc_status": {"present": True, "fresh": True}},
+        policy_snapshot_id="policy-001",
+        actor_identity="operator:alice",
+        human_approval_state=approval_state,
+        bind_context_metadata={"session_id": "bind-001"},
+        now=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    assert result.status == "fail"
+    assert _approval_reason(result) == "human_approval_receipt_required"
+
+
+def test_dev_posture_keeps_compatibility_state_support(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VERITAS_POSTURE", "dev")
+    validator = RuntimeAuthorityValidator()
+    approval_state = build_human_approval_state(
+        _receipt(),
+        requested_scope=["ledger:debit"],
+        action_class="wire_transfer",
+        policy_snapshot_id="policy-001",
+        now=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    result = validator.validate(
+        action_contract=_contract(),
+        authority_evidence=_authority(),
+        requested_scope=["ledger:debit"],
+        required_evidence_metadata={"kyc_status": {"present": True, "fresh": True}},
+        policy_snapshot_id="policy-001",
+        actor_identity="operator:alice",
+        human_approval_state=approval_state,
+        bind_context_metadata={"session_id": "bind-001"},
+        now=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    assert result.status == "pass"
+
+
+def test_dev_posture_rejects_raw_approved_dict(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VERITAS_POSTURE", "dev")
+    validator = RuntimeAuthorityValidator()
+
+    result = validator.validate(
+        action_contract=_contract(),
+        authority_evidence=_authority(),
+        requested_scope=["ledger:debit"],
+        required_evidence_metadata={"kyc_status": {"present": True, "fresh": True}},
+        policy_snapshot_id="policy-001",
+        actor_identity="operator:alice",
+        human_approval_state={"approved": True},
+        bind_context_metadata={"session_id": "bind-001"},
+        now=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    assert result.status == "fail"
+    assert _approval_reason(result) == "human_approval_receipt_missing"
+
+
+@pytest.mark.parametrize("posture", ["secure", "prod"])
+@pytest.mark.parametrize(
+    ("receipt_overrides", "expected_reason"),
+    [
+        ({"expires_at": "2026-04-01T00:00:00+00:00"}, "human_approval_expired"),
+        ({"signature_verified": False}, "human_approval_signature_unverified"),
+        ({"approved_scope": ["ledger:credit"]}, "human_approval_scope_not_granted"),
+    ],
+)
+def test_strict_posture_invalid_receipt_propagates_validation_reason(
+    monkeypatch: pytest.MonkeyPatch,
+    posture: str,
+    receipt_overrides: dict[str, object],
+    expected_reason: str,
+) -> None:
+    monkeypatch.setenv("VERITAS_POSTURE", posture)
+    validator = RuntimeAuthorityValidator()
+
+    result = validator.validate(
+        action_contract=_contract(),
+        authority_evidence=_authority(),
+        requested_scope=["ledger:debit"],
+        required_evidence_metadata={"kyc_status": {"present": True, "fresh": True}},
+        policy_snapshot_id="policy-001",
+        actor_identity="operator:alice",
+        human_approval_receipt=_receipt(**receipt_overrides),
+        bind_context_metadata={"session_id": "bind-001"},
+        now=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    assert result.status == "fail"
+    assert _approval_reason(result) == expected_reason

--- a/veritas_os/governance/runtime_authority.py
+++ b/veritas_os/governance/runtime_authority.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any, Literal
@@ -386,7 +387,15 @@ class RuntimeAuthorityValidator:
         policy_snapshot_id: str | None,
         now: datetime | None,
     ) -> tuple[bool, str]:
-        """Validate human approval from a receipt before compatibility state."""
+        """Validate human approval using posture-aware trust boundaries.
+
+        Secure and production postures require an explicit
+        ``HumanApprovalReceipt`` (or a future signed approval artifact path) as
+        the authoritative approval source. Compatibility dictionaries remain
+        accepted only in dev/test-style postures because their deterministic
+        validation hash is tamper-evident, not cryptographically signed.
+        """
+        strict_posture = self._requires_receipt_for_human_approval()
         if human_approval_receipt is not None:
             receipt_state = build_human_approval_state(
                 human_approval_receipt,
@@ -397,7 +406,14 @@ class RuntimeAuthorityValidator:
             )
             return self._validated_human_approval_state(receipt_state)
 
+        if strict_posture:
+            return False, "human_approval_receipt_required"
+
         return self._validated_human_approval_state(human_approval_state)
+
+    def _requires_receipt_for_human_approval(self) -> bool:
+        """Return whether current posture requires receipt-backed approval."""
+        return os.getenv("VERITAS_POSTURE", "dev").strip().lower() in {"secure", "prod"}
 
     def _validated_human_approval_state(
         self,


### PR DESCRIPTION
### Motivation

- Prevent deterministic compatibility `human_approval_state` dicts from being treated as authoritative approval in high-trust postures where cryptographic or signed receipts are required. 
- Preserve backwards compatibility for `dev`/`test` workflows that rely on `build_human_approval_state()` for demos and fixtures. 
- Make runtime human-approval validation posture-aware so secure/prod enforces a stronger trust boundary without removing existing local/offline receipt helpers.

### Description

- Update `RuntimeAuthorityValidator._validated_human_approval()` to be posture-aware and require an explicit `HumanApprovalReceipt` in `secure`/`prod` postures; compatibility dicts alone now fail closed with reason `human_approval_receipt_required` when posture is strict (changes in `veritas_os/governance/runtime_authority.py`).
- Add helper `RuntimeAuthorityValidator._requires_receipt_for_human_approval()` which consults `VERITAS_POSTURE` to decide whether receipts are mandatory.
- Preserve dev/test behavior: when posture is not `secure`/`prod`, `build_human_approval_state()`-derived dicts remain accepted (raw `{"approved": True}` is still rejected).
- Add posture-aware tests exercising the new behavior and failure propagation to `tests/governance/test_human_approval_receipt.py` (secure/prod valid receipt passes, secure/prod compatibility-dict without receipt fails with `human_approval_receipt_required`, dev accepts compatibility-state, dev rejects raw approved dicts, and strict posture propagates invalid receipt reasons like `human_approval_expired`, `human_approval_signature_unverified`, `human_approval_scope_not_granted`).
- Update documentation (`docs/en/architecture/human-approval-receipt.md` and `README.md`) to state the posture trust boundary and clarify that `approval_validation_hash` is tamper-evident but not a substitute for cryptographic receipt verification.
- Retain the #2035 hardening (receipt support, validation hash, tamper detection, fail-closed) while strengthening the runtime trust boundary for strict postures.

### Testing

- Code style and static checks: `python -m compileall` (compile) and `ruff check` passed for modified files.
- Unit tests: targeted `tests/governance/test_human_approval_receipt.py` and `tests/governance/test_runtime_authority_validation.py`; running `pytest` in this environment failed during collection due to missing runtime dependency `PyYAML` (`ModuleNotFoundError: No module named 'yaml'`) and environment package fetch failures in the sandbox, so automated test run was incomplete. 
- Behavioural validation: added tests assert strict-posture receipt requirement and correct failure reason propagation; these tests were committed but could not be executed to completion in this environment due to missing test dependencies and network limitations (CI should run full test matrix).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e10aee70c832691471d891c888581)