### PR TITLE
Normalize reviewer demo artifact paths for portable reviewer artifacts

### DIFF
--- a/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/README.md
+++ b/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/README.md
@@ -52,6 +52,15 @@ prefer `--output-dir` so repository files are not modified.
 The suite is covered by a focused CI-safe smoke test using temporary
 output directories.
 
+## Portable generated paths
+
+Reviewer-facing generated artifacts must use repository-relative POSIX paths
+for path-bearing fields such as `input_dir`, `output_dir`, `artifact_ref`,
+`source_path`, and `generated_from`. Do not commit local absolute prefixes such
+as `/workspace/`, `/home/runner/`, `/tmp/`, or Windows drive paths; this keeps
+reviewer evidence portable and reproducible across local, CI, and external
+reviewer environments.
+
 ## Validate checked-in generated examples
 
 ```bash

--- a/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated/demo-summary.generated.example.json
+++ b/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated/demo-summary.generated.example.json
@@ -43,7 +43,7 @@
       "artifact_type": "reviewer_evidence_packet"
     }
   ],
-  "input_dir": "/workspace/veritas_os/docs/en/demo/examples/evaluation-governance-offline-chain-v1",
+  "input_dir": "docs/en/demo/examples/evaluation-governance-offline-chain-v1",
   "issued_at": "2026-01-01T00:00:00Z",
   "non_enforcing": true,
   "non_goals": [

--- a/scripts/demo/run_evaluation_governance_reviewer_demo.py
+++ b/scripts/demo/run_evaluation_governance_reviewer_demo.py
@@ -109,6 +109,30 @@ def canonical_json_hash(payload: Any) -> str:
     return hashlib.sha256(canonical).hexdigest()
 
 
+def normalize_artifact_path(path: Path, repo_root: Path = REPO_ROOT) -> str:
+    """Return a portable POSIX repository-relative artifact path.
+
+    Reviewer-facing generated artifacts must not persist local host absolute
+    path prefixes. Paths inside ``repo_root`` are made repository-relative;
+    already-relative paths are normalized to POSIX separators. Absolute paths
+    outside the repository are rejected because they are not reproducible.
+    """
+    raw_path = Path(path)
+    if not raw_path.is_absolute():
+        return str(raw_path).replace("\\", "/")
+
+    resolved_path = raw_path.resolve(strict=False)
+    resolved_repo_root = repo_root.resolve(strict=False)
+    try:
+        relative_path = resolved_path.relative_to(resolved_repo_root)
+    except ValueError as exc:
+        raise ValueError(
+            "artifact path must be repository-relative or inside repo_root: "
+            f"{path}"
+        ) from exc
+    return relative_path.as_posix()
+
+
 def _artifact_entry(
     artifact_type: str,
     artifact_ref: str,
@@ -151,7 +175,7 @@ def build_demo_summary(
         "issued_at": ISSUED_AT,
         "non_runtime": True,
         "non_enforcing": True,
-        "input_dir": input_dir.as_posix(),
+        "input_dir": normalize_artifact_path(input_dir, REPO_ROOT),
         "generated_artifacts": generated_artifacts,
         "demo_summary": (
             "Synthetic offline Evaluation Governance reviewer demo generated "

--- a/tests/demo/test_evaluation_governance_reviewer_demo_runner.py
+++ b/tests/demo/test_evaluation_governance_reviewer_demo_runner.py
@@ -50,6 +50,7 @@ def test_runner_imports_cleanly() -> None:
     assert callable(runner.build_demo_summary)
     assert callable(runner.write_json)
     assert callable(runner.load_json)
+    assert callable(runner.normalize_artifact_path)
     assert callable(runner.main)
 
 
@@ -70,6 +71,7 @@ def test_run_reviewer_demo_generates_expected_artifacts(tmp_path: Path) -> None:
     assert summary["non_runtime"] is True
     assert summary["non_enforcing"] is True
     assert REQUIRED_NON_GOALS <= set(summary["non_goals"])
+    assert summary["input_dir"] == EXAMPLE_DIR.as_posix()
     assert result.reviewer_packet == packet
     assert result.demo_summary == summary
 
@@ -114,3 +116,21 @@ def test_runner_cli_refuses_implicit_example_mutation() -> None:
 
     assert completed.returncode != 0
     assert "refusing to write checked-in generated examples" in completed.stderr
+
+
+def test_normalize_artifact_path_returns_portable_repo_relative_paths() -> None:
+    absolute_input = runner.REPO_ROOT / EXAMPLE_DIR
+
+    assert runner.normalize_artifact_path(absolute_input) == EXAMPLE_DIR.as_posix()
+    assert runner.normalize_artifact_path(Path("docs\\en\\demo")) == (
+        "docs/en/demo"
+    )
+
+
+def test_normalize_artifact_path_rejects_external_absolute_paths() -> None:
+    try:
+        runner.normalize_artifact_path(Path("/tmp/external-reviewer-demo"))
+    except ValueError as exc:
+        assert "repository-relative or inside repo_root" in str(exc)
+    else:
+        raise AssertionError("external absolute path was accepted")

--- a/tests/demo/test_generated_reviewer_demo_artifact_paths.py
+++ b/tests/demo/test_generated_reviewer_demo_artifact_paths.py
@@ -1,0 +1,57 @@
+"""Regression tests for portable reviewer-facing generated artifact paths."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+GENERATED_REVIEWER_DEMO_DIR = Path(
+    "docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated"
+)
+HOST_SPECIFIC_PREFIXES = (
+    "/workspace/",
+    "/home/runner/",
+    "/tmp/",
+    "C:\\\\",
+)
+PATH_FIELD_NAMES = {
+    "input_dir",
+    "output_dir",
+    "artifact_ref",
+    "source_path",
+    "generated_from",
+}
+
+
+def _walk_path_fields(payload: Any, field_name: str | None = None) -> list[str]:
+    """Collect string values from reviewer path-bearing JSON fields."""
+    if isinstance(payload, dict):
+        values: list[str] = []
+        for key, value in payload.items():
+            values.extend(_walk_path_fields(value, key))
+        return values
+    if isinstance(payload, list):
+        values = []
+        for item in payload:
+            values.extend(_walk_path_fields(item, field_name))
+        return values
+    if isinstance(payload, str) and field_name in PATH_FIELD_NAMES:
+        return [payload]
+    return []
+
+
+def test_generated_reviewer_demo_artifact_paths_are_portable() -> None:
+    generated_files = sorted(GENERATED_REVIEWER_DEMO_DIR.glob("*.json"))
+    assert generated_files, "expected committed reviewer demo JSON artifacts"
+
+    violations: list[str] = []
+    for generated_file in generated_files:
+        payload = json.loads(generated_file.read_text(encoding="utf-8"))
+        for value in _walk_path_fields(payload):
+            if any(prefix in value for prefix in HOST_SPECIFIC_PREFIXES):
+                violations.append(f"{generated_file}: {value}")
+            if "\\" in value:
+                violations.append(f"{generated_file}: {value}")
+
+    assert violations == []


### PR DESCRIPTION
### Motivation
- Reviewer-facing generated artifacts contained host-specific absolute paths which made evidence non-reproducible across local, CI, and external reviewer environments.
- Generated summary fields such as `input_dir` should be repository-relative and POSIX-normalized so review artifacts are deterministic and portable.
- This change also reduces accidental leakage of local machine path prefixes and reminds maintainers not to commit local absolute paths or secrets.  

### Description
- Add `normalize_artifact_path(path: Path, repo_root: Path = REPO_ROOT) -> str` with a docstring that returns POSIX repository-relative paths for in-repo paths, normalizes already-relative paths, and rejects external absolute paths.  
- Use the helper when building the demo summary so `input_dir` is emitted as a repository-relative POSIX path instead of a host absolute path.  
- Regenerate the checked-in demo summary artifact so `docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated/demo-summary.generated.example.json` no longer includes `/workspace/...` and update the demo README to document portability requirements.  
- Add regression tests: a new `tests/demo/test_generated_reviewer_demo_artifact_paths.py` that scans path-bearing fields for host-specific prefixes and backslashes, and extend `tests/demo/test_evaluation_governance_reviewer_demo_runner.py` with unit tests for `normalize_artifact_path`.  

### Testing
- Ran unit tests with `pytest tests/demo/test_evaluation_governance_reviewer_demo_runner.py tests/demo/test_generated_reviewer_demo_artifact_paths.py tests/demo/test_evaluation_governance_reviewer_demo_validator.py -q` which completed successfully (`14 passed`).
- Regenerated the example demo with `python scripts/demo/run_evaluation_governance_reviewer_demo.py --input-dir docs/en/demo/examples/evaluation-governance-offline-chain-v1 --write-example-output` and validated that `input_dir` is now repository-relative.  
- Ran the demo validator with `python scripts/demo/validate_evaluation_governance_reviewer_demo.py --demo-dir docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated --artifact-base-dir docs/en/demo/examples/evaluation-governance-offline-chain-v1 --verify-local-hashes` which reported all validation passes.  
- Performed a repository scan for host-specific prefixes with `rg -n '/workspace/|/home/runner/|/tmp/|[A-Za-z]:\\'` over generated demo artifacts and found no violations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fd021df1883269d80cffe36c1881d)