### PR TITLE
Bind verified human-approval proof into manifests, receipts, verifier, and schemas

### DIFF
--- a/docs/en/architecture/evidence-chain-manifest.md
+++ b/docs/en/architecture/evidence-chain-manifest.md
@@ -33,3 +33,15 @@ It is **not**:
 - regulatory approval
 - third-party certification
 - production access-control validation
+
+## Verified human approval proof continuity
+
+When human approval is required, the manifest summary includes `verified_human_approval_proof_hash` and records whether human approval was required for the chain. This lets reviewers verify continuity across:
+
+- the decision artifact,
+- the bind receipt or bind-time decision evidence,
+- the human approval receipt and sealed verified proof,
+- the outcome receipt, and
+- the evidence-chain manifest.
+
+The manifest-level proof hash must match the proof hash embedded in the `OutcomeReceipt` metadata and the actual `VerifiedHumanApprovalReceipt.verification_proof_hash`. If policy explicitly allows no human approval, the manifest may set human approval as not required and omit the proof hash while preserving valid no-approval flows.

--- a/docs/en/architecture/evidence-chain-verifier.md
+++ b/docs/en/architecture/evidence-chain-verifier.md
@@ -55,3 +55,13 @@ This verifier is not legal advice, regulatory approval, third-party
 certification, production audit certification, or proof of live production audit
 coverage. It is a deterministic local/offline consistency checker for governance
 artifacts supplied to it.
+
+## Human approval proof substitution checks
+
+For approval-required chains, verification fails closed when the verified human approval proof hash is missing or inconsistent. The verifier checks that:
+
+- the manifest carries `verified_human_approval_proof_hash`,
+- the outcome metadata carries the same `verified_human_approval_proof_hash`, and
+- the supplied `VerifiedHumanApprovalReceipt` carries that same `verification_proof_hash`.
+
+Deterministic failure reasons include `human_approval_proof_hash_missing`, `human_approval_proof_hash_mismatch`, `outcome_human_approval_proof_hash_mismatch`, and `manifest_human_approval_proof_hash_mismatch`. These checks prevent approval substitution after bind-time validation by proving that the committed outcome and evidence-chain manifest refer to the same sealed approval proof.

--- a/docs/en/architecture/outcome-receipt.md
+++ b/docs/en/architecture/outcome-receipt.md
@@ -25,3 +25,13 @@ Boundary in this PR:
 - No live SaaS/IdP/IAM/SSO/bank/sanctions/customer-system integrations
 - Not proof of live production execution
 - Not legal advice, regulatory approval, third-party certification, or production access-control validation
+
+## Verified human approval proof binding
+
+When an action requires human approval and bind-time validation uses a sealed `VerifiedHumanApprovalReceipt`, the resulting `OutcomeReceipt` carries the exact approval proof in metadata:
+
+- `verified_human_approval_proof_hash`
+- `verified_human_approval_receipt_id`
+- `human_approval_verification_source`
+
+These metadata fields are included in the deterministic outcome hash payload. Reviewers can therefore check that the committed outcome references the same verified approval proof that passed bind-time validation, rather than a later substituted approval artifact. No-approval-required paths remain valid without these metadata fields.

--- a/docs/en/demo/examples/context-bound-approval-replay-prevention-v1.json
+++ b/docs/en/demo/examples/context-bound-approval-replay-prevention-v1.json
@@ -31,7 +31,8 @@
         "generated_at": "2026-05-10T00:00:00+00:00",
         "human_approval_receipt_hash": "ee7949ac4e2ff999c6c3681fe90d6d4cbf4ce3f0143c7b7e59ce3aa0103d2042",
         "human_approval_receipt_id": "har-replay-001",
-        "manifest_hash": "500e061d7bd00b0562b8f962fd18590447f63680b35ffc5c5cec08555d4d81be",
+        "human_approval_required": true,
+        "manifest_hash": "ec3ea1e78def9c3d5f24869b0c371d87a682955a7ba051d13255caef2396edf9",
         "manifest_id": "manifest-valid_same_context",
         "metadata": {
           "signature_validity_alone_is_insufficient": true
@@ -46,7 +47,8 @@
           "workspace:permission:update"
         ],
         "target_resource": "workspace:demo",
-        "target_system": "local-demo-iam"
+        "target_system": "local-demo-iam",
+        "verified_human_approval_proof_hash": null
       },
       "evidence_chain_verification_summary": {
         "decision_id": "decision-replay-001",
@@ -61,7 +63,7 @@
         "mismatched_links": [],
         "missing_links": [],
         "operation_id": "operation-valid_same_context",
-        "recomputed_manifest_hash": "500e061d7bd00b0562b8f962fd18590447f63680b35ffc5c5cec08555d4d81be",
+        "recomputed_manifest_hash": "ec3ea1e78def9c3d5f24869b0c371d87a682955a7ba051d13255caef2396edf9",
         "verification_status": "verified",
         "verified_at": "2026-05-10T00:00:00+00:00",
         "verified_links": [
@@ -146,7 +148,8 @@
         "generated_at": "2026-05-10T00:00:00+00:00",
         "human_approval_receipt_hash": "ee7949ac4e2ff999c6c3681fe90d6d4cbf4ce3f0143c7b7e59ce3aa0103d2042",
         "human_approval_receipt_id": "har-replay-001",
-        "manifest_hash": "116b8f569634bf937df5182318c394e6994ba951de54ba05596c33b2b0432fff",
+        "human_approval_required": true,
+        "manifest_hash": "e945dd62aadf843adee7aceffbc5d6f0c0e2b8df248ffd4bbf2d57734e598fbf",
         "manifest_id": "manifest-replay_different_request_ref",
         "metadata": {
           "signature_validity_alone_is_insufficient": true
@@ -163,7 +166,8 @@
           "workspace:permission:update"
         ],
         "target_resource": "workspace:demo",
-        "target_system": "local-demo-iam"
+        "target_system": "local-demo-iam",
+        "verified_human_approval_proof_hash": null
       },
       "evidence_chain_verification_summary": {
         "decision_id": "decision-replay-001",
@@ -182,7 +186,7 @@
         ],
         "missing_links": [],
         "operation_id": "operation-replay_different_request_ref",
-        "recomputed_manifest_hash": "116b8f569634bf937df5182318c394e6994ba951de54ba05596c33b2b0432fff",
+        "recomputed_manifest_hash": "e945dd62aadf843adee7aceffbc5d6f0c0e2b8df248ffd4bbf2d57734e598fbf",
         "verification_status": "failed",
         "verified_at": "2026-05-10T00:00:00+00:00",
         "verified_links": [
@@ -275,7 +279,8 @@
         "generated_at": "2026-05-10T00:00:00+00:00",
         "human_approval_receipt_hash": "ee7949ac4e2ff999c6c3681fe90d6d4cbf4ce3f0143c7b7e59ce3aa0103d2042",
         "human_approval_receipt_id": "har-replay-001",
-        "manifest_hash": "8a5ddd8ea86184eb6ac4a7eb50a9224f677bdc527447838f28485210eaa0a6c7",
+        "human_approval_required": true,
+        "manifest_hash": "459fabb0620270130ea9eb34b1dadcddd4751b9b17d36abc3e8767ca64e05fee",
         "manifest_id": "manifest-replay_different_action_class",
         "metadata": {
           "signature_validity_alone_is_insufficient": true
@@ -292,7 +297,8 @@
           "workspace:permission:update"
         ],
         "target_resource": "workspace:demo",
-        "target_system": "local-demo-iam"
+        "target_system": "local-demo-iam",
+        "verified_human_approval_proof_hash": null
       },
       "evidence_chain_verification_summary": {
         "decision_id": "decision-replay-001",
@@ -311,7 +317,7 @@
         ],
         "missing_links": [],
         "operation_id": "operation-replay_different_action_class",
-        "recomputed_manifest_hash": "8a5ddd8ea86184eb6ac4a7eb50a9224f677bdc527447838f28485210eaa0a6c7",
+        "recomputed_manifest_hash": "459fabb0620270130ea9eb34b1dadcddd4751b9b17d36abc3e8767ca64e05fee",
         "verification_status": "failed",
         "verified_at": "2026-05-10T00:00:00+00:00",
         "verified_links": [
@@ -404,7 +410,8 @@
         "generated_at": "2026-05-10T00:00:00+00:00",
         "human_approval_receipt_hash": "ee7949ac4e2ff999c6c3681fe90d6d4cbf4ce3f0143c7b7e59ce3aa0103d2042",
         "human_approval_receipt_id": "har-replay-001",
-        "manifest_hash": "655a6d507b285a50d0e3db8bd80d0c5fa76149acc200536daaf7d0fd813d5969",
+        "human_approval_required": true,
+        "manifest_hash": "3c7ff11156413f169003a961375aba601daf95ff34206ce1758f8f440e7f00ee",
         "manifest_id": "manifest-replay_different_bind_context_hash",
         "metadata": {
           "signature_validity_alone_is_insufficient": true
@@ -421,7 +428,8 @@
           "workspace:permission:update"
         ],
         "target_resource": "workspace:demo",
-        "target_system": "local-demo-iam"
+        "target_system": "local-demo-iam",
+        "verified_human_approval_proof_hash": null
       },
       "evidence_chain_verification_summary": {
         "decision_id": "decision-replay-001",
@@ -440,7 +448,7 @@
         ],
         "missing_links": [],
         "operation_id": "operation-replay_different_bind_context_hash",
-        "recomputed_manifest_hash": "655a6d507b285a50d0e3db8bd80d0c5fa76149acc200536daaf7d0fd813d5969",
+        "recomputed_manifest_hash": "3c7ff11156413f169003a961375aba601daf95ff34206ce1758f8f440e7f00ee",
         "verification_status": "failed",
         "verified_at": "2026-05-10T00:00:00+00:00",
         "verified_links": [
@@ -518,7 +526,7 @@
   "demo_id": "context-bound-approval-replay-prevention-v1",
   "generated_at": "2026-05-10T00:00:00+00:00",
   "local_offline_only": true,
-  "packet_hash": "a304c94baa2cf4fcb699f7c97de3d2f940090864604beed0231e3d7f63ae18e8",
+  "packet_hash": "758f29352aa26676ec2371e7e46079066ad2fceec14f324aa66c3a172a7e6a74",
   "packet_id": "reviewer-evidence-packet-approval-replay-prevention-v1",
   "packet_version": "v1",
   "reviewer_notes": [

--- a/docs/en/demo/examples/evaluation-governance-chain-reviewer-packet-v1/reviewer-evidence-packet.generated.example.json
+++ b/docs/en/demo/examples/evaluation-governance-chain-reviewer-packet-v1/reviewer-evidence-packet.generated.example.json
@@ -31,7 +31,8 @@
         "generated_at": "2026-04-26T00:00:00+00:00",
         "human_approval_receipt_hash": "22c26614740e5a495beea2a46f1e8a498303e8c50d96a2f25a2a8e788d1c4547",
         "human_approval_receipt_id": "har-saas-001",
-        "manifest_hash": "66e0d0a277ca167b9021191e721a87c19edffa954f70d671e35bfe434613db8e",
+        "human_approval_required": true,
+        "manifest_hash": "62ff0ccbe8428576cf885a78855f473d958310236b24f3299625742c4aa9da06",
         "manifest_id": "ecm-saas-permission-change-missing_authority",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -53,7 +54,8 @@
           "saas:grant_admin"
         ],
         "target_resource": "synthetic_offline_resource",
-        "target_system": "mock_saas_directory"
+        "target_system": "mock_saas_directory",
+        "verified_human_approval_proof_hash": null
       },
       "evidence_chain_verification_summary": {
         "decision_id": "decision-saas-001",
@@ -71,7 +73,7 @@
           "authority_evidence_hash"
         ],
         "operation_id": "saas-permission-change-missing_authority",
-        "recomputed_manifest_hash": "66e0d0a277ca167b9021191e721a87c19edffa954f70d671e35bfe434613db8e",
+        "recomputed_manifest_hash": "62ff0ccbe8428576cf885a78855f473d958310236b24f3299625742c4aa9da06",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -176,7 +178,8 @@
         "generated_at": "2026-04-26T00:00:00+00:00",
         "human_approval_receipt_hash": null,
         "human_approval_receipt_id": null,
-        "manifest_hash": "de5f807be0e901dc94a3968a831a30485aa059dc04722e479771199d1226477b",
+        "human_approval_required": true,
+        "manifest_hash": "6336bd4b68ad353846c0b01eb5ad880e36ef3ebd0cb2f701543ec42e42fb2171",
         "manifest_id": "ecm-saas-permission-change-missing_human_approval",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -196,7 +199,8 @@
           "saas:grant_admin"
         ],
         "target_resource": "synthetic_offline_resource",
