### PR TITLE
Require reviewer approval proof continuity in reviewer packet validation

### DIFF
--- a/.github/ci-retrigger/pr-2056.txt
+++ b/.github/ci-retrigger/pr-2056.txt
@@ -1,0 +1,2 @@
+Temporary CI retrigger marker for PR #2056.
+This file will be removed immediately so the final PR diff stays clean.

--- a/.github/ci-retrigger/pr-2056.txt
+++ b/.github/ci-retrigger/pr-2056.txt
@@ -1,2 +1,0 @@
-Temporary CI retrigger marker for PR #2056.
-This file will be removed immediately so the final PR diff stays clean.

--- a/docs/en/demo/fixtures/reviewer-evidence-packet-saas-permission-change-v1.json
+++ b/docs/en/demo/fixtures/reviewer-evidence-packet-saas-permission-change-v1.json
@@ -32,7 +32,7 @@
         "human_approval_receipt_hash": "55db4aa2686f01d6e1133b880ee85e82572957b3e0e3dd63bce692a8be4d38ba",
         "human_approval_receipt_id": "har-saas-001",
         "human_approval_required": true,
-        "manifest_hash": "4c59caecf410cce8c718a7fa43ff5de32174d142a32048e22b6977d8b91220f3",
+        "manifest_hash": "d474a76144e6f01ec07f2a8d6840b68db4a531e3e188dbb3d0b6c10a3757f582",
         "manifest_id": "ecm-saas-permission-change-missing_authority",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -43,7 +43,7 @@
         ],
         "observed_effects_summary": [],
         "operation_id": "saas-permission-change-missing_authority",
-        "outcome_receipt_hash": "8f28c45ec0f7efd2f8f4cd25b02fe46450c012b10a06ed715d9ed25f899ea71f",
+        "outcome_receipt_hash": "ac119d8f8e5ffd6087bf55cc885e5801c394b68312802ca96bb7d0915d08b274",
         "outcome_receipt_id": "outcome-saas-permission-change-missing_authority",
         "refusal_basis": [
           "authority_expired_or_missing",
@@ -55,7 +55,7 @@
         ],
         "target_resource": "contractor:external.user@example.test",
         "target_system": "mock_saas_directory",
-        "verified_human_approval_proof_hash": null
+        "verified_human_approval_proof_hash": "bf5b481f4fda72e10b63dfc90a1d3eaff240a97d68a2a7e19890117a398645be"
       },
       "evidence_chain_verification_summary": {
         "decision_id": "decision-saas-001",
@@ -73,14 +73,15 @@
           "authority_evidence_hash"
         ],
         "operation_id": "saas-permission-change-missing_authority",
-        "recomputed_manifest_hash": "4c59caecf410cce8c718a7fa43ff5de32174d142a32048e22b6977d8b91220f3",
+        "recomputed_manifest_hash": "d474a76144e6f01ec07f2a8d6840b68db4a531e3e188dbb3d0b6c10a3757f582",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
           "bind_coverage_operation_id",
           "human_approval_receipt_hash",
           "manifest_hash",
-          "outcome_receipt_hash"
+          "outcome_receipt_hash",
+          "verified_human_approval_proof_hash"
         ]
       },
       "expected_outcome": "block",
@@ -128,11 +129,14 @@
         "intended_action": "grant_admin_permission",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
-          "fixture_only": true
+          "fixture_only": true,
+          "human_approval_verification_source": "signed_human_approval_artifact",
+          "verified_human_approval_proof_hash": "bf5b481f4fda72e10b63dfc90a1d3eaff240a97d68a2a7e19890117a398645be",
+          "verified_human_approval_receipt_id": "har-saas-001"
         },
         "observed_effects": [],
         "operation_id": "saas-permission-change-missing_authority",
-        "outcome_hash": "8f28c45ec0f7efd2f8f4cd25b02fe46450c012b10a06ed715d9ed25f899ea71f",
+        "outcome_hash": "ac119d8f8e5ffd6087bf55cc885e5801c394b68312802ca96bb7d0915d08b274",
         "outcome_receipt_id": "outcome-saas-permission-change-missing_authority",
         "post_state_fingerprint": null,
         "postcondition_status": "skipped",
