### PR TITLE
Reject TestHumanApprovalSignatureVerifier in secure/prod posture

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Boundary:
 
 ## Human Approval Receipt v1
 
-VERITAS now includes a local/offline Human Approval Receipt v1 artifact. It represents human approval as a deterministic, hashable, scope-bound, expiry-aware governance artifact. Dev/test local workflows may convert receipts into compatibility `human_approval_state` dictionaries for demos, fixtures, and migration, but `secure`/`prod` posture requires an explicit `HumanApprovalReceipt` object or a future signed approval artifact path when human approval is needed. The `approval_validation_hash` is tamper-evident metadata, not a substitute for cryptographic receipt verification. This does not add live IdP, SSO, IAM, KMS/HSM, e-signature, or production approval workflow integration.
+VERITAS now includes a local/offline Human Approval Receipt v1 artifact. It represents human approval as a deterministic, hashable, scope-bound, expiry-aware governance artifact. Dev/test local workflows may convert receipts into compatibility `human_approval_state` dictionaries for demos, fixtures, and migration, but `secure`/`prod` posture requires an explicit `HumanApprovalReceipt` object with verifier-derived provenance, a signed approval artifact plus production verifier, or a sealed verified proof when human approval is needed. `TestHumanApprovalSignatureVerifier` is blocked in `secure`/`prod`; production deployments must provide their own verifier bound to KMS/HSM or trusted public-key infrastructure. The `approval_validation_hash` is tamper-evident metadata, not a substitute for cryptographic receipt verification. This does not add live IdP, SSO, IAM, KMS/HSM, e-signature, or production approval workflow integration.
 
 Boundary:
 

--- a/docs/en/architecture/human-approval-receipt.md
+++ b/docs/en/architecture/human-approval-receipt.md
@@ -128,7 +128,7 @@ class HumanApprovalSignatureVerifier(Protocol):
 
 Production deployments must bind this contract to deployment-controlled cryptographic infrastructure, such as KMS, HSM, or trusted public-key verification. The verifier must return verifier-derived `verified`, `key_id`, `algorithm`, `signer_identity`, `signer_role`, and `reason` metadata. `RuntimeAuthorityValidator` remains implementation agnostic: it can use `human_approval_signature_verifier` or the older `verify_human_approval_signature_fn`, but `secure`/`prod` should prefer the interface and still rejects bare boolean results.
 
-No production verifier is provided or assumed by default. `TestHumanApprovalSignatureVerifier` is a deterministic test/dev-only helper for fixtures and demos; it is not production assurance and must not be treated as evidence of real cryptographic verification.
+No production verifier is provided or assumed by default. Production deployments must provide their own `HumanApprovalSignatureVerifier` bound to deployment-controlled KMS, HSM, or trusted public-key infrastructure. `TestHumanApprovalSignatureVerifier` is a deterministic test/dev-only helper for fixtures and demos; it is explicitly marked test-only and `RuntimeAuthorityValidator` blocks it in `secure`/`prod` posture with `human_approval_test_signature_verifier_not_allowed`. Local/dev demos may use the test verifier only outside strict posture; it is not production assurance and must not be treated as evidence of real cryptographic verification.
 
 ## Explicit boundary (non-goals)
 

--- a/tests/governance/test_human_approval_receipt.py
+++ b/tests/governance/test_human_approval_receipt.py
@@ -92,6 +92,23 @@ def _signature_result(**overrides: object) -> HumanApprovalSignatureVerification
     return HumanApprovalSignatureVerificationResult(**payload)
 
 