-        "target_system": "mock_saas_directory"
+        "target_system": "mock_saas_directory",
+        "verified_human_approval_proof_hash": null
       },
       "evidence_chain_verification_summary": {
         "decision_id": "decision-saas-001",
@@ -214,7 +218,7 @@
           "human_approval_receipt_hash"
         ],
         "operation_id": "saas-permission-change-missing_human_approval",
-        "recomputed_manifest_hash": "de5f807be0e901dc94a3968a831a30485aa059dc04722e479771199d1226477b",
+        "recomputed_manifest_hash": "6336bd4b68ad353846c0b01eb5ad880e36ef3ebd0cb2f701543ec42e42fb2171",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -313,7 +317,8 @@
         "generated_at": "2026-04-26T00:00:00+00:00",
         "human_approval_receipt_hash": null,
         "human_approval_receipt_id": null,
-        "manifest_hash": "a01e60928b028538839d9d0709424d92d7bf164efd209adcc7cfcc768982f20a",
+        "human_approval_required": true,
+        "manifest_hash": "01e7b387b8f643b0dde77f0bec570016c598ae943ae3afaaa3c3485a77970457",
         "manifest_id": "ecm-saas-permission-change-expired_human_approval",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -333,7 +338,8 @@
           "saas:grant_admin"
         ],
         "target_resource": "synthetic_offline_resource",
-        "target_system": "mock_saas_directory"
+        "target_system": "mock_saas_directory",
+        "verified_human_approval_proof_hash": null
       },
       "evidence_chain_verification_summary": {
         "decision_id": "decision-saas-001",
@@ -351,7 +357,7 @@
           "human_approval_receipt_hash"
         ],
         "operation_id": "saas-permission-change-expired_human_approval",
-        "recomputed_manifest_hash": "a01e60928b028538839d9d0709424d92d7bf164efd209adcc7cfcc768982f20a",
+        "recomputed_manifest_hash": "01e7b387b8f643b0dde77f0bec570016c598ae943ae3afaaa3c3485a77970457",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -450,7 +456,8 @@
         "generated_at": "2026-04-26T00:00:00+00:00",
         "human_approval_receipt_hash": null,
         "human_approval_receipt_id": null,
-        "manifest_hash": "4e3785488ebac6a6e58abf0f23303ff0f7737f1899ec1618ac809432934d7484",
+        "human_approval_required": true,
+        "manifest_hash": "4a8ee2ed20eef406321f857901cced1ccba59bc1096248f132b77a34f13b2025",
         "manifest_id": "ecm-saas-permission-change-scope_mismatch",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -471,7 +478,8 @@
           "saas:grant_admin"
         ],
         "target_resource": "synthetic_offline_resource",
-        "target_system": "mock_saas_directory"
+        "target_system": "mock_saas_directory",
+        "verified_human_approval_proof_hash": null
       },
       "evidence_chain_verification_summary": {
         "decision_id": "decision-saas-001",
@@ -489,7 +497,7 @@
           "human_approval_receipt_hash"
         ],
         "operation_id": "saas-permission-change-scope_mismatch",
-        "recomputed_manifest_hash": "4e3785488ebac6a6e58abf0f23303ff0f7737f1899ec1618ac809432934d7484",
+        "recomputed_manifest_hash": "4a8ee2ed20eef406321f857901cced1ccba59bc1096248f132b77a34f13b2025",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -591,7 +599,8 @@
         "generated_at": "2026-04-26T00:00:00+00:00",
         "human_approval_receipt_hash": "22c26614740e5a495beea2a46f1e8a498303e8c50d96a2f25a2a8e788d1c4547",
         "human_approval_receipt_id": "har-saas-001",
-        "manifest_hash": "264d650ff037717002e56642e702db0853792e256bf0b624cd5d6df2f5bc1bcb",
+        "human_approval_required": true,
+        "manifest_hash": "251e61b8b66ada5df3b8c9515a3dc18c6da354053c745bf9dcf75283e57914e1",
         "manifest_id": "ecm-saas-permission-change-valid_authority_and_approval",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -614,7 +623,8 @@
           "saas:grant_admin"
         ],
         "target_resource": "synthetic_offline_resource",
-        "target_system": "mock_saas_directory"
+        "target_system": "mock_saas_directory",
+        "verified_human_approval_proof_hash": null
       },
       "evidence_chain_verification_summary": {
         "decision_id": "decision-saas-001",
@@ -630,7 +640,7 @@
         "mismatched_links": [],
         "missing_links": [],
         "operation_id": "saas-permission-change-valid_authority_and_approval",
-        "recomputed_manifest_hash": "264d650ff037717002e56642e702db0853792e256bf0b624cd5d6df2f5bc1bcb",
+        "recomputed_manifest_hash": "251e61b8b66ada5df3b8c9515a3dc18c6da354053c745bf9dcf75283e57914e1",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -803,7 +813,7 @@
     }
   },
   "local_offline_only": true,
-  "packet_hash": "029563fa0a13e59cdc976e27cb1de1bdab7b9a28d471087a7b2ac537c8b3e6e4",
+  "packet_hash": "e02bfef9376d4575b62d9e7adc9319ec49c811fa57855d414a938cf5a5d5078d",
   "packet_id": "reviewer-evidence-packet-saas-permission-change-v1",
   "packet_version": "v1",
   "reviewer_notes": [

--- a/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated/reviewer-evidence-packet.generated.example.json
+++ b/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated/reviewer-evidence-packet.generated.example.json
@@ -31,7 +31,8 @@
         "generated_at": "2026-04-26T00:00:00+00:00",
         "human_approval_receipt_hash": "22c26614740e5a495beea2a46f1e8a498303e8c50d96a2f25a2a8e788d1c4547",
         "human_approval_receipt_id": "har-saas-001",
-        "manifest_hash": "66e0d0a277ca167b9021191e721a87c19edffa954f70d671e35bfe434613db8e",
+        "human_approval_required": true,
+        "manifest_hash": "62ff0ccbe8428576cf885a78855f473d958310236b24f3299625742c4aa9da06",
         "manifest_id": "ecm-saas-permission-change-missing_authority",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -53,7 +54,8 @@
           "saas:grant_admin"
         ],
         "target_resource": "synthetic_offline_resource",