@@ -600,7 +604,7 @@
         "human_approval_receipt_hash": "55db4aa2686f01d6e1133b880ee85e82572957b3e0e3dd63bce692a8be4d38ba",
         "human_approval_receipt_id": "har-saas-001",
         "human_approval_required": true,
-        "manifest_hash": "bcb536dc12e621155a2e1c61143fc14875ce04c7b5e23d79fee418bae9f2b31c",
+        "manifest_hash": "fea56617835a8eb6f6bf902871507351a4adb8e0422bb04f090a1afb5da9b329",
         "manifest_id": "ecm-saas-permission-change-valid_authority_and_approval",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -616,7 +620,7 @@
           }
         ],
         "operation_id": "saas-permission-change-valid_authority_and_approval",
-        "outcome_receipt_hash": "e8eb969be01b97993b20283a6f0314f5e83be4d6377e879f7b3719562e5a036a",
+        "outcome_receipt_hash": "37cd4a35ec1469091eaa0bf39ad91618656c6017de9419f909e8903ac593eeb8",
         "outcome_receipt_id": "outcome-saas-permission-change-valid_authority_and_approval",
         "refusal_basis": [],
         "requested_scope": [
@@ -624,7 +628,7 @@
         ],
         "target_resource": "contractor:external.user@example.test",
         "target_system": "mock_saas_directory",
-        "verified_human_approval_proof_hash": null
+        "verified_human_approval_proof_hash": "bf5b481f4fda72e10b63dfc90a1d3eaff240a97d68a2a7e19890117a398645be"
       },
       "evidence_chain_verification_summary": {
         "decision_id": "decision-saas-001",
@@ -640,7 +644,7 @@
         "mismatched_links": [],
         "missing_links": [],
         "operation_id": "saas-permission-change-valid_authority_and_approval",
-        "recomputed_manifest_hash": "bcb536dc12e621155a2e1c61143fc14875ce04c7b5e23d79fee418bae9f2b31c",
+        "recomputed_manifest_hash": "fea56617835a8eb6f6bf902871507351a4adb8e0422bb04f090a1afb5da9b329",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -648,7 +652,8 @@
           "bind_coverage_operation_id",
           "human_approval_receipt_hash",
           "manifest_hash",
-          "outcome_receipt_hash"
+          "outcome_receipt_hash",
+          "verified_human_approval_proof_hash"
         ]
       },
       "expected_outcome": "commit",
@@ -688,7 +693,10 @@
         "intended_action": "grant_admin_permission",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
-          "fixture_only": true
+          "fixture_only": true,
+          "human_approval_verification_source": "signed_human_approval_artifact",
+          "verified_human_approval_proof_hash": "bf5b481f4fda72e10b63dfc90a1d3eaff240a97d68a2a7e19890117a398645be",
+          "verified_human_approval_receipt_id": "har-saas-001"
         },
         "observed_effects": [
           {
@@ -699,7 +707,7 @@
           }
         ],
         "operation_id": "saas-permission-change-valid_authority_and_approval",
-        "outcome_hash": "e8eb969be01b97993b20283a6f0314f5e83be4d6377e879f7b3719562e5a036a",
+        "outcome_hash": "37cd4a35ec1469091eaa0bf39ad91618656c6017de9419f909e8903ac593eeb8",
         "outcome_receipt_id": "outcome-saas-permission-change-valid_authority_and_approval",
         "post_state_fingerprint": null,
         "postcondition_status": "passed",
@@ -741,7 +749,7 @@
     }
   },
   "local_offline_only": true,
