### PR TITLE
Add signed HumanApprovalReceipt artifact verification

### DIFF
--- a/docs/en/architecture/human-approval-receipt.md
+++ b/docs/en/architecture/human-approval-receipt.md
@@ -1,4 +1,4 @@
-# Human Approval Receipt v1 (local/offline)
+# Human Approval Receipt v1
 
 ## Purpose
 
@@ -26,14 +26,37 @@ It is designed to make approval:
   - policy snapshot mismatch,
   - action-class mismatch.
 - A compatibility helper that converts the receipt into the existing runtime `human_approval_state` shape.
+- A signed approval artifact envelope for crossing external-review and secure/prod runtime trust boundaries.
 
 ## Runtime posture trust boundary
 
 Runtime approval validation is posture-aware:
 
+- `HumanApprovalReceipt` is the local/offline receipt representation used after validation.
+- A signed approval artifact is the preferred external-review and `secure`/`prod` trust-boundary format. It wraps the receipt payload, canonical `receipt_hash`, signature, signer metadata, and `signed_at` timestamp.
+- `signature_verified` must be derived by `verify_human_approval_receipt_artifact()` or an equivalent verifier-controlled path. Raw input is not allowed to self-assert this value across the `secure`/`prod` boundary.
+- `secure` and `prod` posture prefer a signed approval artifact plus verifier. A direct `HumanApprovalReceipt` is accepted only when its `signature_verified` field is already true. Compatibility dictionaries alone are not authoritative in those postures.
 - `dev` and `test` style local workflows may use receipt-derived compatibility `human_approval_state` dictionaries produced by `build_human_approval_state()` for demos, fixtures, and migration.
-- `secure` and `prod` posture require an explicit `HumanApprovalReceipt` object, or a future signed approval artifact path, when human approval is needed. Compatibility dictionaries alone are not authoritative in those postures.
-- `approval_validation_hash` is tamper-evident metadata for accidental/internal mutation detection. It is not cryptographically signed and is not a substitute for receipt verification across an external trust boundary.
+- `approval_validation_hash` is tamper-evident metadata for accidental/internal mutation detection. It is not cryptographically signed and is not a substitute for signed artifact verification across an external trust boundary.
+
+A signed approval artifact has this deterministic v1 envelope shape:
+
+```json
+{
+  "artifact_type": "human_approval_receipt",
+  "artifact_version": "v1",
+  "receipt": { "...": "HumanApprovalReceipt fields except receipt_hash" },
+  "receipt_hash": "canonical sha256 of the receipt payload",
+  "signature": "external signature bytes or encoding",
+  "signer": {
+    "key_id": "review-key-id",
+    "algorithm": "ed25519|ecdsa-p256|test-only"
+  },
+  "signed_at": "2026-05-01T00:00:00+00:00"
+}
+```
+
+Verification is fail-closed: runtime recomputes `receipt_hash`, requires an explicit verifier for signed artifacts, rejects bad signatures, and propagates expiry, scope, policy-snapshot, and action-class validation failures.
 
 ## Explicit boundary (non-goals)
 
@@ -44,7 +67,7 @@ This does **not** include:
 - live IdP integration,
 - SSO/IAM integration,
 - KMS/HSM integration,
-- real e-signature verification,
+- built-in real e-signature verification (callers inject the verifier),
 - production approval workflow integration,
 - network calls,
 - credentials or SaaS bank integrations.

--- a/tests/governance/test_human_approval_receipt.py
+++ b/tests/governance/test_human_approval_receipt.py
@@ -12,6 +12,7 @@ from veritas_os.governance.human_approval_receipt import (
     HumanApprovalReceipt,
     build_human_approval_state,
     validate_human_approval_receipt,
+    verify_human_approval_receipt_artifact,
     with_receipt_hash,
 )
 from veritas_os.governance.runtime_authority import (
@@ -41,6 +42,30 @@ def _receipt(**overrides: object) -> HumanApprovalReceipt:
     }
     payload.update(overrides)
     return HumanApprovalReceipt(**payload)