-        "target_system": "mock_saas_directory"
+        "target_system": "mock_saas_directory",
+        "verified_human_approval_proof_hash": null
       },
       "evidence_chain_verification_summary": {
         "decision_id": "decision-saas-001",
@@ -71,7 +73,7 @@
           "authority_evidence_hash"
         ],
         "operation_id": "saas-permission-change-missing_authority",
-        "recomputed_manifest_hash": "66e0d0a277ca167b9021191e721a87c19edffa954f70d671e35bfe434613db8e",
+        "recomputed_manifest_hash": "62ff0ccbe8428576cf885a78855f473d958310236b24f3299625742c4aa9da06",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -176,7 +178,8 @@
         "generated_at": "2026-04-26T00:00:00+00:00",
         "human_approval_receipt_hash": null,
         "human_approval_receipt_id": null,
-        "manifest_hash": "de5f807be0e901dc94a3968a831a30485aa059dc04722e479771199d1226477b",
+        "human_approval_required": true,
+        "manifest_hash": "6336bd4b68ad353846c0b01eb5ad880e36ef3ebd0cb2f701543ec42e42fb2171",
         "manifest_id": "ecm-saas-permission-change-missing_human_approval",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -196,7 +199,8 @@
           "saas:grant_admin"
         ],
         "target_resource": "synthetic_offline_resource",
-        "target_system": "mock_saas_directory"
+        "target_system": "mock_saas_directory",
+        "verified_human_approval_proof_hash": null
       },
       "evidence_chain_verification_summary": {
         "decision_id": "decision-saas-001",
@@ -214,7 +218,7 @@
           "human_approval_receipt_hash"
         ],
         "operation_id": "saas-permission-change-missing_human_approval",
-        "recomputed_manifest_hash": "de5f807be0e901dc94a3968a831a30485aa059dc04722e479771199d1226477b",
+        "recomputed_manifest_hash": "6336bd4b68ad353846c0b01eb5ad880e36ef3ebd0cb2f701543ec42e42fb2171",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -313,7 +317,8 @@
         "generated_at": "2026-04-26T00:00:00+00:00",
         "human_approval_receipt_hash": null,
         "human_approval_receipt_id": null,
-        "manifest_hash": "a01e60928b028538839d9d0709424d92d7bf164efd209adcc7cfcc768982f20a",
+        "human_approval_required": true,
+        "manifest_hash": "01e7b387b8f643b0dde77f0bec570016c598ae943ae3afaaa3c3485a77970457",
         "manifest_id": "ecm-saas-permission-change-expired_human_approval",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -333,7 +338,8 @@
           "saas:grant_admin"
         ],
         "target_resource": "synthetic_offline_resource",
-        "target_system": "mock_saas_directory"
+        "target_system": "mock_saas_directory",
+        "verified_human_approval_proof_hash": null
       },
       "evidence_chain_verification_summary": {
         "decision_id": "decision-saas-001",
@@ -351,7 +357,7 @@
           "human_approval_receipt_hash"
         ],
         "operation_id": "saas-permission-change-expired_human_approval",
-        "recomputed_manifest_hash": "a01e60928b028538839d9d0709424d92d7bf164efd209adcc7cfcc768982f20a",
+        "recomputed_manifest_hash": "01e7b387b8f643b0dde77f0bec570016c598ae943ae3afaaa3c3485a77970457",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -450,7 +456,8 @@
         "generated_at": "2026-04-26T00:00:00+00:00",
         "human_approval_receipt_hash": null,
         "human_approval_receipt_id": null,
-        "manifest_hash": "4e3785488ebac6a6e58abf0f23303ff0f7737f1899ec1618ac809432934d7484",
+        "human_approval_required": true,
+        "manifest_hash": "4a8ee2ed20eef406321f857901cced1ccba59bc1096248f132b77a34f13b2025",
         "manifest_id": "ecm-saas-permission-change-scope_mismatch",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -471,7 +478,8 @@
           "saas:grant_admin"
         ],
         "target_resource": "synthetic_offline_resource",
-        "target_system": "mock_saas_directory"
+        "target_system": "mock_saas_directory",
+        "verified_human_approval_proof_hash": null
       },
       "evidence_chain_verification_summary": {
         "decision_id": "decision-saas-001",
@@ -489,7 +497,7 @@
           "human_approval_receipt_hash"
         ],
         "operation_id": "saas-permission-change-scope_mismatch",
-        "recomputed_manifest_hash": "4e3785488ebac6a6e58abf0f23303ff0f7737f1899ec1618ac809432934d7484",
+        "recomputed_manifest_hash": "4a8ee2ed20eef406321f857901cced1ccba59bc1096248f132b77a34f13b2025",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -591,7 +599,8 @@
         "generated_at": "2026-04-26T00:00:00+00:00",
         "human_approval_receipt_hash": "22c26614740e5a495beea2a46f1e8a498303e8c50d96a2f25a2a8e788d1c4547",
         "human_approval_receipt_id": "har-saas-001",
-        "manifest_hash": "264d650ff037717002e56642e702db0853792e256bf0b624cd5d6df2f5bc1bcb",
+        "human_approval_required": true,
+        "manifest_hash": "251e61b8b66ada5df3b8c9515a3dc18c6da354053c745bf9dcf75283e57914e1",
         "manifest_id": "ecm-saas-permission-change-valid_authority_and_approval",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -614,7 +623,8 @@
           "saas:grant_admin"
         ],
         "target_resource": "synthetic_offline_resource",
-        "target_system": "mock_saas_directory"
+        "target_system": "mock_saas_directory",
+        "verified_human_approval_proof_hash": null
       },
       "evidence_chain_verification_summary": {
         "decision_id": "decision-saas-001",
@@ -630,7 +640,7 @@
         "mismatched_links": [],
         "missing_links": [],
         "operation_id": "saas-permission-change-valid_authority_and_approval",
-        "recomputed_manifest_hash": "264d650ff037717002e56642e702db0853792e256bf0b624cd5d6df2f5bc1bcb",
+        "recomputed_manifest_hash": "251e61b8b66ada5df3b8c9515a3dc18c6da354053c745bf9dcf75283e57914e1",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -803,7 +813,7 @@
     }
   },
   "local_offline_only": true,
-  "packet_hash": "0af1c55b6af685456fa8c1779b2cfee850196c61634a2098aeaa58da8e3d2561",
+  "packet_hash": "ea2a322e6e6cb789d70b713e0b9eae451d61af323f748170710c9e7f00358590",
   "packet_id": "reviewer-evidence-packet-saas-permission-change-v1",
   "packet_version": "v1",
   "reviewer_notes": [

--- a/docs/en/demo/examples/reviewer-evidence-packet-with-evaluation-governance-v1.json
+++ b/docs/en/demo/examples/reviewer-evidence-packet-with-evaluation-governance-v1.json
@@ -31,7 +31,8 @@
         "generated_at": "2026-04-26T00:00:00+00:00",
         "human_approval_receipt_hash": "22c26614740e5a495beea2a46f1e8a498303e8c50d96a2f25a2a8e788d1c4547",
         "human_approval_receipt_id": "har-saas-001",
-        "manifest_hash": "66e0d0a277ca167b9021191e721a87c19edffa954f70d671e35bfe434613db8e",
+        "human_approval_required": true,
+        "manifest_hash": "8b12d0c3f8a916f357e8311dcd1e20ad16bc3e468192016e491d86c3cbfe1f7b",
         "manifest_id": "ecm-saas-permission-change-missing_authority",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -53,7 +54,8 @@
           "saas:grant_admin"
         ],
         "target_resource": "contractor:external.user@example.test",
-        "target_system": "mock_saas_directory"
+        "target_system": "mock_saas_directory",
+        "verified_human_approval_proof_hash": null
       },
       "evidence_chain_verification_summary": {
         "decision_id": "decision-saas-001",
@@ -71,7 +73,7 @@
           "authority_evidence_hash"
         ],
         "operation_id": "saas-permission-change-missing_authority",
-        "recomputed_manifest_hash": "66e0d0a277ca167b9021191e721a87c19edffa954f70d671e35bfe434613db8e",
+        "recomputed_manifest_hash": "8b12d0c3f8a916f357e8311dcd1e20ad16bc3e468192016e491d86c3cbfe1f7b",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -176,7 +178,8 @@
         "generated_at": "2026-04-26T00:00:00+00:00",
         "human_approval_receipt_hash": null,
         "human_approval_receipt_id": null,
