### PR TITLE
Add verifier lifecycle audit fixtures and reviewer validation for Human Approval

### DIFF
--- a/docs/en/demo/fixtures/reviewer-evidence-packet-saas-permission-change-v1.json
+++ b/docs/en/demo/fixtures/reviewer-evidence-packet-saas-permission-change-v1.json
@@ -117,8 +117,14 @@
         "verification_proof_hash": "4c5825bb7e0f647e705ca280a411695d052bfb8e65382f13804e86c0f485ef0c",
         "verifier_id": "veritas-human-approval-verifier-v1",
         "verifier_key_id": "local-demo-verifier-key",
+        "verifier_lifecycle_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
+        "verifier_lifecycle_status": "rotated",
         "verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
-        "verifier_policy_id": "human-approval-verifier-policy-v1"
+        "verifier_policy_id": "human-approval-verifier-policy-v1",
+        "verifier_revocation_reason": null,
+        "verifier_revoked_at": null,
+        "verifier_valid_from": "2026-04-01T00:00:00+00:00",
+        "verifier_valid_until": "2026-04-30T00:00:00+00:00"
       },
       "outcome_receipt_summary": {
         "action_class": "permission_change",
@@ -276,8 +282,14 @@
         "verification_proof_hash": null,
         "verifier_id": null,
         "verifier_key_id": null,
+        "verifier_lifecycle_policy_hash": null,
+        "verifier_lifecycle_status": null,
         "verifier_policy_hash": null,
-        "verifier_policy_id": null
+        "verifier_policy_id": null,
+        "verifier_revocation_reason": null,
+        "verifier_revoked_at": null,
+        "verifier_valid_from": null,
+        "verifier_valid_until": null
       },
       "outcome_receipt_summary": {
         "action_class": "permission_change",
@@ -424,8 +436,14 @@
         "verification_proof_hash": null,
         "verifier_id": null,
         "verifier_key_id": null,
+        "verifier_lifecycle_policy_hash": null,
+        "verifier_lifecycle_status": null,
         "verifier_policy_hash": null,
-        "verifier_policy_id": null
+        "verifier_policy_id": null,
+        "verifier_revocation_reason": null,
+        "verifier_revoked_at": null,
+        "verifier_valid_from": null,
+        "verifier_valid_until": null
       },
       "outcome_receipt_summary": {
         "action_class": "permission_change",
@@ -574,8 +592,14 @@
         "verification_proof_hash": null,
         "verifier_id": null,
         "verifier_key_id": null,
+        "verifier_lifecycle_policy_hash": null,
+        "verifier_lifecycle_status": null,
         "verifier_policy_hash": null,
-        "verifier_policy_id": null
+        "verifier_policy_id": null,
+        "verifier_revocation_reason": null,
+        "verifier_revoked_at": null,
+        "verifier_valid_from": null,
+        "verifier_valid_until": null
       },
       "outcome_receipt_summary": {
         "action_class": "permission_change",
@@ -725,8 +749,14 @@
         "verification_proof_hash": "4c5825bb7e0f647e705ca280a411695d052bfb8e65382f13804e86c0f485ef0c",
         "verifier_id": "veritas-human-approval-verifier-v1",
         "verifier_key_id": "local-demo-verifier-key",
+        "verifier_lifecycle_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
+        "verifier_lifecycle_status": "rotated",
         "verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
-        "verifier_policy_id": "human-approval-verifier-policy-v1"
+        "verifier_policy_id": "human-approval-verifier-policy-v1",
+        "verifier_revocation_reason": null,
+        "verifier_revoked_at": null,
+        "verifier_valid_from": "2026-04-01T00:00:00+00:00",
+        "verifier_valid_until": "2026-04-30T00:00:00+00:00"
       },
       "outcome_receipt_summary": {
         "action_class": "permission_change",
@@ -802,7 +832,7 @@
     }
   },
   "local_offline_only": true,
