### PR TITLE
Add verifier lifecycle snapshot hash continuity

### DIFF
--- a/docs/en/demo/examples/context-bound-approval-replay-prevention-v1.json
+++ b/docs/en/demo/examples/context-bound-approval-replay-prevention-v1.json
@@ -36,7 +36,7 @@
         "human_approval_verifier_key_id": "local-demo-verifier-key",
         "human_approval_verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
         "human_approval_verifier_policy_id": "human-approval-verifier-policy-v1",
-        "manifest_hash": "ec3ea1e78def9c3d5f24869b0c371d87a682955a7ba051d13255caef2396edf9",
+        "manifest_hash": "abdeea27ee17193835115426219c172d4074a97c50954bf74f59022506c4fd40",
         "manifest_id": "manifest-valid_same_context",
         "metadata": {
           "signature_validity_alone_is_insufficient": true
@@ -44,7 +44,7 @@
         "missing_links": [],
         "observed_effects_summary": [],
         "operation_id": "operation-valid_same_context",
-        "outcome_receipt_hash": "3b30184cfee6dba9d26da3e5f3431a518c3da27d30b0709099a712b359090a36",
+        "outcome_receipt_hash": "6f99cb13661b325565519e428cbf09b762d3d3921b5aa1717e4bb53193565348",
         "outcome_receipt_id": "outcome-valid_same_context",
         "refusal_basis": [],
         "requested_scope": [
@@ -67,7 +67,7 @@
         "mismatched_links": [],
         "missing_links": [],
         "operation_id": "operation-valid_same_context",
-        "recomputed_manifest_hash": "ec3ea1e78def9c3d5f24869b0c371d87a682955a7ba051d13255caef2396edf9",
+        "recomputed_manifest_hash": "abdeea27ee17193835115426219c172d4074a97c50954bf74f59022506c4fd40",
         "verification_status": "verified",
         "verified_at": "2026-05-10T00:00:00+00:00",
         "verified_links": [
@@ -127,7 +127,7 @@
         },
         "observed_effects": [],
         "operation_id": "operation-valid_same_context",
-        "outcome_hash": "3b30184cfee6dba9d26da3e5f3431a518c3da27d30b0709099a712b359090a36",
+        "outcome_hash": "6f99cb13661b325565519e428cbf09b762d3d3921b5aa1717e4bb53193565348",
         "outcome_receipt_id": "outcome-valid_same_context",
         "postcondition_status": "passed",
         "requested_scope": [
@@ -151,6 +151,7 @@
         "verifier_id": "veritas-human-approval-verifier-v1",
         "verifier_key_id": "local-demo-verifier-key",
         "verifier_lifecycle_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
+        "verifier_lifecycle_snapshot_hash": "f48b71ec17e99dbf4785defcd6a7f2de3a51333adcb47c5739a81a969f7430fa",
         "verifier_lifecycle_status": "rotated",
         "verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
         "verifier_policy_id": "human-approval-verifier-policy-v1",
@@ -184,7 +185,7 @@
         "human_approval_verifier_key_id": null,
         "human_approval_verifier_policy_hash": null,
         "human_approval_verifier_policy_id": null,
-        "manifest_hash": "e945dd62aadf843adee7aceffbc5d6f0c0e2b8df248ffd4bbf2d57734e598fbf",
+        "manifest_hash": "78f2eb2def66fc1ef2c248be23e96a610e83a64e1a3a2018ff9d2a259671b543",
         "manifest_id": "manifest-replay_different_request_ref",
         "metadata": {
           "signature_validity_alone_is_insufficient": true
@@ -221,7 +222,7 @@
         ],
         "missing_links": [],
         "operation_id": "operation-replay_different_request_ref",
-        "recomputed_manifest_hash": "e945dd62aadf843adee7aceffbc5d6f0c0e2b8df248ffd4bbf2d57734e598fbf",
+        "recomputed_manifest_hash": "78f2eb2def66fc1ef2c248be23e96a610e83a64e1a3a2018ff9d2a259671b543",
         "verification_status": "failed",
         "verified_at": "2026-05-10T00:00:00+00:00",
         "verified_links": [
@@ -326,7 +327,7 @@
         "human_approval_verifier_key_id": null,
         "human_approval_verifier_policy_hash": null,
         "human_approval_verifier_policy_id": null,
-        "manifest_hash": "459fabb0620270130ea9eb34b1dadcddd4751b9b17d36abc3e8767ca64e05fee",
+        "manifest_hash": "ffe687e6cb23e6f23e3bef24bfd50cff17b6a1336bea03cf3b0bbe871d325840",
         "manifest_id": "manifest-replay_different_action_class",
         "metadata": {
           "signature_validity_alone_is_insufficient": true
@@ -363,7 +364,7 @@
         ],
         "missing_links": [],
         "operation_id": "operation-replay_different_action_class",
-        "recomputed_manifest_hash": "459fabb0620270130ea9eb34b1dadcddd4751b9b17d36abc3e8767ca64e05fee",
+        "recomputed_manifest_hash": "ffe687e6cb23e6f23e3bef24bfd50cff17b6a1336bea03cf3b0bbe871d325840",
         "verification_status": "failed",
         "verified_at": "2026-05-10T00:00:00+00:00",
         "verified_links": [
@@ -468,7 +469,7 @@
         "human_approval_verifier_key_id": null,
         "human_approval_verifier_policy_hash": null,
         "human_approval_verifier_policy_id": null,
-        "manifest_hash": "3c7ff11156413f169003a961375aba601daf95ff34206ce1758f8f440e7f00ee",
+        "manifest_hash": "08e9d65f926a930af825dd00b0f75fd1ee7cd7748bddc781cc05ac2d339ee2c0",
         "manifest_id": "manifest-replay_different_bind_context_hash",
         "metadata": {
           "signature_validity_alone_is_insufficient": true
@@ -505,7 +506,7 @@
         ],
         "missing_links": [],
         "operation_id": "operation-replay_different_bind_context_hash",
-        "recomputed_manifest_hash": "3c7ff11156413f169003a961375aba601daf95ff34206ce1758f8f440e7f00ee",
+        "recomputed_manifest_hash": "08e9d65f926a930af825dd00b0f75fd1ee7cd7748bddc781cc05ac2d339ee2c0",
         "verification_status": "failed",
         "verified_at": "2026-05-10T00:00:00+00:00",
         "verified_links": [
@@ -590,7 +591,7 @@
   "demo_id": "context-bound-approval-replay-prevention-v1",
   "generated_at": "2026-05-10T00:00:00+00:00",
   "local_offline_only": true,
-  "packet_hash": "cd6922218a3d716632f6ab0f69ab34e7238b61e14dee504e69c6e6ca69059d36",
+  "packet_hash": "08de1927366a5a09ba72fd233df86ed63bc2fc7e8b4fd27fb48497e4424e2680",
   "packet_id": "reviewer-evidence-packet-approval-replay-prevention-v1",
   "packet_version": "v1",
   "reviewer_notes": [

--- a/docs/en/demo/examples/evaluation-governance-chain-reviewer-packet-v1/reviewer-evidence-packet.generated.example.json
+++ b/docs/en/demo/examples/evaluation-governance-chain-reviewer-packet-v1/reviewer-evidence-packet.generated.example.json
@@ -181,6 +181,7 @@
         "verifier_id": "veritas-human-approval-verifier-v1",
         "verifier_key_id": "local-demo-verifier-key",
         "verifier_lifecycle_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
+        "verifier_lifecycle_snapshot_hash": "f48b71ec17e99dbf4785defcd6a7f2de3a51333adcb47c5739a81a969f7430fa",
         "verifier_lifecycle_status": "rotated",
         "verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
         "verifier_policy_id": "human-approval-verifier-policy-v1",
@@ -808,6 +809,7 @@
         "verifier_id": "veritas-human-approval-verifier-v1",
         "verifier_key_id": "local-demo-verifier-key",
         "verifier_lifecycle_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
+        "verifier_lifecycle_snapshot_hash": "f48b71ec17e99dbf4785defcd6a7f2de3a51333adcb47c5739a81a969f7430fa",
         "verifier_lifecycle_status": "rotated",
         "verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
         "verifier_policy_id": "human-approval-verifier-policy-v1",
@@ -908,7 +910,7 @@
     }
   },
   "local_offline_only": true,
-  "packet_hash": "150a81b7300f964bb60ed7f5213fff3c5e04feeb326662404d61e0b78d00fd51",
+  "packet_hash": "2622e0c2a729a9a9755fd3a232a4b11bc514b4122ce92c753bbcd9baa5d98205",
   "packet_id": "reviewer-evidence-packet-saas-permission-change-v1",
   "packet_version": "v1",
   "reviewer_notes": [

--- a/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated/demo-summary.generated.example.json
+++ b/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated/demo-summary.generated.example.json
@@ -38,7 +38,7 @@
       "artifact_type": "chain_manifest"
     },
     {
-      "artifact_hash": "6e4ece8c11cd2aeb06b205abff9dcf18659244e5fd98a9b6c087414caac3bfa8",
+      "artifact_hash": "e0107c5be4e3208ee8bbd8f9a8bd4117258e221e3d09d46eeb1d78f98764d06c",
       "artifact_ref": "reviewer-evidence-packet.generated.example.json",
       "artifact_type": "reviewer_evidence_packet"
     }

--- a/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated/reviewer-evidence-packet.generated.example.json
+++ b/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated/reviewer-evidence-packet.generated.example.json
@@ -181,6 +181,7 @@
         "verifier_id": "veritas-human-approval-verifier-v1",
         "verifier_key_id": "local-demo-verifier-key",
         "verifier_lifecycle_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
+        "verifier_lifecycle_snapshot_hash": "f48b71ec17e99dbf4785defcd6a7f2de3a51333adcb47c5739a81a969f7430fa",
         "verifier_lifecycle_status": "rotated",
         "verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
         "verifier_policy_id": "human-approval-verifier-policy-v1",
@@ -808,6 +809,7 @@
         "verifier_id": "veritas-human-approval-verifier-v1",
         "verifier_key_id": "local-demo-verifier-key",
         "verifier_lifecycle_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
+        "verifier_lifecycle_snapshot_hash": "f48b71ec17e99dbf4785defcd6a7f2de3a51333adcb47c5739a81a969f7430fa",
         "verifier_lifecycle_status": "rotated",
         "verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
         "verifier_policy_id": "human-approval-verifier-policy-v1",
@@ -908,7 +910,7 @@
     }
   },
   "local_offline_only": true,
-  "packet_hash": "150a81b7300f964bb60ed7f5213fff3c5e04feeb326662404d61e0b78d00fd51",
+  "packet_hash": "2622e0c2a729a9a9755fd3a232a4b11bc514b4122ce92c753bbcd9baa5d98205",
   "packet_id": "reviewer-evidence-packet-saas-permission-change-v1",
   "packet_version": "v1",
   "reviewer_notes": [

--- a/docs/en/demo/examples/reviewer-evidence-packet-with-evaluation-governance-v1.json
+++ b/docs/en/demo/examples/reviewer-evidence-packet-with-evaluation-governance-v1.json
@@ -181,6 +181,7 @@
         "verifier_id": "veritas-human-approval-verifier-v1",
         "verifier_key_id": "local-demo-verifier-key",
         "verifier_lifecycle_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
+        "verifier_lifecycle_snapshot_hash": "f48b71ec17e99dbf4785defcd6a7f2de3a51333adcb47c5739a81a969f7430fa",
         "verifier_lifecycle_status": "rotated",
         "verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
         "verifier_policy_id": "human-approval-verifier-policy-v1",
@@ -808,6 +809,7 @@
         "verifier_id": "veritas-human-approval-verifier-v1",
         "verifier_key_id": "local-demo-verifier-key",
         "verifier_lifecycle_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
+        "verifier_lifecycle_snapshot_hash": "f48b71ec17e99dbf4785defcd6a7f2de3a51333adcb47c5739a81a969f7430fa",
         "verifier_lifecycle_status": "rotated",
         "verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
         "verifier_policy_id": "human-approval-verifier-policy-v1",
@@ -908,7 +910,7 @@
     }
   },
   "local_offline_only": true,
-  "packet_hash": "150a81b7300f964bb60ed7f5213fff3c5e04feeb326662404d61e0b78d00fd51",
+  "packet_hash": "2622e0c2a729a9a9755fd3a232a4b11bc514b4122ce92c753bbcd9baa5d98205",
   "packet_id": "reviewer-evidence-packet-saas-permission-change-v1",
   "packet_version": "v1",
   "reviewer_notes": [

--- a/docs/en/demo/fixtures/reviewer-evidence-packet-decision-candidate-refusal-v1.json
+++ b/docs/en/demo/fixtures/reviewer-evidence-packet-decision-candidate-refusal-v1.json
@@ -181,6 +181,7 @@
         "verifier_id": "veritas-human-approval-verifier-v1",
         "verifier_key_id": "local-demo-verifier-key",
         "verifier_lifecycle_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
+        "verifier_lifecycle_snapshot_hash": "f48b71ec17e99dbf4785defcd6a7f2de3a51333adcb47c5739a81a969f7430fa",
         "verifier_lifecycle_status": "rotated",
         "verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
         "verifier_policy_id": "human-approval-verifier-policy-v1",
@@ -808,6 +809,7 @@
         "verifier_id": "veritas-human-approval-verifier-v1",
         "verifier_key_id": "local-demo-verifier-key",
         "verifier_lifecycle_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
+        "verifier_lifecycle_snapshot_hash": "f48b71ec17e99dbf4785defcd6a7f2de3a51333adcb47c5739a81a969f7430fa",
         "verifier_lifecycle_status": "rotated",
         "verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
         "verifier_policy_id": "human-approval-verifier-policy-v1",
@@ -868,7 +870,7 @@
     }
   },
   "local_offline_only": true,
-  "packet_hash": "fb2068e78b119139de8c919c836b1fb13345fa0731e4be5026a087358935463b",
+  "packet_hash": "1990eecea8d17d26b1eddbb819a64bbd176a2e84daa8016626f9c1b277eb0cfe",
   "packet_id": "reviewer-evidence-packet-decision-candidate-refusal-v1",
   "packet_version": "v1",
   "reviewer_notes": [

--- a/docs/en/demo/fixtures/reviewer-evidence-packet-saas-permission-change-v1.json
+++ b/docs/en/demo/fixtures/reviewer-evidence-packet-saas-permission-change-v1.json
@@ -181,6 +181,7 @@
         "verifier_id": "veritas-human-approval-verifier-v1",
         "verifier_key_id": "local-demo-verifier-key",
         "verifier_lifecycle_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
+        "verifier_lifecycle_snapshot_hash": "f48b71ec17e99dbf4785defcd6a7f2de3a51333adcb47c5739a81a969f7430fa",
         "verifier_lifecycle_status": "rotated",
         "verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
         "verifier_policy_id": "human-approval-verifier-policy-v1",
@@ -808,6 +809,7 @@
         "verifier_id": "veritas-human-approval-verifier-v1",
         "verifier_key_id": "local-demo-verifier-key",
         "verifier_lifecycle_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
+        "verifier_lifecycle_snapshot_hash": "f48b71ec17e99dbf4785defcd6a7f2de3a51333adcb47c5739a81a969f7430fa",
         "verifier_lifecycle_status": "rotated",
         "verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
         "verifier_policy_id": "human-approval-verifier-policy-v1",
@@ -836,7 +838,7 @@
     }
   },
   "local_offline_only": true,