-        "manifest_hash": "de5f807be0e901dc94a3968a831a30485aa059dc04722e479771199d1226477b",
+        "human_approval_required": true,
+        "manifest_hash": "1992a33be9389de9394ffa43291c46105f2d703485c904422a299e6834cb2a5f",
         "manifest_id": "ecm-saas-permission-change-missing_human_approval",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -196,7 +199,8 @@
           "saas:grant_admin"
         ],
         "target_resource": "contractor:external.user@example.test",
-        "target_system": "mock_saas_directory"
+        "target_system": "mock_saas_directory",
+        "verified_human_approval_proof_hash": null
       },
       "evidence_chain_verification_summary": {
         "decision_id": "decision-saas-001",
@@ -214,7 +218,7 @@
           "human_approval_receipt_hash"
         ],
         "operation_id": "saas-permission-change-missing_human_approval",
-        "recomputed_manifest_hash": "de5f807be0e901dc94a3968a831a30485aa059dc04722e479771199d1226477b",
+        "recomputed_manifest_hash": "1992a33be9389de9394ffa43291c46105f2d703485c904422a299e6834cb2a5f",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -313,7 +317,8 @@
         "generated_at": "2026-04-26T00:00:00+00:00",
         "human_approval_receipt_hash": null,
         "human_approval_receipt_id": null,
-        "manifest_hash": "a01e60928b028538839d9d0709424d92d7bf164efd209adcc7cfcc768982f20a",
+        "human_approval_required": true,
+        "manifest_hash": "01269f1895cd817090ea87e50df0dac9f5f8177de62ac2998154fee5d2b4d36c",
         "manifest_id": "ecm-saas-permission-change-expired_human_approval",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -333,7 +338,8 @@
           "saas:grant_admin"
         ],
         "target_resource": "contractor:external.user@example.test",
-        "target_system": "mock_saas_directory"
+        "target_system": "mock_saas_directory",
+        "verified_human_approval_proof_hash": null
       },
       "evidence_chain_verification_summary": {
         "decision_id": "decision-saas-001",
@@ -351,7 +357,7 @@
           "human_approval_receipt_hash"
         ],
         "operation_id": "saas-permission-change-expired_human_approval",
-        "recomputed_manifest_hash": "a01e60928b028538839d9d0709424d92d7bf164efd209adcc7cfcc768982f20a",
+        "recomputed_manifest_hash": "01269f1895cd817090ea87e50df0dac9f5f8177de62ac2998154fee5d2b4d36c",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -450,7 +456,8 @@
         "generated_at": "2026-04-26T00:00:00+00:00",
         "human_approval_receipt_hash": null,
         "human_approval_receipt_id": null,
-        "manifest_hash": "4e3785488ebac6a6e58abf0f23303ff0f7737f1899ec1618ac809432934d7484",
+        "human_approval_required": true,
+        "manifest_hash": "88824854f29f8d6e1a7d8447d7a1d2012670a258bdc58fdcaf3d7e12be573cd0",
         "manifest_id": "ecm-saas-permission-change-scope_mismatch",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -471,7 +478,8 @@
           "saas:grant_admin"
         ],
         "target_resource": "contractor:external.user@example.test",
-        "target_system": "mock_saas_directory"
+        "target_system": "mock_saas_directory",
+        "verified_human_approval_proof_hash": null
       },
       "evidence_chain_verification_summary": {
         "decision_id": "decision-saas-001",
@@ -489,7 +497,7 @@
           "human_approval_receipt_hash"
         ],
         "operation_id": "saas-permission-change-scope_mismatch",
-        "recomputed_manifest_hash": "4e3785488ebac6a6e58abf0f23303ff0f7737f1899ec1618ac809432934d7484",
+        "recomputed_manifest_hash": "88824854f29f8d6e1a7d8447d7a1d2012670a258bdc58fdcaf3d7e12be573cd0",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -591,7 +599,8 @@
         "generated_at": "2026-04-26T00:00:00+00:00",
         "human_approval_receipt_hash": "22c26614740e5a495beea2a46f1e8a498303e8c50d96a2f25a2a8e788d1c4547",
         "human_approval_receipt_id": "har-saas-001",
-        "manifest_hash": "264d650ff037717002e56642e702db0853792e256bf0b624cd5d6df2f5bc1bcb",
+        "human_approval_required": true,
+        "manifest_hash": "c3a7ed2805f936c898340168d8ae693b9734c9732b517a16fa53ab5c4d7aecb9",
         "manifest_id": "ecm-saas-permission-change-valid_authority_and_approval",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -614,7 +623,8 @@
           "saas:grant_admin"
         ],
         "target_resource": "contractor:external.user@example.test",
-        "target_system": "mock_saas_directory"
+        "target_system": "mock_saas_directory",
+        "verified_human_approval_proof_hash": null
       },
       "evidence_chain_verification_summary": {
         "decision_id": "decision-saas-001",
@@ -630,7 +640,7 @@
         "mismatched_links": [],
         "missing_links": [],
         "operation_id": "saas-permission-change-valid_authority_and_approval",
-        "recomputed_manifest_hash": "264d650ff037717002e56642e702db0853792e256bf0b624cd5d6df2f5bc1bcb",
+        "recomputed_manifest_hash": "c3a7ed2805f936c898340168d8ae693b9734c9732b517a16fa53ab5c4d7aecb9",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -788,7 +798,7 @@
   ],
   "generated_at": "2026-04-26T00:00:00+00:00",
   "local_offline_only": true,
-  "packet_hash": "92718ae128217ce02e97cd7fe4a6d2f0065e9e8244379e23e4a72e994c322ccf",
+  "packet_hash": "492aae331c7900b5f6e600da5f4db915dd46056c0ec6efb69639d5a70639a0af",
   "packet_id": "reviewer-evidence-packet-saas-permission-change-v1",
   "packet_version": "v1",
   "reviewer_notes": [

--- a/docs/en/demo/fixtures/reviewer-evidence-packet-decision-candidate-refusal-v1.json
+++ b/docs/en/demo/fixtures/reviewer-evidence-packet-decision-candidate-refusal-v1.json
@@ -31,7 +31,8 @@
         "generated_at": "2026-04-26T00:00:00+00:00",
         "human_approval_receipt_hash": "22c26614740e5a495beea2a46f1e8a498303e8c50d96a2f25a2a8e788d1c4547",
         "human_approval_receipt_id": "har-saas-001",
-        "manifest_hash": "66e0d0a277ca167b9021191e721a87c19edffa954f70d671e35bfe434613db8e",
+        "human_approval_required": true,
+        "manifest_hash": "8b12d0c3f8a916f357e8311dcd1e20ad16bc3e468192016e491d86c3cbfe1f7b",
         "manifest_id": "ecm-saas-permission-change-missing_authority",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -53,7 +54,8 @@
           "saas:grant_admin"
         ],
         "target_resource": "contractor:external.user@example.test",
-        "target_system": "mock_saas_directory"
+        "target_system": "mock_saas_directory",
+        "verified_human_approval_proof_hash": null
       },
       "evidence_chain_verification_summary": {
         "decision_id": "decision-saas-001",
@@ -71,7 +73,7 @@
           "authority_evidence_hash"
         ],
         "operation_id": "saas-permission-change-missing_authority",
-        "recomputed_manifest_hash": "66e0d0a277ca167b9021191e721a87c19edffa954f70d671e35bfe434613db8e",
+        "recomputed_manifest_hash": "8b12d0c3f8a916f357e8311dcd1e20ad16bc3e468192016e491d86c3cbfe1f7b",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -176,7 +178,8 @@
         "generated_at": "2026-04-26T00:00:00+00:00",
         "human_approval_receipt_hash": null,
         "human_approval_receipt_id": null,
-        "manifest_hash": "de5f807be0e901dc94a3968a831a30485aa059dc04722e479771199d1226477b",
+        "human_approval_required": true,
+        "manifest_hash": "1992a33be9389de9394ffa43291c46105f2d703485c904422a299e6834cb2a5f",
         "manifest_id": "ecm-saas-permission-change-missing_human_approval",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -196,7 +199,8 @@
           "saas:grant_admin"
         ],
         "target_resource": "contractor:external.user@example.test",
-        "target_system": "mock_saas_directory"
+        "target_system": "mock_saas_directory",
+        "verified_human_approval_proof_hash": null
       },
       "evidence_chain_verification_summary": {
         "decision_id": "decision-saas-001",
@@ -214,7 +218,7 @@
           "human_approval_receipt_hash"
         ],
         "operation_id": "saas-permission-change-missing_human_approval",
-        "recomputed_manifest_hash": "de5f807be0e901dc94a3968a831a30485aa059dc04722e479771199d1226477b",
+        "recomputed_manifest_hash": "1992a33be9389de9394ffa43291c46105f2d703485c904422a299e6834cb2a5f",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -313,7 +317,8 @@
         "generated_at": "2026-04-26T00:00:00+00:00",
         "human_approval_receipt_hash": null,
         "human_approval_receipt_id": null,
-        "manifest_hash": "a01e60928b028538839d9d0709424d92d7bf164efd209adcc7cfcc768982f20a",
+        "human_approval_required": true,
+        "manifest_hash": "01269f1895cd817090ea87e50df0dac9f5f8177de62ac2998154fee5d2b4d36c",
         "manifest_id": "ecm-saas-permission-change-expired_human_approval",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -333,7 +338,8 @@
           "saas:grant_admin"
         ],
         "target_resource": "contractor:external.user@example.test",