-  "packet_hash": "7d6d456dc0c2a019d00843af29e3aca566bf3b27769f021f5a18353c6bffef83",
+  "packet_hash": "f2bb77f50d1dabd86c7bd845b09e28a8ca35d80a8422a98a9f32210d801af158",
   "packet_id": "reviewer-evidence-packet-saas-permission-change-v1",
   "packet_version": "v1",
   "reviewer_notes": [

--- a/docs/en/demo/fixtures/verifier-lifecycle-audit-fixtures-v1.json
+++ b/docs/en/demo/fixtures/verifier-lifecycle-audit-fixtures-v1.json
@@ -1,0 +1,90 @@
+{
+  "cases": [
+    {
+      "case_id": "valid_at_verification_time",
+      "expected_reasons": [],
+      "later_lifecycle_event": {
+        "event_type": "rotated",
+        "rotated_at": "2026-05-01T00:00:00+00:00",
+        "verifier_key_id": "local-demo-verifier-key-rotated",
+        "verifier_policy_hash": "5c515f36ab1333a9473147536105919bfe420646b9393fb7f4d224f7c69ed0f0",
+        "verifier_policy_id": "human-approval-verifier-policy-v2"
+      },
+      "lifecycle_snapshot": {
+        "lifecycle_status": "rotated",
+        "revocation_reason": null,
+        "revoked_at": null,
+        "valid_from": "2026-04-01T00:00:00+00:00",
+        "valid_until": "2026-04-30T00:00:00+00:00",
+        "verifier_id": "veritas-human-approval-verifier-v1",
+        "verifier_key_id": "local-demo-verifier-key",
+        "verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
+        "verifier_policy_id": "human-approval-verifier-policy-v1"
+      },
+      "proof": {
+        "verified_at": "2026-04-26T00:00:00+00:00",
+        "verifier_id": "veritas-human-approval-verifier-v1",
+        "verifier_key_id": "local-demo-verifier-key",
+        "verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
+        "verifier_policy_id": "human-approval-verifier-policy-v1"
+      }
+    },
+    {
+      "case_id": "revoked_before_verification",
+      "expected_reasons": [
+        "reviewer_packet_verifier_revoked_before_verification"
+      ],
+      "lifecycle_snapshot": {
+        "lifecycle_status": "revoked",
+        "revocation_reason": "demo_compromise_drill",
+        "revoked_at": "2026-04-24T00:00:00+00:00",
+        "valid_from": "2026-04-01T00:00:00+00:00",
+        "valid_until": "2026-04-30T00:00:00+00:00",
+        "verifier_id": "veritas-human-approval-verifier-v1",
+        "verifier_key_id": "local-demo-verifier-key",
+        "verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
+        "verifier_policy_id": "human-approval-verifier-policy-v1"
+      },
+      "proof": {
+        "verified_at": "2026-04-26T00:00:00+00:00",
+        "verifier_id": "veritas-human-approval-verifier-v1",
+        "verifier_key_id": "local-demo-verifier-key",
+        "verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
+        "verifier_policy_id": "human-approval-verifier-policy-v1"
+      }
+    },
+    {
+      "case_id": "policy_hash_mismatch_after_rotation",
+      "expected_reasons": [
+        "reviewer_packet_verifier_lifecycle_key_mismatch",
+        "reviewer_packet_verifier_lifecycle_policy_hash_mismatch"
+      ],
+      "lifecycle_snapshot": {
+        "lifecycle_status": "active",
+        "revocation_reason": null,
+        "revoked_at": null,
+        "valid_from": "2026-04-01T00:00:00+00:00",
+        "valid_until": "2026-04-30T00:00:00+00:00",
+        "verifier_id": "veritas-human-approval-verifier-v1",
+        "verifier_key_id": "local-demo-verifier-key-rotated",
+        "verifier_policy_hash": "5c515f36ab1333a9473147536105919bfe420646b9393fb7f4d224f7c69ed0f0",
+        "verifier_policy_id": "human-approval-verifier-policy-v1"
+      },
+      "proof": {
+        "verified_at": "2026-04-26T00:00:00+00:00",
+        "verifier_id": "veritas-human-approval-verifier-v1",
+        "verifier_key_id": "local-demo-verifier-key",
+        "verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
+        "verifier_policy_id": "human-approval-verifier-policy-v1"
+      }
+    },
+    {
+      "case_id": "no_approval_required",
+      "expected_reasons": [],
+      "lifecycle_snapshot": null,
+      "proof": null
+    }
+  ],
+  "fixture_id": "human-approval-verifier-lifecycle-audit-v1",
+  "generated_at": "2026-04-26T00:00:00+00:00"
+}

--- a/docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json
+++ b/docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json
@@ -215,6 +215,12 @@
         "verifier_policy_id",
         "verifier_policy_hash",
         "verification_proof_hash",
+        "verifier_lifecycle_status",
+        "verifier_valid_from",
+        "verifier_valid_until",
+        "verifier_revoked_at",
+        "verifier_revocation_reason",
+        "verifier_lifecycle_policy_hash",
         "failure_reasons",
         "context_binding"
       ],
