### PR TITLE
docs: track temporary Starlette pip-audit ignores (PR #2048)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,7 +162,7 @@ jobs:
       - name: Block high/critical CVEs in Python core production dependencies
         run: |
           set +e
-          # Temporary narrow Starlette exceptions:
+          # Temporary narrow Starlette exceptions (tracking: PR #2048):
           # - PYSEC-2026-161 is fixed in starlette>=1.0.1.
           # - GHSA-wqp7-x3pw-xc5r / CVE-2026-48818 and
           #   GHSA-x746-7m8f-x49c / CVE-2026-48817 are fixed in

--- a/.github/workflows/security-gates.yml
+++ b/.github/workflows/security-gates.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Python core production dependency audit (pip-audit, blocking)
         run: |
           set +e
-          # Temporary narrow Starlette exceptions:
+          # Temporary narrow Starlette exceptions (tracking: PR #2048):
           # - PYSEC-2026-161 is fixed in starlette>=1.0.1.
           # - GHSA-wqp7-x3pw-xc5r / CVE-2026-48818 and
           #   GHSA-x746-7m8f-x49c / CVE-2026-48817 are fixed in

--- a/docs/en/operations/dependency-profiles.md
+++ b/docs/en/operations/dependency-profiles.md
@@ -73,6 +73,10 @@ keeping full backward compatibility via the `[full]` extra.
 ## CI / Docker Behavior
 
 - **CI blocking dependency audit** (`main.yml`, `security-gates.yml`): `pip-audit -r veritas_os/requirements-core.txt --desc`.
+  The Starlette `--ignore-vuln` entries added in PR #2048 are temporary,
+  narrowly scoped audit exceptions for the current FastAPI resolver constraint.
+  Remove those ignores as soon as FastAPI resolves with `starlette>=1.3.1`;
+  do not add adjacent Starlette ignores or weaken the blocking audit gate.
 - **CI informational full audit**: `pip-audit -r veritas_os/requirements.txt --desc` with non-blocking status, so optional ML/security posture remains visible.
 - **CI install paths**: Some jobs still install `requirements.txt` for full-coverage test environments.
 - **Docker** (`Dockerfile`): Installs via `requirements.txt` → full dependency set. No change needed.


### PR DESCRIPTION
### Motivation
- The CI pip-audit run includes narrow `--ignore-vuln` entries for Starlette added to work around the current FastAPI resolver constraint, and those exceptions need an explicit tracking reference. 
- Leaving this note helps reviewers know the exceptions are temporary and warns that broadening or persisting them is a security risk and must be avoided. 

### Description
- Add a tracking reference ` (tracking: PR #2048)` to the Starlette exception comments in `.github/workflows/main.yml` and `.github/workflows/security-gates.yml` to indicate the ignores are temporary. 
- Add a short reminder to `docs/en/operations/dependency-profiles.md` documenting that the Starlette `--ignore-vuln` entries from PR #2048 are temporary and should be removed once FastAPI resolves with `starlette>=1.3.1`, and to not broaden those ignores. 
- Make no changes to the `--ignore-vuln` list itself and do not alter runtime behavior or broaden the vulnerability scope. 

### Testing
- Ran `git diff --check` and it produced no issues. 
- No other automated tests were required because this is a documentation/comment-only change and does not modify runtime behavior or the dependency-audit ignore list.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32285997188326a8d2e7122d6de668)