### PR TITLE
Validate signed human approval signer policy

### DIFF
--- a/docs/en/architecture/human-approval-receipt.md
+++ b/docs/en/architecture/human-approval-receipt.md
@@ -36,11 +36,13 @@ Runtime approval validation is posture-aware:
 - `HumanApprovalReceipt` is the local/offline receipt representation used after validation. It is not, by itself, a cross-process trust-boundary proof.
 - A signed approval artifact is the preferred external-review and `secure`/`prod` trust-boundary format. It wraps the receipt payload, canonical `receipt_hash`, signature, signer metadata, and `signed_at` timestamp.
 - `signature_verified=True` alone is not sufficient across `secure`/`prod` trust boundaries. Raw input is not allowed to self-assert signature verification.
-- Signed artifact verification is the source of runtime approval trust for `secure`/`prod`. `verify_human_approval_receipt_artifact_to_proof()` recomputes the receipt hash, requires the injected verifier, rejects bad signatures, validates scope/action/policy/expiry, and returns a `VerifiedHumanApprovalReceipt`.
-- `VerifiedHumanApprovalReceipt` is the runtime verified proof object. It carries the validated receipt plus signer metadata, `verified_at`, `verification_source`, and `verification_proof_hash` computed over canonical verifier-derived proof fields.
+- Signed artifact verification is the source of runtime approval trust for `secure`/`prod`. `verify_human_approval_receipt_artifact_to_proof()` recomputes the receipt hash, requires the injected verifier, rejects bad signatures, validates signer key ID/algorithm/role/action-class/policy-snapshot authorization against `HumanApprovalSignerPolicy`, validates scope/action/policy/expiry, and returns a `VerifiedHumanApprovalReceipt`.
+- `VerifiedHumanApprovalReceipt` is the runtime verified proof object. It carries the validated receipt plus signer metadata, signer policy provenance, `signature_verification_reason`, `verified_at`, `verification_source`, and `verification_proof_hash` computed over canonical verifier-derived proof fields including `signer_policy_hash`.
 - `secure` and `prod` posture should use either a `VerifiedHumanApprovalReceipt` proof object or the signed artifact verification path. A direct `HumanApprovalReceipt` is accepted only under the transitional in-process registry provenance path. Compatibility dictionaries alone are not authoritative in those postures.
 - A direct `HumanApprovalReceipt` without verifier-derived provenance is a local/offline representation, not a secure/prod trust-boundary proof.
 - `dev` and `test` style local workflows may use receipt-derived compatibility `human_approval_state` dictionaries produced by `build_human_approval_state()` for demos, fixtures, and migration.
+- Cryptographic signature validity is necessary but not sufficient: signer authorization must also be policy-checked before a signed approval is admissible.
+- `VerifiedHumanApprovalReceipt` proves both receipt integrity/signature verification and signer admissibility under governance policy.
 - `approval_validation_hash` is tamper-evident metadata for accidental/internal mutation detection. It is not cryptographically signed and is not a substitute for signed artifact verification across an external trust boundary.
 
 A signed approval artifact has this deterministic v1 envelope shape:
@@ -54,13 +56,15 @@ A signed approval artifact has this deterministic v1 envelope shape:
   "signature": "external signature bytes or encoding",
   "signer": {
     "key_id": "review-key-id",
-    "algorithm": "ed25519|ecdsa-p256|test-only"
+    "algorithm": "ed25519|ecdsa-p256|test-only",
+    "identity": "operator:approver-1",
+    "role": "risk_manager"
   },
   "signed_at": "2026-05-01T00:00:00+00:00"
 }
 ```
 
-Verification is fail-closed: runtime recomputes `receipt_hash`, requires an explicit verifier for signed artifacts, rejects bad signatures, verifies `verification_proof_hash` for proof objects, requires verifier-derived provenance for transitional direct receipts in `secure`/`prod`, and propagates expiry, scope, policy-snapshot, and action-class validation failures.
+Verification is fail-closed: runtime recomputes `receipt_hash`, requires an explicit verifier and `HumanApprovalSignerPolicy` for signed artifacts, rejects bad signatures, rejects signer policy violations with deterministic reasons (`human_approval_signer_key_not_allowed`, `human_approval_signer_algorithm_not_allowed`, `human_approval_signer_role_not_allowed`, `human_approval_signer_action_class_not_allowed`, `human_approval_signer_policy_snapshot_not_allowed`), verifies `verification_proof_hash` for proof objects, requires verifier-derived provenance for transitional direct receipts in `secure`/`prod`, and propagates expiry, scope, policy-snapshot, and action-class validation failures.
 
 Successful artifact verification returns a proof object similar to:
 
@@ -72,6 +76,11 @@ Successful artifact verification returns a proof object similar to:
   "receipt_hash": "canonical sha256 of the receipt payload",
   "signer_key_id": "review-key-id",
   "signer_algorithm": "ed25519",
+  "signer_identity": "operator:approver-1",
+  "signer_role": "risk_manager",
+  "signer_policy_id": "approval-signer-policy-v1",
+  "signer_policy_hash": "canonical sha256 of signer policy",
+  "signature_verification_reason": "kms_signature_valid",
   "signed_at": "2026-05-01T00:00:00+00:00",
   "verified_at": "2026-05-01T00:00:01+00:00",
   "verification_source": "signed_human_approval_artifact",
@@ -88,6 +97,11 @@ For backward compatibility, `verify_human_approval_receipt_artifact()` still ret
   "artifact_version": "v1",
   "signer_key_id": "review-key-id",
   "signer_algorithm": "ed25519",
+  "signer_identity": "operator:approver-1",
+  "signer_role": "risk_manager",
+  "signer_policy_id": "approval-signer-policy-v1",
+  "signer_policy_hash": "canonical sha256 of signer policy",
+  "signature_verification_reason": "kms_signature_valid",
   "signed_at": "2026-05-01T00:00:00+00:00",
   "verified_at": "2026-05-01T00:00:01+00:00",
   "receipt_hash_verified": true,

--- a/tests/governance/test_human_approval_receipt.py
+++ b/tests/governance/test_human_approval_receipt.py
@@ -11,6 +11,8 @@ from veritas_os.governance.action_contracts import ActionClassContract
 from veritas_os.governance.authority_evidence import AuthorityEvidence, VerificationResult
 from veritas_os.governance.human_approval_receipt import (
     HumanApprovalReceipt,
+    HumanApprovalSignatureVerificationResult,
+    HumanApprovalSignerPolicy,
     VerifiedHumanApprovalReceipt,
     build_human_approval_state,
     validate_human_approval_receipt,
@@ -64,11 +66,29 @@ def _signed_artifact(
         "receipt": receipt_payload,
         "receipt_hash": digest_receipt.deterministic_digest(),
         "signature": "test-signature",
-        "signer": {"key_id": "test-key", "algorithm": "test-only"},
+        "signer": {
+            "key_id": "test-key",
+            "algorithm": "test-only",
+            "identity": "operator:approver-1",
+            "role": "risk_manager",
+        },
         "signed_at": "2026-05-01T00:00:00+00:00",
     }
     artifact.update(overrides)
     return artifact
+
+
+def _signer_policy(**overrides: object) -> HumanApprovalSignerPolicy:
+    payload = {
+        "policy_id": "signer-policy-001",
+        "allowed_key_ids": ["test-key"],
+        "allowed_algorithms": ["test-only"],
+        "required_signer_roles": ["risk_manager"],
+        "allowed_action_classes": ["wire_transfer"],
+        "allowed_policy_snapshot_ids": ["policy-001"],
+    }
+    payload.update(overrides)
+    return HumanApprovalSignerPolicy(**payload)
 
 
 def _contract(**overrides: object) -> ActionClassContract:
@@ -661,6 +681,7 @@ def test_signed_human_approval_artifact_verification_sets_signature_verified() -
         action_class="wire_transfer",
         policy_snapshot_id="policy-001",
         now=datetime(2026, 5, 10, tzinfo=UTC),
+        signer_policy=_signer_policy(),
     )
 
     assert receipt.signature_verified is True
@@ -687,6 +708,7 @@ def test_signed_human_approval_artifact_bad_signature_fails() -> None:
             action_class="wire_transfer",
             policy_snapshot_id="policy-001",
             now=datetime(2026, 5, 10, tzinfo=UTC),
+            signer_policy=_signer_policy(),
         )
 
 
@@ -701,6 +723,7 @@ def test_signed_human_approval_artifact_tampered_receipt_hash_fails() -> None:
             action_class="wire_transfer",
             policy_snapshot_id="policy-001",
             now=datetime(2026, 5, 10, tzinfo=UTC),
+            signer_policy=_signer_policy(),
         )
 
 
@@ -713,6 +736,7 @@ def test_signed_human_approval_artifact_without_verifier_fails() -> None:
             action_class="wire_transfer",
             policy_snapshot_id="policy-001",
             now=datetime(2026, 5, 10, tzinfo=UTC),
+            signer_policy=_signer_policy(),
         )
 
 
@@ -789,6 +813,7 @@ def test_strict_posture_accepts_receipt_returned_by_artifact_verifier(
         action_class="wire_transfer",
         policy_snapshot_id="policy-001",
         now=datetime(2026, 5, 10, tzinfo=UTC),
+        signer_policy=_signer_policy(),
     )
 
     result = RuntimeAuthorityValidator().validate(
@@ -823,6 +848,7 @@ def test_strict_posture_passes_with_valid_signed_human_approval_artifact(
         actor_identity="operator:alice",
         human_approval_artifact=_signed_artifact(),
         verify_human_approval_signature_fn=lambda _artifact: True,
+        human_approval_signer_policy=_signer_policy(),
         bind_context_metadata={"session_id": "bind-001"},
         now=datetime(2026, 5, 10, tzinfo=UTC),
     )
@@ -871,6 +897,7 @@ def test_strict_posture_rejects_signed_artifact_with_tampered_receipt_hash(
         actor_identity="operator:alice",
         human_approval_artifact=_signed_artifact(receipt_hash="f" * 64),
         verify_human_approval_signature_fn=lambda _artifact: True,
+        human_approval_signer_policy=_signer_policy(),
         bind_context_metadata={"session_id": "bind-001"},
         now=datetime(2026, 5, 10, tzinfo=UTC),
     )
@@ -910,6 +937,7 @@ def test_signed_human_approval_artifact_verification_produces_proof() -> None:
         action_class="wire_transfer",
         policy_snapshot_id="policy-001",
         now=datetime(2026, 5, 10, tzinfo=UTC),
+        signer_policy=_signer_policy(),
     )
 
     assert isinstance(proof, VerifiedHumanApprovalReceipt)
@@ -919,6 +947,94 @@ def test_signed_human_approval_artifact_verification_produces_proof() -> None:
     assert proof.artifact_version == "v1"
     assert proof.verification_source == "signed_human_approval_artifact"
     assert len(proof.verification_proof_hash) == 64
+
+
+def test_signed_human_approval_artifact_valid_signer_policy_passes() -> None:
+    proof = verify_human_approval_receipt_artifact_to_proof(
+        _signed_artifact(),
+        lambda _artifact: HumanApprovalSignatureVerificationResult(
+            verified=True,
+            key_id="test-key",
+            algorithm="test-only",
+            signer_identity="operator:approver-1",
+            signer_role="risk_manager",
+            reason="test_verified",
+        ),
+        requested_scope=["ledger:debit"],
+        action_class="wire_transfer",
+        policy_snapshot_id="policy-001",
+        now=datetime(2026, 5, 10, tzinfo=UTC),
+        signer_policy=_signer_policy(),
+    )
+
+    assert proof.signer_identity == "operator:approver-1"
+    assert proof.signer_role == "risk_manager"
+    assert proof.signer_policy_id == "signer-policy-001"
+    assert proof.signature_verification_reason == "test_verified"
+
+
+@pytest.mark.parametrize(
+    ("policy", "expected_reason"),
+    [
+        (
+            _signer_policy(allowed_key_ids=["other-key"]),
+            "human_approval_signer_key_not_allowed",
+        ),
+        (
+            _signer_policy(allowed_algorithms=["ed25519"]),
+            "human_approval_signer_algorithm_not_allowed",
+        ),
+        (
+            _signer_policy(required_signer_roles=["security_reviewer"]),
+            "human_approval_signer_role_not_allowed",
+        ),
+        (
+            _signer_policy(allowed_action_classes=["account_closure"]),
+            "human_approval_signer_action_class_not_allowed",
+        ),
+        (
+            _signer_policy(allowed_policy_snapshot_ids=["policy-999"]),
+            "human_approval_signer_policy_snapshot_not_allowed",
+        ),
+    ],
+)
+def test_signed_human_approval_artifact_signer_policy_failures(
+    policy: HumanApprovalSignerPolicy,
+    expected_reason: str,
+) -> None:
+    with pytest.raises(ValueError, match=expected_reason):
+        verify_human_approval_receipt_artifact_to_proof(
+            _signed_artifact(),
+            lambda _artifact: True,
+            requested_scope=["ledger:debit"],
+            action_class="wire_transfer",
+            policy_snapshot_id="policy-001",
+            now=datetime(2026, 5, 10, tzinfo=UTC),
+            signer_policy=policy,
+        )
+
+
+def test_signed_human_approval_proof_hash_changes_with_signer_policy_hash() -> None:
+    first = verify_human_approval_receipt_artifact_to_proof(
+        _signed_artifact(),
+        lambda _artifact: True,
+        requested_scope=["ledger:debit"],
+        action_class="wire_transfer",
+        policy_snapshot_id="policy-001",
+        now=datetime(2026, 5, 10, tzinfo=UTC),
+        signer_policy=_signer_policy(policy_hash="a" * 64),
+    )
+    second = verify_human_approval_receipt_artifact_to_proof(
+        _signed_artifact(),
+        lambda _artifact: True,
+        requested_scope=["ledger:debit"],
+        action_class="wire_transfer",
+        policy_snapshot_id="policy-001",
+        now=datetime(2026, 5, 10, tzinfo=UTC),
+        signer_policy=_signer_policy(policy_hash="b" * 64),
+    )
+
+    assert first.verification_proof_hash != second.verification_proof_hash
 
 
 @pytest.mark.parametrize("posture", ["secure", "prod"])
@@ -934,6 +1050,7 @@ def test_strict_posture_passes_with_valid_verified_human_approval_proof(
         action_class="wire_transfer",
         policy_snapshot_id="policy-001",
         now=datetime(2026, 5, 10, tzinfo=UTC),
+        signer_policy=_signer_policy(),
     )
 
     result = RuntimeAuthorityValidator().validate(
@@ -965,6 +1082,7 @@ def test_strict_posture_rejects_tampered_verified_proof_hash(
         action_class="wire_transfer",
         policy_snapshot_id="policy-001",
         now=datetime(2026, 5, 10, tzinfo=UTC),
+        signer_policy=_signer_policy(),
     )
 
     result = RuntimeAuthorityValidator().validate(
@@ -998,6 +1116,7 @@ def test_strict_posture_rejects_tampered_verified_receipt_hash(
         action_class="wire_transfer",
         policy_snapshot_id="policy-001",
         now=datetime(2026, 5, 10, tzinfo=UTC),
+        signer_policy=_signer_policy(),
     )
 
     result = RuntimeAuthorityValidator().validate(

--- a/veritas_os/governance/__init__.py
+++ b/veritas_os/governance/__init__.py
@@ -23,6 +23,8 @@ from veritas_os.governance.action_contracts import (
 )
 from veritas_os.governance.human_approval_receipt import (
     HumanApprovalReceipt,
+    HumanApprovalSignatureVerificationResult,
+    HumanApprovalSignerPolicy,
     VerifiedHumanApprovalReceipt,
     HumanApprovalValidationResult,
     build_human_approval_state,
@@ -85,6 +87,8 @@ __all__ = [
     "build_human_approval_state",
     "HumanApprovalValidationResult",
     "HumanApprovalReceipt",
+    "HumanApprovalSignatureVerificationResult",
+    "HumanApprovalSignerPolicy",
     "VerifiedHumanApprovalReceipt",
     "with_receipt_hash",
     "verify_human_approval_receipt_artifact_to_proof",

--- a/veritas_os/governance/human_approval_receipt.py
+++ b/veritas_os/governance/human_approval_receipt.py
@@ -28,6 +28,11 @@ VERIFICATION_PROOF_HASH_FIELDS = (
     "signed_at",
     "verified_at",
     "verification_source",
+    "signer_identity",
+    "signer_role",
+    "signer_policy_id",
+    "signer_policy_hash",
+    "signature_verification_reason",
 )
 VERIFIER_DERIVED_PROVENANCE_KEYS = frozenset(
     {
@@ -40,9 +45,68 @@ VERIFIER_DERIVED_PROVENANCE_KEYS = frozenset(
         "verified_at",
         "receipt_hash_verified",
         "signature_verified_by_runtime",
+        "signer_identity",
+        "signer_role",
+        "signer_policy_id",
+        "signer_policy_hash",
+        "signature_verification_reason",
     }
 )
 _VERIFIED_RECEIPT_REGISTRY: dict[int, str] = {}
+
+
+@dataclass(frozen=True)
+class HumanApprovalSignerPolicy:
+    """Policy constraints for signed HumanApprovalReceipt signers."""
+
+    policy_id: str
+    allowed_key_ids: list[str]
+    allowed_algorithms: list[str]
+    required_signer_roles: list[str] | None = None
+    allowed_action_classes: list[str] | None = None
+    allowed_policy_snapshot_ids: list[str] | None = None
+    policy_hash: str | None = None
+
+    def to_dict_for_hash(self) -> dict[str, Any]:
+        """Return canonical signer policy fields for provenance hashing."""
+        return {
+            "policy_id": self.policy_id,
+            "allowed_key_ids": sorted(str(item) for item in self.allowed_key_ids),
+            "allowed_algorithms": sorted(str(item) for item in self.allowed_algorithms),
+            "required_signer_roles": (
+                None
+                if self.required_signer_roles is None
+                else sorted(str(item) for item in self.required_signer_roles)
+            ),
+            "allowed_action_classes": (
+                None
+                if self.allowed_action_classes is None
+                else sorted(str(item) for item in self.allowed_action_classes)
+            ),
+            "allowed_policy_snapshot_ids": (
+                None
+                if self.allowed_policy_snapshot_ids is None
+                else sorted(str(item) for item in self.allowed_policy_snapshot_ids)
+            ),
+        }
+
+    def deterministic_hash(self) -> str:
+        """Return the explicit policy hash or a canonical hash of policy fields."""
+        if self.policy_hash:
+            return self.policy_hash
+        return sha256_of_canonical_json(self.to_dict_for_hash())
+
+
+@dataclass(frozen=True)
+class HumanApprovalSignatureVerificationResult:
+    """Structured cryptographic verification result with signer metadata."""
+
+    verified: bool
+    key_id: str | None = None
+    algorithm: str | None = None
+    signer_identity: str | None = None
+    signer_role: str | None = None
+    reason: str | None = None
 
 
 @dataclass(frozen=True)
@@ -115,6 +179,11 @@ class VerifiedHumanApprovalReceipt:
     receipt_hash: str
     signer_key_id: str | None
     signer_algorithm: str | None
+    signer_identity: str | None
+    signer_role: str | None
+    signer_policy_id: str
+    signer_policy_hash: str
+    signature_verification_reason: str | None
     signed_at: str | None
     verified_at: str
     verification_source: Literal["signed_human_approval_artifact"]
@@ -128,6 +197,11 @@ class VerifiedHumanApprovalReceipt:
             "artifact_version": self.artifact_version,
             "signer_key_id": self.signer_key_id,
             "signer_algorithm": self.signer_algorithm,
+            "signer_identity": self.signer_identity,
+            "signer_role": self.signer_role,
+            "signer_policy_id": self.signer_policy_id,
+            "signer_policy_hash": self.signer_policy_hash,
+            "signature_verification_reason": self.signature_verification_reason,
             "signed_at": self.signed_at,
             "verified_at": self.verified_at,
             "verification_source": self.verification_source,
@@ -183,6 +257,55 @@ def _artifact_signer_metadata(artifact: dict[str, Any]) -> tuple[str | None, str
     )
 
 
+def _structured_verification_result(
+    raw_result: bool | HumanApprovalSignatureVerificationResult,
+    artifact: dict[str, Any],
+) -> HumanApprovalSignatureVerificationResult:
+    """Normalize legacy bool verifier output into structured metadata."""
+    if isinstance(raw_result, HumanApprovalSignatureVerificationResult):
+        return raw_result
+    key_id, algorithm = _artifact_signer_metadata(artifact)
+    signer = artifact.get("signer") if isinstance(artifact.get("signer"), dict) else {}
+    return HumanApprovalSignatureVerificationResult(
+        verified=raw_result is True,
+        key_id=key_id,
+        algorithm=algorithm,
+        signer_identity=(
+            None
+            if signer.get("identity") is None
+            else str(signer.get("identity"))
+        ),
+        signer_role=None if signer.get("role") is None else str(signer.get("role")),
+        reason="legacy_bool_verifier" if raw_result is True else None,
+    )
+
+
+def _validate_signer_policy(
+    result: HumanApprovalSignatureVerificationResult,
+    policy: HumanApprovalSignerPolicy,
+    *,
+    action_class: str | None,
+    policy_snapshot_id: str | None,
+) -> None:
+    """Fail closed when verifier signer metadata violates signer policy."""
+    if result.key_id not in {str(item) for item in policy.allowed_key_ids}:
+        raise ValueError("human_approval_signer_key_not_allowed")
+    if result.algorithm not in {str(item) for item in policy.allowed_algorithms}:
+        raise ValueError("human_approval_signer_algorithm_not_allowed")
+    if policy.required_signer_roles is not None:
+        roles = {str(item) for item in policy.required_signer_roles}
+        if result.signer_role not in roles:
+            raise ValueError("human_approval_signer_role_not_allowed")
+    if policy.allowed_action_classes is not None:
+        actions = {str(item) for item in policy.allowed_action_classes}
+        if action_class not in actions:
+            raise ValueError("human_approval_signer_action_class_not_allowed")
+    if policy.allowed_policy_snapshot_ids is not None:
+        snapshots = {str(item) for item in policy.allowed_policy_snapshot_ids}
+        if policy_snapshot_id not in snapshots:
+            raise ValueError("human_approval_signer_policy_snapshot_not_allowed")
+
+
 def has_verified_human_approval_artifact_provenance(
     receipt: HumanApprovalReceipt,
 ) -> bool:
@@ -210,12 +333,16 @@ def has_verified_human_approval_artifact_provenance(
 
 def verify_human_approval_receipt_artifact_to_proof(
     artifact: dict[str, Any],
-    verify_signature_fn: Callable[[dict[str, Any]], bool] | None,
+    verify_signature_fn: (
+        Callable[[dict[str, Any]], bool | HumanApprovalSignatureVerificationResult]
+        | None
+    ),
     *,
     requested_scope: list[str],
     action_class: str | None,
     policy_snapshot_id: str | None,
     now: datetime | None = None,
+    signer_policy: HumanApprovalSignerPolicy | None = None,
 ) -> VerifiedHumanApprovalReceipt:
     """Verify a signed artifact and return a sealed approval proof.
 
@@ -243,10 +370,23 @@ def verify_human_approval_receipt_artifact_to_proof(
     if artifact.get("receipt_hash") != expected_hash:
         raise ValueError("human_approval_receipt_hash_mismatch")
 
-    if verify_signature_fn(artifact) is not True:
+    verification_result = _structured_verification_result(
+        verify_signature_fn(artifact), artifact
+    )
+    if verification_result.verified is not True:
         raise ValueError("human_approval_signature_verification_failed")
+    if signer_policy is None:
+        raise ValueError("human_approval_signer_policy_required")
+    _validate_signer_policy(
+        verification_result,
+        signer_policy,
+        action_class=action_class,
+        policy_snapshot_id=policy_snapshot_id,
+    )
 
-    signer_key_id, signer_algorithm = _artifact_signer_metadata(artifact)
+    signer_key_id = verification_result.key_id
+    signer_algorithm = verification_result.algorithm
+    signer_policy_hash = signer_policy.deterministic_hash()
     verified_at = (now or datetime.now(UTC)).isoformat()
     runtime_token = uuid4().hex
     verified_payload = unsigned_receipt.to_dict()
@@ -260,6 +400,11 @@ def verify_human_approval_receipt_artifact_to_proof(
             "artifact_version": SIGNED_APPROVAL_ARTIFACT_VERSION,
             "signer_key_id": signer_key_id,
             "signer_algorithm": signer_algorithm,
+            "signer_identity": verification_result.signer_identity,
+            "signer_role": verification_result.signer_role,
+            "signer_policy_id": signer_policy.policy_id,
+            "signer_policy_hash": signer_policy_hash,
+            "signature_verification_reason": verification_result.reason,
             "signed_at": artifact.get("signed_at"),
             "verified_at": verified_at,
             "receipt_hash_verified": True,
@@ -287,6 +432,11 @@ def verify_human_approval_receipt_artifact_to_proof(
         "receipt_hash": expected_hash,
         "signer_key_id": signer_key_id,
         "signer_algorithm": signer_algorithm,
+        "signer_identity": verification_result.signer_identity,
+        "signer_role": verification_result.signer_role,
+        "signer_policy_id": signer_policy.policy_id,
+        "signer_policy_hash": signer_policy_hash,
+        "signature_verification_reason": verification_result.reason,
         "signed_at": artifact.get("signed_at"),
         "verified_at": verified_at,
         "verification_source": VERIFICATION_SOURCE_SIGNED_ARTIFACT,
@@ -297,12 +447,16 @@ def verify_human_approval_receipt_artifact_to_proof(
 
 def verify_human_approval_receipt_artifact(
     artifact: dict[str, Any],
-    verify_signature_fn: Callable[[dict[str, Any]], bool] | None,
+    verify_signature_fn: (
+        Callable[[dict[str, Any]], bool | HumanApprovalSignatureVerificationResult]
+        | None
+    ),
     *,
     requested_scope: list[str],
     action_class: str | None,
     policy_snapshot_id: str | None,
     now: datetime | None = None,
+    signer_policy: HumanApprovalSignerPolicy | None = None,
 ) -> HumanApprovalReceipt:
     """Verify a signed artifact and return its validated receipt.
 
@@ -318,6 +472,7 @@ def verify_human_approval_receipt_artifact(
         action_class=action_class,
         policy_snapshot_id=policy_snapshot_id,
         now=now,
+        signer_policy=signer_policy,
     ).receipt
 
 

--- a/veritas_os/governance/runtime_authority.py
+++ b/veritas_os/governance/runtime_authority.py
@@ -16,6 +16,8 @@ from veritas_os.governance.authority_evidence import (
 from veritas_os.governance.human_approval_receipt import (
     HUMAN_APPROVAL_STATE_SOURCE,
     HumanApprovalReceipt,
+    HumanApprovalSignatureVerificationResult,
+    HumanApprovalSignerPolicy,
     VerifiedHumanApprovalReceipt,
     build_human_approval_state,
     has_verified_human_approval_artifact_provenance,
@@ -80,8 +82,10 @@ class RuntimeAuthorityValidator:
         verified_human_approval: VerifiedHumanApprovalReceipt | None = None,
         human_approval_artifact: dict[str, Any] | None = None,
         verify_human_approval_signature_fn: (
-            Callable[[dict[str, Any]], bool] | None
+            Callable[[dict[str, Any]], bool | HumanApprovalSignatureVerificationResult]
+            | None
         ) = None,
+        human_approval_signer_policy: HumanApprovalSignerPolicy | None = None,
         bind_context_metadata: dict[str, Any] | None = None,
         now: datetime | None = None,
     ) -> RuntimeAuthorityValidationResult:
@@ -293,6 +297,7 @@ class RuntimeAuthorityValidator:
                 verified_human_approval=verified_human_approval,
                 human_approval_artifact=human_approval_artifact,
                 verify_human_approval_signature_fn=verify_human_approval_signature_fn,
+                human_approval_signer_policy=human_approval_signer_policy,
                 requested_scope=requested_scope,
                 action_contract=action_contract,
                 policy_snapshot_id=policy_snapshot_id,
@@ -396,7 +401,11 @@ class RuntimeAuthorityValidator:
         human_approval_receipt: HumanApprovalReceipt | None,
         verified_human_approval: VerifiedHumanApprovalReceipt | None,
         human_approval_artifact: dict[str, Any] | None,
-        verify_human_approval_signature_fn: Callable[[dict[str, Any]], bool] | None,
+        verify_human_approval_signature_fn: (
+            Callable[[dict[str, Any]], bool | HumanApprovalSignatureVerificationResult]
+            | None
+        ),
+        human_approval_signer_policy: HumanApprovalSignerPolicy | None,
         requested_scope: list[str],
         action_contract: ActionClassContract | None,
         policy_snapshot_id: str | None,
@@ -434,6 +443,7 @@ class RuntimeAuthorityValidator:
                     action_class=action_class,
                     policy_snapshot_id=policy_snapshot_id,
                     now=now,
+                    signer_policy=human_approval_signer_policy,
                 )
             except ValueError as exc:
                 return False, str(exc)


### PR DESCRIPTION
### Motivation
- Cryptographic signature validity alone is insufficient to prove that a human approver was authorized; verifier output must include signer metadata and be checked against a signer policy to enforce governance constraints.

### Description
- Add `HumanApprovalSignerPolicy` and `HumanApprovalSignatureVerificationResult` dataclasses and canonical hashing for signer policy provenance in `veritas_os/governance/human_approval_receipt.py`.
- Normalize legacy bool verifier output to the structured `HumanApprovalSignatureVerificationResult`, require a `HumanApprovalSignerPolicy` after cryptographic verification, and fail-closed with deterministic reasons (`human_approval_signer_key_not_allowed`, `human_approval_signer_algorithm_not_allowed`, `human_approval_signer_role_not_allowed`, `human_approval_signer_action_class_not_allowed`, `human_approval_signer_policy_snapshot_not_allowed`).
- Extend `VerifiedHumanApprovalReceipt` and `verification_proof_hash` to include signer identity, signer role, signer policy id/hash, and `signature_verification_reason`, and persist signer provenance into receipt metadata.
- Thread signer-policy parameters through runtime validation by updating `RuntimeAuthorityValidator` to accept signer policy and the structured verifier return type, and adjust `verify_human_approval_receipt_artifact(_to_proof)` call sites accordingly.
- Add unit tests exercising valid signer policy, disallowed key/algorithm/role/action/policy-snapshot failures, and proof-hash changes when signer policy hash changes, and update architecture docs to explain signer authorization is checked in addition to cryptographic validity.

### Testing
- Performed byte-compile checks on modified modules with `python -m py_compile veritas_os/governance/human_approval_receipt.py veritas_os/governance/runtime_authority.py tests/governance/test_human_approval_receipt.py`, which succeeded.
- Ran style/static checks with `ruff` (`python -m ruff check ...`) which passed with no issues.
- Attempted to run the focused test module `python -m pytest tests/governance/test_human_approval_receipt.py -q` locally, but test collection failed due to a missing environment dependency (`PyYAML` / `yaml`) in the local runner; CI should run the full pytest matrix and is expected to validate the new tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f4f24e7f48326991dc7d8d3e0c26f)