-  "packet_hash": "37060999d4a4d934999f78208eb12333b4eba6c8a7c92f62b039ebe42c5ab252",
+  "packet_hash": "a2783c7eeaddad468a5fd5e1209d56b812bdc4e3796f4366de62fa54a1335163",
   "packet_id": "reviewer-evidence-packet-saas-permission-change-v1",
   "packet_version": "v1",
   "reviewer_notes": [

--- a/docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json
+++ b/docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json
@@ -1029,6 +1029,7 @@
             "verifier_revoked_at",
             "verifier_revocation_reason",
             "verifier_lifecycle_policy_hash",
+            "verifier_lifecycle_snapshot_hash",
             "failure_reasons"
           ],
           "properties": {
@@ -1080,6 +1081,9 @@
               ]
             },
             "verifier_lifecycle_policy_hash": {
+              "$ref": "#/$defs/sha256_hex"
+            },
+            "verifier_lifecycle_snapshot_hash": {
               "$ref": "#/$defs/sha256_hex"
             },
             "failure_reasons": {

--- a/samples/evidence_bundle/key_provenance_review/reviewer-evidence-packet.json
+++ b/samples/evidence_bundle/key_provenance_review/reviewer-evidence-packet.json
@@ -162,6 +162,7 @@
         "verifier_id": "veritas-human-approval-verifier-v1",
         "verifier_key_id": "local-demo-verifier-key",
         "verifier_lifecycle_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
+        "verifier_lifecycle_snapshot_hash": "f48b71ec17e99dbf4785defcd6a7f2de3a51333adcb47c5739a81a969f7430fa",
         "verifier_lifecycle_status": "rotated",
         "verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
         "verifier_policy_id": "human-approval-verifier-policy-v1",
@@ -190,7 +191,7 @@
     }
   },
   "local_offline_only": true,
