### PR TITLE
fix: require signed approval provenance in strict posture

### DIFF
--- a/docs/en/architecture/human-approval-receipt.md
+++ b/docs/en/architecture/human-approval-receipt.md
@@ -34,8 +34,10 @@ Runtime approval validation is posture-aware:
 
 - `HumanApprovalReceipt` is the local/offline receipt representation used after validation.
 - A signed approval artifact is the preferred external-review and `secure`/`prod` trust-boundary format. It wraps the receipt payload, canonical `receipt_hash`, signature, signer metadata, and `signed_at` timestamp.
-- `signature_verified` must be derived by `verify_human_approval_receipt_artifact()` or an equivalent verifier-controlled path. Raw input is not allowed to self-assert this value across the `secure`/`prod` boundary.
-- `secure` and `prod` posture prefer a signed approval artifact plus verifier. A direct `HumanApprovalReceipt` is accepted only when its `signature_verified` field is already true. Compatibility dictionaries alone are not authoritative in those postures.
+- `signature_verified=True` alone is not sufficient across `secure`/`prod` trust boundaries. Raw input is not allowed to self-assert signature verification.
+- Signed artifact verification is the source of runtime approval trust for `secure`/`prod`. `verify_human_approval_receipt_artifact()` recomputes the receipt hash, calls the injected verifier, and only then attaches verifier-derived provenance metadata to the returned receipt.
+- `secure` and `prod` posture prefer a signed approval artifact plus verifier. A direct `HumanApprovalReceipt` is accepted only when it has `signature_verified=True` and verifier-derived provenance showing `verification_source="signed_human_approval_artifact"`, `signature_verified_by_runtime=true`, and `receipt_hash_verified=true`. Compatibility dictionaries alone are not authoritative in those postures.
+- A direct `HumanApprovalReceipt` without verifier-derived provenance is a local/offline representation, not a secure/prod trust-boundary proof.
 - `dev` and `test` style local workflows may use receipt-derived compatibility `human_approval_state` dictionaries produced by `build_human_approval_state()` for demos, fixtures, and migration.
 - `approval_validation_hash` is tamper-evident metadata for accidental/internal mutation detection. It is not cryptographically signed and is not a substitute for signed artifact verification across an external trust boundary.
 