-        "target_system": "mock_saas_directory"
+        "target_system": "mock_saas_directory",
+        "verified_human_approval_proof_hash": null
       },
       "evidence_chain_verification_summary": {
         "decision_id": "decision-saas-001",
@@ -351,7 +357,7 @@
           "human_approval_receipt_hash"
         ],
         "operation_id": "saas-permission-change-expired_human_approval",
-        "recomputed_manifest_hash": "a01e60928b028538839d9d0709424d92d7bf164efd209adcc7cfcc768982f20a",
+        "recomputed_manifest_hash": "01269f1895cd817090ea87e50df0dac9f5f8177de62ac2998154fee5d2b4d36c",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -450,7 +456,8 @@
         "generated_at": "2026-04-26T00:00:00+00:00",
         "human_approval_receipt_hash": null,
         "human_approval_receipt_id": null,
-        "manifest_hash": "4e3785488ebac6a6e58abf0f23303ff0f7737f1899ec1618ac809432934d7484",
+        "human_approval_required": true,
+        "manifest_hash": "88824854f29f8d6e1a7d8447d7a1d2012670a258bdc58fdcaf3d7e12be573cd0",
         "manifest_id": "ecm-saas-permission-change-scope_mismatch",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -471,7 +478,8 @@
           "saas:grant_admin"
         ],
         "target_resource": "contractor:external.user@example.test",
-        "target_system": "mock_saas_directory"
+        "target_system": "mock_saas_directory",
+        "verified_human_approval_proof_hash": null
       },
       "evidence_chain_verification_summary": {
         "decision_id": "decision-saas-001",
@@ -489,7 +497,7 @@
           "human_approval_receipt_hash"
         ],
         "operation_id": "saas-permission-change-scope_mismatch",
-        "recomputed_manifest_hash": "4e3785488ebac6a6e58abf0f23303ff0f7737f1899ec1618ac809432934d7484",
+        "recomputed_manifest_hash": "88824854f29f8d6e1a7d8447d7a1d2012670a258bdc58fdcaf3d7e12be573cd0",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -591,7 +599,8 @@
         "generated_at": "2026-04-26T00:00:00+00:00",
         "human_approval_receipt_hash": "22c26614740e5a495beea2a46f1e8a498303e8c50d96a2f25a2a8e788d1c4547",
         "human_approval_receipt_id": "har-saas-001",
-        "manifest_hash": "264d650ff037717002e56642e702db0853792e256bf0b624cd5d6df2f5bc1bcb",
+        "human_approval_required": true,
+        "manifest_hash": "c3a7ed2805f936c898340168d8ae693b9734c9732b517a16fa53ab5c4d7aecb9",
         "manifest_id": "ecm-saas-permission-change-valid_authority_and_approval",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -614,7 +623,8 @@
           "saas:grant_admin"
         ],
         "target_resource": "contractor:external.user@example.test",
-        "target_system": "mock_saas_directory"
+        "target_system": "mock_saas_directory",
+        "verified_human_approval_proof_hash": null
       },
       "evidence_chain_verification_summary": {
         "decision_id": "decision-saas-001",
@@ -630,7 +640,7 @@
         "mismatched_links": [],
         "missing_links": [],
         "operation_id": "saas-permission-change-valid_authority_and_approval",
-        "recomputed_manifest_hash": "264d650ff037717002e56642e702db0853792e256bf0b624cd5d6df2f5bc1bcb",
+        "recomputed_manifest_hash": "c3a7ed2805f936c898340168d8ae693b9734c9732b517a16fa53ab5c4d7aecb9",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -763,7 +773,7 @@
     }
   },
   "local_offline_only": true,
-  "packet_hash": "ca2ececd9d08e1a16f5a74ca033ca54a5ef66438ecb7abaabcdeb93bef670ca9",
+  "packet_hash": "52dd018a01d0fe2dc1d72c880b3d64b22f868c4ea60ae6a9c7f47cee714c5799",
   "packet_id": "reviewer-evidence-packet-decision-candidate-refusal-v1",
   "packet_version": "v1",
   "reviewer_notes": [

--- a/docs/en/demo/fixtures/reviewer-evidence-packet-saas-permission-change-v1.json
+++ b/docs/en/demo/fixtures/reviewer-evidence-packet-saas-permission-change-v1.json
@@ -31,7 +31,8 @@
         "generated_at": "2026-04-26T00:00:00+00:00",
         "human_approval_receipt_hash": "55db4aa2686f01d6e1133b880ee85e82572957b3e0e3dd63bce692a8be4d38ba",
         "human_approval_receipt_id": "har-saas-001",
-        "manifest_hash": "3b3c9e99917f7c5e4f20f32ea086106b5481c93fe6fd9d5fb75624bffe829b76",
+        "human_approval_required": true,
+        "manifest_hash": "4c59caecf410cce8c718a7fa43ff5de32174d142a32048e22b6977d8b91220f3",
         "manifest_id": "ecm-saas-permission-change-missing_authority",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -53,7 +54,8 @@
           "saas:grant_admin"
         ],
         "target_resource": "contractor:external.user@example.test",
-        "target_system": "mock_saas_directory"
+        "target_system": "mock_saas_directory",
+        "verified_human_approval_proof_hash": null
       },
       "evidence_chain_verification_summary": {
         "decision_id": "decision-saas-001",
@@ -71,7 +73,7 @@
           "authority_evidence_hash"
         ],
         "operation_id": "saas-permission-change-missing_authority",
-        "recomputed_manifest_hash": "3b3c9e99917f7c5e4f20f32ea086106b5481c93fe6fd9d5fb75624bffe829b76",
+        "recomputed_manifest_hash": "4c59caecf410cce8c718a7fa43ff5de32174d142a32048e22b6977d8b91220f3",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -176,7 +178,8 @@
         "generated_at": "2026-04-26T00:00:00+00:00",
         "human_approval_receipt_hash": null,
         "human_approval_receipt_id": null,
-        "manifest_hash": "de5f807be0e901dc94a3968a831a30485aa059dc04722e479771199d1226477b",
+        "human_approval_required": true,
+        "manifest_hash": "1992a33be9389de9394ffa43291c46105f2d703485c904422a299e6834cb2a5f",
         "manifest_id": "ecm-saas-permission-change-missing_human_approval",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -196,7 +199,8 @@
           "saas:grant_admin"
         ],
         "target_resource": "contractor:external.user@example.test",
-        "target_system": "mock_saas_directory"
+        "target_system": "mock_saas_directory",
+        "verified_human_approval_proof_hash": null
       },
       "evidence_chain_verification_summary": {
         "decision_id": "decision-saas-001",
@@ -214,7 +218,7 @@
           "human_approval_receipt_hash"
         ],
         "operation_id": "saas-permission-change-missing_human_approval",
-        "recomputed_manifest_hash": "de5f807be0e901dc94a3968a831a30485aa059dc04722e479771199d1226477b",
+        "recomputed_manifest_hash": "1992a33be9389de9394ffa43291c46105f2d703485c904422a299e6834cb2a5f",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -313,7 +317,8 @@
         "generated_at": "2026-04-26T00:00:00+00:00",
         "human_approval_receipt_hash": null,
         "human_approval_receipt_id": null,
-        "manifest_hash": "5fe5e0f4a5b8758f9ef550dfb5007116c3a2e8dedc6952f944e84529532ea628",
+        "human_approval_required": true,
+        "manifest_hash": "a4deefad2a5a2bcf2a4738d812a83099f794b19a06f85df2bd7e2dc493d210c1",
         "manifest_id": "ecm-saas-permission-change-expired_human_approval",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -333,7 +338,8 @@
           "saas:grant_admin"
         ],
         "target_resource": "contractor:external.user@example.test",
-        "target_system": "mock_saas_directory"
+        "target_system": "mock_saas_directory",
+        "verified_human_approval_proof_hash": null
       },
       "evidence_chain_verification_summary": {
         "decision_id": "decision-saas-001",
@@ -351,7 +357,7 @@
           "human_approval_receipt_hash"
         ],
         "operation_id": "saas-permission-change-expired_human_approval",
-        "recomputed_manifest_hash": "5fe5e0f4a5b8758f9ef550dfb5007116c3a2e8dedc6952f944e84529532ea628",
+        "recomputed_manifest_hash": "a4deefad2a5a2bcf2a4738d812a83099f794b19a06f85df2bd7e2dc493d210c1",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -450,7 +456,8 @@
         "generated_at": "2026-04-26T00:00:00+00:00",
         "human_approval_receipt_hash": null,
         "human_approval_receipt_id": null,
-        "manifest_hash": "3b46df974ec6ff40375387ba377546be1c04a277db90535d3570d577206ab7d3",
+        "human_approval_required": true,
+        "manifest_hash": "7d2954a9e6f222e64f1f1fbcd87626e5bdbe9c8c2960528b11c2df1cb2257b47",
         "manifest_id": "ecm-saas-permission-change-scope_mismatch",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -471,7 +478,8 @@
           "saas:grant_admin"
         ],
         "target_resource": "contractor:external.user@example.test",