-  "packet_hash": "945341d3035c60f628eaffdcc568cfbdd2b5128d89fc4f3cad6a97cdf0cf7282",
+  "packet_hash": "a97903b53ff00d956031d2b33b8f121dce4c8d693868110dc955dfa8eb39c9b9",
   "packet_id": "reviewer-evidence-packet-saas-permission-change-v1",
   "packet_version": "v1",
   "reviewer_notes": [

--- a/docs/en/demo/reviewer-evidence-packet.md
+++ b/docs/en/demo/reviewer-evidence-packet.md
@@ -64,6 +64,17 @@ python3 scripts/demo/export_context_bound_approval_replay_packet.py
 
 The command performs no network calls and requires no credentials.
 
+## Approval proof continuity validation
+
+Reviewer Evidence Packet validation now checks human approval proof continuity for approval-required committed outcomes. When `human_approval_required=true` and the packet presents a committed outcome, the packet is invalid unless:
+
+- `evidence_chain_manifest_summary.verified_human_approval_proof_hash` is present;
+- `outcome_receipt_summary.metadata.verified_human_approval_proof_hash` is present;
+- both proof hashes match; and
+- a verified `evidence_chain_verification_summary` includes `verified_human_approval_proof_hash` in `verified_links`.
+
+For failed or incomplete evidence-chain verification caused by approval proof continuity, reviewer validation expects deterministic failure reasons from the evidence-chain verifier. This prevents reviewer-facing artifacts from presenting a committed outcome with a substituted, missing, or unverified human approval proof. No-approval-required flows may keep the proof hash fields absent and do not need the proof hash link in `verified_links`.
+
 ## Local/offline boundary
 
 Reviewer Evidence Packet v1 is a local/offline fixture export only.

--- a/samples/evidence_bundle/key_provenance_review/reviewer-evidence-packet.json
+++ b/samples/evidence_bundle/key_provenance_review/reviewer-evidence-packet.json
@@ -74,7 +74,8 @@
           "authority_evidence",
           "human_approval_receipt",
           "bind_receipt",
-          "outcome_receipt"
+          "outcome_receipt",
+          "verified_human_approval_proof_hash"
         ]
       },
       "expected_outcome": "Reviewer can follow illustrative key provenance artifact references.",