+
+
+def _signed_artifact(
+    receipt: HumanApprovalReceipt | None = None,
+    **overrides: object,
+) -> dict[str, object]:
+    base_receipt = receipt or _receipt(signature_verified=False)
+    receipt_payload = base_receipt.to_dict_for_hash()
+    receipt_payload["signature_verified"] = True
+    digest_payload = dict(receipt_payload)
+    digest_payload["signature_verified"] = False
+    digest_payload["receipt_hash"] = ""
+    digest_receipt = HumanApprovalReceipt(**digest_payload)
+    artifact = {
+        "artifact_type": "human_approval_receipt",
+        "artifact_version": "v1",
+        "receipt": receipt_payload,
+        "receipt_hash": digest_receipt.deterministic_digest(),
+        "signature": "test-signature",
+        "signer": {"key_id": "test-key", "algorithm": "test-only"},
+        "signed_at": "2026-05-01T00:00:00+00:00",
+    }
+    artifact.update(overrides)
+    return artifact
 
 
 def _contract(**overrides: object) -> ActionClassContract:
@@ -601,3 +626,154 @@ def test_strict_posture_invalid_receipt_propagates_validation_reason(
 
     assert result.status == "fail"
     assert _approval_reason(result) == expected_reason
+
+
+def test_signed_human_approval_artifact_verification_sets_signature_verified() -> None:
+    artifact = _signed_artifact()
+
+    receipt = verify_human_approval_receipt_artifact(
+        artifact,
+        lambda signed_artifact: signed_artifact["signature"] == "test-signature",
+        requested_scope=["ledger:debit"],
+        action_class="wire_transfer",
+        policy_snapshot_id="policy-001",
+        now=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    assert receipt.signature_verified is True
+    assert receipt.receipt_hash == artifact["receipt_hash"]
+
+
+def test_signed_human_approval_artifact_bad_signature_fails() -> None:
+    artifact = _signed_artifact()
+
+    with pytest.raises(ValueError, match="human_approval_signature_verification_failed"):
+        verify_human_approval_receipt_artifact(
+            artifact,
+            lambda _artifact: False,
+            requested_scope=["ledger:debit"],
+            action_class="wire_transfer",
+            policy_snapshot_id="policy-001",
+            now=datetime(2026, 5, 10, tzinfo=UTC),
+        )
+
+
+def test_signed_human_approval_artifact_tampered_receipt_hash_fails() -> None:
+    artifact = _signed_artifact(receipt_hash="f" * 64)
+
+    with pytest.raises(ValueError, match="human_approval_receipt_hash_mismatch"):
+        verify_human_approval_receipt_artifact(
+            artifact,
+            lambda _artifact: True,
+            requested_scope=["ledger:debit"],
+            action_class="wire_transfer",
+            policy_snapshot_id="policy-001",
+            now=datetime(2026, 5, 10, tzinfo=UTC),
+        )
+
+
+def test_signed_human_approval_artifact_without_verifier_fails() -> None:
+    with pytest.raises(ValueError, match="human_approval_signature_verifier_required"):
+        verify_human_approval_receipt_artifact(
+            _signed_artifact(),
+            None,
+            requested_scope=["ledger:debit"],
+            action_class="wire_transfer",
+            policy_snapshot_id="policy-001",
+            now=datetime(2026, 5, 10, tzinfo=UTC),
+        )
+
+
+@pytest.mark.parametrize("posture", ["secure", "prod"])
+def test_strict_posture_passes_with_valid_signed_human_approval_artifact(
+    monkeypatch: pytest.MonkeyPatch,
+    posture: str,
+) -> None:
+    monkeypatch.setenv("VERITAS_POSTURE", posture)
+
+    result = RuntimeAuthorityValidator().validate(
+        action_contract=_contract(),
+        authority_evidence=_authority(),
+        requested_scope=["ledger:debit"],
+        required_evidence_metadata={"kyc_status": {"present": True, "fresh": True}},
+        policy_snapshot_id="policy-001",
+        actor_identity="operator:alice",
+        human_approval_artifact=_signed_artifact(),
+        verify_human_approval_signature_fn=lambda _artifact: True,
+        bind_context_metadata={"session_id": "bind-001"},
+        now=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    assert result.status == "pass"
+    assert result.recommended_outcome == "commit"
+
+
+@pytest.mark.parametrize("posture", ["secure", "prod"])
+def test_strict_posture_rejects_signed_artifact_with_bad_signature(
+    monkeypatch: pytest.MonkeyPatch,
+    posture: str,
+) -> None:
+    monkeypatch.setenv("VERITAS_POSTURE", posture)
+
+    result = RuntimeAuthorityValidator().validate(
+        action_contract=_contract(),
+        authority_evidence=_authority(),
+        requested_scope=["ledger:debit"],
+        required_evidence_metadata={"kyc_status": {"present": True, "fresh": True}},
+        policy_snapshot_id="policy-001",
+        actor_identity="operator:alice",
+        human_approval_artifact=_signed_artifact(),
+        verify_human_approval_signature_fn=lambda _artifact: False,
+        bind_context_metadata={"session_id": "bind-001"},
+        now=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    assert result.status == "fail"
+    assert _approval_reason(result) == "human_approval_signature_verification_failed"
+
+
+@pytest.mark.parametrize("posture", ["secure", "prod"])
+def test_strict_posture_rejects_signed_artifact_with_tampered_receipt_hash(
+    monkeypatch: pytest.MonkeyPatch,
+    posture: str,
+) -> None:
+    monkeypatch.setenv("VERITAS_POSTURE", posture)
+
+    result = RuntimeAuthorityValidator().validate(
+        action_contract=_contract(),
+        authority_evidence=_authority(),
+        requested_scope=["ledger:debit"],
+        required_evidence_metadata={"kyc_status": {"present": True, "fresh": True}},
+        policy_snapshot_id="policy-001",
+        actor_identity="operator:alice",
+        human_approval_artifact=_signed_artifact(receipt_hash="f" * 64),
+        verify_human_approval_signature_fn=lambda _artifact: True,
+        bind_context_metadata={"session_id": "bind-001"},
+        now=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    assert result.status == "fail"
+    assert _approval_reason(result) == "human_approval_receipt_hash_mismatch"
+
+
+@pytest.mark.parametrize("posture", ["secure", "prod"])
+def test_strict_posture_rejects_signed_artifact_without_verifier(
+    monkeypatch: pytest.MonkeyPatch,
+    posture: str,
+) -> None:
+    monkeypatch.setenv("VERITAS_POSTURE", posture)
+
+    result = RuntimeAuthorityValidator().validate(
+        action_contract=_contract(),
+        authority_evidence=_authority(),
+        requested_scope=["ledger:debit"],
+        required_evidence_metadata={"kyc_status": {"present": True, "fresh": True}},
+        policy_snapshot_id="policy-001",
+        actor_identity="operator:alice",
+        human_approval_artifact=_signed_artifact(),
+        bind_context_metadata={"session_id": "bind-001"},
+        now=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    assert result.status == "fail"
+    assert _approval_reason(result) == "human_approval_signature_verifier_required"

--- a/veritas_os/governance/human_approval_receipt.py
+++ b/veritas_os/governance/human_approval_receipt.py
@@ -8,13 +8,15 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from typing import Any, Literal
+from typing import Any, Callable, Literal
 
 from veritas_os.security.hash import sha256_of_canonical_json
 
 HUMAN_APPROVAL_STATE_SOURCE = "validated_human_approval_receipt"
 
 ApprovalResult = Literal["approved", "denied", "expired", "indeterminate"]
+SIGNED_APPROVAL_ARTIFACT_TYPE = "human_approval_receipt"
+SIGNED_APPROVAL_ARTIFACT_VERSION = "v1"
 
 
 @dataclass(frozen=True)
@@ -76,6 +78,70 @@ def with_receipt_hash(receipt: HumanApprovalReceipt) -> HumanApprovalReceipt:
     data = receipt.to_dict()
     data["receipt_hash"] = digest
     return HumanApprovalReceipt(**data)
+
+
+def _receipt_from_signed_payload(payload: dict[str, Any]) -> HumanApprovalReceipt:
+    """Build a receipt from signed artifact payload without trusting signature state."""
+    receipt_payload = dict(payload)
+    receipt_payload.pop("receipt_hash", None)
+    receipt_payload["signature_verified"] = False
+    receipt_payload["receipt_hash"] = ""
+    return HumanApprovalReceipt(**receipt_payload)
+
+
+def verify_human_approval_receipt_artifact(
+    artifact: dict[str, Any],
+    verify_signature_fn: Callable[[dict[str, Any]], bool] | None,
+    *,
+    requested_scope: list[str],
+    action_class: str | None,
+    policy_snapshot_id: str | None,
+    now: datetime | None = None,
+) -> HumanApprovalReceipt:
+    """Verify a signed Human Approval Receipt artifact fail-closed.
+
+    The caller-supplied ``signature_verified`` value in raw artifact data is
+    never trusted. This helper recomputes the canonical receipt hash, requires
+    an explicit signature verifier, invokes it over the full artifact, and only
+    then returns a ``HumanApprovalReceipt`` with ``signature_verified=True``.
+    Existing receipt validation errors are raised as deterministic reason
+    strings so runtime authority can propagate them without opening a bypass.
+    """
+    if not isinstance(artifact, dict):
+        raise ValueError("human_approval_artifact_invalid")
+    if artifact.get("artifact_type") != SIGNED_APPROVAL_ARTIFACT_TYPE:
+        raise ValueError("human_approval_artifact_type_invalid")
+    if artifact.get("artifact_version") != SIGNED_APPROVAL_ARTIFACT_VERSION:
+        raise ValueError("human_approval_artifact_version_invalid")
+    if verify_signature_fn is None:
+        raise ValueError("human_approval_signature_verifier_required")
+
+    receipt_payload = artifact.get("receipt")
+    if not isinstance(receipt_payload, dict):
+        raise ValueError("human_approval_receipt_missing")
+
+    unsigned_receipt = _receipt_from_signed_payload(receipt_payload)
+    expected_hash = unsigned_receipt.deterministic_digest()
+    if artifact.get("receipt_hash") != expected_hash:
+        raise ValueError("human_approval_receipt_hash_mismatch")
+
+    if verify_signature_fn(artifact) is not True:
+        raise ValueError("human_approval_signature_verification_failed")
+
+    verified_payload = unsigned_receipt.to_dict()
+    verified_payload["signature_verified"] = True
+    verified_payload["receipt_hash"] = expected_hash
+    verified_receipt = HumanApprovalReceipt(**verified_payload)
+    validation_result = validate_human_approval_receipt(
+        verified_receipt,
+        requested_scope=requested_scope,
+        action_class=action_class,
+        policy_snapshot_id=policy_snapshot_id,
+        now=now,
+    )
+    if not validation_result.is_valid:
+        raise ValueError(validation_result.failure_reasons[0])
+    return verified_receipt
 
 
 @dataclass(frozen=True)

--- a/veritas_os/governance/runtime_authority.py
+++ b/veritas_os/governance/runtime_authority.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from typing import Any, Literal
+from typing import Any, Callable, Literal
 
 from veritas_os.governance.action_contracts import ActionClassContract
 from veritas_os.governance.authority_evidence import (
@@ -18,6 +18,7 @@ from veritas_os.governance.human_approval_receipt import (
     HumanApprovalReceipt,
     build_human_approval_state,
     human_approval_state_validation_hash,
+    verify_human_approval_receipt_artifact,
 )
 from veritas_os.governance.predicates import PredicateResult
 
@@ -73,6 +74,10 @@ class RuntimeAuthorityValidator:
         actor_identity: str | None,
         human_approval_state: dict[str, Any] | None = None,
         human_approval_receipt: HumanApprovalReceipt | None = None,
+        human_approval_artifact: dict[str, Any] | None = None,
+        verify_human_approval_signature_fn: (
+            Callable[[dict[str, Any]], bool] | None
+        ) = None,
         bind_context_metadata: dict[str, Any] | None = None,
         now: datetime | None = None,
     ) -> RuntimeAuthorityValidationResult:
@@ -281,6 +286,8 @@ class RuntimeAuthorityValidator:
             approval_ok, approval_reason = self._validated_human_approval(
                 human_approval_state=human_approval_state,
                 human_approval_receipt=human_approval_receipt,
+                human_approval_artifact=human_approval_artifact,
+                verify_human_approval_signature_fn=verify_human_approval_signature_fn,
                 requested_scope=requested_scope,
                 action_contract=action_contract,
                 policy_snapshot_id=policy_snapshot_id,
@@ -382,6 +389,8 @@ class RuntimeAuthorityValidator:
         *,
         human_approval_state: dict[str, Any],
         human_approval_receipt: HumanApprovalReceipt | None,
+        human_approval_artifact: dict[str, Any] | None,
+        verify_human_approval_signature_fn: Callable[[dict[str, Any]], bool] | None,
         requested_scope: list[str],
         action_contract: ActionClassContract | None,
         policy_snapshot_id: str | None,
@@ -390,17 +399,40 @@ class RuntimeAuthorityValidator:
         """Validate human approval using posture-aware trust boundaries.
 
         Secure and production postures require an explicit
-        ``HumanApprovalReceipt`` (or a future signed approval artifact path) as
-        the authoritative approval source. Compatibility dictionaries remain
-        accepted only in dev/test-style postures because their deterministic
+        signed approval artifact, or a ``HumanApprovalReceipt`` whose signature
+        has already been verified, as the authoritative approval source.
+        Compatibility dictionaries remain accepted only in dev/test-style
+        postures because their deterministic
         validation hash is tamper-evident, not cryptographically signed.
         """
         strict_posture = self._requires_receipt_for_human_approval()
+        action_class = action_contract.action_class if action_contract else None
+        if human_approval_artifact is not None:
+            try:
+                verified_receipt = verify_human_approval_receipt_artifact(
+                    human_approval_artifact,
+                    verify_human_approval_signature_fn,
+                    requested_scope=requested_scope,
+                    action_class=action_class,
+                    policy_snapshot_id=policy_snapshot_id,
+                    now=now,
+                )
+            except ValueError as exc:
+                return False, str(exc)
+            receipt_state = build_human_approval_state(
+                verified_receipt,
+                requested_scope=requested_scope,
+                action_class=action_class,
+                policy_snapshot_id=policy_snapshot_id,
+                now=now,
+            )
+            return self._validated_human_approval_state(receipt_state)
+
         if human_approval_receipt is not None:
             receipt_state = build_human_approval_state(
                 human_approval_receipt,
                 requested_scope=requested_scope,
-                action_class=action_contract.action_class if action_contract else None,
+                action_class=action_class,
                 policy_snapshot_id=policy_snapshot_id,
                 now=now,
             )


### PR DESCRIPTION
### Motivation
- Close the trust gap where `HumanApprovalReceipt.signature_verified` could be set in raw input without independent verification, so secure/prod postures enforce cryptographic verification across trust boundaries. 
- Provide a deterministic signed approval artifact v1 envelope and a fail-closed verification helper to enable independent signature checks and tamper detection. 
- Make signed artifacts the preferred authoritative approval source for strict postures while preserving dev/test compatibility for local workflows. 

### Description
- Add artifact constants `SIGNED_APPROVAL_ARTIFACT_TYPE = "human_approval_receipt"` and `SIGNED_APPROVAL_ARTIFACT_VERSION = "v1"` and a fail-closed `verify_human_approval_receipt_artifact()` helper that recomputes `receipt_hash`, requires a caller-provided verifier, rejects hash/signature mismatches, and sets `signature_verified=True` only after success (`veritas_os/governance/human_approval_receipt.py`).
- Integrate signed artifact support into `RuntimeAuthorityValidator.validate()` by adding `human_approval_artifact` and `verify_human_approval_signature_fn` parameters and making signed artifacts the preferred source (falling back to already-verified `HumanApprovalReceipt` in secure/prod and compatibility dicts in dev/test) (`veritas_os/governance/runtime_authority.py`).
- Add unit tests exercising valid signed artifacts, bad signatures, tampered `receipt_hash`, missing verifier, and secure/prod validation paths, and update the human-approval receipt tests to cover artifact-based flows (`tests/governance/test_human_approval_receipt.py`).
- Update the Human Approval Receipt architecture doc to describe the signed artifact envelope, verification semantics, and the rule that `signature_verified` must be derived by verification rather than trusted from raw input (`docs/en/architecture/human-approval-receipt.md`).

### Testing
- Ran static/style checks: `ruff check` succeeded for the modified files. 
- Ran syntax/compile validation: `python -m py_compile` succeeded for the modified modules and tests. 
- Ran repository checks: `git diff --check` passed with no whitespace or diff errors. 
- Attempted to run the new pytest suite (`pytest tests/governance/test_human_approval_receipt.py`) but automated test execution in this environment was blocked because `PyYAML` is not installed and the container could not fetch dependencies from PyPI; therefore full pytest runs were not completed here.

Security note: the helper intentionally requires an injected `verify_signature_fn` and does not implement KMS/HSM/IdP integrations; deployments must provide and securely configure a verifier that enforces signer identity, key policy, and allowed algorithms to avoid bypassing signature checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ee3a224bc832685b7fe65db10df15)