@@ -56,7 +58,25 @@ A signed approval artifact has this deterministic v1 envelope shape:
 }
 ```
 
-Verification is fail-closed: runtime recomputes `receipt_hash`, requires an explicit verifier for signed artifacts, rejects bad signatures, and propagates expiry, scope, policy-snapshot, and action-class validation failures.
+Verification is fail-closed: runtime recomputes `receipt_hash`, requires an explicit verifier for signed artifacts, rejects bad signatures, requires verifier-derived provenance for direct receipts in `secure`/`prod`, and propagates expiry, scope, policy-snapshot, and action-class validation failures.
+
+Successful artifact verification returns a receipt with verifier-derived metadata similar to:
+
+```json
+{
+  "verification_source": "signed_human_approval_artifact",
+  "artifact_type": "human_approval_receipt",
+  "artifact_version": "v1",
+  "signer_key_id": "review-key-id",
+  "signer_algorithm": "ed25519",
+  "signed_at": "2026-05-01T00:00:00+00:00",
+  "verified_at": "2026-05-01T00:00:01+00:00",
+  "receipt_hash_verified": true,
+  "signature_verified_by_runtime": true
+}
+```
+
+These fields are verifier-derived only when set by `verify_human_approval_receipt_artifact()`. Caller-supplied copies are stripped from raw signed payload metadata before verification and are not treated as cryptographic proof on their own. Current direct-receipt provenance uses an in-process verification registry to reject simple forged metadata, but serialized copies remain a known limitation because the dataclass is not sealed. TODO: add a sealed/internal verified receipt type or signer-backed proof object for cryptographic provenance portability.
 
 ## Explicit boundary (non-goals)
 

--- a/tests/governance/test_human_approval_receipt.py
+++ b/tests/governance/test_human_approval_receipt.py
@@ -492,7 +492,7 @@ def _approval_reason(result: RuntimeAuthorityValidationResult) -> str:
 
 
 @pytest.mark.parametrize("posture", ["secure", "prod"])
-def test_strict_posture_passes_with_valid_human_approval_receipt(
+def test_strict_posture_rejects_valid_receipt_without_artifact_provenance(
     monkeypatch: pytest.MonkeyPatch,
     posture: str,
 ) -> None:
@@ -511,8 +511,8 @@ def test_strict_posture_passes_with_valid_human_approval_receipt(
         now=datetime(2026, 5, 10, tzinfo=UTC),
     )
 
-    assert result.status == "pass"
-    assert result.recommended_outcome == "commit"
+    assert result.status == "fail"
+    assert _approval_reason(result) == "human_approval_artifact_provenance_required"
 
 
 @pytest.mark.parametrize("posture", ["secure", "prod"])
@@ -574,6 +574,27 @@ def test_dev_posture_keeps_compatibility_state_support(
     assert result.status == "pass"
 
 
+def test_dev_posture_accepts_direct_signature_verified_receipt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VERITAS_POSTURE", "dev")
+
+    result = RuntimeAuthorityValidator().validate(
+        action_contract=_contract(),
+        authority_evidence=_authority(),
+        requested_scope=["ledger:debit"],
+        required_evidence_metadata={"kyc_status": {"present": True, "fresh": True}},
+        policy_snapshot_id="policy-001",
+        actor_identity="operator:alice",
+        human_approval_receipt=_receipt(signature_verified=True),
+        bind_context_metadata={"session_id": "bind-001"},
+        now=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    assert result.status == "pass"
+    assert result.recommended_outcome == "commit"
+
+
 def test_dev_posture_rejects_raw_approved_dict(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("VERITAS_POSTURE", "dev")
     validator = RuntimeAuthorityValidator()
@@ -596,18 +617,17 @@ def test_dev_posture_rejects_raw_approved_dict(monkeypatch: pytest.MonkeyPatch) 
 
 @pytest.mark.parametrize("posture", ["secure", "prod"])
 @pytest.mark.parametrize(
-    ("receipt_overrides", "expected_reason"),
+    "receipt_overrides",
     [
-        ({"expires_at": "2026-04-01T00:00:00+00:00"}, "human_approval_expired"),
-        ({"signature_verified": False}, "human_approval_signature_unverified"),
-        ({"approved_scope": ["ledger:credit"]}, "human_approval_scope_not_granted"),
+        {"expires_at": "2026-04-01T00:00:00+00:00"},
+        {"signature_verified": False},
+        {"approved_scope": ["ledger:credit"]},
     ],
 )
-def test_strict_posture_invalid_receipt_propagates_validation_reason(
+def test_strict_posture_invalid_direct_receipt_requires_provenance(
     monkeypatch: pytest.MonkeyPatch,
     posture: str,
     receipt_overrides: dict[str, object],
-    expected_reason: str,
 ) -> None:
     monkeypatch.setenv("VERITAS_POSTURE", posture)
     validator = RuntimeAuthorityValidator()
@@ -625,7 +645,7 @@ def test_strict_posture_invalid_receipt_propagates_validation_reason(
     )
 
     assert result.status == "fail"
-    assert _approval_reason(result) == expected_reason
+    assert _approval_reason(result) == "human_approval_artifact_provenance_required"
 
 
 def test_signed_human_approval_artifact_verification_sets_signature_verified() -> None:
@@ -642,6 +662,15 @@ def test_signed_human_approval_artifact_verification_sets_signature_verified() -
 
     assert receipt.signature_verified is True
     assert receipt.receipt_hash == artifact["receipt_hash"]
+    assert receipt.metadata["verification_source"] == "signed_human_approval_artifact"
+    assert receipt.metadata["artifact_type"] == "human_approval_receipt"
+    assert receipt.metadata["artifact_version"] == "v1"
+    assert receipt.metadata["signer_key_id"] == "test-key"
+    assert receipt.metadata["signer_algorithm"] == "test-only"
+    assert receipt.metadata["signed_at"] == "2026-05-01T00:00:00+00:00"
+    assert receipt.metadata["verified_at"] == "2026-05-10T00:00:00+00:00"
+    assert receipt.metadata["receipt_hash_verified"] is True
+    assert receipt.metadata["signature_verified_by_runtime"] is True
 
 
 def test_signed_human_approval_artifact_bad_signature_fails() -> None:
@@ -682,6 +711,97 @@ def test_signed_human_approval_artifact_without_verifier_fails() -> None:
             policy_snapshot_id="policy-001",
             now=datetime(2026, 5, 10, tzinfo=UTC),
         )
+
+
+@pytest.mark.parametrize("posture", ["secure", "prod"])
+def test_strict_posture_rejects_naked_signature_verified_receipt(
+    monkeypatch: pytest.MonkeyPatch,
+    posture: str,
+) -> None:
+    monkeypatch.setenv("VERITAS_POSTURE", posture)
+
+    result = RuntimeAuthorityValidator().validate(
+        action_contract=_contract(),
+        authority_evidence=_authority(),
+        requested_scope=["ledger:debit"],
+        required_evidence_metadata={"kyc_status": {"present": True, "fresh": True}},
+        policy_snapshot_id="policy-001",
+        actor_identity="operator:alice",
+        human_approval_receipt=_receipt(signature_verified=True),
+        bind_context_metadata={"session_id": "bind-001"},
+        now=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    assert result.status == "fail"
+    assert _approval_reason(result) == "human_approval_artifact_provenance_required"
+
+
+@pytest.mark.parametrize("posture", ["secure", "prod"])
+def test_strict_posture_rejects_forged_receipt_provenance(
+    monkeypatch: pytest.MonkeyPatch,
+    posture: str,
+) -> None:
+    monkeypatch.setenv("VERITAS_POSTURE", posture)
+    forged_receipt = _receipt(
+        signature_verified=True,
+        metadata={
+            "verification_source": "signed_human_approval_artifact",
+            "artifact_type": "human_approval_receipt",
+            "artifact_version": "v1",
+            "signer_key_id": "attacker-key",
+            "signer_algorithm": "test-only",
+            "signed_at": "2026-05-01T00:00:00+00:00",
+            "verified_at": "2026-05-10T00:00:00+00:00",
+            "receipt_hash_verified": True,
+            "signature_verified_by_runtime": True,
+        },
+    )
+
+    result = RuntimeAuthorityValidator().validate(
+        action_contract=_contract(),
+        authority_evidence=_authority(),
+        requested_scope=["ledger:debit"],
+        required_evidence_metadata={"kyc_status": {"present": True, "fresh": True}},
+        policy_snapshot_id="policy-001",
+        actor_identity="operator:alice",
+        human_approval_receipt=forged_receipt,
+        bind_context_metadata={"session_id": "bind-001"},
+        now=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    assert result.status == "fail"
+    assert _approval_reason(result) == "human_approval_artifact_provenance_required"
+
+
+@pytest.mark.parametrize("posture", ["secure", "prod"])
+def test_strict_posture_accepts_receipt_returned_by_artifact_verifier(
+    monkeypatch: pytest.MonkeyPatch,
+    posture: str,
+) -> None:
+    monkeypatch.setenv("VERITAS_POSTURE", posture)
+    verified_receipt = verify_human_approval_receipt_artifact(
+        _signed_artifact(),
+        lambda _artifact: True,
+        requested_scope=["ledger:debit"],
+        action_class="wire_transfer",
+        policy_snapshot_id="policy-001",
+        now=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    result = RuntimeAuthorityValidator().validate(
+        action_contract=_contract(),
+        authority_evidence=_authority(),
+        requested_scope=["ledger:debit"],
+        required_evidence_metadata={"kyc_status": {"present": True, "fresh": True}},
+        policy_snapshot_id="policy-001",
+        actor_identity="operator:alice",
+        human_approval_receipt=verified_receipt,
+        bind_context_metadata={"session_id": "bind-001"},
+        now=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    assert result.status == "pass"
+    assert result.recommended_outcome == "commit"
 
 
 @pytest.mark.parametrize("posture", ["secure", "prod"])

--- a/veritas_os/governance/human_approval_receipt.py
+++ b/veritas_os/governance/human_approval_receipt.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from uuid import uuid4
 from typing import Any, Callable, Literal
 
 from veritas_os.security.hash import sha256_of_canonical_json
@@ -17,6 +18,21 @@ HUMAN_APPROVAL_STATE_SOURCE = "validated_human_approval_receipt"
 ApprovalResult = Literal["approved", "denied", "expired", "indeterminate"]
 SIGNED_APPROVAL_ARTIFACT_TYPE = "human_approval_receipt"
 SIGNED_APPROVAL_ARTIFACT_VERSION = "v1"
+VERIFICATION_SOURCE_SIGNED_ARTIFACT = "signed_human_approval_artifact"
+VERIFIER_DERIVED_PROVENANCE_KEYS = frozenset(
+    {
+        "verification_source",
+        "artifact_type",
+        "artifact_version",
+        "signer_key_id",
+        "signer_algorithm",
+        "signed_at",
+        "verified_at",
+        "receipt_hash_verified",
+        "signature_verified_by_runtime",
+    }
+)
+_VERIFIED_RECEIPT_REGISTRY: dict[int, str] = {}
 
 
 @dataclass(frozen=True)
@@ -86,7 +102,58 @@ def _receipt_from_signed_payload(payload: dict[str, Any]) -> HumanApprovalReceip
     receipt_payload.pop("receipt_hash", None)
     receipt_payload["signature_verified"] = False
     receipt_payload["receipt_hash"] = ""
+    receipt_payload["metadata"] = _without_verifier_derived_provenance(
+        receipt_payload.get("metadata")
+    )
     return HumanApprovalReceipt(**receipt_payload)
+
+
+def _without_verifier_derived_provenance(value: Any) -> dict[str, Any]:
+    """Return caller metadata with verifier-controlled provenance stripped."""
+    if not isinstance(value, dict):
+        return {}
+    return {
+        str(key): item
+        for key, item in value.items()
+        if str(key) not in VERIFIER_DERIVED_PROVENANCE_KEYS
+    }
+
+
+def _artifact_signer_metadata(artifact: dict[str, Any]) -> tuple[str | None, str | None]:
+    signer = artifact.get("signer")
+    if not isinstance(signer, dict):
+        return None, None
+    key_id = signer.get("key_id")
+    algorithm = signer.get("algorithm")
+    return (
+        None if key_id is None else str(key_id),
+        None if algorithm is None else str(algorithm),
+    )
+
+
+def has_verified_human_approval_artifact_provenance(
+    receipt: HumanApprovalReceipt,
+) -> bool:
+    """Return whether a receipt has in-process verifier-derived provenance.
+
+    The public metadata fields are inspectable and serializable, but they are
+    not cryptographically sealed. This in-process registry prevents a naked
+    caller-constructed dataclass with forged metadata from being accepted in
+    the current runtime process. A serialized copy still requires future sealed
+    receipt/proof-object work before it can be distinguished cryptographically.
+    """
+    metadata = receipt.metadata
+    runtime_token = metadata.get("_runtime_verification_token")
+    return (
+        isinstance(runtime_token, str)
+        and _VERIFIED_RECEIPT_REGISTRY.get(id(receipt)) == runtime_token
+        and receipt.signature_verified is True
+        and metadata.get("verification_source") == VERIFICATION_SOURCE_SIGNED_ARTIFACT
+        and metadata.get("artifact_type") == SIGNED_APPROVAL_ARTIFACT_TYPE
+        and metadata.get("artifact_version") == SIGNED_APPROVAL_ARTIFACT_VERSION
+        and metadata.get("signature_verified_by_runtime") is True
+        and metadata.get("receipt_hash_verified") is True
+    )
 
 
 def verify_human_approval_receipt_artifact(
@@ -128,10 +195,30 @@ def verify_human_approval_receipt_artifact(
     if verify_signature_fn(artifact) is not True:
         raise ValueError("human_approval_signature_verification_failed")
 
+    signer_key_id, signer_algorithm = _artifact_signer_metadata(artifact)
+    verified_at = (now or datetime.now(UTC)).isoformat()
     verified_payload = unsigned_receipt.to_dict()
     verified_payload["signature_verified"] = True
     verified_payload["receipt_hash"] = expected_hash
+    runtime_token = uuid4().hex
+    verified_metadata = dict(verified_payload.get("metadata") or {})
+    verified_metadata.update(
+        {
+            "verification_source": VERIFICATION_SOURCE_SIGNED_ARTIFACT,
+            "artifact_type": SIGNED_APPROVAL_ARTIFACT_TYPE,
+            "artifact_version": SIGNED_APPROVAL_ARTIFACT_VERSION,
+            "signer_key_id": signer_key_id,
+            "signer_algorithm": signer_algorithm,
+            "signed_at": artifact.get("signed_at"),
+            "verified_at": verified_at,
+            "receipt_hash_verified": True,
+            "signature_verified_by_runtime": True,
+            "_runtime_verification_token": runtime_token,
+        }
+    )
+    verified_payload["metadata"] = verified_metadata
     verified_receipt = HumanApprovalReceipt(**verified_payload)
+    _VERIFIED_RECEIPT_REGISTRY[id(verified_receipt)] = runtime_token
     validation_result = validate_human_approval_receipt(
         verified_receipt,
         requested_scope=requested_scope,

--- a/veritas_os/governance/runtime_authority.py
+++ b/veritas_os/governance/runtime_authority.py
@@ -17,6 +17,7 @@ from veritas_os.governance.human_approval_receipt import (
     HUMAN_APPROVAL_STATE_SOURCE,
     HumanApprovalReceipt,
     build_human_approval_state,
+    has_verified_human_approval_artifact_provenance,
     human_approval_state_validation_hash,
     verify_human_approval_receipt_artifact,
 )
@@ -398,9 +399,11 @@ class RuntimeAuthorityValidator:
     ) -> tuple[bool, str]:
         """Validate human approval using posture-aware trust boundaries.
 
-        Secure and production postures require an explicit
-        signed approval artifact, or a ``HumanApprovalReceipt`` whose signature
-        has already been verified, as the authoritative approval source.
+        Secure and production postures require an explicit signed approval
+        artifact, or a ``HumanApprovalReceipt`` carrying verifier-derived
+        signed-artifact provenance from this runtime process, as the
+        authoritative approval source. A raw ``signature_verified=True`` flag
+        is not trusted across those boundaries.
         Compatibility dictionaries remain accepted only in dev/test-style
         postures because their deterministic
         validation hash is tamper-evident, not cryptographically signed.
@@ -429,6 +432,10 @@ class RuntimeAuthorityValidator:
             return self._validated_human_approval_state(receipt_state)
 
         if human_approval_receipt is not None:
+            if strict_posture and not has_verified_human_approval_artifact_provenance(
+                human_approval_receipt
+            ):
+                return False, "human_approval_artifact_provenance_required"
             receipt_state = build_human_approval_state(
                 human_approval_receipt,
                 requested_scope=requested_scope,


### PR DESCRIPTION
### Motivation
- Close a trust-boundary gap so `secure`/`prod` runtime posture cannot be satisfied by a naked `HumanApprovalReceipt(signature_verified=True)` constructed by callers. 
- Ensure verified receipts carry verifier-derived provenance metadata so runtime can distinguish receipts produced by artifact verification from raw inputs. 
- Preserve dev/test compatibility while enforcing fail-closed behavior in higher-security postures.

### Description
- Add verifier-derived provenance constants and keys, strip caller-supplied verifier provenance from signed payloads, and attach verifier-derived metadata on successful artifact verification (including signer metadata, timestamps, and verification flags). 
- Maintain an in-process verification registry and helper `has_verified_human_approval_artifact_provenance()` to detect receipts produced by `verify_human_approval_receipt_artifact()` and reject forged/naked provenance at runtime. 
- Update `verify_human_approval_receipt_artifact()` to populate provenance metadata (e.g. `verification_source`, `artifact_type`, `artifact_version`, `signer_key_id`, `signer_algorithm`, `signed_at`, `verified_at`, `receipt_hash_verified`, `signature_verified_by_runtime`) and register a runtime token used for in-process provenance checks. 
- Update `RuntimeAuthorityValidator` strict-posture logic so in `secure`/`prod` a direct `HumanApprovalReceipt` is accepted only when it carries verifier-derived provenance; otherwise validation fails with `human_approval_artifact_provenance_required`. 
- Add/adjust tests to cover: signer metadata on verified artifacts, strict-posture rejection of naked `signature_verified=True` receipts, rejection of forged provenance supplied by callers, acceptance of receipts returned by the verifier, and dev-posture backwards compatibility. 
- Update documentation (`docs/en/architecture/human-approval-receipt.md`) to clarify that `signature_verified=True` alone is not sufficient across `secure`/`prod`, explain verifier-derived provenance, and note the limitation that the dataclass is not cryptographically sealed (TODO: sealed verified receipt/proof-object).

### Testing
- Static checks: `ruff` lint (`python -m ruff check ...`) passed for modified files. 
- Byte-compile checks: `python -m py_compile` succeeded for the modified modules and tests. 
- Unit tests: attempted to run `pytest` for the human approval receipt tests but could not fetch/install uncached dependencies in the offline environment, so `pytest` was not executed here; the added/modified tests compile and are included for CI. 
- CI expectation: the new tests exercise strict/dev posture cases and signed-artifact failure modes and are expected to pass when CI installs dependencies and runs the full test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f376bbc548326a79811cc676df6c2)