-        "target_system": "mock_saas_directory"
+        "target_system": "mock_saas_directory",
+        "verified_human_approval_proof_hash": null
       },
       "evidence_chain_verification_summary": {
         "decision_id": "decision-saas-001",
@@ -489,7 +497,7 @@
           "human_approval_receipt_hash"
         ],
         "operation_id": "saas-permission-change-scope_mismatch",
-        "recomputed_manifest_hash": "3b46df974ec6ff40375387ba377546be1c04a277db90535d3570d577206ab7d3",
+        "recomputed_manifest_hash": "7d2954a9e6f222e64f1f1fbcd87626e5bdbe9c8c2960528b11c2df1cb2257b47",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -591,7 +599,8 @@
         "generated_at": "2026-04-26T00:00:00+00:00",
         "human_approval_receipt_hash": "55db4aa2686f01d6e1133b880ee85e82572957b3e0e3dd63bce692a8be4d38ba",
         "human_approval_receipt_id": "har-saas-001",
-        "manifest_hash": "db051eac92da9e63d462315018048c52470abcdda0136e18f9f5373f5c874ed9",
+        "human_approval_required": true,
+        "manifest_hash": "bcb536dc12e621155a2e1c61143fc14875ce04c7b5e23d79fee418bae9f2b31c",
         "manifest_id": "ecm-saas-permission-change-valid_authority_and_approval",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -614,7 +623,8 @@
           "saas:grant_admin"
         ],
         "target_resource": "contractor:external.user@example.test",
-        "target_system": "mock_saas_directory"
+        "target_system": "mock_saas_directory",
+        "verified_human_approval_proof_hash": null
       },
       "evidence_chain_verification_summary": {
         "decision_id": "decision-saas-001",
@@ -630,7 +640,7 @@
         "mismatched_links": [],
         "missing_links": [],
         "operation_id": "saas-permission-change-valid_authority_and_approval",
-        "recomputed_manifest_hash": "db051eac92da9e63d462315018048c52470abcdda0136e18f9f5373f5c874ed9",
+        "recomputed_manifest_hash": "bcb536dc12e621155a2e1c61143fc14875ce04c7b5e23d79fee418bae9f2b31c",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -731,7 +741,7 @@
     }
   },
   "local_offline_only": true,
-  "packet_hash": "629cc9ca2f926525880b330b967518c69ffb431bf70b394cea4cb347a0b1fa92",
+  "packet_hash": "945341d3035c60f628eaffdcc568cfbdd2b5128d89fc4f3cad6a97cdf0cf7282",
   "packet_id": "reviewer-evidence-packet-saas-permission-change-v1",
   "packet_version": "v1",
   "reviewer_notes": [

--- a/docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json
+++ b/docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json
@@ -453,6 +453,8 @@
         "authority_evidence_hash",
         "human_approval_receipt_id",
         "human_approval_receipt_hash",
+        "verified_human_approval_proof_hash",
+        "human_approval_required",
         "bind_receipt_id",
         "bind_receipt_hash",
         "outcome_receipt_id",
@@ -567,6 +569,12 @@
         },
         "metadata": {
           "type": "object"
+        },
+        "verified_human_approval_proof_hash": {
+          "$ref": "#/$defs/nullable_sha256_hex"
+        },
+        "human_approval_required": {
+          "type": "boolean"
         }
       }
     },

--- a/samples/evidence_bundle/key_provenance_review/reviewer-evidence-packet.json
+++ b/samples/evidence_bundle/key_provenance_review/reviewer-evidence-packet.json
@@ -31,6 +31,7 @@
         "generated_at": "2026-01-15T12:05:00Z",
         "human_approval_receipt_hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
         "human_approval_receipt_id": "sample-human-approval",
+        "human_approval_required": true,
         "manifest_hash": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
         "manifest_id": "sample-evidence-chain-manifest",
         "metadata": {
@@ -50,7 +51,8 @@
           "sample:review"
         ],
         "target_resource": "sample-evidence-bundle",
-        "target_system": "sample-review-system"
+        "target_system": "sample-review-system",
+        "verified_human_approval_proof_hash": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
       },
       "evidence_chain_verification_summary": {
         "decision_id": "sample-decision",
@@ -157,7 +159,7 @@
     }
   },
   "local_offline_only": true,
-  "packet_hash": "3668c4cac2b61685d35830f7d9d8ef06836d8a19fef2fe84e31e8ec64cabe3fa",
+  "packet_hash": "6213cb99f0e2f6e310df2242cb6d4a4c978cbe61e7df5c0649966dea00982650",
   "packet_id": "reviewer-evidence-packet-saas-permission-change-v1",
   "packet_version": "v1",
   "reviewer_notes": [

--- a/samples/evidence_bundle/key_provenance_review/sample-artifact-manifest.json
+++ b/samples/evidence_bundle/key_provenance_review/sample-artifact-manifest.json
@@ -31,7 +31,7 @@
       "artifact_name": "reviewer-evidence-packet.json",
       "role": "reviewer_evidence_packet",
       "schema_id": "docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json",
-      "sha256": "d340b2e6f285d1f7250ca1ff9bd73b3f9c37f5932ded22ebef6d3e20f81ebd40"
+      "sha256": "811cde1d3faf543b705f5b22c4609d5c11aaf0ca55d115df12a32076652f5c3c"
     },
     {
       "artifact_name": "reviewer-handoff-review-result.json",

--- a/tests/governance/test_evidence_chain_manifest.py
+++ b/tests/governance/test_evidence_chain_manifest.py
@@ -24,6 +24,8 @@ def _base_manifest() -> EvidenceChainManifest:
         authority_evidence_hash="a" * 64,
         human_approval_receipt_id="har-1",
         human_approval_receipt_hash="b" * 64,
+        verified_human_approval_proof_hash="p" * 64,
+        human_approval_required=True,
         bind_receipt_id=None,
         bind_receipt_hash=None,
         outcome_receipt_id="outcome-1",
@@ -130,6 +132,8 @@ def test_build_evidence_chain_manifest_returns_hash_populated_manifest() -> None
         final_outcome="commit",
         authority_evidence_hash="a" * 64,
         human_approval_receipt_hash="b" * 64,
+        verified_human_approval_proof_hash="p" * 64,
+        human_approval_required=True,
         outcome_receipt_hash="c" * 64,
         bind_coverage_operation_id="saas_permission_change_demo",
         generated_at="2026-04-26T00:00:00+00:00",
@@ -149,6 +153,8 @@ def test_build_evidence_chain_manifest_derives_complete_when_required_links_exis
         final_outcome="commit",
         authority_evidence_hash="a" * 64,
         human_approval_receipt_hash="b" * 64,
+        verified_human_approval_proof_hash="p" * 64,
+        human_approval_required=True,
         outcome_receipt_hash="c" * 64,
         bind_coverage_operation_id="cov",
         generated_at="2026-04-26T00:00:00+00:00",
@@ -185,3 +191,26 @@ def test_build_evidence_chain_manifest_derives_incomplete_when_non_blocked_lacks
         generated_at="2026-04-26T00:00:00+00:00",
     )
     assert manifest.chain_status == "incomplete"
+
+
+def test_build_evidence_chain_manifest_includes_verified_human_approval_proof_hash() -> None:
+    manifest = build_evidence_chain_manifest(
+        decision_id="d",
+        execution_intent_id="i",
+        operation_id="op",
+        action_class="ac",
+        target_system="ts",
+        target_resource="tr",
+        requested_scope=["x"],
+        final_outcome="commit",
+        authority_evidence_hash="a" * 64,
+        human_approval_receipt_hash="b" * 64,
+        verified_human_approval_proof_hash="p" * 64,
+        human_approval_required=True,
+        outcome_receipt_hash="c" * 64,
+        bind_coverage_operation_id="cov",
+        generated_at="2026-04-26T00:00:00+00:00",
+    )
+
+    assert manifest.verified_human_approval_proof_hash == "p" * 64
+    assert manifest.to_dict()["verified_human_approval_proof_hash"] == "p" * 64

--- a/tests/governance/test_evidence_chain_verifier.py
+++ b/tests/governance/test_evidence_chain_verifier.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from types import SimpleNamespace
 
 from veritas_os.governance.evidence_chain_manifest import (
     EvidenceChainManifest,
@@ -18,6 +19,7 @@ VERIFIED_AT = "2026-04-26T00:00:00+00:00"
 AUTHORITY_HASH = "a" * 64
 APPROVAL_HASH = "b" * 64
 OUTCOME_HASH = "c" * 64
+PROOF_HASH = "p" * 64
 
 
 @dataclass(frozen=True)
@@ -49,6 +51,7 @@ def _complete_manifest() -> EvidenceChainManifest:
         authority_evidence_hash=AUTHORITY_HASH,
         human_approval_receipt_id="har-1",
         human_approval_receipt_hash=APPROVAL_HASH,
+        verified_human_approval_proof_hash=PROOF_HASH,
         outcome_receipt_id="outcome-1",
         outcome_receipt_hash=OUTCOME_HASH,
         bind_coverage_operation_id="saas_permission_change_demo",
@@ -62,7 +65,12 @@ def _verify_complete(**overrides: object) -> EvidenceChainVerificationResult:
         "manifest": _complete_manifest(),
         "authority_evidence": {"evidence_hash": AUTHORITY_HASH},
         "human_approval_receipt": {"receipt_hash": APPROVAL_HASH},
-        "outcome_receipt": {"outcome_hash": OUTCOME_HASH},
+        "outcome_receipt": {
+            "outcome_hash": OUTCOME_HASH,
+            "metadata": {"verified_human_approval_proof_hash": PROOF_HASH},
+        },
+        "verified_human_approval": SimpleNamespace(verification_proof_hash=PROOF_HASH),
+        "approval_required": True,
         "bind_coverage_operation_id": "saas_permission_change_demo",
         "verified_at": VERIFIED_AT,
     }