+class _ProductionHumanApprovalSignatureVerifier:
+    """Non-test verifier fixture that satisfies the production verifier contract."""
+
+    def __init__(
+        self,
+        result: HumanApprovalSignatureVerificationResult | None = None,
+    ) -> None:
+        self._result = result or _signature_result()
+
+    def verify(
+        self,
+        artifact: dict[str, object],
+    ) -> HumanApprovalSignatureVerificationResult:
+        """Return a structured verification result for production-path tests."""
+        return self._result
+
+
 def _signer_policy(**overrides: object) -> HumanApprovalSignerPolicy:
     payload = {
         "policy_id": "signer-policy-001",
@@ -850,7 +867,7 @@ def test_strict_posture_accepts_receipt_returned_by_artifact_verifier(
 
 
 @pytest.mark.parametrize("posture", ["secure", "prod"])
-def test_strict_posture_passes_with_human_approval_signature_verifier(
+def test_strict_posture_rejects_test_human_approval_signature_verifier(
     monkeypatch: pytest.MonkeyPatch,
     posture: str,
 ) -> None:
@@ -865,6 +882,33 @@ def test_strict_posture_passes_with_human_approval_signature_verifier(
         actor_identity="operator:alice",
         human_approval_artifact=_signed_artifact(),
         human_approval_signature_verifier=TestHumanApprovalSignatureVerifier(),
+        human_approval_signer_policy=_signer_policy(),
+        bind_context_metadata={"session_id": "bind-001"},
+        now=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    assert result.status == "fail"
+    assert _approval_reason(result) == (
+        "human_approval_test_signature_verifier_not_allowed"
+    )
+
+
+@pytest.mark.parametrize("posture", ["secure", "prod"])
+def test_strict_posture_accepts_non_test_human_approval_signature_verifier(
+    monkeypatch: pytest.MonkeyPatch,
+    posture: str,
+) -> None:
+    monkeypatch.setenv("VERITAS_POSTURE", posture)
+
+    result = RuntimeAuthorityValidator().validate(
+        action_contract=_contract(),
+        authority_evidence=_authority(),
+        requested_scope=["ledger:debit"],
+        required_evidence_metadata={"kyc_status": {"present": True, "fresh": True}},
+        policy_snapshot_id="policy-001",
+        actor_identity="operator:alice",
+        human_approval_artifact=_signed_artifact(),
+        human_approval_signature_verifier=_ProductionHumanApprovalSignatureVerifier(),
         human_approval_signer_policy=_signer_policy(),
         bind_context_metadata={"session_id": "bind-001"},
         now=datetime(2026, 5, 10, tzinfo=UTC),
@@ -892,7 +936,7 @@ def test_strict_posture_prefers_human_approval_signature_verifier(
         verify_human_approval_signature_fn=lambda _artifact: _signature_result(
             verified=False
         ),
-        human_approval_signature_verifier=TestHumanApprovalSignatureVerifier(),
+        human_approval_signature_verifier=_ProductionHumanApprovalSignatureVerifier(),
         human_approval_signer_policy=_signer_policy(),
         bind_context_metadata={"session_id": "bind-001"},
         now=datetime(2026, 5, 10, tzinfo=UTC),
@@ -901,10 +945,12 @@ def test_strict_posture_prefers_human_approval_signature_verifier(
     assert result.status == "pass"
 
 
-def test_dev_posture_can_use_test_human_approval_signature_verifier(
+@pytest.mark.parametrize("posture", ["dev", "test"])
+def test_dev_test_posture_can_use_test_human_approval_signature_verifier(
     monkeypatch: pytest.MonkeyPatch,
+    posture: str,
 ) -> None:
-    monkeypatch.setenv("VERITAS_POSTURE", "dev")
+    monkeypatch.setenv("VERITAS_POSTURE", posture)
 
     result = RuntimeAuthorityValidator().validate(
         action_contract=_contract(),
@@ -921,7 +967,6 @@ def test_dev_posture_can_use_test_human_approval_signature_verifier(
     )
 
     assert result.status == "pass"
-
 
 
 def test_strict_posture_rejects_incomplete_signature_verifier_result(
@@ -937,7 +982,9 @@ def test_strict_posture_rejects_incomplete_signature_verifier_result(
         policy_snapshot_id="policy-001",
         actor_identity="operator:alice",
         human_approval_artifact=_signed_artifact(),
-        human_approval_signature_verifier=TestHumanApprovalSignatureVerifier(key_id=""),
+        human_approval_signature_verifier=_ProductionHumanApprovalSignatureVerifier(
+            _signature_result(key_id="")
+        ),
         human_approval_signer_policy=_signer_policy(),
         bind_context_metadata={"session_id": "bind-001"},
         now=datetime(2026, 5, 10, tzinfo=UTC),
@@ -971,6 +1018,7 @@ def test_strict_posture_rejects_signature_verifier_exception(
 
     assert result.status == "fail"
     assert _approval_reason(result) == "human_approval_signature_verification_failed"
+
 
 @pytest.mark.parametrize("posture", ["secure", "prod"])
 def test_strict_posture_passes_with_valid_signed_human_approval_artifact(

--- a/veritas_os/governance/human_approval_receipt.py
+++ b/veritas_os/governance/human_approval_receipt.py
@@ -148,6 +148,7 @@ class TestHumanApprovalSignatureVerifier:
     signer_role: str = "risk_manager"
     verified: bool = True
     reason: str = "test_dev_only_verifier"
+    is_test_verifier: bool = True
 
     def verify(
         self,

--- a/veritas_os/governance/runtime_authority.py
+++ b/veritas_os/governance/runtime_authority.py
@@ -439,6 +439,13 @@ class RuntimeAuthorityValidator:
             return proof_valid, proof_reason
 
         if human_approval_artifact is not None:
+            if (
+                strict_posture
+                and self._is_test_human_approval_signature_verifier(
+                    human_approval_signature_verifier
+                )
+            ):
+                return False, "human_approval_test_signature_verifier_not_allowed"
             verification_fn = self._human_approval_signature_verification_fn(
                 human_approval_signature_verifier=human_approval_signature_verifier,
                 verify_human_approval_signature_fn=verify_human_approval_signature_fn,
@@ -486,6 +493,13 @@ class RuntimeAuthorityValidator:
 
         return self._validated_human_approval_state(human_approval_state)
 
+    def _is_test_human_approval_signature_verifier(
+        self,
+        verifier: HumanApprovalSignatureVerifier | None,
+    ) -> bool:
+        """Return whether ``verifier`` is explicitly marked test/dev-only."""
+        return bool(getattr(verifier, "is_test_verifier", False))
+
     def _human_approval_signature_verification_fn(
         self,
         *,
@@ -499,7 +513,6 @@ class RuntimeAuthorityValidator:
         if human_approval_signature_verifier is not None:
             return human_approval_signature_verifier.verify
         return verify_human_approval_signature_fn
-
 
     def _validated_human_approval_proof(
         self,


### PR DESCRIPTION
### Motivation
- Prevent accidental acceptance of the deterministic test verifier in `secure`/`prod` postures by explicitly marking the test verifier and failing closed when it is presented in strict postures.

### Description
- Mark `TestHumanApprovalSignatureVerifier` with an explicit `is_test_verifier: bool = True` flag so it can be identified as test/dev-only.
- Add a runtime guard in `RuntimeAuthorityValidator` that, when `VERITAS_POSTURE` is `secure` or `prod`, rejects `human_approval_signature_verifier` instances marked as test-only and returns failure reason `human_approval_test_signature_verifier_not_allowed`.
- Preserve the generic production verifier contract and the legacy callable verification path so non-test `HumanApprovalSignatureVerifier` implementations and structured `HumanApprovalSignatureVerificationResult` returns continue to work.
- Update tests to assert strict-posture rejection of the test verifier, strict-posture acceptance of a non-test verifier fixture, and dev/test acceptance of the test verifier; add a small non-test verifier fixture used by those tests.
- Update documentation in `README.md` and `docs/en/architecture/human-approval-receipt.md` to state that the test verifier is blocked in strict posture and that production deployments must bind their own KMS/HSM/public-key-backed verifier.

### Testing
- Ran Python compile check: `python -m py_compile veritas_os/governance/human_approval_receipt.py veritas_os/governance/runtime_authority.py tests/governance/test_human_approval_receipt.py` which succeeded.
- Ran static checks/formatters: `black` reformatted the touched files and `ruff check` passed on the modified files.
- Attempted to run the targeted pytest suite (`tests/governance/test_human_approval_receipt.py`) but test execution was blocked by environment issues: missing `yaml` dependency during test collection and a network/dependency-fetch failure in the ephemeral test runner, so full `pytest` could not be completed here.  The added tests exercise the new strict-posture rejection (`human_approval_test_signature_verifier_not_allowed`) and the dev/test acceptance paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f9292e3488326b41ebf98b4d7b7cd)