@@ -336,6 +342,46 @@
               ]
             }
           }
+        },
+        "verifier_lifecycle_status": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "active",
+            "rotated",
+            "revoked",
+            "expired",
+            null
+          ]
+        },
+        "verifier_valid_from": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "verifier_valid_until": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "verifier_revoked_at": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "verifier_revocation_reason": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "verifier_lifecycle_policy_hash": {
+          "$ref": "#/$defs/nullable_sha256_hex"
         }
       }
     },

--- a/scripts/demo/export_reviewer_evidence_packet.py
+++ b/scripts/demo/export_reviewer_evidence_packet.py
@@ -123,6 +123,18 @@ def _human_approval_summary(
         "verification_proof_hash": human_approval_state.get(
             "verification_proof_hash"
         ),
+        "verifier_lifecycle_status": human_approval_state.get(
+            "verifier_lifecycle_status"
+        ),
+        "verifier_valid_from": human_approval_state.get("verifier_valid_from"),
+        "verifier_valid_until": human_approval_state.get("verifier_valid_until"),
+        "verifier_revoked_at": human_approval_state.get("verifier_revoked_at"),
+        "verifier_revocation_reason": human_approval_state.get(
+            "verifier_revocation_reason"
+        ),
+        "verifier_lifecycle_policy_hash": human_approval_state.get(
+            "verifier_lifecycle_policy_hash"
+        ),
         "failure_reasons": list(human_approval_state.get("failure_reasons", [])),
         "context_binding": _human_approval_context_binding(
             human_approval_state, case

--- a/scripts/demo/saas_permission_change_governed_demo.py
+++ b/scripts/demo/saas_permission_change_governed_demo.py
@@ -28,6 +28,11 @@ from veritas_os.governance.authority_evidence_ingestion import (
     ingest_authority_evidence_payload,
 )
 from veritas_os.security.hash import sha256_of_canonical_json
+from scripts.demo.verifier_lifecycle_fixture import (
+    reviewer_packet_lifecycle_summary,
+    verifier_lifecycle_record,
+    verifier_policy_hash,
+)
 
 FIXED_NOW = datetime.fromisoformat("2026-04-26T00:00:00").replace(tzinfo=UTC)
 REQUESTED_SCOPE = ["saas:grant_admin"]
@@ -130,19 +135,7 @@ def _verified_human_approval_proof(
         "verifier_id": "veritas-human-approval-verifier-v1",
         "verifier_key_id": "local-demo-verifier-key",
         "verifier_policy_id": "human-approval-verifier-policy-v1",
-        "verifier_policy_hash": sha256_of_canonical_json(
-            {
-                "approved_human_approval_verifiers": [
-                    {
-                        "verifier_id": "veritas-human-approval-verifier-v1",
-                        "trust_level": "production",
-                        "verifier_key_id": "local-demo-verifier-key",
-                        "policy_id": "human-approval-verifier-policy-v1",
-                    }
-                ],
-                "fixture_only": True,
-            }
-        ),
+        "verifier_policy_hash": verifier_policy_hash(),
         "signed_at": finalized.approved_at,
         "verified_at": FIXED_NOW.isoformat(),
         "verification_source": VERIFICATION_SOURCE_SIGNED_ARTIFACT,
@@ -264,8 +257,11 @@ def _evaluate_case(
     verified_human_approval = None
     if receipt is not None and human_approval_state.get("approved"):
         verified_human_approval = _verified_human_approval_proof(receipt)
+        lifecycle_snapshot = verifier_lifecycle_record()
         human_approval_state.update(
             {
+                **reviewer_packet_lifecycle_summary(lifecycle_snapshot),
+                "verifier_lifecycle_snapshot": lifecycle_snapshot,
                 "verifier_id": verified_human_approval.verifier_id,
                 "verifier_key_id": verified_human_approval.verifier_key_id,
                 "verifier_policy_id": verified_human_approval.verifier_policy_id,
@@ -275,6 +271,9 @@ def _evaluate_case(
                 ),
             }
         )
+
+    if verified_human_approval is None:
+        human_approval_state.update(reviewer_packet_lifecycle_summary(None))
 
     outcome_receipt = build_outcome_receipt(
         decision_id="decision-saas-001",

--- a/scripts/demo/validate_reviewer_evidence_packet.py
+++ b/scripts/demo/validate_reviewer_evidence_packet.py
@@ -14,6 +14,9 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from scripts.demo.verifier_lifecycle_fixture import (  # noqa: E402
+    validate_human_approval_verifier_lifecycle_snapshot,
+)
 from scripts.demo.export_reviewer_evidence_packet import (  # noqa: E402
     BOUNDARY_NOTE,
     PACKET_ID,
@@ -116,6 +119,9 @@ FAILURE_REASON_BY_CHECK = {
     "no_mismatched_links_in_demo": "demo_mismatched_links_present",
     "approval_proof_continuity_valid": (
         "reviewer_packet_human_approval_proof_continuity_invalid"
+    ),
+    "verifier_lifecycle_snapshots_valid": (
+        "reviewer_packet_verifier_lifecycle_invalid"
     ),
     "local_offline_boundary_present": "local_offline_boundary_missing",
 }
@@ -436,6 +442,63 @@ def _approval_proof_continuity_valid(packet: dict[str, Any]) -> bool:
     return not _approval_proof_continuity_reasons(packet)
 
 
+
+def _case_verifier_lifecycle_reasons(case: dict[str, Any]) -> list[str]:
+    """Return verifier lifecycle validation reasons for one packet case."""
+    summary = case.get("human_approval_summary", {})
+    if not isinstance(summary, dict):
+        return []
+    if not summary.get("verification_proof_hash"):
+        return []
+    proof = {
+        "verifier_id": summary.get("verifier_id"),
+        "verifier_key_id": summary.get("verifier_key_id"),
+        "verifier_policy_id": summary.get("verifier_policy_id"),
+        "verifier_policy_hash": summary.get("verifier_policy_hash"),
+        "verified_at": case.get("evidence_chain_verification_summary", {}).get(
+            "verified_at"
+        ),
+    }
+    if not summary.get("verifier_lifecycle_status"):
+        lifecycle_snapshot = None
+    else:
+        lifecycle_snapshot = {
+            "verifier_id": summary.get("verifier_id"),
+            "verifier_key_id": summary.get("verifier_key_id"),
+            "verifier_policy_id": summary.get("verifier_policy_id"),
+            "verifier_policy_hash": summary.get("verifier_lifecycle_policy_hash"),
+            "valid_from": summary.get("verifier_valid_from"),
+            "valid_until": summary.get("verifier_valid_until"),
+            "revoked_at": summary.get("verifier_revoked_at"),
+            "revocation_reason": summary.get("verifier_revocation_reason"),
+            "lifecycle_status": summary.get("verifier_lifecycle_status"),
+        }
+    return validate_human_approval_verifier_lifecycle_snapshot(
+        proof=proof,
+        lifecycle_snapshot=lifecycle_snapshot,
+    )
+
+
+def _verifier_lifecycle_reasons(packet: dict[str, Any]) -> list[str]:
+    """Return deterministic verifier lifecycle reasons for all cases."""
+    cases = packet.get("cases")
+    if not isinstance(cases, list):
+        return ["required_case_fields_missing"]
+    reasons: list[str] = []
+    for case in cases:
+        if not isinstance(case, dict):
+            reasons.append("required_case_fields_missing")
+            continue
+        for reason in _case_verifier_lifecycle_reasons(case):
+            if reason not in reasons:
+                reasons.append(reason)
+    return reasons
+
+
+def _verifier_lifecycle_snapshots_valid(packet: dict[str, Any]) -> bool:
+    """Return whether proof-bearing cases have valid lifecycle snapshots."""
+    return not _verifier_lifecycle_reasons(packet)
+
 def _local_offline_boundary_present(packet: dict[str, Any]) -> bool:
     """Return whether packet-level local/offline boundary markers are present."""
     boundary_note = packet.get("boundary_note")
@@ -492,6 +555,15 @@ def _build_checks(
         "approval_proof_continuity_valid": _approval_proof_continuity_valid(
             generated_packet
         ),
+        "approval_proof_continuity_reasons": (
+            _approval_proof_continuity_reasons(generated_packet)
+        ),
+        "verifier_lifecycle_snapshots_valid": (
+            _verifier_lifecycle_snapshots_valid(generated_packet)
+        ),
+        "verifier_lifecycle_reasons": _verifier_lifecycle_reasons(
+            generated_packet
+        ),
         "local_offline_boundary_present": _local_offline_boundary_present(
             generated_packet
         ),
@@ -509,6 +581,9 @@ def _failure_reasons(checks: dict[str, Any]) -> list[str]:
         if failed:
             reasons.append(reason)
     for reason in checks.get("approval_proof_continuity_reasons", []):
+        if reason not in reasons:
+            reasons.append(reason)
+    for reason in checks.get("verifier_lifecycle_reasons", []):
         if reason not in reasons:
             reasons.append(reason)
     return reasons

--- a/scripts/demo/verifier_lifecycle_fixture.py
+++ b/scripts/demo/verifier_lifecycle_fixture.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Deterministic verifier lifecycle fixtures for reviewer packet audits."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from veritas_os.security.hash import sha256_of_canonical_json
+
+VERIFIER_ID = "veritas-human-approval-verifier-v1"
+VERIFIER_KEY_ID = "local-demo-verifier-key"
+VERIFIER_POLICY_ID = "human-approval-verifier-policy-v1"
+ROTATED_KEY_ID = "local-demo-verifier-key-rotated"
+ROTATED_POLICY_ID = "human-approval-verifier-policy-v2"
+VALID_FROM = "2026-04-01T00:00:00+00:00"
+VALID_UNTIL = "2026-04-30T00:00:00+00:00"
+ROTATED_AT = "2026-05-01T00:00:00+00:00"
+REVOKED_AT = "2026-04-24T00:00:00+00:00"
+
+
+def verifier_policy_hash(
+    *,
+    verifier_id: str = VERIFIER_ID,
+    verifier_key_id: str = VERIFIER_KEY_ID,
+    verifier_policy_id: str = VERIFIER_POLICY_ID,
+) -> str:
+    """Return the deterministic demo verifier policy hash."""
+    return sha256_of_canonical_json(
+        {
+            "approved_human_approval_verifiers": [
+                {
+                    "verifier_id": verifier_id,
+                    "trust_level": "production",
+                    "verifier_key_id": verifier_key_id,
+                    "policy_id": verifier_policy_id,
+                }
+            ],
+            "fixture_only": True,
+        }
+    )
+
+
+def verifier_lifecycle_record(
+    *,
+    lifecycle_status: str = "rotated",
+    verifier_id: str = VERIFIER_ID,
+    verifier_key_id: str = VERIFIER_KEY_ID,
+    verifier_policy_id: str = VERIFIER_POLICY_ID,
+    verifier_policy_hash_value: str | None = None,
+    valid_from: str = VALID_FROM,
+    valid_until: str | None = VALID_UNTIL,
+    revoked_at: str | None = None,
+    revocation_reason: str | None = None,
+) -> dict[str, Any]:
+    """Build one reviewer-facing verifier lifecycle snapshot record."""
+    policy_hash = verifier_policy_hash_value or verifier_policy_hash(
+        verifier_id=verifier_id,
+        verifier_key_id=verifier_key_id,
+        verifier_policy_id=verifier_policy_id,
+    )
+    return {
+        "verifier_id": verifier_id,
+        "verifier_key_id": verifier_key_id,
+        "verifier_policy_id": verifier_policy_id,
+        "verifier_policy_hash": policy_hash,
+        "valid_from": valid_from,
+        "valid_until": valid_until,
+        "revoked_at": revoked_at,
+        "revocation_reason": revocation_reason,
+        "lifecycle_status": lifecycle_status,
+    }
+
+
+def reviewer_packet_lifecycle_summary(
+    record: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Return the compact lifecycle section exposed in reviewer packets."""
+    if record is None:
+        return {
+            "verifier_lifecycle_status": None,
+            "verifier_valid_from": None,
+            "verifier_valid_until": None,
+            "verifier_revoked_at": None,
+            "verifier_revocation_reason": None,
+            "verifier_lifecycle_policy_hash": None,
+        }
+    return {
+        "verifier_lifecycle_status": record.get("lifecycle_status"),
+        "verifier_valid_from": record.get("valid_from"),
+        "verifier_valid_until": record.get("valid_until"),
+        "verifier_revoked_at": record.get("revoked_at"),
+        "verifier_revocation_reason": record.get("revocation_reason"),
+        "verifier_lifecycle_policy_hash": record.get("verifier_policy_hash"),
+    }
+
+
+def _parse_timestamp(value: str | None) -> datetime | None:
+    if value is None:
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def validate_human_approval_verifier_lifecycle_snapshot(
+    *,
+    proof: dict[str, Any] | None,
+    lifecycle_snapshot: dict[str, Any] | None,
+) -> list[str]:
+    """Validate a proof against its deterministic reviewer lifecycle snapshot.
+
+    This helper is intentionally local/offline fixture logic, not production key
+    management. It preserves reviewer auditability for historical approvals by
+    checking verifier identity, key, policy, policy hash, validity window, and
+    revocation time as they were captured in the reviewer-facing artifacts.
+    """
+    if not proof:
+        return []
+    if lifecycle_snapshot is None:
+        return ["reviewer_packet_verifier_lifecycle_missing"]
+
+    reasons: list[str] = []
+    if proof.get("verifier_id") != lifecycle_snapshot.get("verifier_id"):
+        reasons.append("reviewer_packet_verifier_lifecycle_id_mismatch")
+    proof_key_id = proof.get("verifier_key_id")
+    if proof_key_id and proof_key_id != lifecycle_snapshot.get("verifier_key_id"):
+        reasons.append("reviewer_packet_verifier_lifecycle_key_mismatch")
+    if proof.get("verifier_policy_id") != lifecycle_snapshot.get(
+        "verifier_policy_id"
+    ):
+        reasons.append("reviewer_packet_verifier_lifecycle_policy_id_mismatch")
+    if proof.get("verifier_policy_hash") != lifecycle_snapshot.get(
+        "verifier_policy_hash"
+    ):
+        reasons.append("reviewer_packet_verifier_lifecycle_policy_hash_mismatch")
+
+    proof_time = _parse_timestamp(
+        proof.get("verified_at") or proof.get("approved_at")
+    )
+    valid_from = _parse_timestamp(lifecycle_snapshot.get("valid_from"))
+    valid_until = _parse_timestamp(lifecycle_snapshot.get("valid_until"))
+    revoked_at = _parse_timestamp(lifecycle_snapshot.get("revoked_at"))
+    if (
+        proof_time is not None
+        and valid_from is not None
+        and proof_time < valid_from
+    ):
+        reasons.append("reviewer_packet_verifier_not_yet_valid")
+    if (
+        proof_time is not None
+        and valid_until is not None
+        and proof_time > valid_until
+    ):
+        reasons.append("reviewer_packet_verifier_expired_before_verification")
+    if (
+        proof_time is not None
+        and revoked_at is not None
+        and proof_time >= revoked_at
+    ):
+        reasons.append("reviewer_packet_verifier_revoked_before_verification")
+    return reasons
+
+
+def demo_lifecycle_audit_fixtures() -> dict[str, Any]:
+    """Return deterministic verifier lifecycle audit fixture cases."""
+    active_record = verifier_lifecycle_record()
+    proof = {
+        "verifier_id": VERIFIER_ID,
+        "verifier_key_id": VERIFIER_KEY_ID,
+        "verifier_policy_id": VERIFIER_POLICY_ID,
+        "verifier_policy_hash": active_record["verifier_policy_hash"],
+        "verified_at": "2026-04-26T00:00:00+00:00",
+    }
+    rotated_hash = verifier_policy_hash(
+        verifier_key_id=ROTATED_KEY_ID,
+        verifier_policy_id=ROTATED_POLICY_ID,
+    )
+    return {
+        "fixture_id": "human-approval-verifier-lifecycle-audit-v1",
+        "generated_at": "2026-04-26T00:00:00+00:00",
+        "cases": [
+            {
+                "case_id": "valid_at_verification_time",
+                "proof": proof,
+                "lifecycle_snapshot": active_record,
+                "later_lifecycle_event": {
+                    "event_type": "rotated",
+                    "rotated_at": ROTATED_AT,
+                    "verifier_key_id": ROTATED_KEY_ID,
+                    "verifier_policy_id": ROTATED_POLICY_ID,
+                    "verifier_policy_hash": rotated_hash,
+                },
+                "expected_reasons": [],
+            },
+            {
+                "case_id": "revoked_before_verification",
+                "proof": proof,
+                "lifecycle_snapshot": verifier_lifecycle_record(
+                    lifecycle_status="revoked",
+                    revoked_at=REVOKED_AT,
+                    revocation_reason="demo_compromise_drill",
+                ),
+                "expected_reasons": [
+                    "reviewer_packet_verifier_revoked_before_verification"
+                ],
+            },
+            {
+                "case_id": "policy_hash_mismatch_after_rotation",
+                "proof": proof,
+                "lifecycle_snapshot": verifier_lifecycle_record(
+                    lifecycle_status="active",
+                    verifier_key_id=ROTATED_KEY_ID,
+                    verifier_policy_id=VERIFIER_POLICY_ID,
+                    verifier_policy_hash_value=rotated_hash,
+                ),
+                "expected_reasons": [
+                    "reviewer_packet_verifier_lifecycle_key_mismatch",
+                    "reviewer_packet_verifier_lifecycle_policy_hash_mismatch",
+                ],
+            },
+            {
+                "case_id": "no_approval_required",
+                "proof": None,
+                "lifecycle_snapshot": None,
+                "expected_reasons": [],
+            },
+        ],
+    }

--- a/tests/demo/test_reviewer_verifier_lifecycle_fixture.py
+++ b/tests/demo/test_reviewer_verifier_lifecycle_fixture.py
@@ -1,0 +1,142 @@
+"""Tests for deterministic reviewer verifier lifecycle audit fixtures."""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.demo.export_reviewer_evidence_packet import build_reviewer_evidence_packet
+from scripts.demo.validate_reviewer_evidence_packet import (
+    _case_verifier_lifecycle_reasons,
+)
+from scripts.demo.verifier_lifecycle_fixture import (
+    demo_lifecycle_audit_fixtures,
+    validate_human_approval_verifier_lifecycle_snapshot,
+    verifier_lifecycle_record,
+)
+
+FIXTURE_PATH = Path(
+    "docs/en/demo/fixtures/verifier-lifecycle-audit-fixtures-v1.json"
+)
+
+
+def _case(case_id: str) -> dict[str, Any]:
+    fixtures = demo_lifecycle_audit_fixtures()
+    return next(case for case in fixtures["cases"] if case["case_id"] == case_id)
+
+
+@pytest.mark.parametrize(
+    ("case_id", "expected_reasons"),
+    [
+        ("valid_at_verification_time", []),
+        (
+            "revoked_before_verification",
+            ["reviewer_packet_verifier_revoked_before_verification"],
+        ),
+        (
+            "policy_hash_mismatch_after_rotation",
+            [
+                "reviewer_packet_verifier_lifecycle_key_mismatch",
+                "reviewer_packet_verifier_lifecycle_policy_hash_mismatch",
+            ],
+        ),
+        ("no_approval_required", []),
+    ],
+)
+def test_lifecycle_fixture_cases_validate_deterministically(
+    case_id: str,
+    expected_reasons: list[str],
+) -> None:
+    case = _case(case_id)
+
+    assert validate_human_approval_verifier_lifecycle_snapshot(
+        proof=case["proof"],
+        lifecycle_snapshot=case["lifecycle_snapshot"],
+    ) == expected_reasons
+
+
+def test_expired_before_verification_fails() -> None:
+    case = _case("valid_at_verification_time")
+    expired_snapshot = verifier_lifecycle_record(
+        lifecycle_status="expired",
+        valid_until="2026-04-25T00:00:00+00:00",
+    )
+
+    assert validate_human_approval_verifier_lifecycle_snapshot(
+        proof=case["proof"],
+        lifecycle_snapshot=expired_snapshot,
+    ) == ["reviewer_packet_verifier_expired_before_verification"]
+
+
+def test_missing_lifecycle_snapshot_fails_only_when_approval_proof_is_present() -> None:
+    case = _case("valid_at_verification_time")
+
+    assert validate_human_approval_verifier_lifecycle_snapshot(
+        proof=case["proof"],
+        lifecycle_snapshot=None,
+    ) == ["reviewer_packet_verifier_lifecycle_missing"]
+    assert validate_human_approval_verifier_lifecycle_snapshot(
+        proof=None,
+        lifecycle_snapshot=None,
+    ) == []
+
+
+def test_reviewer_packet_exposes_valid_lifecycle_for_historical_rotation() -> None:
+    packet = build_reviewer_evidence_packet()
+    valid_case = next(
+        case
+        for case in packet["cases"]
+        if case["case_id"] == "valid_authority_and_approval"
+    )
+    summary = valid_case["human_approval_summary"]
+
+    assert summary["verifier_lifecycle_status"] == "rotated"
+    assert summary["verifier_valid_from"] == "2026-04-01T00:00:00+00:00"
+    assert summary["verifier_valid_until"] == "2026-04-30T00:00:00+00:00"
+    assert summary["verifier_revoked_at"] is None
+    assert (
+        summary["verifier_lifecycle_policy_hash"]
+        == summary["verifier_policy_hash"]
+    )
+    assert _case_verifier_lifecycle_reasons(valid_case) == []
+
+
+def test_reviewer_packet_policy_hash_mismatch_fails_closed() -> None:
+    packet = build_reviewer_evidence_packet()
+    valid_case = copy.deepcopy(
+        next(
+            case
+            for case in packet["cases"]
+            if case["case_id"] == "valid_authority_and_approval"
+        )
+    )
+    valid_case["human_approval_summary"][
+        "verifier_lifecycle_policy_hash"
+    ] = "0" * 64
+
+    assert _case_verifier_lifecycle_reasons(valid_case) == [
+        "reviewer_packet_verifier_lifecycle_policy_hash_mismatch"
+    ]
+
+
+def test_no_approval_required_path_does_not_require_lifecycle_snapshot() -> None:
+    packet = build_reviewer_evidence_packet()
+    no_approval_case = next(
+        case for case in packet["cases"] if case["case_id"] == "missing_human_approval"
+    )
+
+    assert (
+        no_approval_case["human_approval_summary"]["verification_proof_hash"]
+        is None
+    )
+    assert _case_verifier_lifecycle_reasons(no_approval_case) == []
+
+
+def test_lifecycle_fixture_file_matches_generated_fixture() -> None:
+    assert json.loads(FIXTURE_PATH.read_text(encoding="utf-8")) == (
+        demo_lifecycle_audit_fixtures()
+    )


### PR DESCRIPTION
### Motivation
- Provide deterministic, reviewer-facing evidence about verifier lifecycle (rotation, revocation, expiration) so reviewers can determine whether a Human Approval verifier was valid at the time of verification.
- Keep this lightweight and offline/demo-only (no KMS/HSM, no external revocation service, no production allowlist changes) while improving auditability and reviewer packets.
- Preserve existing approval-proof continuity checks while adding lifecycle-aware failure reasons for reviewer validation.

### Description
- Add a deterministic verifier lifecycle fixture and helper functions in `scripts/demo/verifier_lifecycle_fixture.py` that model `verifier_id`, `verifier_key_id`, `verifier_policy_id`, `verifier_policy_hash`, `valid_from`, `valid_until`, `revoked_at`, `revocation_reason`, and `lifecycle_status`, and expose `validate_human_approval_verifier_lifecycle_snapshot(...)` with deterministic failure reasons.
- Add demo audit fixtures at `docs/en/demo/fixtures/verifier-lifecycle-audit-fixtures-v1.json` covering `valid_at_verification_time`, `revoked_before_verification`, `policy_hash_mismatch_after_rotation`, and `no_approval_required` scenarios.
- Expose compact lifecycle summary fields in reviewer packets and add a detailed `verifier_lifecycle_snapshot` for approved cases by updating `scripts/demo/saas_permission_change_governed_demo.py` and `scripts/demo/export_reviewer_evidence_packet.py` (fields: `verifier_lifecycle_status`, `verifier_valid_from`, `verifier_valid_until`, `verifier_revoked_at`, `verifier_revocation_reason`, `verifier_lifecycle_policy_hash`).
- Extend offline reviewer validation in `scripts/demo/validate_reviewer_evidence_packet.py` to call lifecycle validation and to surface lifecycle failure reasons as deterministic failure codes, without changing existing verifier-proof continuity fields.
- Add regression/unit tests in `tests/demo/test_reviewer_verifier_lifecycle_fixture.py` that assert correct pass/fail behaviour for historical rotation, revoked-before-verification, expired-before-verification, policy-hash mismatch, missing snapshot semantics, and the no-approval path.

### Testing
- Ran `python -m py_compile` on the new/modified demo and test modules to ensure syntax validity under supported interpreters, which succeeded.
- Ran the demo unit test subset with a local YAML stub to avoid external network installs using `PYTHONPATH=/tmp/veritas_stub:$PYTHONPATH PYENV_VERSION=3.11.15 python -m pytest tests/demo/test_reviewer_verifier_lifecycle_fixture.py tests/demo/test_reviewer_evidence_packet_validation_report.py tests/demo/test_reviewer_verifier_policy_snapshot_continuity.py` and observed `43 passed, 1 warning`.
- Executed the demo validator `scripts/demo/validate_reviewer_evidence_packet.py` against the generated fixture and observed a `pass` validation report with no failure reasons.
- Note: an initial test collection run failed due to the local environment missing `PyYAML`; this was addressed for deterministic demo execution by using a local stub for YAML parsing during test runs and validation.

Security note: these changes introduce deterministic demo/audit artifacts only and do not add key management, external revocation, secret handling, or change production allowlist behavior; reviewers should not treat fixtures as production trust roots.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e01e112688326aa052a24f6f61081)