### PR TITLE
Add VerifiedHumanApprovalReceipt sealed proof object and proof-based verification path

### DIFF
--- a/docs/en/architecture/human-approval-receipt.md
+++ b/docs/en/architecture/human-approval-receipt.md
@@ -27,16 +27,18 @@ It is designed to make approval:
   - action-class mismatch.
 - A compatibility helper that converts the receipt into the existing runtime `human_approval_state` shape.
 - A signed approval artifact envelope for crossing external-review and secure/prod runtime trust boundaries.
+- A sealed `VerifiedHumanApprovalReceipt` proof object emitted only after signed-artifact verification succeeds.
 
 ## Runtime posture trust boundary
 
 Runtime approval validation is posture-aware:
 
-- `HumanApprovalReceipt` is the local/offline receipt representation used after validation.
+- `HumanApprovalReceipt` is the local/offline receipt representation used after validation. It is not, by itself, a cross-process trust-boundary proof.
 - A signed approval artifact is the preferred external-review and `secure`/`prod` trust-boundary format. It wraps the receipt payload, canonical `receipt_hash`, signature, signer metadata, and `signed_at` timestamp.
 - `signature_verified=True` alone is not sufficient across `secure`/`prod` trust boundaries. Raw input is not allowed to self-assert signature verification.
-- Signed artifact verification is the source of runtime approval trust for `secure`/`prod`. `verify_human_approval_receipt_artifact()` recomputes the receipt hash, calls the injected verifier, and only then attaches verifier-derived provenance metadata to the returned receipt.
-- `secure` and `prod` posture prefer a signed approval artifact plus verifier. A direct `HumanApprovalReceipt` is accepted only when it has `signature_verified=True` and verifier-derived provenance showing `verification_source="signed_human_approval_artifact"`, `signature_verified_by_runtime=true`, and `receipt_hash_verified=true`. Compatibility dictionaries alone are not authoritative in those postures.
+- Signed artifact verification is the source of runtime approval trust for `secure`/`prod`. `verify_human_approval_receipt_artifact_to_proof()` recomputes the receipt hash, requires the injected verifier, rejects bad signatures, validates scope/action/policy/expiry, and returns a `VerifiedHumanApprovalReceipt`.
+- `VerifiedHumanApprovalReceipt` is the runtime verified proof object. It carries the validated receipt plus signer metadata, `verified_at`, `verification_source`, and `verification_proof_hash` computed over canonical verifier-derived proof fields.
+- `secure` and `prod` posture should use either a `VerifiedHumanApprovalReceipt` proof object or the signed artifact verification path. A direct `HumanApprovalReceipt` is accepted only under the transitional in-process registry provenance path. Compatibility dictionaries alone are not authoritative in those postures.
 - A direct `HumanApprovalReceipt` without verifier-derived provenance is a local/offline representation, not a secure/prod trust-boundary proof.
 - `dev` and `test` style local workflows may use receipt-derived compatibility `human_approval_state` dictionaries produced by `build_human_approval_state()` for demos, fixtures, and migration.
 - `approval_validation_hash` is tamper-evident metadata for accidental/internal mutation detection. It is not cryptographically signed and is not a substitute for signed artifact verification across an external trust boundary.