@@ -112,7 +113,8 @@
         "final_outcome": "commit",
         "intended_action": "assemble illustrative reviewer evidence packet",
         "metadata": {
-          "sample_context": "key provenance reviewer walkthrough"
+          "sample_context": "key provenance reviewer walkthrough",
+          "verified_human_approval_proof_hash": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
         },
         "observed_effects": [
           {

--- a/samples/evidence_bundle/key_provenance_review/sample-artifact-manifest.json
+++ b/samples/evidence_bundle/key_provenance_review/sample-artifact-manifest.json
@@ -31,7 +31,7 @@
       "artifact_name": "reviewer-evidence-packet.json",
       "role": "reviewer_evidence_packet",
       "schema_id": "docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json",
-      "sha256": "811cde1d3faf543b705f5b22c4609d5c11aaf0ca55d115df12a32076652f5c3c"
+      "sha256": "e399a3757e6bfe5159546dac9be968cb639ce87c2bf65112a26c3470e7f0ed2f"
     },
     {
       "artifact_name": "reviewer-handoff-review-result.json",

--- a/scripts/demo/saas_permission_change_governed_demo.py
+++ b/scripts/demo/saas_permission_change_governed_demo.py
@@ -12,15 +12,22 @@ from veritas_os.governance import (
     CommitBoundaryEvaluator,
     HumanApprovalReceipt,
     RuntimeAuthorityValidator,
+    VerifiedHumanApprovalReceipt,
     build_evidence_chain_manifest,
     build_outcome_receipt,
     build_human_approval_state,
     verify_evidence_chain_manifest,
     with_receipt_hash,
 )
+from veritas_os.governance.human_approval_receipt import (
+    SIGNED_APPROVAL_ARTIFACT_TYPE,
+    SIGNED_APPROVAL_ARTIFACT_VERSION,
+    VERIFICATION_SOURCE_SIGNED_ARTIFACT,
+)
 from veritas_os.governance.authority_evidence_ingestion import (
     ingest_authority_evidence_payload,
 )
+from veritas_os.security.hash import sha256_of_canonical_json
 
 FIXED_NOW = datetime.fromisoformat("2026-04-26T00:00:00").replace(tzinfo=UTC)
 REQUESTED_SCOPE = ["saas:grant_admin"]
@@ -98,6 +105,49 @@ def _human_approval_receipt(
         receipt_hash="",
         metadata={"fixture": True},
     )
+
+
+def _verified_human_approval_proof(
+    receipt: HumanApprovalReceipt,
+) -> VerifiedHumanApprovalReceipt:
+    """Return a deterministic local/offline verified approval proof fixture."""
+    finalized = with_receipt_hash(receipt)
+    proof_payload = {
+        "receipt": finalized,
+        "artifact_type": SIGNED_APPROVAL_ARTIFACT_TYPE,
+        "artifact_version": SIGNED_APPROVAL_ARTIFACT_VERSION,
+        "receipt_hash": finalized.receipt_hash,
+        "signer_key_id": "local-demo-key",
+        "signer_algorithm": "local-offline-fixture",
+        "signer_identity": finalized.approver_identity,
+        "signer_role": finalized.approver_role,
+        "signer_policy_id": "local-demo-signer-policy",
+        "signer_policy_hash": sha256_of_canonical_json(
+            {"policy_id": "local-demo-signer-policy", "fixture_only": True}
+        ),
+        "signature_verification_reason": "local_offline_fixture_verified",
+        "verifier_trust_level": "production",
+        "signed_at": finalized.approved_at,
+        "verified_at": FIXED_NOW.isoformat(),
+        "verification_source": VERIFICATION_SOURCE_SIGNED_ARTIFACT,
+        "request_ref": finalized.request_ref,
+        "ai_output_ref": finalized.ai_output_ref,
+        "execution_intent_id": finalized.execution_intent_id,
+        "decision_id": finalized.decision_id,
+        "action_class": finalized.approved_action_class,
+        "policy_snapshot_id": finalized.policy_snapshot_id,
+        "authority_evidence_id": finalized.authority_evidence_id,
+        "bind_context_hash": finalized.bind_context_hash,
+    }
+    proof_hash_payload = {
+        key: value
+        for key, value in proof_payload.items()
+        if key != "receipt"
+    }
+    proof_payload["verification_proof_hash"] = sha256_of_canonical_json(
+        proof_hash_payload
+    )
+    return VerifiedHumanApprovalReceipt(**proof_payload)
 
 
 def _evaluate_case(
@@ -195,6 +245,10 @@ def _evaluate_case(
         ]
         postcondition_status = "passed"
 
+    verified_human_approval = None
+    if receipt is not None and human_approval_state.get("approved"):
+        verified_human_approval = _verified_human_approval_proof(receipt)
+
     outcome_receipt = build_outcome_receipt(
         decision_id="decision-saas-001",
         execution_intent_id="intent-saas-001",
@@ -212,6 +266,7 @@ def _evaluate_case(
         rollback_status=None,
         evaluated_at=FIXED_NOW.isoformat(),
         metadata={"fixture_only": True, "boundary_note": BOUNDARY_NOTE},
+        verified_human_approval=verified_human_approval,
     )
     authority_evidence_id = (
         authority_evidence.authority_evidence_id
@@ -255,17 +310,25 @@ def _evaluate_case(
         observed_effects_summary=observed_effects,
         generated_at=FIXED_NOW.isoformat(),
         metadata={"fixture_only": True, "boundary_note": BOUNDARY_NOTE},
+        verified_human_approval_proof_hash=(
+            verified_human_approval.verification_proof_hash
+            if verified_human_approval is not None
+            else None
+        ),
     )
 
-    finalized_human_approval_receipt = None
-    if receipt is not None and human_approval_state.get("approved"):
-        finalized_human_approval_receipt = with_receipt_hash(receipt)
+    finalized_human_approval_receipt = (
+        verified_human_approval.receipt
+        if verified_human_approval is not None
+        else None
+    )
 
     evidence_chain_verification = verify_evidence_chain_manifest(
         manifest=evidence_chain_manifest,
         authority_evidence=authority_evidence,
         human_approval_receipt=finalized_human_approval_receipt,
         outcome_receipt=outcome_receipt,
+        verified_human_approval=verified_human_approval,
         bind_coverage_operation_id="saas_permission_change_demo",
         verified_at=FIXED_NOW.isoformat(),
         metadata={"fixture_only": True, "boundary_note": BOUNDARY_NOTE},

--- a/scripts/demo/validate_reviewer_evidence_packet.py
+++ b/scripts/demo/validate_reviewer_evidence_packet.py
@@ -114,6 +114,9 @@ FAILURE_REASON_BY_CHECK = {
     "evidence_chain_verification_present": "evidence_chain_verification_missing",
     "valid_case_chain_verified": "valid_case_chain_not_verified",
     "no_mismatched_links_in_demo": "demo_mismatched_links_present",
+    "approval_proof_continuity_valid": (
+        "reviewer_packet_human_approval_proof_continuity_invalid"
+    ),
     "local_offline_boundary_present": "local_offline_boundary_missing",
 }
 
@@ -295,6 +298,115 @@ def _no_mismatched_links_in_demo(packet: dict[str, Any]) -> bool:
     )
 
 
+def _case_approval_proof_continuity_reasons(case: dict[str, Any]) -> list[str]:
+    """Return reviewer-facing approval proof continuity validation reasons.
+
+    Reviewer packets must prove that approval-required cases bind the same
+    verified human approval proof hash in the EvidenceChainManifest, the
+    OutcomeReceipt metadata, and verified evidence-chain links.
+    """
+    reasons: list[str] = []
+    manifest = case.get("evidence_chain_manifest_summary", {})
+    outcome = case.get("outcome_receipt_summary", {})
+    verification = case.get("evidence_chain_verification_summary")
+    if not isinstance(manifest, dict):
+        manifest = {}
+    if not isinstance(outcome, dict):
+        outcome = {}
+
+    committed = outcome.get("committed") is True
+    has_proof_binding = bool(
+        manifest.get("verified_human_approval_proof_hash")
+        or (
+            isinstance(outcome.get("metadata", {}), dict)
+            and outcome.get("metadata", {}).get(
+                "verified_human_approval_proof_hash"
+            )
+        )
+    )
+    approval_required = manifest.get("human_approval_required") is True
+    if not approval_required or (not committed and not has_proof_binding):
+        return reasons
+
+    manifest_hash = str(
+        manifest.get("verified_human_approval_proof_hash") or ""
+    ).strip()
+    metadata = outcome.get("metadata", {})
+    if not isinstance(metadata, dict):
+        metadata = {}
+    outcome_hash = str(
+        metadata.get("verified_human_approval_proof_hash") or ""
+    ).strip()
+
+    if not manifest_hash:
+        reasons.append("reviewer_packet_human_approval_proof_hash_missing")
+    if not outcome_hash:
+        reasons.append("reviewer_packet_outcome_human_approval_proof_hash_missing")
+    if manifest_hash and outcome_hash and manifest_hash != outcome_hash:
+        reasons.append("reviewer_packet_human_approval_proof_hash_mismatch")
+
+    if isinstance(verification, dict):
+        status = verification.get("verification_status")
+        verified_links = verification.get("verified_links", [])
+        if not isinstance(verified_links, list):
+            verified_links = []
+        failure_reasons = verification.get("failure_reasons", [])
+        if not isinstance(failure_reasons, list):
+            failure_reasons = []
+        continuity_failure_reasons = {
+            "human_approval_proof_hash_missing",
+            "outcome_human_approval_proof_hash_mismatch",
+            "manifest_human_approval_proof_hash_mismatch",
+            "human_approval_proof_hash_mismatch",
+        }
+        if (
+            status == "verified"
+            and "verified_human_approval_proof_hash" not in verified_links
+        ):
+            reasons.append("reviewer_packet_human_approval_proof_link_not_verified")
+        if status in {"failed", "incomplete"} and (
+            "verified_human_approval_proof_hash"
+            in verification.get("missing_links", [])
+            or "outcome_verified_human_approval_proof_hash" in verification.get(
+                "missing_links", []
+            )
+            or "verified_human_approval_proof_hash" in verification.get(
+                "mismatched_links", []
+            )
+            or "outcome_verified_human_approval_proof_hash" in verification.get(
+                "mismatched_links", []
+            )
+        ):
+            if not any(
+                reason in continuity_failure_reasons for reason in failure_reasons
+            ):
+                reasons.append(
+                    "reviewer_packet_human_approval_proof_link_not_verified"
+                )
+    return reasons
+
+
+def _approval_proof_continuity_reasons(packet: dict[str, Any]) -> list[str]:
+    """Return deterministic approval proof continuity reasons for all cases."""
+    cases = packet.get("cases")
+    if not isinstance(cases, list):
+        return ["required_case_fields_missing"]
+    reasons: list[str] = []
+    for case in cases:
+        if not isinstance(case, dict):
+            reasons.append("required_case_fields_missing")
+            continue
+        for reason in _case_approval_proof_continuity_reasons(case):
+            if reason not in reasons:
+                reasons.append(reason)
+    return reasons
+
+
+def _approval_proof_continuity_valid(packet: dict[str, Any]) -> bool:
+    """Return whether all cases preserve reviewer approval proof continuity."""
+    return not _approval_proof_continuity_reasons(packet)
+
+
 def _local_offline_boundary_present(packet: dict[str, Any]) -> bool:
     """Return whether packet-level local/offline boundary markers are present."""
     boundary_note = packet.get("boundary_note")
@@ -348,6 +460,9 @@ def _build_checks(
         ),
         "valid_case_chain_verified": _valid_case_chain_verified(generated_packet),
         "no_mismatched_links_in_demo": _no_mismatched_links_in_demo(generated_packet),
+        "approval_proof_continuity_valid": _approval_proof_continuity_valid(
+            generated_packet
+        ),
         "local_offline_boundary_present": _local_offline_boundary_present(
             generated_packet
         ),
@@ -363,6 +478,9 @@ def _failure_reasons(checks: dict[str, Any]) -> list[str]:
             check_name == "schema_validation_status" and value == "fail"
         )
         if failed:
+            reasons.append(reason)
+    for reason in checks.get("approval_proof_continuity_reasons", []):
+        if reason not in reasons:
             reasons.append(reason)
     return reasons
 
@@ -402,6 +520,9 @@ def _build_report_for_packet(
         fixture_parseable,
         schema_exists,
         schema_parseable,
+    )
+    checks["approval_proof_continuity_reasons"] = (
+        _approval_proof_continuity_reasons(packet)
     )
     failure_reasons = _failure_reasons(checks)
     return {

--- a/tests/demo/test_reviewer_evidence_packet_validation_report.py
+++ b/tests/demo/test_reviewer_evidence_packet_validation_report.py
@@ -142,3 +142,107 @@ def test_validation_report_detects_missing_evidence_chain_verification() -> None
     assert report["status"] == "fail"
     assert "required_case_fields_missing" in report["failure_reasons"]
     assert "evidence_chain_verification_missing" in report["failure_reasons"]
+
+def _valid_case_packet() -> dict[str, object]:
+    packet = copy.deepcopy(build_reviewer_evidence_packet())
+    packet["cases"] = [
+        case
+        for case in packet["cases"]
+        if case["case_id"] == "valid_authority_and_approval"
+    ]
+    return packet
+
+
+def test_approval_required_packet_passes_with_matching_proof_hashes() -> None:
+    report = _report_for_mutated_packet(_valid_case_packet())
+
+    assert report["checks"]["approval_proof_continuity_valid"] is True
+    assert report["checks"]["approval_proof_continuity_reasons"] == []
+
+
+def test_approval_required_packet_fails_when_manifest_proof_hash_missing() -> None:
+    packet = _valid_case_packet()
+    packet["cases"][0]["evidence_chain_manifest_summary"][
+        "verified_human_approval_proof_hash"
+    ] = None
+
+    report = _report_for_mutated_packet(packet)
+
+    assert report["status"] == "fail"
+    assert (
+        "reviewer_packet_human_approval_proof_hash_missing"
+        in report["failure_reasons"]
+    )
+
+
+def test_approval_required_packet_fails_when_outcome_proof_hash_missing() -> None:
+    packet = _valid_case_packet()
+    packet["cases"][0]["outcome_receipt_summary"]["metadata"].pop(
+        "verified_human_approval_proof_hash"
+    )
+
+    report = _report_for_mutated_packet(packet)
+
+    assert report["status"] == "fail"
+    assert (
+        "reviewer_packet_outcome_human_approval_proof_hash_missing"
+        in report["failure_reasons"]
+    )
+
+
+def test_approval_required_packet_fails_when_proof_hashes_differ() -> None:
+    packet = _valid_case_packet()
+    packet["cases"][0]["outcome_receipt_summary"]["metadata"][
+        "verified_human_approval_proof_hash"
+    ] = "f" * 64
+
+    report = _report_for_mutated_packet(packet)
+
+    assert report["status"] == "fail"
+    assert (
+        "reviewer_packet_human_approval_proof_hash_mismatch"
+        in report["failure_reasons"]
+    )
+
+
+def test_approval_required_verified_packet_fails_when_link_not_verified() -> None:
+    packet = _valid_case_packet()
+    links = packet["cases"][0]["evidence_chain_verification_summary"][
+        "verified_links"
+    ]
+    links.remove("verified_human_approval_proof_hash")
+
+    report = _report_for_mutated_packet(packet)
+
+    assert report["status"] == "fail"
+    assert (
+        "reviewer_packet_human_approval_proof_link_not_verified"
+        in report["failure_reasons"]
+    )
+
+
+def test_no_approval_required_packet_passes_without_proof_hash() -> None:
+    packet = _valid_case_packet()
+    case = packet["cases"][0]
+    case["evidence_chain_manifest_summary"]["human_approval_required"] = False
+    case["evidence_chain_manifest_summary"][
+        "verified_human_approval_proof_hash"
+    ] = None
+    case["outcome_receipt_summary"]["metadata"].pop(
+        "verified_human_approval_proof_hash", None
+    )
+    case["evidence_chain_verification_summary"]["verified_links"].remove(
+        "verified_human_approval_proof_hash"
+    )
+
+    report = _report_for_mutated_packet(packet)
+
+    assert "reviewer_packet_human_approval_proof_hash_missing" not in report[
+        "failure_reasons"
+    ]
+    assert "reviewer_packet_outcome_human_approval_proof_hash_missing" not in report[
+        "failure_reasons"
+    ]
+    assert "reviewer_packet_human_approval_proof_link_not_verified" not in report[
+        "failure_reasons"
+    ]


### PR DESCRIPTION
### Motivation
- Close a validation gap so reviewer-facing packets enforce the same verified human approval proof continuity the core EvidenceChainVerification enforces. 
- Prevent reviewer artifacts from claiming a committed outcome when the human approval proof hash is missing, substituted, or not verified.
- Preserve no-approval-required flows while failing closed for approval-required committed outcomes.

### Description
- Add deterministic reviewer continuity checks and failure reasons in `scripts/demo/validate_reviewer_evidence_packet.py`, including `_case_approval_proof_continuity_reasons`, `_approval_proof_continuity_reasons`, and `_approval_proof_continuity_valid`, and wire them into the report checks and failure-reasons aggregation.
- Introduce reviewer-facing deterministic reason codes: `reviewer_packet_human_approval_proof_hash_missing`, `reviewer_packet_outcome_human_approval_proof_hash_missing`, `reviewer_packet_human_approval_proof_hash_mismatch`, and `reviewer_packet_human_approval_proof_link_not_verified` and ensure continuity summary contributions are surfaced in `failure_reasons`.
- Update the SaaS demo generator `scripts/demo/saas_permission_change_governed_demo.py` to produce a deterministic local/offline `VerifiedHumanApprovalReceipt` fixture, bind its `verification_proof_hash` into the `OutcomeReceipt` metadata and `EvidenceChainManifest`, and pass the sealed proof into chain verification so `verified_links` can include `verified_human_approval_proof_hash`.
- Regenerate and update deterministic fixtures/samples to reflect the continuity binding: `docs/en/demo/fixtures/reviewer-evidence-packet-saas-permission-change-v1.json` and `samples/evidence_bundle/key_provenance_review/reviewer-evidence-packet.json`.
- Add tests to `tests/demo/test_reviewer_evidence_packet_validation_report.py` that cover: valid approval-required packet, missing manifest proof hash, missing outcome metadata proof hash, mismatched hashes, missing verified link when chain is verified, and the no-approval-required path.
- Document the new reviewer validation behavior in `docs/en/demo/reviewer-evidence-packet.md`.

### Testing
- Compiled modified modules successfully with `python3 -m py_compile scripts/demo/saas_permission_change_governed_demo.py scripts/demo/validate_reviewer_evidence_packet.py tests/demo/test_reviewer_evidence_packet_validation_report.py` (success).
- Ran the deterministic reviewer validation script `python3 scripts/demo/validate_reviewer_evidence_packet.py` against the regenerated fixture and confirmed the report `status` is `pass` and `approval_proof_continuity_valid` check passes for the golden fixture (success).
- Verified updated JSON fixtures parse and contain the expected bound `verified_human_approval_proof_hash` and `verified_links` entries (success).
- Added targeted unit tests for continuity and exercised them via the validation-report builder; attempted full `pytest` run was blocked by an environment limitation (missing `PyYAML`) and package-index access being unavailable, so full test-suite execution could not be completed in this environment (blocked by dependency installation / network policy).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3559e3c7d0832681af744f4a0106bd)