-  "packet_hash": "a4507a97c956fe19eab9a09891723df0dcf8d941103effb13ecd1d9b7b64ee35",
+  "packet_hash": "d02fc7e2efc97a8922ed5abf5966e11f9d0821b664258dcb0ffa7468d672135f",
   "packet_id": "reviewer-evidence-packet-saas-permission-change-v1",
   "packet_version": "v1",
   "reviewer_notes": [

--- a/samples/evidence_bundle/key_provenance_review/sample-artifact-manifest.json
+++ b/samples/evidence_bundle/key_provenance_review/sample-artifact-manifest.json
@@ -28,7 +28,7 @@
       "artifact_name": "reviewer-evidence-packet.json",
       "role": "reviewer_evidence_packet",
       "schema_id": "docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json",
-      "sha256": "1064b1652e7c163b6101c73b3edb933445bd47c0be9a4540db3b1f4902826b8b"
+      "sha256": "6f1d9dafaa3b9cd72cdb2b14912d422b815f1f42fe55d156c2111a0541e162ed"
     },
     {
       "artifact_name": "reviewer-handoff-review-result.json",

--- a/scripts/demo/validate_reviewer_evidence_packet.py
+++ b/scripts/demo/validate_reviewer_evidence_packet.py
@@ -15,6 +15,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from scripts.demo.verifier_lifecycle import (  # noqa: E402
+    compute_verifier_lifecycle_snapshot_hash,
     validate_human_approval_verifier_lifecycle_snapshot,
 )
 from scripts.demo.export_reviewer_evidence_packet import (  # noqa: E402
@@ -123,6 +124,15 @@ FAILURE_REASON_BY_CHECK = {
     ),
     "verifier_lifecycle_valid": (
         "reviewer_packet_verifier_lifecycle_invalid"
+    ),
+    "verifier_lifecycle_snapshot_hashes_present": (
+        "reviewer_packet_verifier_lifecycle_snapshot_hash_missing"
+    ),
+    "verifier_lifecycle_snapshot_hashes_match": (
+        "reviewer_packet_verifier_lifecycle_snapshot_hash_mismatch"
+    ),
+    "committed_lifecycle_status_clean": (
+        "reviewer_packet_committed_lifecycle_status_not_clean"
     ),
     "local_offline_boundary_present": "local_offline_boundary_missing",
 }
@@ -471,6 +481,60 @@ def _verifier_lifecycle_valid(packet: dict[str, Any]) -> bool:
     return not _verifier_lifecycle_reasons(packet)
 
 
+def _lifecycle_summaries(packet: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return non-null verifier lifecycle summaries from packet cases."""
+    cases = packet.get("cases")
+    if not isinstance(cases, list):
+        return []
+    return [
+        case["verifier_lifecycle_summary"]
+        for case in cases
+        if isinstance(case, dict)
+        and isinstance(case.get("verifier_lifecycle_summary"), dict)
+    ]
+
+
+def _verifier_lifecycle_snapshot_hashes_present(packet: dict[str, Any]) -> bool:
+    """Return whether every lifecycle summary carries its snapshot hash."""
+    return all(
+        bool(summary.get("verifier_lifecycle_snapshot_hash"))
+        and bool(
+            SHA256_HEX_PATTERN.fullmatch(
+                str(summary.get("verifier_lifecycle_snapshot_hash"))
+            )
+        )
+        for summary in _lifecycle_summaries(packet)
+    )
+
+
+def _verifier_lifecycle_snapshot_hashes_match(packet: dict[str, Any]) -> bool:
+    """Return whether lifecycle snapshot hashes match the displayed fields."""
+    return all(
+        summary.get("verifier_lifecycle_snapshot_hash")
+        == compute_verifier_lifecycle_snapshot_hash(summary)
+        for summary in _lifecycle_summaries(packet)
+    )
+
+
+def _committed_lifecycle_status_clean(packet: dict[str, Any]) -> bool:
+    """Return whether committed cases carry clean lifecycle evidence."""
+    cases = packet.get("cases")
+    if not isinstance(cases, list):
+        return False
+    for case in cases:
+        if not isinstance(case, dict):
+            return False
+        outcome = case.get("outcome_receipt_summary", {})
+        if not isinstance(outcome, dict) or outcome.get("committed") is not True:
+            continue
+        lifecycle = case.get("verifier_lifecycle_summary")
+        if not isinstance(lifecycle, dict):
+            return False
+        if lifecycle.get("failure_reasons") != []:
+            return False
+    return True
+
+
 def _local_offline_boundary_present(packet: dict[str, Any]) -> bool:
     """Return whether packet-level local/offline boundary markers are present."""
     boundary_note = packet.get("boundary_note")
@@ -529,6 +593,15 @@ def _build_checks(
         ),
         "verifier_lifecycle_valid": _verifier_lifecycle_valid(generated_packet),
         "verifier_lifecycle_reasons": _verifier_lifecycle_reasons(generated_packet),
+        "verifier_lifecycle_snapshot_hashes_present": (
+            _verifier_lifecycle_snapshot_hashes_present(generated_packet)
+        ),
+        "verifier_lifecycle_snapshot_hashes_match": (
+            _verifier_lifecycle_snapshot_hashes_match(generated_packet)
+        ),
+        "committed_lifecycle_status_clean": _committed_lifecycle_status_clean(
+            generated_packet
+        ),
         "local_offline_boundary_present": _local_offline_boundary_present(
             generated_packet
         ),

--- a/scripts/demo/verifier_lifecycle.py
+++ b/scripts/demo/verifier_lifecycle.py
@@ -11,6 +11,19 @@ from typing import Any
 
 from veritas_os.security.hash import sha256_of_canonical_json
 
+LIFECYCLE_SNAPSHOT_HASH_FIELDS = (
+    "verifier_id",
+    "verifier_key_id",
+    "verifier_policy_id",
+    "verifier_policy_hash",
+    "verifier_lifecycle_status",
+    "verifier_valid_from",
+    "verifier_valid_until",
+    "verifier_revoked_at",
+    "verifier_revocation_reason",
+    "verifier_lifecycle_policy_hash",
+)
+
 VERIFIER_ID = "veritas-human-approval-verifier-v1"
 VERIFIER_KEY_ID = "local-demo-verifier-key"
 VERIFIER_POLICY_ID = "human-approval-verifier-policy-v1"
@@ -93,7 +106,7 @@ def verifier_lifecycle_summary_from_human_approval(
         lifecycle_snapshot=lifecycle,
         proof_verified_at=human_approval_summary.get("verified_at"),
     )
-    return {
+    summary = {
         "verifier_id": lifecycle["verifier_id"],
         "verifier_key_id": lifecycle["verifier_key_id"],
         "verifier_policy_id": lifecycle["verifier_policy_id"],
@@ -106,6 +119,26 @@ def verifier_lifecycle_summary_from_human_approval(
         "verifier_lifecycle_policy_hash": lifecycle["verifier_policy_hash"],
         "failure_reasons": failure_reasons,
     }
+    summary["verifier_lifecycle_snapshot_hash"] = (
+        compute_verifier_lifecycle_snapshot_hash(summary)
+    )
+    return summary
+
+
+def compute_verifier_lifecycle_snapshot_hash(
+    lifecycle_summary: dict[str, Any],
+) -> str:
+    """Compute the canonical SHA-256 hash of lifecycle-relevant fields.
+
+    The hash intentionally excludes validation failure reasons and the hash
+    field itself so reviewer packets can verify that the lifecycle evidence used
+    for validation is exactly the lifecycle field snapshot presented to them.
+    """
+    payload = {
+        field: lifecycle_summary.get(field)
+        for field in LIFECYCLE_SNAPSHOT_HASH_FIELDS
+    }
+    return sha256_of_canonical_json(payload)
 
 
 def validate_human_approval_verifier_lifecycle_snapshot(
@@ -127,6 +160,15 @@ def validate_human_approval_verifier_lifecycle_snapshot(
     if not isinstance(lifecycle_snapshot, dict):
         return ["reviewer_packet_verifier_lifecycle_missing"]
 
+    if "verifier_lifecycle_status" in lifecycle_snapshot:
+        snapshot_hash = lifecycle_snapshot.get("verifier_lifecycle_snapshot_hash")
+        if not isinstance(snapshot_hash, str) or not snapshot_hash.strip():
+            return ["reviewer_packet_verifier_lifecycle_snapshot_hash_missing"]
+        if snapshot_hash != compute_verifier_lifecycle_snapshot_hash(
+            lifecycle_snapshot
+        ):
+            return ["reviewer_packet_verifier_lifecycle_snapshot_hash_mismatch"]
+
     checks = (
         ("verifier_id", "reviewer_packet_verifier_lifecycle_id_mismatch"),
         ("verifier_key_id", "reviewer_packet_verifier_lifecycle_key_mismatch"),
@@ -147,9 +189,18 @@ def validate_human_approval_verifier_lifecycle_snapshot(
     verified_at = _parse_timestamp(
         proof_verified_at or human_approval_summary.get("verified_at")
     )
-    valid_from = _parse_timestamp(lifecycle_snapshot.get("valid_from"))
-    valid_until = _parse_timestamp(lifecycle_snapshot.get("valid_until"))
-    revoked_at = _parse_timestamp(lifecycle_snapshot.get("revoked_at"))
+    valid_from = _parse_timestamp(
+        lifecycle_snapshot.get("verifier_valid_from")
+        or lifecycle_snapshot.get("valid_from")
+    )
+    valid_until = _parse_timestamp(
+        lifecycle_snapshot.get("verifier_valid_until")
+        or lifecycle_snapshot.get("valid_until")
+    )
+    revoked_at = _parse_timestamp(
+        lifecycle_snapshot.get("verifier_revoked_at")
+        or lifecycle_snapshot.get("revoked_at")
+    )
 
     if verified_at is None:
         return ["reviewer_packet_verifier_lifecycle_missing"]

--- a/tests/demo/test_reviewer_evidence_packet_schema.py
+++ b/tests/demo/test_reviewer_evidence_packet_schema.py
@@ -90,6 +90,7 @@ REQUIRED_VERIFIER_LIFECYCLE_FIELDS = [
     "verifier_revoked_at",
     "verifier_revocation_reason",
     "verifier_lifecycle_policy_hash",
+    "verifier_lifecycle_snapshot_hash",
     "failure_reasons",
 ]
 
@@ -330,6 +331,7 @@ def _assert_verifier_lifecycle_shape(
         lifecycle["verifier_revocation_reason"], str
     )
     _assert_nullable_hash(lifecycle["verifier_lifecycle_policy_hash"])
+    _assert_nullable_hash(lifecycle["verifier_lifecycle_snapshot_hash"])
     _assert_string_array(lifecycle["failure_reasons"])
 
 
@@ -792,6 +794,9 @@ def test_committed_verified_approval_cases_have_valid_lifecycle() -> None:
             lifecycle = case["verifier_lifecycle_summary"]
             assert lifecycle is not None, packet_path
             assert lifecycle["failure_reasons"] == [], packet_path
+            assert SHA256_HEX_PATTERN.fullmatch(
+                lifecycle["verifier_lifecycle_snapshot_hash"]
+            ), packet_path
             verified_at = _parse_iso_timestamp(human_approval["verified_at"])
             valid_from = _parse_iso_timestamp(lifecycle["verifier_valid_from"])
             assert verified_at >= valid_from, packet_path

--- a/tests/demo/test_verifier_lifecycle.py
+++ b/tests/demo/test_verifier_lifecycle.py
@@ -8,7 +8,9 @@ from pathlib import Path
 from typing import Any
 
 from scripts.demo.verifier_lifecycle import (
+    compute_verifier_lifecycle_snapshot_hash,
     validate_human_approval_verifier_lifecycle_snapshot,
+    verifier_lifecycle_summary_from_human_approval,
 )
 
 FIXTURE_PATH = Path("docs/en/demo/fixtures/verifier-policy-lifecycle-audit-v1.json")
@@ -85,3 +87,53 @@ def test_lifecycle_fixture_expected_failure_reasons_are_deterministic() -> None:
     for case in _fixture_cases().values():
         assert _validate(case) == case["expected_failure_reasons"]
         assert (_validate(case) == []) is case["expected_valid"]
+
+
+def test_lifecycle_snapshot_hash_is_deterministic() -> None:
+    """Lifecycle summary hash is canonical and repeatable."""
+    case = _fixture_cases()["valid_at_verification_time"]
+    summary = verifier_lifecycle_summary_from_human_approval(
+        case["human_approval_summary"]
+    )
+
+    assert summary is not None
+    assert summary["verifier_lifecycle_snapshot_hash"] == (
+        compute_verifier_lifecycle_snapshot_hash(summary)
+    )
+    assert verifier_lifecycle_summary_from_human_approval(
+        case["human_approval_summary"]
+    )["verifier_lifecycle_snapshot_hash"] == summary[
+        "verifier_lifecycle_snapshot_hash"
+    ]
+
+
+def test_lifecycle_snapshot_hash_changes_when_valid_until_changes() -> None:
+    """Changing verifier_valid_until changes lifecycle hash continuity."""
+    case = _fixture_cases()["valid_at_verification_time"]
+    summary = verifier_lifecycle_summary_from_human_approval(
+        case["human_approval_summary"]
+    )
+    changed = copy.deepcopy(summary)
+    changed["verifier_valid_until"] = "2026-04-25T00:00:00+00:00"
+
+    assert summary is not None
+    assert compute_verifier_lifecycle_snapshot_hash(changed) != summary[
+        "verifier_lifecycle_snapshot_hash"
+    ]
+
+
+def test_lifecycle_snapshot_hash_changes_when_policy_hash_changes() -> None:
+    """Changing verifier_policy_hash changes lifecycle hash continuity."""
+    case = _fixture_cases()["valid_at_verification_time"]
+    summary = verifier_lifecycle_summary_from_human_approval(
+        case["human_approval_summary"]
+    )
+    changed = copy.deepcopy(summary)
+    changed["verifier_policy_hash"] = (
+        "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+    )
+
+    assert summary is not None
+    assert compute_verifier_lifecycle_snapshot_hash(changed) != summary[
+        "verifier_lifecycle_snapshot_hash"
+    ]


### PR DESCRIPTION
### Motivation
- Make reviewer-facing verifier lifecycle evidence tamper-evident and reviewer-verifiable by binding a deterministic snapshot hash to the lifecycle summary so a reviewer can prove the exact snapshot used during validation.
- Preserve the demo/reviewer-only scope: do not introduce KMS/HSM, external revocation services, or change runtime verifier allowlist behaviour.

### Description
- Add `verifier_lifecycle_snapshot_hash` to non-null `verifier_lifecycle_summary` objects and compute it with `compute_verifier_lifecycle_snapshot_hash(...)` over the canonical lifecycle fields: `verifier_id`, `verifier_key_id`, `verifier_policy_id`, `verifier_policy_hash`, `verifier_lifecycle_status`, `verifier_valid_from`, `verifier_valid_until`, `verifier_revoked_at`, `verifier_revocation_reason`, and `verifier_lifecycle_policy_hash`; the hash is a lowercase SHA-256 hex of canonical JSON and intentionally excludes `failure_reasons` and the hash field itself. (`scripts/demo/verifier_lifecycle.py`)
- Validate the snapshot hash during reviewer packet validation by checking presence and canonical match, and add packet-level checks reporting whether snapshot hashes are present, match, and that committed cases carry clean lifecycle evidence. (`scripts/demo/validate_reviewer_evidence_packet.py`)
- Update the Reviewer Evidence Packet schema (`docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json`) to require `verifier_lifecycle_snapshot_hash` when `verifier_lifecycle_summary` is an object and to validate it as a SHA-256 hex string.
- Regenerate and update affected fixtures and examples and recompute packet/artifact hashes for reviewer packets and samples to include the new field; update tests to assert snapshot hash presence, determinism, and sensitivity to lifecycle field changes. (fixtures and examples under `docs/en/demo/...` and `samples/evidence_bundle/...`) 

### Testing
- Ran `python3 scripts/demo/validate_reviewer_evidence_packet.py` and the validation report returned status `pass` with lifecycle snapshot checks reporting present/match/clean (`True, True, True`).
- Ran unit tests: `PYENV_VERSION=3.11.15 pytest -q tests/demo/test_verifier_lifecycle.py tests/demo/test_reviewer_verifier_lifecycle_commit_consistency.py` which passed (tests for lifecycle validation and commit-consistency succeeded).
- Performed static compile checks with `python3 -m py_compile` on the modified demo scripts which succeeded.
- Note: running the full schema test in a local environment initially surfaced a missing `yaml` (PyYAML) dependency; CI environments that provide test dependencies (including PyYAML) are expected to run the full schema tests and should pass there.

Security note: this change only increases reviewer-side tamper-evidence by adding deterministic hashes and does not add secret handling, KMS/HSM, or external revocation calls; do not treat the snapshot hash as a substitute for out-of-band production allowlist or revocation checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e9e3aff8c8326974466ad52d9a481)