@@ -88,6 +96,7 @@ def test_valid_complete_chain_verifies_successfully() -> None:
         "human_approval_receipt_hash",
         "manifest_hash",
         "outcome_receipt_hash",
+        "verified_human_approval_proof_hash",
     ]
     assert result.failure_reasons == []
 
@@ -171,3 +180,71 @@ def test_extract_artifact_hash_supports_dict_hash_fields() -> None:
 
 def test_extract_artifact_hash_returns_none_for_unsupported_artifacts() -> None:
     assert _extract_artifact_hash(UnsupportedArtifact()) is None
+
+
+def test_approval_required_verifies_proof_hash_continuity() -> None:
+    result = _verify_complete()
+    assert result.verification_status == "verified"
+    assert "verified_human_approval_proof_hash" in result.verified_links
+
+
+def test_approval_required_fails_when_outcome_proof_hash_missing() -> None:
+    result = _verify_complete(outcome_receipt={"outcome_hash": OUTCOME_HASH})
+    assert result.verification_status == "incomplete"
+    assert "human_approval_proof_hash_missing" in result.failure_reasons
+
+
+def test_approval_required_fails_when_manifest_proof_hash_missing() -> None:
+    manifest = _complete_manifest()
+    manifest = type(manifest)(
+        **{**manifest.to_dict(), "verified_human_approval_proof_hash": None}
+    )
+    result = _verify_complete(manifest=manifest)
+    assert result.verification_status == "failed"
+    assert "human_approval_proof_hash_missing" in result.failure_reasons
+
+
+def test_outcome_proof_hash_mismatch_fails_verification() -> None:
+    result = _verify_complete(
+        outcome_receipt={
+            "outcome_hash": OUTCOME_HASH,
+            "metadata": {"verified_human_approval_proof_hash": "x" * 64},
+        }
+    )
+    assert result.verification_status == "failed"
+    assert "outcome_human_approval_proof_hash_mismatch" in result.failure_reasons
+
+
+def test_manifest_proof_hash_mismatch_against_actual_proof_fails_verification() -> None:
+    result = _verify_complete(
+        verified_human_approval=SimpleNamespace(verification_proof_hash="x" * 64)
+    )
+    assert result.verification_status == "failed"
+    assert "manifest_human_approval_proof_hash_mismatch" in result.failure_reasons
+
+
+def test_no_approval_required_path_allows_missing_proof_hash() -> None:
+    manifest = build_evidence_chain_manifest(
+        decision_id="decision-1",
+        execution_intent_id="intent-1",
+        operation_id="operation-1",
+        action_class="read_only",
+        target_system="mock_saas",
+        target_resource="user:alice",
+        requested_scope=["saas:read"],
+        final_outcome="commit",
+        authority_evidence_hash=AUTHORITY_HASH,
+        outcome_receipt_hash=OUTCOME_HASH,
+        bind_coverage_operation_id="saas_read_demo",
+        human_approval_required=False,
+        generated_at=VERIFIED_AT,
+    )
+    result = verify_evidence_chain_manifest(
+        manifest=manifest,
+        authority_evidence={"evidence_hash": AUTHORITY_HASH},
+        outcome_receipt={"outcome_hash": OUTCOME_HASH},
+        bind_coverage_operation_id="saas_read_demo",
+        approval_required=False,
+        verified_at=VERIFIED_AT,
+    )
+    assert result.verification_status == "verified"

--- a/tests/governance/test_outcome_receipt.py
+++ b/tests/governance/test_outcome_receipt.py
@@ -115,3 +115,37 @@ def test_build_outcome_receipt_returns_hash_populated_receipt() -> None:
         evaluated_at="2026-04-26T00:00:00+00:00",
     )
     assert receipt.outcome_hash
+
+
+def test_build_outcome_receipt_binds_verified_human_approval_proof_metadata() -> None:
+    proof = type(
+        "Proof",
+        (),
+        {
+            "verification_proof_hash": "p" * 64,
+            "verification_source": "signed_human_approval_artifact",
+            "receipt": type("Receipt", (), {"approval_receipt_id": "har-1"})(),
+        },
+    )()
+
+    receipt = build_outcome_receipt(
+        decision_id="decision-001",
+        execution_intent_id="intent-001",
+        bind_receipt_id="bind-001",
+        operation_id="op-001",
+        action_class="permission_change",
+        target_system="mock_saas_directory",
+        target_resource="contractor:external.user@example.test",
+        intended_action="grant_admin_permission",
+        requested_scope=["saas:grant_admin"],
+        final_outcome="commit",
+        evaluated_at="2026-04-26T00:00:00+00:00",
+        verified_human_approval=proof,
+    )
+
+    assert receipt.metadata["verified_human_approval_proof_hash"] == "p" * 64
+    assert receipt.metadata["verified_human_approval_receipt_id"] == "har-1"
+    assert (
+        receipt.metadata["human_approval_verification_source"]
+        == "signed_human_approval_artifact"
+    )

--- a/veritas_os/governance/evidence_chain_manifest.py
+++ b/veritas_os/governance/evidence_chain_manifest.py
@@ -34,6 +34,8 @@ class EvidenceChainManifest:
     authority_evidence_hash: str | None
     human_approval_receipt_id: str | None
     human_approval_receipt_hash: str | None
+    verified_human_approval_proof_hash: str | None
+    human_approval_required: bool
     bind_receipt_id: str | None
     bind_receipt_hash: str | None
     outcome_receipt_id: str | None
@@ -63,6 +65,10 @@ class EvidenceChainManifest:
             "authority_evidence_hash": self.authority_evidence_hash,
             "human_approval_receipt_id": self.human_approval_receipt_id,
             "human_approval_receipt_hash": self.human_approval_receipt_hash,
+            "verified_human_approval_proof_hash": (
+                self.verified_human_approval_proof_hash
+            ),
+            "human_approval_required": self.human_approval_required,
             "bind_receipt_id": self.bind_receipt_id,
             "bind_receipt_hash": self.bind_receipt_hash,
             "outcome_receipt_id": self.outcome_receipt_id,