@@ -58,9 +60,26 @@ A signed approval artifact has this deterministic v1 envelope shape:
 }
 ```
 
-Verification is fail-closed: runtime recomputes `receipt_hash`, requires an explicit verifier for signed artifacts, rejects bad signatures, requires verifier-derived provenance for direct receipts in `secure`/`prod`, and propagates expiry, scope, policy-snapshot, and action-class validation failures.
+Verification is fail-closed: runtime recomputes `receipt_hash`, requires an explicit verifier for signed artifacts, rejects bad signatures, verifies `verification_proof_hash` for proof objects, requires verifier-derived provenance for transitional direct receipts in `secure`/`prod`, and propagates expiry, scope, policy-snapshot, and action-class validation failures.
 
-Successful artifact verification returns a receipt with verifier-derived metadata similar to:
+Successful artifact verification returns a proof object similar to:
+
+```json
+{
+  "receipt": { "...": "validated HumanApprovalReceipt" },
+  "artifact_type": "human_approval_receipt",
+  "artifact_version": "v1",
+  "receipt_hash": "canonical sha256 of the receipt payload",
+  "signer_key_id": "review-key-id",
+  "signer_algorithm": "ed25519",
+  "signed_at": "2026-05-01T00:00:00+00:00",
+  "verified_at": "2026-05-01T00:00:01+00:00",
+  "verification_source": "signed_human_approval_artifact",
+  "verification_proof_hash": "canonical sha256 of proof metadata"
+}
+```
+
+For backward compatibility, `verify_human_approval_receipt_artifact()` still returns the validated receipt from this proof. That receipt includes verifier-derived metadata similar to:
 
 ```json
 {
@@ -76,7 +95,7 @@ Successful artifact verification returns a receipt with verifier-derived metadat
 }
 ```
 
-These fields are verifier-derived only when set by `verify_human_approval_receipt_artifact()`. Caller-supplied copies are stripped from raw signed payload metadata before verification and are not treated as cryptographic proof on their own. Current direct-receipt provenance uses an in-process verification registry to reject simple forged metadata, but serialized copies remain a known limitation because the dataclass is not sealed. TODO: add a sealed/internal verified receipt type or signer-backed proof object for cryptographic provenance portability.
+These fields are verifier-derived only when set through signed-artifact verification. Caller-supplied copies are stripped from raw signed payload metadata before verification and are not treated as cryptographic proof on their own. Current direct-receipt provenance still uses an in-process verification registry as a transitional compatibility control; it rejects simple forged metadata in one runtime process, but it should not be treated as cross-process cryptographic sealing. Cross-process callers should pass `VerifiedHumanApprovalReceipt` or the original signed artifact plus verifier.
 
 ## Explicit boundary (non-goals)
 

--- a/tests/governance/test_human_approval_receipt.py
+++ b/tests/governance/test_human_approval_receipt.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import UTC, datetime
 
 import pytest
@@ -10,9 +11,11 @@ from veritas_os.governance.action_contracts import ActionClassContract
 from veritas_os.governance.authority_evidence import AuthorityEvidence, VerificationResult
 from veritas_os.governance.human_approval_receipt import (
     HumanApprovalReceipt,
+    VerifiedHumanApprovalReceipt,
     build_human_approval_state,
     validate_human_approval_receipt,
     verify_human_approval_receipt_artifact,
+    verify_human_approval_receipt_artifact_to_proof,
     with_receipt_hash,
 )
 from veritas_os.governance.runtime_authority import (
@@ -897,3 +900,138 @@ def test_strict_posture_rejects_signed_artifact_without_verifier(
 
     assert result.status == "fail"
     assert _approval_reason(result) == "human_approval_signature_verifier_required"
+
+
+def test_signed_human_approval_artifact_verification_produces_proof() -> None:
+    proof = verify_human_approval_receipt_artifact_to_proof(
+        _signed_artifact(),
+        lambda _artifact: True,
+        requested_scope=["ledger:debit"],
+        action_class="wire_transfer",
+        policy_snapshot_id="policy-001",
+        now=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    assert isinstance(proof, VerifiedHumanApprovalReceipt)
+    assert proof.receipt.signature_verified is True
+    assert proof.receipt_hash == proof.receipt.receipt_hash
+    assert proof.artifact_type == "human_approval_receipt"
+    assert proof.artifact_version == "v1"
+    assert proof.verification_source == "signed_human_approval_artifact"
+    assert len(proof.verification_proof_hash) == 64
+
+
+@pytest.mark.parametrize("posture", ["secure", "prod"])
+def test_strict_posture_passes_with_valid_verified_human_approval_proof(
+    monkeypatch: pytest.MonkeyPatch,
+    posture: str,
+) -> None:
+    monkeypatch.setenv("VERITAS_POSTURE", posture)
+    proof = verify_human_approval_receipt_artifact_to_proof(
+        _signed_artifact(),
+        lambda _artifact: True,
+        requested_scope=["ledger:debit"],
+        action_class="wire_transfer",
+        policy_snapshot_id="policy-001",
+        now=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    result = RuntimeAuthorityValidator().validate(
+        action_contract=_contract(),
+        authority_evidence=_authority(),
+        requested_scope=["ledger:debit"],
+        required_evidence_metadata={"kyc_status": {"present": True, "fresh": True}},
+        policy_snapshot_id="policy-001",
+        actor_identity="operator:alice",
+        verified_human_approval=proof,
+        bind_context_metadata={"session_id": "bind-001"},
+        now=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    assert result.status == "pass"
+    assert result.recommended_outcome == "commit"
+
+
+@pytest.mark.parametrize("posture", ["secure", "prod"])
+def test_strict_posture_rejects_tampered_verified_proof_hash(
+    monkeypatch: pytest.MonkeyPatch,
+    posture: str,
+) -> None:
+    monkeypatch.setenv("VERITAS_POSTURE", posture)
+    proof = verify_human_approval_receipt_artifact_to_proof(
+        _signed_artifact(),
+        lambda _artifact: True,
+        requested_scope=["ledger:debit"],
+        action_class="wire_transfer",
+        policy_snapshot_id="policy-001",
+        now=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    result = RuntimeAuthorityValidator().validate(
+        action_contract=_contract(),
+        authority_evidence=_authority(),
+        requested_scope=["ledger:debit"],
+        required_evidence_metadata={"kyc_status": {"present": True, "fresh": True}},
+        policy_snapshot_id="policy-001",
+        actor_identity="operator:alice",
+        verified_human_approval=replace(proof, verification_proof_hash="f" * 64),
+        bind_context_metadata={"session_id": "bind-001"},
+        now=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    assert result.status == "fail"
+    assert _approval_reason(result) == (
+        "human_approval_verification_proof_hash_mismatch"
+    )
+
+
+@pytest.mark.parametrize("posture", ["secure", "prod"])
+def test_strict_posture_rejects_tampered_verified_receipt_hash(
+    monkeypatch: pytest.MonkeyPatch,
+    posture: str,
+) -> None:
+    monkeypatch.setenv("VERITAS_POSTURE", posture)
+    proof = verify_human_approval_receipt_artifact_to_proof(
+        _signed_artifact(),
+        lambda _artifact: True,
+        requested_scope=["ledger:debit"],
+        action_class="wire_transfer",
+        policy_snapshot_id="policy-001",
+        now=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    result = RuntimeAuthorityValidator().validate(
+        action_contract=_contract(),
+        authority_evidence=_authority(),
+        requested_scope=["ledger:debit"],
+        required_evidence_metadata={"kyc_status": {"present": True, "fresh": True}},
+        policy_snapshot_id="policy-001",
+        actor_identity="operator:alice",
+        verified_human_approval=replace(proof, receipt_hash="f" * 64),
+        bind_context_metadata={"session_id": "bind-001"},
+        now=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    assert result.status == "fail"
+    assert _approval_reason(result) == "human_approval_receipt_hash_mismatch"
+
+
+def test_dev_posture_plain_receipt_compatibility_remains_intact(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VERITAS_POSTURE", "dev")
+
+    result = RuntimeAuthorityValidator().validate(
+        action_contract=_contract(),
+        authority_evidence=_authority(),
+        requested_scope=["ledger:debit"],
+        required_evidence_metadata={"kyc_status": {"present": True, "fresh": True}},
+        policy_snapshot_id="policy-001",
+        actor_identity="operator:alice",
+        human_approval_receipt=_receipt(signature_verified=True),
+        bind_context_metadata={"session_id": "bind-001"},
+        now=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    assert result.status == "pass"
+    assert result.recommended_outcome == "commit"

--- a/veritas_os/governance/__init__.py
+++ b/veritas_os/governance/__init__.py
@@ -23,9 +23,11 @@ from veritas_os.governance.action_contracts import (
 )
 from veritas_os.governance.human_approval_receipt import (
     HumanApprovalReceipt,
+    VerifiedHumanApprovalReceipt,
     HumanApprovalValidationResult,
     build_human_approval_state,
     validate_human_approval_receipt,
+    verify_human_approval_receipt_artifact_to_proof,
     with_receipt_hash,
 )
 
@@ -83,7 +85,9 @@ __all__ = [
     "build_human_approval_state",
     "HumanApprovalValidationResult",
     "HumanApprovalReceipt",
+    "VerifiedHumanApprovalReceipt",
     "with_receipt_hash",
+    "verify_human_approval_receipt_artifact_to_proof",
     "OutcomeReceipt",
     "EvidenceChainManifest",
     "EvidenceChainManifestValidationResult",

--- a/veritas_os/governance/human_approval_receipt.py
+++ b/veritas_os/governance/human_approval_receipt.py
@@ -19,6 +19,16 @@ ApprovalResult = Literal["approved", "denied", "expired", "indeterminate"]
 SIGNED_APPROVAL_ARTIFACT_TYPE = "human_approval_receipt"
 SIGNED_APPROVAL_ARTIFACT_VERSION = "v1"
 VERIFICATION_SOURCE_SIGNED_ARTIFACT = "signed_human_approval_artifact"
+VERIFICATION_PROOF_HASH_FIELDS = (
+    "receipt_hash",
+    "artifact_type",
+    "artifact_version",
+    "signer_key_id",
+    "signer_algorithm",
+    "signed_at",
+    "verified_at",
+    "verification_source",
+)
 VERIFIER_DERIVED_PROVENANCE_KEYS = frozenset(
     {
         "verification_source",
@@ -86,6 +96,48 @@ class HumanApprovalReceipt:
     def deterministic_digest(self) -> str:
         """Compute canonical SHA-256 digest of the receipt hash payload."""
         return sha256_of_canonical_json(self.to_dict_for_hash())
+
+
+@dataclass(frozen=True)
+class VerifiedHumanApprovalReceipt:
+    """Sealed runtime proof for a verified Human Approval Receipt artifact.
+
+    Instances are emitted only by
+    ``verify_human_approval_receipt_artifact_to_proof`` after receipt hash,
+    signature, scope, action-class, policy-snapshot, and expiry checks pass.
+    The ``verification_proof_hash`` seals verifier-derived provenance so runtime
+    code can detect tampering when the proof crosses process boundaries.
+    """
+
+    receipt: HumanApprovalReceipt
+    artifact_type: str
+    artifact_version: str
+    receipt_hash: str
+    signer_key_id: str | None
+    signer_algorithm: str | None
+    signed_at: str | None
+    verified_at: str
+    verification_source: Literal["signed_human_approval_artifact"]
+    verification_proof_hash: str
+
+    def proof_hash_payload(self) -> dict[str, Any]:
+        """Return canonical verifier-derived proof fields for hashing."""
+        return {
+            "receipt_hash": self.receipt_hash,
+            "artifact_type": self.artifact_type,
+            "artifact_version": self.artifact_version,
+            "signer_key_id": self.signer_key_id,
+            "signer_algorithm": self.signer_algorithm,
+            "signed_at": self.signed_at,
+            "verified_at": self.verified_at,
+            "verification_source": self.verification_source,
+        }
+
+
+def _verification_proof_hash(payload: dict[str, Any]) -> str:
+    """Compute the canonical proof hash for verifier-derived fields."""
+    proof_payload = {field: payload.get(field) for field in VERIFICATION_PROOF_HASH_FIELDS}
+    return sha256_of_canonical_json(proof_payload)
 
 
 def with_receipt_hash(receipt: HumanApprovalReceipt) -> HumanApprovalReceipt:
@@ -156,7 +208,7 @@ def has_verified_human_approval_artifact_provenance(
     )
 
 
-def verify_human_approval_receipt_artifact(
+def verify_human_approval_receipt_artifact_to_proof(
     artifact: dict[str, Any],
     verify_signature_fn: Callable[[dict[str, Any]], bool] | None,
     *,
@@ -164,15 +216,14 @@ def verify_human_approval_receipt_artifact(
     action_class: str | None,
     policy_snapshot_id: str | None,
     now: datetime | None = None,
-) -> HumanApprovalReceipt:
-    """Verify a signed Human Approval Receipt artifact fail-closed.
+) -> VerifiedHumanApprovalReceipt:
+    """Verify a signed artifact and return a sealed approval proof.
 
     The caller-supplied ``signature_verified`` value in raw artifact data is
     never trusted. This helper recomputes the canonical receipt hash, requires
-    an explicit signature verifier, invokes it over the full artifact, and only
-    then returns a ``HumanApprovalReceipt`` with ``signature_verified=True``.
-    Existing receipt validation errors are raised as deterministic reason
-    strings so runtime authority can propagate them without opening a bypass.
+    an explicit signature verifier, rejects bad signatures, validates receipt
+    scope/action/policy/expiry, and only then emits a
+    ``VerifiedHumanApprovalReceipt`` with a canonical proof hash.
     """
     if not isinstance(artifact, dict):
         raise ValueError("human_approval_artifact_invalid")
@@ -197,10 +248,10 @@ def verify_human_approval_receipt_artifact(
 
     signer_key_id, signer_algorithm = _artifact_signer_metadata(artifact)
     verified_at = (now or datetime.now(UTC)).isoformat()
+    runtime_token = uuid4().hex
     verified_payload = unsigned_receipt.to_dict()
     verified_payload["signature_verified"] = True
     verified_payload["receipt_hash"] = expected_hash
-    runtime_token = uuid4().hex
     verified_metadata = dict(verified_payload.get("metadata") or {})
     verified_metadata.update(
         {
@@ -228,7 +279,46 @@ def verify_human_approval_receipt_artifact(
     )
     if not validation_result.is_valid:
         raise ValueError(validation_result.failure_reasons[0])
-    return verified_receipt
+
+    proof_payload = {
+        "receipt": verified_receipt,
+        "artifact_type": SIGNED_APPROVAL_ARTIFACT_TYPE,
+        "artifact_version": SIGNED_APPROVAL_ARTIFACT_VERSION,
+        "receipt_hash": expected_hash,
+        "signer_key_id": signer_key_id,
+        "signer_algorithm": signer_algorithm,
+        "signed_at": artifact.get("signed_at"),
+        "verified_at": verified_at,
+        "verification_source": VERIFICATION_SOURCE_SIGNED_ARTIFACT,
+    }
+    proof_payload["verification_proof_hash"] = _verification_proof_hash(proof_payload)
+    return VerifiedHumanApprovalReceipt(**proof_payload)
+
+
+def verify_human_approval_receipt_artifact(
+    artifact: dict[str, Any],
+    verify_signature_fn: Callable[[dict[str, Any]], bool] | None,
+    *,
+    requested_scope: list[str],
+    action_class: str | None,
+    policy_snapshot_id: str | None,
+    now: datetime | None = None,
+) -> HumanApprovalReceipt:
+    """Verify a signed artifact and return its validated receipt.
+
+    Compatibility wrapper for callers that still consume
+    ``HumanApprovalReceipt``. Secure/prod runtime validation should prefer
+    ``verify_human_approval_receipt_artifact_to_proof`` and pass the resulting
+    ``VerifiedHumanApprovalReceipt``.
+    """
+    return verify_human_approval_receipt_artifact_to_proof(
+        artifact,
+        verify_signature_fn,
+        requested_scope=requested_scope,
+        action_class=action_class,
+        policy_snapshot_id=policy_snapshot_id,
+        now=now,
+    ).receipt
 
 
 @dataclass(frozen=True)

--- a/veritas_os/governance/runtime_authority.py
+++ b/veritas_os/governance/runtime_authority.py
@@ -16,12 +16,14 @@ from veritas_os.governance.authority_evidence import (
 from veritas_os.governance.human_approval_receipt import (
     HUMAN_APPROVAL_STATE_SOURCE,
     HumanApprovalReceipt,
+    VerifiedHumanApprovalReceipt,
     build_human_approval_state,
     has_verified_human_approval_artifact_provenance,
     human_approval_state_validation_hash,
-    verify_human_approval_receipt_artifact,
+    verify_human_approval_receipt_artifact_to_proof,
 )
 from veritas_os.governance.predicates import PredicateResult
+from veritas_os.security.hash import sha256_of_canonical_json
 
 RuntimeValidationStatus = Literal["pass", "fail"]
 RecommendedOutcome = Literal["commit", "block", "escalate", "refuse"]
@@ -75,6 +77,7 @@ class RuntimeAuthorityValidator:
         actor_identity: str | None,
         human_approval_state: dict[str, Any] | None = None,
         human_approval_receipt: HumanApprovalReceipt | None = None,
+        verified_human_approval: VerifiedHumanApprovalReceipt | None = None,
         human_approval_artifact: dict[str, Any] | None = None,
         verify_human_approval_signature_fn: (
             Callable[[dict[str, Any]], bool] | None
@@ -287,6 +290,7 @@ class RuntimeAuthorityValidator:
             approval_ok, approval_reason = self._validated_human_approval(
                 human_approval_state=human_approval_state,
                 human_approval_receipt=human_approval_receipt,
+                verified_human_approval=verified_human_approval,
                 human_approval_artifact=human_approval_artifact,
                 verify_human_approval_signature_fn=verify_human_approval_signature_fn,
                 requested_scope=requested_scope,
@@ -390,6 +394,7 @@ class RuntimeAuthorityValidator:
         *,
         human_approval_state: dict[str, Any],
         human_approval_receipt: HumanApprovalReceipt | None,
+        verified_human_approval: VerifiedHumanApprovalReceipt | None,
         human_approval_artifact: dict[str, Any] | None,
         verify_human_approval_signature_fn: Callable[[dict[str, Any]], bool] | None,
         requested_scope: list[str],
@@ -410,9 +415,19 @@ class RuntimeAuthorityValidator:
         """
         strict_posture = self._requires_receipt_for_human_approval()
         action_class = action_contract.action_class if action_contract else None
+        if verified_human_approval is not None:
+            proof_valid, proof_reason = self._validated_human_approval_proof(
+                verified_human_approval,
+                requested_scope=requested_scope,
+                action_class=action_class,
+                policy_snapshot_id=policy_snapshot_id,
+                now=now,
+            )
+            return proof_valid, proof_reason
+
         if human_approval_artifact is not None:
             try:
-                verified_receipt = verify_human_approval_receipt_artifact(
+                verified_proof = verify_human_approval_receipt_artifact_to_proof(
                     human_approval_artifact,
                     verify_human_approval_signature_fn,
                     requested_scope=requested_scope,
@@ -423,7 +438,7 @@ class RuntimeAuthorityValidator:
             except ValueError as exc:
                 return False, str(exc)
             receipt_state = build_human_approval_state(
-                verified_receipt,
+                verified_proof.receipt,
                 requested_scope=requested_scope,
                 action_class=action_class,
                 policy_snapshot_id=policy_snapshot_id,
@@ -449,6 +464,37 @@ class RuntimeAuthorityValidator:
             return False, "human_approval_receipt_required"
 
         return self._validated_human_approval_state(human_approval_state)
+
+
+    def _validated_human_approval_proof(
+        self,
+        proof: VerifiedHumanApprovalReceipt,
+        *,
+        requested_scope: list[str],
+        action_class: str | None,
+        policy_snapshot_id: str | None,
+        now: datetime | None,
+    ) -> tuple[bool, str]:
+        """Validate a sealed verified approval proof fail-closed."""
+        if proof.verification_source != "signed_human_approval_artifact":
+            return False, "human_approval_artifact_provenance_required"
+        if proof.receipt.signature_verified is not True:
+            return False, "human_approval_signature_unverified"
+        if proof.receipt_hash != proof.receipt.receipt_hash:
+            return False, "human_approval_receipt_hash_mismatch"
+
+        expected_proof_hash = sha256_of_canonical_json(proof.proof_hash_payload())
+        if proof.verification_proof_hash != expected_proof_hash:
+            return False, "human_approval_verification_proof_hash_mismatch"
+
+        receipt_state = build_human_approval_state(
+            proof.receipt,
+            requested_scope=requested_scope,
+            action_class=action_class,
+            policy_snapshot_id=policy_snapshot_id,
+            now=now,
+        )
+        return self._validated_human_approval_state(receipt_state)
 
     def _requires_receipt_for_human_approval(self) -> bool:
         """Return whether current posture requires receipt-backed approval."""


### PR DESCRIPTION
### Motivation
- The existing in-process verifier-derived provenance prevents forged `HumanApprovalReceipt` objects only inside a single runtime process and is not portable across process boundaries. A sealed, canonical proof object is needed so verified approval can be safely passed between processes. 
- Provide a runtime-first verified proof that bundles the validated receipt plus signer/verification metadata and a tamper-evident `verification_proof_hash` for cross-process integrity checks. 
- Preserve compatibility for callers that expect a `HumanApprovalReceipt` while steering `secure`/`prod` to use a sealed proof; keep the signed-artifact verifier as the trust root and warn that key-management/signing infrastructure remains required for production security. 

### Description
- Added a frozen `VerifiedHumanApprovalReceipt` dataclass carrying the validated `HumanApprovalReceipt`, signer metadata, `verified_at`, `verification_source`, and a canonical `verification_proof_hash` computed from canonical proof fields. 
- Implemented `verify_human_approval_receipt_artifact_to_proof(...)` that recomputes the receipt hash, requires an injected `verify_signature_fn`, rejects bad signatures, validates scope/action/policy/expiry, and returns a `VerifiedHumanApprovalReceipt` whose `verification_proof_hash` seals the verifier-derived fields. 
- Kept `verify_human_approval_receipt_artifact(...)` as a compatibility wrapper that returns the validated `HumanApprovalReceipt` extracted from the proof. 
- Integrated an optional `verified_human_approval: VerifiedHumanApprovalReceipt | None` parameter into `RuntimeAuthorityValidator.validate(...)` with strict precedence: (1) `verified_human_approval`, (2) `human_approval_artifact + verifier`, (3) `HumanApprovalReceipt` with in-process provenance (transitional). Added `_validated_human_approval_proof(...)` to enforce checks: `verification_source`, `receipt.signature_verified`, receipt-hash equality, recomputed `verification_proof_hash` match, and normal receipt validation. 
- Added PEP8-compliant docstrings and updated architecture docs to explain `HumanApprovalReceipt` vs signed artifact vs `VerifiedHumanApprovalReceipt` and the transitional nature of the in-process registry. 
- Added unit tests covering proof creation, secure/prod acceptance of valid proofs, tampered proof-hash rejection, tampered receipt-hash rejection, and dev-mode compatibility with plain receipts. 

### Testing
- Ran static/style/compile checks: `ruff` checks passed. 
- Python byte-compile checks passed via `python -m py_compile` and `python -m compileall`. 
- Repository lint/format/quick checks (`git diff --check`) passed. 
- Attempted to run `pytest` locally but test collection was blocked due to the local environment: the configured interpreter in `.python-version` was unavailable and `PyYAML` could not be installed because the package index returned 403 responses, so full pytest execution could not complete locally. 
- The new tests are included and are expected to run in CI (which has proper interpreter and dependency availability); please run full test suite in CI and review the proof-path tests in `tests/governance/test_human_approval_receipt.py`. 

Security note: the change improves cross-process tamper detection by sealing verifier-derived fields with `verification_proof_hash`, but the signed-artifact verifier and proper key-management remain the trust root; treat the in-process registry as transitional and not a cryptographic substitute for signing/KMS in production.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f4124da348326a27698b1e648fe5c)