@@ -134,7 +140,12 @@ def validate_evidence_chain_manifest(
         failure_reasons.append("evidence_chain_invalid_chain_status")
 
     if manifest.chain_status == "complete":
-        for field_name in _REQUIRED_COMPLETE_HASH_FIELDS:
+        required_fields = [
+            field
+            for field in _REQUIRED_COMPLETE_HASH_FIELDS
+            if field != "human_approval_receipt_hash" or manifest.human_approval_required
+        ]
+        for field_name in required_fields:
             if not str(getattr(manifest, field_name) or "").strip():
                 failure_reasons.append("evidence_chain_complete_missing_required_hash")
                 break
@@ -176,6 +187,8 @@ def build_evidence_chain_manifest(
     authority_evidence_hash: str | None = None,
     human_approval_receipt_id: str | None = None,
     human_approval_receipt_hash: str | None = None,
+    verified_human_approval_proof_hash: str | None = None,
+    human_approval_required: bool = True,
     bind_receipt_id: str | None = None,
     bind_receipt_hash: str | None = None,
     outcome_receipt_id: str | None = None,
@@ -190,12 +203,14 @@ def build_evidence_chain_manifest(
     missing_links: list[str] = []
     for label, value in (
         ("authority_evidence_hash", authority_evidence_hash),
-        ("human_approval_receipt_hash", human_approval_receipt_hash),
         ("outcome_receipt_hash", outcome_receipt_hash),
         ("bind_coverage_operation_id", bind_coverage_operation_id),
     ):
         if not str(value or "").strip():
             missing_links.append(label)
+
+    if human_approval_required and not str(human_approval_receipt_hash or "").strip():
+        missing_links.append("human_approval_receipt_hash")
 
     normalized_outcome = str(final_outcome).strip().lower()
     if normalized_outcome in _BLOCKED_OUTCOMES:
@@ -220,6 +235,8 @@ def build_evidence_chain_manifest(
         authority_evidence_hash=authority_evidence_hash,
         human_approval_receipt_id=human_approval_receipt_id,
         human_approval_receipt_hash=human_approval_receipt_hash,
+        verified_human_approval_proof_hash=verified_human_approval_proof_hash,
+        human_approval_required=human_approval_required,
         bind_receipt_id=bind_receipt_id,
         bind_receipt_hash=bind_receipt_hash,
         outcome_receipt_id=outcome_receipt_id,

--- a/veritas_os/governance/evidence_chain_verifier.py
+++ b/veritas_os/governance/evidence_chain_verifier.py
@@ -68,6 +68,8 @@ def verify_evidence_chain_manifest(
     authority_evidence: Any | None = None,
     human_approval_receipt: Any | None = None,
     outcome_receipt: Any | None = None,
+    verified_human_approval: Any | None = None,
+    approval_required: bool = False,
     bind_coverage_operation_id: str | None = None,
     bind_receipt: Any | None = None,
     verified_at: str,
@@ -154,6 +156,17 @@ def verify_evidence_chain_manifest(
         missing_links=missing_links,
         mismatched_links=mismatched_links,
         indeterminate_links=indeterminate_links,
+        failure_reasons=failure_reasons,
+    )
+
+    _verify_human_approval_proof_hash_binding(
+        approval_required=approval_required,
+        manifest=manifest,
+        outcome_receipt=outcome_receipt,
+        verified_human_approval=verified_human_approval,
+        verified_links=verified_links,
+        missing_links=missing_links,
+        mismatched_links=mismatched_links,
         failure_reasons=failure_reasons,
     )
 
@@ -265,6 +278,106 @@ def _verify_hash_link(
     else:
         mismatched_links.append(link_name)
         failure_reasons.append(mismatch_reason)
+
+
+def _metadata_value(artifact: Any | None, key: str) -> str | None:
+    """Return a string metadata value from a mapping or dataclass artifact."""
+    if artifact is None:
+        return None
+    metadata = (
+        artifact.get("metadata")
+        if isinstance(artifact, dict)
+        else getattr(artifact, "metadata", None)
+    )
+    if not isinstance(metadata, dict):
+        return None
+    value = metadata.get(key)
+    return None if value is None else str(value)
+
+
+def _proof_hash_value(proof: Any | None) -> str | None:
+    """Return the hash of a VerifiedHumanApprovalReceipt-like proof."""
+    if proof is None:
+        return None
+    value = (
+        proof.get("verification_proof_hash")
+        if isinstance(proof, dict)
+        else getattr(proof, "verification_proof_hash", None)
+    )
+    return None if value is None else str(value)
+
+
+def _approval_required_for_proof_binding(
+    *,
+    approval_required: bool,
+    manifest: EvidenceChainManifest,
+    outcome_receipt: Any | None,
+    verified_human_approval: Any | None,
+) -> bool:
+    """Infer whether approval-proof continuity must be enforced."""
+    return bool(
+        approval_required
+        or str(getattr(manifest, "verified_human_approval_proof_hash", "") or "").strip()
+        or _metadata_value(outcome_receipt, "verified_human_approval_proof_hash")
+        or verified_human_approval is not None
+    )
+
+
+def _verify_human_approval_proof_hash_binding(
+    *,
+    approval_required: bool,
+    manifest: EvidenceChainManifest,
+    outcome_receipt: Any | None,
+    verified_human_approval: Any | None,
+    verified_links: list[str],
+    missing_links: list[str],
+    mismatched_links: list[str],
+    failure_reasons: list[str],
+) -> None:
+    """Fail closed when required approval proof hash continuity is broken."""
+    if not _approval_required_for_proof_binding(
+        approval_required=approval_required,
+        manifest=manifest,
+        outcome_receipt=outcome_receipt,
+        verified_human_approval=verified_human_approval,
+    ):
+        return
+
+    manifest_hash = str(
+        getattr(manifest, "verified_human_approval_proof_hash", "") or ""
+    ).strip()
+    outcome_hash = str(
+        _metadata_value(outcome_receipt, "verified_human_approval_proof_hash") or ""
+    ).strip()
+    actual_hash = str(_proof_hash_value(verified_human_approval) or "").strip()
+
+    if not manifest_hash:
+        missing_links.append("verified_human_approval_proof_hash")
+        failure_reasons.append("human_approval_proof_hash_missing")
+    if not outcome_hash:
+        missing_links.append("outcome_verified_human_approval_proof_hash")
+        failure_reasons.append("human_approval_proof_hash_missing")
+    if not actual_hash:
+        missing_links.append("verified_human_approval")
+        failure_reasons.append("human_approval_proof_hash_missing")
+
+    if manifest_hash and outcome_hash and manifest_hash != outcome_hash:
+        mismatched_links.append("verified_human_approval_proof_hash")
+        failure_reasons.append("outcome_human_approval_proof_hash_mismatch")
+    if manifest_hash and actual_hash and manifest_hash != actual_hash:
+        mismatched_links.append("verified_human_approval_proof_hash")
+        failure_reasons.append("manifest_human_approval_proof_hash_mismatch")
+    if outcome_hash and actual_hash and outcome_hash != actual_hash:
+        mismatched_links.append("outcome_verified_human_approval_proof_hash")
+        failure_reasons.append("human_approval_proof_hash_mismatch")
+
+    if (
+        manifest_hash
+        and outcome_hash
+        and actual_hash
+        and manifest_hash == outcome_hash == actual_hash
+    ):
+        verified_links.append("verified_human_approval_proof_hash")
 
 
 def _validate_verified_at(verified_at: str, failure_reasons: list[str]) -> None:

--- a/veritas_os/governance/outcome_receipt.py
+++ b/veritas_os/governance/outcome_receipt.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any, Literal
 
+from veritas_os.governance.human_approval_receipt import VerifiedHumanApprovalReceipt
 from veritas_os.security.hash import sha256_of_canonical_json
 
 PostconditionStatus = Literal["passed", "failed", "skipped", "indeterminate"]
@@ -166,14 +167,35 @@ def build_outcome_receipt(
     rollback_status: str | None = None,
     evaluated_at: str = "",
     metadata: dict[str, Any] | None = None,
+    verified_human_approval: VerifiedHumanApprovalReceipt | None = None,
 ) -> OutcomeReceipt:
-    """Build a deterministic local/offline finalized outcome receipt."""
+    """Build a deterministic local/offline finalized outcome receipt.
+
+    When a sealed verified human approval proof is supplied, its proof hash,
+    receipt id, and verification source are bound into metadata before the
+    outcome hash is finalized.
+    """
     normalized_outcome = str(final_outcome).strip().lower()
     normalized_rollback = str(rollback_status or "").strip().lower()
     committed = normalized_outcome in _COMMITTED_OUTCOMES
     blocked = normalized_outcome in {"block", "blocked", "refuse", "refused"}
     escalated = normalized_outcome in {"escalate", "escalated"}
     rolled_back = normalized_rollback in {"performed", "rolled_back", "success", "completed"}
+    receipt_metadata = dict(metadata or {})
+    if verified_human_approval is not None:
+        receipt_metadata.update(
+            {
+                "verified_human_approval_proof_hash": (
+                    verified_human_approval.verification_proof_hash
+                ),
+                "verified_human_approval_receipt_id": (
+                    verified_human_approval.receipt.approval_receipt_id
+                ),
+                "human_approval_verification_source": (
+                    verified_human_approval.verification_source
+                ),
+            }
+        )
 
     receipt = OutcomeReceipt(
         outcome_receipt_id=f"outcome-{operation_id}",
@@ -199,7 +221,7 @@ def build_outcome_receipt(
         rollback_status=rollback_status,
         evaluated_at=evaluated_at,
         outcome_hash="",
-        metadata=dict(metadata or {}),
+        metadata=receipt_metadata,
     )
     return with_outcome_hash(receipt)
 


### PR DESCRIPTION
### Motivation

- Ensure continuity and anti-substitution of human approvals by binding a sealed human-approval proof hash into the evidence-chain manifest, outcome receipt, and verification flow.
- Make approval-required vs no-approval flows explicit so the verifier can fail closed when an approval proof is expected but missing or inconsistent.

### Description

- Add `verified_human_approval_proof_hash` and `human_approval_required` fields to `EvidenceChainManifest` and include them in canonical hashing and `to_dict` payloads. 
- Update `build_evidence_chain_manifest`, `validate_evidence_chain_manifest`, and manifest validation logic to respect `human_approval_required` when deriving `chain_status` and checking required hashes. 
- Add outcome binding in `build_outcome_receipt` to copy a sealed `VerifiedHumanApprovalReceipt`'s proof hash, receipt id, and verification source into outcome `metadata` before finalizing `outcome_hash`. 
- Extend the verifier with `_verify_human_approval_proof_hash_binding`, `_approval_required_for_proof_binding`, and helpers to extract metadata and proof hash, and enforce deterministic continuity checks across manifest, outcome receipt metadata, and the supplied verified approval object with explicit failure reasons. 
- Update JSON schema (`reviewer-evidence-packet-v1.schema.json`) and many demo/fixture example files to include the new manifest fields and updated manifest/packet hashes. 
- Add and adjust unit tests covering manifest generation, verification happy path and failure modes (missing/mismatched proof hash, no-approval path), plus an outcome receipt test for proof metadata binding.

### Testing

- Ran the governance unit tests including `tests/governance/test_evidence_chain_manifest.py`, `tests/governance/test_evidence_chain_verifier.py`, and `tests/governance/test_outcome_receipt.py` which exercise creation, validation, and verification behavior for approval-proof continuity, and all assertions passed.
- Updated example/fixture JSON artifacts were regenerated and schema-checked as part of the test changes with no validation failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34b2290ef8832694cd7b35c1e22e67)