### PR TITLE
Bind verifier lifecycle snapshot hash into EvidenceChainManifest and OutcomeReceipt and add continuity validation

### DIFF
--- a/docs/en/demo/examples/context-bound-approval-replay-prevention-v1.json
+++ b/docs/en/demo/examples/context-bound-approval-replay-prevention-v1.json
@@ -37,7 +37,7 @@
         "human_approval_verifier_lifecycle_snapshot_hash": "f48b71ec17e99dbf4785defcd6a7f2de3a51333adcb47c5739a81a969f7430fa",
         "human_approval_verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
         "human_approval_verifier_policy_id": "human-approval-verifier-policy-v1",
-        "manifest_hash": "229049ea9bc2553276ad38c1a57d24932fc4b82d19488b9e26580df8e3a9d482",
+        "manifest_hash": "e6005e60ed20b1dfc0c6c3df49c6359f01935240780ca64aeeb8d9726931098f",
         "manifest_id": "manifest-valid_same_context",
         "metadata": {
           "signature_validity_alone_is_insufficient": true
@@ -45,7 +45,7 @@
         "missing_links": [],
         "observed_effects_summary": [],
         "operation_id": "operation-valid_same_context",
-        "outcome_receipt_hash": "860c0f91b44c750913d5e738946358764f689caf87f8258187c4541561e61f61",
+        "outcome_receipt_hash": "ef0a9acfd135902e7abbc3cf9ff6cb788f0a29ee3aac617c9388c98ad100d7b0",
         "outcome_receipt_id": "outcome-valid_same_context",
         "refusal_basis": [],
         "requested_scope": [
@@ -68,7 +68,7 @@
         "mismatched_links": [],
         "missing_links": [],
         "operation_id": "operation-valid_same_context",
-        "recomputed_manifest_hash": "229049ea9bc2553276ad38c1a57d24932fc4b82d19488b9e26580df8e3a9d482",
+        "recomputed_manifest_hash": "e6005e60ed20b1dfc0c6c3df49c6359f01935240780ca64aeeb8d9726931098f",
         "verification_status": "verified",
         "verified_at": "2026-05-10T00:00:00+00:00",
         "verified_links": [
@@ -129,7 +129,7 @@
         },
         "observed_effects": [],
         "operation_id": "operation-valid_same_context",
-        "outcome_hash": "860c0f91b44c750913d5e738946358764f689caf87f8258187c4541561e61f61",
+        "outcome_hash": "ef0a9acfd135902e7abbc3cf9ff6cb788f0a29ee3aac617c9388c98ad100d7b0",
         "outcome_receipt_id": "outcome-valid_same_context",
         "postcondition_status": "passed",
         "requested_scope": [
@@ -188,7 +188,7 @@
         "human_approval_verifier_lifecycle_snapshot_hash": null,
         "human_approval_verifier_policy_hash": null,
         "human_approval_verifier_policy_id": null,
-        "manifest_hash": "31492f955dc7f0e786ed2b0398edbba1032b25235f76c9f406ed09da003ebcf4",
+        "manifest_hash": "66b26630eca872d5f2b9480d0beedad3d733ff25ebd05f6ff76dd3098cc0df38",
         "manifest_id": "manifest-replay_different_request_ref",
         "metadata": {
           "signature_validity_alone_is_insufficient": true
@@ -196,7 +196,7 @@
         "missing_links": [],
         "observed_effects_summary": [],
         "operation_id": "operation-replay_different_request_ref",
-        "outcome_receipt_hash": "ec37e4aca9d80eae84e91360dd9a7e0ac9619a7bcca65f35b15dbc276b844a4d",
+        "outcome_receipt_hash": "be348b0e7a9a0e5be0440df7150853817de5313544d46504ee10390705324974",
         "outcome_receipt_id": "outcome-replay_different_request_ref",
         "refusal_basis": [
           "human_approval_request_ref_mismatch"
@@ -225,7 +225,7 @@
         ],
         "missing_links": [],
         "operation_id": "operation-replay_different_request_ref",
-        "recomputed_manifest_hash": "31492f955dc7f0e786ed2b0398edbba1032b25235f76c9f406ed09da003ebcf4",
+        "recomputed_manifest_hash": "66b26630eca872d5f2b9480d0beedad3d733ff25ebd05f6ff76dd3098cc0df38",
         "verification_status": "failed",
         "verified_at": "2026-05-10T00:00:00+00:00",
         "verified_links": [
@@ -283,7 +283,7 @@
         },
         "observed_effects": [],
         "operation_id": "operation-replay_different_request_ref",
-        "outcome_hash": "ec37e4aca9d80eae84e91360dd9a7e0ac9619a7bcca65f35b15dbc276b844a4d",
+        "outcome_hash": "be348b0e7a9a0e5be0440df7150853817de5313544d46504ee10390705324974",
         "outcome_receipt_id": "outcome-replay_different_request_ref",
         "postcondition_status": "skipped",
         "requested_scope": [
@@ -331,7 +331,7 @@
         "human_approval_verifier_lifecycle_snapshot_hash": null,
         "human_approval_verifier_policy_hash": null,
         "human_approval_verifier_policy_id": null,
-        "manifest_hash": "14a99193e34ffb7cd487116b1c6591f6a647f2d6cc73f311f22f5fa87058c236",
+        "manifest_hash": "c5283dace06598cf5ca5e1e153ee7c8d8fa00b14d472e439766668ddf6a6af4d",
         "manifest_id": "manifest-replay_different_action_class",
         "metadata": {
           "signature_validity_alone_is_insufficient": true
@@ -339,7 +339,7 @@
         "missing_links": [],
         "observed_effects_summary": [],
         "operation_id": "operation-replay_different_action_class",
-        "outcome_receipt_hash": "b006d62316529d82228822d55bb4c7b452c630746caf6af5d335681bc4211bdf",
+        "outcome_receipt_hash": "c4fde9b7603a8ecc7b9c549eda1171137964e3d444c7ea7144859c46ef8a2b53",
         "outcome_receipt_id": "outcome-replay_different_action_class",
         "refusal_basis": [
           "human_approval_action_class_mismatch"
@@ -368,7 +368,7 @@
         ],
         "missing_links": [],
         "operation_id": "operation-replay_different_action_class",
-        "recomputed_manifest_hash": "14a99193e34ffb7cd487116b1c6591f6a647f2d6cc73f311f22f5fa87058c236",
+        "recomputed_manifest_hash": "c5283dace06598cf5ca5e1e153ee7c8d8fa00b14d472e439766668ddf6a6af4d",
         "verification_status": "failed",
         "verified_at": "2026-05-10T00:00:00+00:00",
         "verified_links": [
@@ -426,7 +426,7 @@
         },
         "observed_effects": [],
         "operation_id": "operation-replay_different_action_class",
-        "outcome_hash": "b006d62316529d82228822d55bb4c7b452c630746caf6af5d335681bc4211bdf",
+        "outcome_hash": "c4fde9b7603a8ecc7b9c549eda1171137964e3d444c7ea7144859c46ef8a2b53",
         "outcome_receipt_id": "outcome-replay_different_action_class",
         "postcondition_status": "skipped",
         "requested_scope": [
@@ -474,7 +474,7 @@
         "human_approval_verifier_lifecycle_snapshot_hash": null,
         "human_approval_verifier_policy_hash": null,
         "human_approval_verifier_policy_id": null,
-        "manifest_hash": "151ee7c95baae04c07d04786d1c8b178e4727857dda2f89eaa9e636730f96ba8",
+        "manifest_hash": "7cdba51e92fed99f61c00f590875a1b81e645a8aceb2fe3b823a3fb5c4a52be9",
         "manifest_id": "manifest-replay_different_bind_context_hash",
         "metadata": {
           "signature_validity_alone_is_insufficient": true
@@ -482,7 +482,7 @@
         "missing_links": [],
         "observed_effects_summary": [],
         "operation_id": "operation-replay_different_bind_context_hash",
-        "outcome_receipt_hash": "41a9bf20fb5f8603f01c85e54cbe8375a25f1062b84f710a20601a56255e5470",
+        "outcome_receipt_hash": "c479f9f527706465741daf8a72f442ef4814651e54ed4e58c83481d90d30a88b",
         "outcome_receipt_id": "outcome-replay_different_bind_context_hash",
         "refusal_basis": [
           "human_approval_bind_context_hash_mismatch"
@@ -511,7 +511,7 @@
         ],
         "missing_links": [],
         "operation_id": "operation-replay_different_bind_context_hash",
-        "recomputed_manifest_hash": "151ee7c95baae04c07d04786d1c8b178e4727857dda2f89eaa9e636730f96ba8",
+        "recomputed_manifest_hash": "7cdba51e92fed99f61c00f590875a1b81e645a8aceb2fe3b823a3fb5c4a52be9",
         "verification_status": "failed",
         "verified_at": "2026-05-10T00:00:00+00:00",
         "verified_links": [
@@ -569,7 +569,7 @@
         },
         "observed_effects": [],
         "operation_id": "operation-replay_different_bind_context_hash",
-        "outcome_hash": "41a9bf20fb5f8603f01c85e54cbe8375a25f1062b84f710a20601a56255e5470",
+        "outcome_hash": "c479f9f527706465741daf8a72f442ef4814651e54ed4e58c83481d90d30a88b",
         "outcome_receipt_id": "outcome-replay_different_bind_context_hash",
         "postcondition_status": "skipped",
         "requested_scope": [
@@ -596,7 +596,7 @@
   "demo_id": "context-bound-approval-replay-prevention-v1",
   "generated_at": "2026-05-10T00:00:00+00:00",
   "local_offline_only": true,
-  "packet_hash": "cfd8e6bd79b8afaf9e3ff80c8566f9b2f051cec536438b00ad5a53a03d365951",
+  "packet_hash": "bc935111791a65c80840d20ae1ceb6349e695e9984a276dd4e64463c265815d6",
   "packet_id": "reviewer-evidence-packet-approval-replay-prevention-v1",
   "packet_version": "v1",
   "reviewer_notes": [

--- a/docs/en/demo/examples/context-bound-approval-replay-prevention-v1.json
+++ b/docs/en/demo/examples/context-bound-approval-replay-prevention-v1.json
@@ -34,9 +34,10 @@
         "human_approval_required": true,
         "human_approval_verifier_id": "veritas-human-approval-verifier-v1",
         "human_approval_verifier_key_id": "local-demo-verifier-key",
+        "human_approval_verifier_lifecycle_snapshot_hash": "f48b71ec17e99dbf4785defcd6a7f2de3a51333adcb47c5739a81a969f7430fa",
         "human_approval_verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
         "human_approval_verifier_policy_id": "human-approval-verifier-policy-v1",
-        "manifest_hash": "abdeea27ee17193835115426219c172d4074a97c50954bf74f59022506c4fd40",
+        "manifest_hash": "229049ea9bc2553276ad38c1a57d24932fc4b82d19488b9e26580df8e3a9d482",
         "manifest_id": "manifest-valid_same_context",
         "metadata": {
           "signature_validity_alone_is_insufficient": true
@@ -44,7 +45,7 @@
         "missing_links": [],
         "observed_effects_summary": [],
         "operation_id": "operation-valid_same_context",
-        "outcome_receipt_hash": "6f99cb13661b325565519e428cbf09b762d3d3921b5aa1717e4bb53193565348",
+        "outcome_receipt_hash": "860c0f91b44c750913d5e738946358764f689caf87f8258187c4541561e61f61",
         "outcome_receipt_id": "outcome-valid_same_context",
         "refusal_basis": [],
         "requested_scope": [
@@ -67,7 +68,7 @@
         "mismatched_links": [],
         "missing_links": [],
         "operation_id": "operation-valid_same_context",
-        "recomputed_manifest_hash": "abdeea27ee17193835115426219c172d4074a97c50954bf74f59022506c4fd40",
+        "recomputed_manifest_hash": "229049ea9bc2553276ad38c1a57d24932fc4b82d19488b9e26580df8e3a9d482",
         "verification_status": "verified",
         "verified_at": "2026-05-10T00:00:00+00:00",
         "verified_links": [
@@ -120,6 +121,7 @@
           "human_approval_verification_source": "signed_human_approval_artifact",
           "human_approval_verifier_id": "veritas-human-approval-verifier-v1",
           "human_approval_verifier_key_id": "local-demo-verifier-key",
+          "human_approval_verifier_lifecycle_snapshot_hash": "f48b71ec17e99dbf4785defcd6a7f2de3a51333adcb47c5739a81a969f7430fa",
           "human_approval_verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
           "human_approval_verifier_policy_id": "human-approval-verifier-policy-v1",
           "verified_human_approval_proof_hash": "4c5825bb7e0f647e705ca280a411695d052bfb8e65382f13804e86c0f485ef0c",
@@ -127,7 +129,7 @@
         },
         "observed_effects": [],
         "operation_id": "operation-valid_same_context",
-        "outcome_hash": "6f99cb13661b325565519e428cbf09b762d3d3921b5aa1717e4bb53193565348",
+        "outcome_hash": "860c0f91b44c750913d5e738946358764f689caf87f8258187c4541561e61f61",
         "outcome_receipt_id": "outcome-valid_same_context",
         "postcondition_status": "passed",
         "requested_scope": [
@@ -183,9 +185,10 @@
         "human_approval_required": true,
         "human_approval_verifier_id": null,
         "human_approval_verifier_key_id": null,
+        "human_approval_verifier_lifecycle_snapshot_hash": null,
         "human_approval_verifier_policy_hash": null,
         "human_approval_verifier_policy_id": null,
-        "manifest_hash": "78f2eb2def66fc1ef2c248be23e96a610e83a64e1a3a2018ff9d2a259671b543",
+        "manifest_hash": "31492f955dc7f0e786ed2b0398edbba1032b25235f76c9f406ed09da003ebcf4",
         "manifest_id": "manifest-replay_different_request_ref",
         "metadata": {
           "signature_validity_alone_is_insufficient": true
@@ -222,7 +225,7 @@
         ],
         "missing_links": [],
         "operation_id": "operation-replay_different_request_ref",
-        "recomputed_manifest_hash": "78f2eb2def66fc1ef2c248be23e96a610e83a64e1a3a2018ff9d2a259671b543",
+        "recomputed_manifest_hash": "31492f955dc7f0e786ed2b0398edbba1032b25235f76c9f406ed09da003ebcf4",
         "verification_status": "failed",
         "verified_at": "2026-05-10T00:00:00+00:00",
         "verified_links": [
@@ -325,9 +328,10 @@
         "human_approval_required": true,
         "human_approval_verifier_id": null,
         "human_approval_verifier_key_id": null,
+        "human_approval_verifier_lifecycle_snapshot_hash": null,
         "human_approval_verifier_policy_hash": null,
         "human_approval_verifier_policy_id": null,
-        "manifest_hash": "ffe687e6cb23e6f23e3bef24bfd50cff17b6a1336bea03cf3b0bbe871d325840",
+        "manifest_hash": "14a99193e34ffb7cd487116b1c6591f6a647f2d6cc73f311f22f5fa87058c236",
         "manifest_id": "manifest-replay_different_action_class",
         "metadata": {
           "signature_validity_alone_is_insufficient": true
@@ -364,7 +368,7 @@
         ],
         "missing_links": [],
         "operation_id": "operation-replay_different_action_class",
-        "recomputed_manifest_hash": "ffe687e6cb23e6f23e3bef24bfd50cff17b6a1336bea03cf3b0bbe871d325840",
+        "recomputed_manifest_hash": "14a99193e34ffb7cd487116b1c6591f6a647f2d6cc73f311f22f5fa87058c236",
         "verification_status": "failed",
         "verified_at": "2026-05-10T00:00:00+00:00",
         "verified_links": [
@@ -467,9 +471,10 @@
         "human_approval_required": true,
         "human_approval_verifier_id": null,
         "human_approval_verifier_key_id": null,
+        "human_approval_verifier_lifecycle_snapshot_hash": null,
         "human_approval_verifier_policy_hash": null,
         "human_approval_verifier_policy_id": null,
-        "manifest_hash": "08e9d65f926a930af825dd00b0f75fd1ee7cd7748bddc781cc05ac2d339ee2c0",
+        "manifest_hash": "151ee7c95baae04c07d04786d1c8b178e4727857dda2f89eaa9e636730f96ba8",
         "manifest_id": "manifest-replay_different_bind_context_hash",
         "metadata": {
           "signature_validity_alone_is_insufficient": true
@@ -506,7 +511,7 @@
         ],
         "missing_links": [],
         "operation_id": "operation-replay_different_bind_context_hash",
-        "recomputed_manifest_hash": "08e9d65f926a930af825dd00b0f75fd1ee7cd7748bddc781cc05ac2d339ee2c0",
+        "recomputed_manifest_hash": "151ee7c95baae04c07d04786d1c8b178e4727857dda2f89eaa9e636730f96ba8",
         "verification_status": "failed",
         "verified_at": "2026-05-10T00:00:00+00:00",
         "verified_links": [
@@ -591,7 +596,7 @@
   "demo_id": "context-bound-approval-replay-prevention-v1",
   "generated_at": "2026-05-10T00:00:00+00:00",
   "local_offline_only": true,
-  "packet_hash": "08de1927366a5a09ba72fd233df86ed63bc2fc7e8b4fd27fb48497e4424e2680",
+  "packet_hash": "cfd8e6bd79b8afaf9e3ff80c8566f9b2f051cec536438b00ad5a53a03d365951",
   "packet_id": "reviewer-evidence-packet-approval-replay-prevention-v1",
   "packet_version": "v1",
   "reviewer_notes": [

--- a/docs/en/demo/examples/evaluation-governance-chain-reviewer-packet-v1/reviewer-evidence-packet.generated.example.json
+++ b/docs/en/demo/examples/evaluation-governance-chain-reviewer-packet-v1/reviewer-evidence-packet.generated.example.json
@@ -34,9 +34,10 @@
         "human_approval_required": true,
         "human_approval_verifier_id": "veritas-human-approval-verifier-v1",
         "human_approval_verifier_key_id": "local-demo-verifier-key",
+        "human_approval_verifier_lifecycle_snapshot_hash": "f48b71ec17e99dbf4785defcd6a7f2de3a51333adcb47c5739a81a969f7430fa",
         "human_approval_verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
         "human_approval_verifier_policy_id": "human-approval-verifier-policy-v1",
-        "manifest_hash": "14327240a9d6f9f79be76862f582600d7486985466aae73d8aa2ea95159d4bca",
+        "manifest_hash": "9620ca1bb4eb9f6fb45e71415430a4513254db22a455d4628fa2ac59f0c38b7c",
         "manifest_id": "ecm-saas-permission-change-missing_authority",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -47,7 +48,7 @@
         ],
         "observed_effects_summary": [],
         "operation_id": "saas-permission-change-missing_authority",
-        "outcome_receipt_hash": "a8ab4ae248e01c15debe8889d17c401c2d287d4480d3988534a98404187df7b0",
+        "outcome_receipt_hash": "54a4b593be499ee0f5fe62274189479d00352646cc6676d196d07ed483b50a90",
         "outcome_receipt_id": "outcome-saas-permission-change-missing_authority",
         "refusal_basis": [
           "authority_expired_or_missing",
@@ -77,7 +78,7 @@
           "authority_evidence_hash"
         ],
         "operation_id": "saas-permission-change-missing_authority",
-        "recomputed_manifest_hash": "14327240a9d6f9f79be76862f582600d7486985466aae73d8aa2ea95159d4bca",
+        "recomputed_manifest_hash": "9620ca1bb4eb9f6fb45e71415430a4513254db22a455d4628fa2ac59f0c38b7c",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -143,6 +144,7 @@
           "human_approval_verification_source": "signed_human_approval_artifact",
           "human_approval_verifier_id": "veritas-human-approval-verifier-v1",
           "human_approval_verifier_key_id": "local-demo-verifier-key",
+          "human_approval_verifier_lifecycle_snapshot_hash": "f48b71ec17e99dbf4785defcd6a7f2de3a51333adcb47c5739a81a969f7430fa",
           "human_approval_verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
           "human_approval_verifier_policy_id": "human-approval-verifier-policy-v1",
           "verified_human_approval_proof_hash": "4c5825bb7e0f647e705ca280a411695d052bfb8e65382f13804e86c0f485ef0c",
@@ -150,7 +152,7 @@
         },
         "observed_effects": [],
         "operation_id": "saas-permission-change-missing_authority",
-        "outcome_hash": "a8ab4ae248e01c15debe8889d17c401c2d287d4480d3988534a98404187df7b0",
+        "outcome_hash": "54a4b593be499ee0f5fe62274189479d00352646cc6676d196d07ed483b50a90",
         "outcome_receipt_id": "outcome-saas-permission-change-missing_authority",
         "post_state_fingerprint": null,
         "postcondition_status": "skipped",
@@ -213,9 +215,10 @@
         "human_approval_required": true,
         "human_approval_verifier_id": null,
         "human_approval_verifier_key_id": null,
+        "human_approval_verifier_lifecycle_snapshot_hash": null,
         "human_approval_verifier_policy_hash": null,
         "human_approval_verifier_policy_id": null,
-        "manifest_hash": "1992a33be9389de9394ffa43291c46105f2d703485c904422a299e6834cb2a5f",
+        "manifest_hash": "20b395802fcdf88e4f81bb867b0f810dcc4182530e444fdcebbe1171a4be3612",
         "manifest_id": "ecm-saas-permission-change-missing_human_approval",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -226,7 +229,7 @@
         ],
         "observed_effects_summary": [],
         "operation_id": "saas-permission-change-missing_human_approval",
-        "outcome_receipt_hash": "9675064eed76fafddc5aae73292bba314f31a3e106f81451c4a0f3d472bf6ebd",
+        "outcome_receipt_hash": "f94d52a89c6aafd19bd2a19bba13d51e49fee1080a804d822a8699b8330c0dce",
         "outcome_receipt_id": "outcome-saas-permission-change-missing_human_approval",
         "refusal_basis": [
           "human_approval_missing"
@@ -254,7 +257,7 @@
           "human_approval_receipt_hash"
         ],
         "operation_id": "saas-permission-change-missing_human_approval",
-        "recomputed_manifest_hash": "1992a33be9389de9394ffa43291c46105f2d703485c904422a299e6834cb2a5f",
+        "recomputed_manifest_hash": "20b395802fcdf88e4f81bb867b0f810dcc4182530e444fdcebbe1171a4be3612",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -315,7 +318,7 @@
         },
         "observed_effects": [],
         "operation_id": "saas-permission-change-missing_human_approval",
-        "outcome_hash": "9675064eed76fafddc5aae73292bba314f31a3e106f81451c4a0f3d472bf6ebd",
+        "outcome_hash": "f94d52a89c6aafd19bd2a19bba13d51e49fee1080a804d822a8699b8330c0dce",
         "outcome_receipt_id": "outcome-saas-permission-change-missing_human_approval",
         "post_state_fingerprint": null,
         "postcondition_status": "skipped",
@@ -363,9 +366,10 @@
         "human_approval_required": true,
         "human_approval_verifier_id": null,
         "human_approval_verifier_key_id": null,
+        "human_approval_verifier_lifecycle_snapshot_hash": null,
         "human_approval_verifier_policy_hash": null,
         "human_approval_verifier_policy_id": null,
-        "manifest_hash": "01269f1895cd817090ea87e50df0dac9f5f8177de62ac2998154fee5d2b4d36c",
+        "manifest_hash": "b91be527347ed42b0dc47fcd0a07ea0412ba0456f871cafb4242898cdc8f0af4",
         "manifest_id": "ecm-saas-permission-change-expired_human_approval",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -376,7 +380,7 @@
         ],
         "observed_effects_summary": [],
         "operation_id": "saas-permission-change-expired_human_approval",
-        "outcome_receipt_hash": "04f7b00e736648ed570282482a90bf453e4e8d871e26f4ca4d173467f0be92af",
+        "outcome_receipt_hash": "f170bf3595f0ef68027b1ab6bb4079fcdbf5ccd13a6bf7c053da1d917dd95f03",
         "outcome_receipt_id": "outcome-saas-permission-change-expired_human_approval",
         "refusal_basis": [
           "human_approval_missing"
@@ -404,7 +408,7 @@
           "human_approval_receipt_hash"
         ],
         "operation_id": "saas-permission-change-expired_human_approval",
-        "recomputed_manifest_hash": "01269f1895cd817090ea87e50df0dac9f5f8177de62ac2998154fee5d2b4d36c",
+        "recomputed_manifest_hash": "b91be527347ed42b0dc47fcd0a07ea0412ba0456f871cafb4242898cdc8f0af4",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -465,7 +469,7 @@
         },
         "observed_effects": [],
         "operation_id": "saas-permission-change-expired_human_approval",
-        "outcome_hash": "04f7b00e736648ed570282482a90bf453e4e8d871e26f4ca4d173467f0be92af",
+        "outcome_hash": "f170bf3595f0ef68027b1ab6bb4079fcdbf5ccd13a6bf7c053da1d917dd95f03",
         "outcome_receipt_id": "outcome-saas-permission-change-expired_human_approval",
         "post_state_fingerprint": null,
         "postcondition_status": "skipped",
@@ -513,9 +517,10 @@
         "human_approval_required": true,
         "human_approval_verifier_id": null,
         "human_approval_verifier_key_id": null,
+        "human_approval_verifier_lifecycle_snapshot_hash": null,
         "human_approval_verifier_policy_hash": null,
         "human_approval_verifier_policy_id": null,
-        "manifest_hash": "88824854f29f8d6e1a7d8447d7a1d2012670a258bdc58fdcaf3d7e12be573cd0",
+        "manifest_hash": "e0164a6402eba02f98a91343f4c535587e7b2fdfa2ca314fdd6af1c7bc498186",
         "manifest_id": "ecm-saas-permission-change-scope_mismatch",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -526,7 +531,7 @@
         ],
         "observed_effects_summary": [],
         "operation_id": "saas-permission-change-scope_mismatch",
-        "outcome_receipt_hash": "3fff28c56dd93ff5d7e11c71a9ed6ba134c31dc8a057810e72d24b93f2c8a54f",
+        "outcome_receipt_hash": "59bf3c158db3f58b84bd63b31f8aec4682b283d9c71d66c68b1ae6bd1161cd10",
         "outcome_receipt_id": "outcome-saas-permission-change-scope_mismatch",
         "refusal_basis": [
           "authority_invalid",
@@ -555,7 +560,7 @@
           "human_approval_receipt_hash"
         ],
         "operation_id": "saas-permission-change-scope_mismatch",
-        "recomputed_manifest_hash": "88824854f29f8d6e1a7d8447d7a1d2012670a258bdc58fdcaf3d7e12be573cd0",
+        "recomputed_manifest_hash": "e0164a6402eba02f98a91343f4c535587e7b2fdfa2ca314fdd6af1c7bc498186",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -618,7 +623,7 @@
         },
         "observed_effects": [],
         "operation_id": "saas-permission-change-scope_mismatch",
-        "outcome_hash": "3fff28c56dd93ff5d7e11c71a9ed6ba134c31dc8a057810e72d24b93f2c8a54f",
+        "outcome_hash": "59bf3c158db3f58b84bd63b31f8aec4682b283d9c71d66c68b1ae6bd1161cd10",
         "outcome_receipt_id": "outcome-saas-permission-change-scope_mismatch",
         "post_state_fingerprint": null,
         "postcondition_status": "skipped",
@@ -667,9 +672,10 @@
         "human_approval_required": true,
         "human_approval_verifier_id": "veritas-human-approval-verifier-v1",
         "human_approval_verifier_key_id": "local-demo-verifier-key",
+        "human_approval_verifier_lifecycle_snapshot_hash": "f48b71ec17e99dbf4785defcd6a7f2de3a51333adcb47c5739a81a969f7430fa",
         "human_approval_verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
         "human_approval_verifier_policy_id": "human-approval-verifier-policy-v1",
-        "manifest_hash": "5b1a60de9131745f4d53f91c83b021796842dc4882f16b3403844005c6dbe858",
+        "manifest_hash": "2f344ea93088bb92a5148276b94bd2eaf6c97c629f84ed96872869afc28be674",
         "manifest_id": "ecm-saas-permission-change-valid_authority_and_approval",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -685,7 +691,7 @@
           }
         ],
         "operation_id": "saas-permission-change-valid_authority_and_approval",
-        "outcome_receipt_hash": "1186d57ff77b5cd25f3031c569418941140aa5ff16d3eb537c0cc2be816cefdc",
+        "outcome_receipt_hash": "b29ecfff49a64dba77185fac997e4a543045f76e2e332274162d2781ab7587e9",
         "outcome_receipt_id": "outcome-saas-permission-change-valid_authority_and_approval",
         "refusal_basis": [],
         "requested_scope": [
@@ -709,7 +715,7 @@
         "mismatched_links": [],
         "missing_links": [],
         "operation_id": "saas-permission-change-valid_authority_and_approval",
-        "recomputed_manifest_hash": "5b1a60de9131745f4d53f91c83b021796842dc4882f16b3403844005c6dbe858",
+        "recomputed_manifest_hash": "2f344ea93088bb92a5148276b94bd2eaf6c97c629f84ed96872869afc28be674",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -768,6 +774,7 @@
           "human_approval_verification_source": "signed_human_approval_artifact",
           "human_approval_verifier_id": "veritas-human-approval-verifier-v1",
           "human_approval_verifier_key_id": "local-demo-verifier-key",
+          "human_approval_verifier_lifecycle_snapshot_hash": "f48b71ec17e99dbf4785defcd6a7f2de3a51333adcb47c5739a81a969f7430fa",
           "human_approval_verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
           "human_approval_verifier_policy_id": "human-approval-verifier-policy-v1",
           "verified_human_approval_proof_hash": "4c5825bb7e0f647e705ca280a411695d052bfb8e65382f13804e86c0f485ef0c",
@@ -782,7 +789,7 @@
           }
         ],
         "operation_id": "saas-permission-change-valid_authority_and_approval",
-        "outcome_hash": "1186d57ff77b5cd25f3031c569418941140aa5ff16d3eb537c0cc2be816cefdc",
+        "outcome_hash": "b29ecfff49a64dba77185fac997e4a543045f76e2e332274162d2781ab7587e9",
         "outcome_receipt_id": "outcome-saas-permission-change-valid_authority_and_approval",
         "post_state_fingerprint": null,
         "postcondition_status": "passed",
@@ -910,7 +917,7 @@
     }
   },
   "local_offline_only": true,
-  "packet_hash": "2622e0c2a729a9a9755fd3a232a4b11bc514b4122ce92c753bbcd9baa5d98205",
+  "packet_hash": "87b9ac0c05893c471f2df0b811509c267d559b9e8b190c75cebedec87154d1b2",
   "packet_id": "reviewer-evidence-packet-saas-permission-change-v1",
   "packet_version": "v1",
   "reviewer_notes": [

--- a/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated/reviewer-evidence-packet.generated.example.json
+++ b/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated/reviewer-evidence-packet.generated.example.json
@@ -34,9 +34,10 @@
         "human_approval_required": true,
         "human_approval_verifier_id": "veritas-human-approval-verifier-v1",
         "human_approval_verifier_key_id": "local-demo-verifier-key",
+        "human_approval_verifier_lifecycle_snapshot_hash": "f48b71ec17e99dbf4785defcd6a7f2de3a51333adcb47c5739a81a969f7430fa",
         "human_approval_verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
         "human_approval_verifier_policy_id": "human-approval-verifier-policy-v1",
-        "manifest_hash": "14327240a9d6f9f79be76862f582600d7486985466aae73d8aa2ea95159d4bca",
+        "manifest_hash": "9620ca1bb4eb9f6fb45e71415430a4513254db22a455d4628fa2ac59f0c38b7c",
         "manifest_id": "ecm-saas-permission-change-missing_authority",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -47,7 +48,7 @@
         ],
         "observed_effects_summary": [],
         "operation_id": "saas-permission-change-missing_authority",
-        "outcome_receipt_hash": "a8ab4ae248e01c15debe8889d17c401c2d287d4480d3988534a98404187df7b0",
+        "outcome_receipt_hash": "54a4b593be499ee0f5fe62274189479d00352646cc6676d196d07ed483b50a90",
         "outcome_receipt_id": "outcome-saas-permission-change-missing_authority",
         "refusal_basis": [
           "authority_expired_or_missing",
@@ -77,7 +78,7 @@
           "authority_evidence_hash"
         ],
         "operation_id": "saas-permission-change-missing_authority",
-        "recomputed_manifest_hash": "14327240a9d6f9f79be76862f582600d7486985466aae73d8aa2ea95159d4bca",
+        "recomputed_manifest_hash": "9620ca1bb4eb9f6fb45e71415430a4513254db22a455d4628fa2ac59f0c38b7c",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -143,6 +144,7 @@
           "human_approval_verification_source": "signed_human_approval_artifact",
           "human_approval_verifier_id": "veritas-human-approval-verifier-v1",
           "human_approval_verifier_key_id": "local-demo-verifier-key",
+          "human_approval_verifier_lifecycle_snapshot_hash": "f48b71ec17e99dbf4785defcd6a7f2de3a51333adcb47c5739a81a969f7430fa",
           "human_approval_verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
           "human_approval_verifier_policy_id": "human-approval-verifier-policy-v1",
           "verified_human_approval_proof_hash": "4c5825bb7e0f647e705ca280a411695d052bfb8e65382f13804e86c0f485ef0c",
@@ -150,7 +152,7 @@
         },
         "observed_effects": [],
         "operation_id": "saas-permission-change-missing_authority",
-        "outcome_hash": "a8ab4ae248e01c15debe8889d17c401c2d287d4480d3988534a98404187df7b0",
+        "outcome_hash": "54a4b593be499ee0f5fe62274189479d00352646cc6676d196d07ed483b50a90",
         "outcome_receipt_id": "outcome-saas-permission-change-missing_authority",
         "post_state_fingerprint": null,
         "postcondition_status": "skipped",
@@ -213,9 +215,10 @@
         "human_approval_required": true,
         "human_approval_verifier_id": null,
         "human_approval_verifier_key_id": null,
+        "human_approval_verifier_lifecycle_snapshot_hash": null,
         "human_approval_verifier_policy_hash": null,
         "human_approval_verifier_policy_id": null,
-        "manifest_hash": "1992a33be9389de9394ffa43291c46105f2d703485c904422a299e6834cb2a5f",
+        "manifest_hash": "20b395802fcdf88e4f81bb867b0f810dcc4182530e444fdcebbe1171a4be3612",
         "manifest_id": "ecm-saas-permission-change-missing_human_approval",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -226,7 +229,7 @@
         ],
         "observed_effects_summary": [],
         "operation_id": "saas-permission-change-missing_human_approval",
-        "outcome_receipt_hash": "9675064eed76fafddc5aae73292bba314f31a3e106f81451c4a0f3d472bf6ebd",
+        "outcome_receipt_hash": "f94d52a89c6aafd19bd2a19bba13d51e49fee1080a804d822a8699b8330c0dce",
         "outcome_receipt_id": "outcome-saas-permission-change-missing_human_approval",
         "refusal_basis": [
           "human_approval_missing"
@@ -254,7 +257,7 @@
           "human_approval_receipt_hash"
         ],
         "operation_id": "saas-permission-change-missing_human_approval",
-        "recomputed_manifest_hash": "1992a33be9389de9394ffa43291c46105f2d703485c904422a299e6834cb2a5f",
+        "recomputed_manifest_hash": "20b395802fcdf88e4f81bb867b0f810dcc4182530e444fdcebbe1171a4be3612",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -315,7 +318,7 @@
         },
         "observed_effects": [],
         "operation_id": "saas-permission-change-missing_human_approval",
-        "outcome_hash": "9675064eed76fafddc5aae73292bba314f31a3e106f81451c4a0f3d472bf6ebd",
+        "outcome_hash": "f94d52a89c6aafd19bd2a19bba13d51e49fee1080a804d822a8699b8330c0dce",
         "outcome_receipt_id": "outcome-saas-permission-change-missing_human_approval",
         "post_state_fingerprint": null,
         "postcondition_status": "skipped",
@@ -363,9 +366,10 @@
         "human_approval_required": true,
         "human_approval_verifier_id": null,
         "human_approval_verifier_key_id": null,
+        "human_approval_verifier_lifecycle_snapshot_hash": null,
         "human_approval_verifier_policy_hash": null,
         "human_approval_verifier_policy_id": null,
-        "manifest_hash": "01269f1895cd817090ea87e50df0dac9f5f8177de62ac2998154fee5d2b4d36c",
+        "manifest_hash": "b91be527347ed42b0dc47fcd0a07ea0412ba0456f871cafb4242898cdc8f0af4",
         "manifest_id": "ecm-saas-permission-change-expired_human_approval",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -376,7 +380,7 @@
         ],
         "observed_effects_summary": [],
         "operation_id": "saas-permission-change-expired_human_approval",
-        "outcome_receipt_hash": "04f7b00e736648ed570282482a90bf453e4e8d871e26f4ca4d173467f0be92af",
+        "outcome_receipt_hash": "f170bf3595f0ef68027b1ab6bb4079fcdbf5ccd13a6bf7c053da1d917dd95f03",
         "outcome_receipt_id": "outcome-saas-permission-change-expired_human_approval",
         "refusal_basis": [
           "human_approval_missing"
@@ -404,7 +408,7 @@
           "human_approval_receipt_hash"
         ],
         "operation_id": "saas-permission-change-expired_human_approval",
-        "recomputed_manifest_hash": "01269f1895cd817090ea87e50df0dac9f5f8177de62ac2998154fee5d2b4d36c",
+        "recomputed_manifest_hash": "b91be527347ed42b0dc47fcd0a07ea0412ba0456f871cafb4242898cdc8f0af4",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -465,7 +469,7 @@
         },
         "observed_effects": [],
         "operation_id": "saas-permission-change-expired_human_approval",
-        "outcome_hash": "04f7b00e736648ed570282482a90bf453e4e8d871e26f4ca4d173467f0be92af",
+        "outcome_hash": "f170bf3595f0ef68027b1ab6bb4079fcdbf5ccd13a6bf7c053da1d917dd95f03",
         "outcome_receipt_id": "outcome-saas-permission-change-expired_human_approval",
         "post_state_fingerprint": null,
         "postcondition_status": "skipped",
@@ -513,9 +517,10 @@
         "human_approval_required": true,
         "human_approval_verifier_id": null,
         "human_approval_verifier_key_id": null,
+        "human_approval_verifier_lifecycle_snapshot_hash": null,
         "human_approval_verifier_policy_hash": null,
         "human_approval_verifier_policy_id": null,
-        "manifest_hash": "88824854f29f8d6e1a7d8447d7a1d2012670a258bdc58fdcaf3d7e12be573cd0",
+        "manifest_hash": "e0164a6402eba02f98a91343f4c535587e7b2fdfa2ca314fdd6af1c7bc498186",
         "manifest_id": "ecm-saas-permission-change-scope_mismatch",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -526,7 +531,7 @@
         ],
         "observed_effects_summary": [],
         "operation_id": "saas-permission-change-scope_mismatch",
-        "outcome_receipt_hash": "3fff28c56dd93ff5d7e11c71a9ed6ba134c31dc8a057810e72d24b93f2c8a54f",
+        "outcome_receipt_hash": "59bf3c158db3f58b84bd63b31f8aec4682b283d9c71d66c68b1ae6bd1161cd10",
         "outcome_receipt_id": "outcome-saas-permission-change-scope_mismatch",
         "refusal_basis": [
           "authority_invalid",
@@ -555,7 +560,7 @@
           "human_approval_receipt_hash"
         ],
         "operation_id": "saas-permission-change-scope_mismatch",
-        "recomputed_manifest_hash": "88824854f29f8d6e1a7d8447d7a1d2012670a258bdc58fdcaf3d7e12be573cd0",
+        "recomputed_manifest_hash": "e0164a6402eba02f98a91343f4c535587e7b2fdfa2ca314fdd6af1c7bc498186",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -618,7 +623,7 @@
         },
         "observed_effects": [],
         "operation_id": "saas-permission-change-scope_mismatch",
-        "outcome_hash": "3fff28c56dd93ff5d7e11c71a9ed6ba134c31dc8a057810e72d24b93f2c8a54f",
+        "outcome_hash": "59bf3c158db3f58b84bd63b31f8aec4682b283d9c71d66c68b1ae6bd1161cd10",
         "outcome_receipt_id": "outcome-saas-permission-change-scope_mismatch",
         "post_state_fingerprint": null,
         "postcondition_status": "skipped",
@@ -667,9 +672,10 @@
         "human_approval_required": true,
         "human_approval_verifier_id": "veritas-human-approval-verifier-v1",
         "human_approval_verifier_key_id": "local-demo-verifier-key",
+        "human_approval_verifier_lifecycle_snapshot_hash": "f48b71ec17e99dbf4785defcd6a7f2de3a51333adcb47c5739a81a969f7430fa",
         "human_approval_verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
         "human_approval_verifier_policy_id": "human-approval-verifier-policy-v1",
-        "manifest_hash": "5b1a60de9131745f4d53f91c83b021796842dc4882f16b3403844005c6dbe858",
+        "manifest_hash": "2f344ea93088bb92a5148276b94bd2eaf6c97c629f84ed96872869afc28be674",
         "manifest_id": "ecm-saas-permission-change-valid_authority_and_approval",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -685,7 +691,7 @@
           }
         ],
         "operation_id": "saas-permission-change-valid_authority_and_approval",
-        "outcome_receipt_hash": "1186d57ff77b5cd25f3031c569418941140aa5ff16d3eb537c0cc2be816cefdc",
+        "outcome_receipt_hash": "b29ecfff49a64dba77185fac997e4a543045f76e2e332274162d2781ab7587e9",
         "outcome_receipt_id": "outcome-saas-permission-change-valid_authority_and_approval",
         "refusal_basis": [],
         "requested_scope": [
@@ -709,7 +715,7 @@
         "mismatched_links": [],
         "missing_links": [],
         "operation_id": "saas-permission-change-valid_authority_and_approval",
-        "recomputed_manifest_hash": "5b1a60de9131745f4d53f91c83b021796842dc4882f16b3403844005c6dbe858",
+        "recomputed_manifest_hash": "2f344ea93088bb92a5148276b94bd2eaf6c97c629f84ed96872869afc28be674",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -768,6 +774,7 @@
           "human_approval_verification_source": "signed_human_approval_artifact",
           "human_approval_verifier_id": "veritas-human-approval-verifier-v1",
           "human_approval_verifier_key_id": "local-demo-verifier-key",
+          "human_approval_verifier_lifecycle_snapshot_hash": "f48b71ec17e99dbf4785defcd6a7f2de3a51333adcb47c5739a81a969f7430fa",
           "human_approval_verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
           "human_approval_verifier_policy_id": "human-approval-verifier-policy-v1",
           "verified_human_approval_proof_hash": "4c5825bb7e0f647e705ca280a411695d052bfb8e65382f13804e86c0f485ef0c",
@@ -782,7 +789,7 @@
           }
         ],
         "operation_id": "saas-permission-change-valid_authority_and_approval",
-        "outcome_hash": "1186d57ff77b5cd25f3031c569418941140aa5ff16d3eb537c0cc2be816cefdc",
+        "outcome_hash": "b29ecfff49a64dba77185fac997e4a543045f76e2e332274162d2781ab7587e9",
         "outcome_receipt_id": "outcome-saas-permission-change-valid_authority_and_approval",
         "post_state_fingerprint": null,
         "postcondition_status": "passed",
@@ -910,7 +917,7 @@
     }
   },
   "local_offline_only": true,
-  "packet_hash": "2622e0c2a729a9a9755fd3a232a4b11bc514b4122ce92c753bbcd9baa5d98205",
+  "packet_hash": "87b9ac0c05893c471f2df0b811509c267d559b9e8b190c75cebedec87154d1b2",
   "packet_id": "reviewer-evidence-packet-saas-permission-change-v1",
   "packet_version": "v1",
   "reviewer_notes": [

--- a/docs/en/demo/examples/reviewer-evidence-packet-with-evaluation-governance-v1.json
+++ b/docs/en/demo/examples/reviewer-evidence-packet-with-evaluation-governance-v1.json
@@ -34,9 +34,10 @@
         "human_approval_required": true,
         "human_approval_verifier_id": "veritas-human-approval-verifier-v1",
         "human_approval_verifier_key_id": "local-demo-verifier-key",
+        "human_approval_verifier_lifecycle_snapshot_hash": "f48b71ec17e99dbf4785defcd6a7f2de3a51333adcb47c5739a81a969f7430fa",
         "human_approval_verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
         "human_approval_verifier_policy_id": "human-approval-verifier-policy-v1",
-        "manifest_hash": "14327240a9d6f9f79be76862f582600d7486985466aae73d8aa2ea95159d4bca",
+        "manifest_hash": "9620ca1bb4eb9f6fb45e71415430a4513254db22a455d4628fa2ac59f0c38b7c",
         "manifest_id": "ecm-saas-permission-change-missing_authority",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -47,7 +48,7 @@
         ],
         "observed_effects_summary": [],
         "operation_id": "saas-permission-change-missing_authority",
-        "outcome_receipt_hash": "a8ab4ae248e01c15debe8889d17c401c2d287d4480d3988534a98404187df7b0",
+        "outcome_receipt_hash": "54a4b593be499ee0f5fe62274189479d00352646cc6676d196d07ed483b50a90",
         "outcome_receipt_id": "outcome-saas-permission-change-missing_authority",
         "refusal_basis": [
           "authority_expired_or_missing",
@@ -77,7 +78,7 @@
           "authority_evidence_hash"
         ],
         "operation_id": "saas-permission-change-missing_authority",
-        "recomputed_manifest_hash": "14327240a9d6f9f79be76862f582600d7486985466aae73d8aa2ea95159d4bca",
+        "recomputed_manifest_hash": "9620ca1bb4eb9f6fb45e71415430a4513254db22a455d4628fa2ac59f0c38b7c",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -143,6 +144,7 @@
           "human_approval_verification_source": "signed_human_approval_artifact",
           "human_approval_verifier_id": "veritas-human-approval-verifier-v1",
           "human_approval_verifier_key_id": "local-demo-verifier-key",
+          "human_approval_verifier_lifecycle_snapshot_hash": "f48b71ec17e99dbf4785defcd6a7f2de3a51333adcb47c5739a81a969f7430fa",
           "human_approval_verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
           "human_approval_verifier_policy_id": "human-approval-verifier-policy-v1",
           "verified_human_approval_proof_hash": "4c5825bb7e0f647e705ca280a411695d052bfb8e65382f13804e86c0f485ef0c",
@@ -150,7 +152,7 @@
         },
         "observed_effects": [],
         "operation_id": "saas-permission-change-missing_authority",
-        "outcome_hash": "a8ab4ae248e01c15debe8889d17c401c2d287d4480d3988534a98404187df7b0",
+        "outcome_hash": "54a4b593be499ee0f5fe62274189479d00352646cc6676d196d07ed483b50a90",
         "outcome_receipt_id": "outcome-saas-permission-change-missing_authority",
         "post_state_fingerprint": null,
         "postcondition_status": "skipped",
@@ -213,9 +215,10 @@
         "human_approval_required": true,
         "human_approval_verifier_id": null,
         "human_approval_verifier_key_id": null,
+        "human_approval_verifier_lifecycle_snapshot_hash": null,
         "human_approval_verifier_policy_hash": null,
         "human_approval_verifier_policy_id": null,
-        "manifest_hash": "1992a33be9389de9394ffa43291c46105f2d703485c904422a299e6834cb2a5f",
+        "manifest_hash": "20b395802fcdf88e4f81bb867b0f810dcc4182530e444fdcebbe1171a4be3612",
         "manifest_id": "ecm-saas-permission-change-missing_human_approval",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -226,7 +229,7 @@
         ],
         "observed_effects_summary": [],
         "operation_id": "saas-permission-change-missing_human_approval",
-        "outcome_receipt_hash": "9675064eed76fafddc5aae73292bba314f31a3e106f81451c4a0f3d472bf6ebd",
+        "outcome_receipt_hash": "f94d52a89c6aafd19bd2a19bba13d51e49fee1080a804d822a8699b8330c0dce",
         "outcome_receipt_id": "outcome-saas-permission-change-missing_human_approval",
         "refusal_basis": [
           "human_approval_missing"
@@ -254,7 +257,7 @@
           "human_approval_receipt_hash"
         ],
         "operation_id": "saas-permission-change-missing_human_approval",
-        "recomputed_manifest_hash": "1992a33be9389de9394ffa43291c46105f2d703485c904422a299e6834cb2a5f",
+        "recomputed_manifest_hash": "20b395802fcdf88e4f81bb867b0f810dcc4182530e444fdcebbe1171a4be3612",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -315,7 +318,7 @@
         },
         "observed_effects": [],
         "operation_id": "saas-permission-change-missing_human_approval",
-        "outcome_hash": "9675064eed76fafddc5aae73292bba314f31a3e106f81451c4a0f3d472bf6ebd",
+        "outcome_hash": "f94d52a89c6aafd19bd2a19bba13d51e49fee1080a804d822a8699b8330c0dce",
         "outcome_receipt_id": "outcome-saas-permission-change-missing_human_approval",
         "post_state_fingerprint": null,
         "postcondition_status": "skipped",
@@ -363,9 +366,10 @@
         "human_approval_required": true,
         "human_approval_verifier_id": null,
         "human_approval_verifier_key_id": null,
+        "human_approval_verifier_lifecycle_snapshot_hash": null,
         "human_approval_verifier_policy_hash": null,
         "human_approval_verifier_policy_id": null,
-        "manifest_hash": "01269f1895cd817090ea87e50df0dac9f5f8177de62ac2998154fee5d2b4d36c",
+        "manifest_hash": "b91be527347ed42b0dc47fcd0a07ea0412ba0456f871cafb4242898cdc8f0af4",
         "manifest_id": "ecm-saas-permission-change-expired_human_approval",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -376,7 +380,7 @@
         ],
         "observed_effects_summary": [],
         "operation_id": "saas-permission-change-expired_human_approval",
-        "outcome_receipt_hash": "04f7b00e736648ed570282482a90bf453e4e8d871e26f4ca4d173467f0be92af",
+        "outcome_receipt_hash": "f170bf3595f0ef68027b1ab6bb4079fcdbf5ccd13a6bf7c053da1d917dd95f03",
         "outcome_receipt_id": "outcome-saas-permission-change-expired_human_approval",
         "refusal_basis": [
           "human_approval_missing"
@@ -404,7 +408,7 @@
           "human_approval_receipt_hash"
         ],
         "operation_id": "saas-permission-change-expired_human_approval",
-        "recomputed_manifest_hash": "01269f1895cd817090ea87e50df0dac9f5f8177de62ac2998154fee5d2b4d36c",
+        "recomputed_manifest_hash": "b91be527347ed42b0dc47fcd0a07ea0412ba0456f871cafb4242898cdc8f0af4",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -465,7 +469,7 @@
         },
         "observed_effects": [],
         "operation_id": "saas-permission-change-expired_human_approval",
-        "outcome_hash": "04f7b00e736648ed570282482a90bf453e4e8d871e26f4ca4d173467f0be92af",
+        "outcome_hash": "f170bf3595f0ef68027b1ab6bb4079fcdbf5ccd13a6bf7c053da1d917dd95f03",
         "outcome_receipt_id": "outcome-saas-permission-change-expired_human_approval",
         "post_state_fingerprint": null,
         "postcondition_status": "skipped",
@@ -513,9 +517,10 @@
         "human_approval_required": true,
         "human_approval_verifier_id": null,
         "human_approval_verifier_key_id": null,
+        "human_approval_verifier_lifecycle_snapshot_hash": null,
         "human_approval_verifier_policy_hash": null,
         "human_approval_verifier_policy_id": null,
-        "manifest_hash": "88824854f29f8d6e1a7d8447d7a1d2012670a258bdc58fdcaf3d7e12be573cd0",
+        "manifest_hash": "e0164a6402eba02f98a91343f4c535587e7b2fdfa2ca314fdd6af1c7bc498186",
         "manifest_id": "ecm-saas-permission-change-scope_mismatch",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -526,7 +531,7 @@
         ],
         "observed_effects_summary": [],
         "operation_id": "saas-permission-change-scope_mismatch",
-        "outcome_receipt_hash": "3fff28c56dd93ff5d7e11c71a9ed6ba134c31dc8a057810e72d24b93f2c8a54f",
+        "outcome_receipt_hash": "59bf3c158db3f58b84bd63b31f8aec4682b283d9c71d66c68b1ae6bd1161cd10",
         "outcome_receipt_id": "outcome-saas-permission-change-scope_mismatch",
         "refusal_basis": [
           "authority_invalid",
@@ -555,7 +560,7 @@
           "human_approval_receipt_hash"
         ],
         "operation_id": "saas-permission-change-scope_mismatch",
-        "recomputed_manifest_hash": "88824854f29f8d6e1a7d8447d7a1d2012670a258bdc58fdcaf3d7e12be573cd0",
+        "recomputed_manifest_hash": "e0164a6402eba02f98a91343f4c535587e7b2fdfa2ca314fdd6af1c7bc498186",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -618,7 +623,7 @@
         },
         "observed_effects": [],
         "operation_id": "saas-permission-change-scope_mismatch",
-        "outcome_hash": "3fff28c56dd93ff5d7e11c71a9ed6ba134c31dc8a057810e72d24b93f2c8a54f",
+        "outcome_hash": "59bf3c158db3f58b84bd63b31f8aec4682b283d9c71d66c68b1ae6bd1161cd10",
         "outcome_receipt_id": "outcome-saas-permission-change-scope_mismatch",
         "post_state_fingerprint": null,
         "postcondition_status": "skipped",
@@ -667,9 +672,10 @@
         "human_approval_required": true,
         "human_approval_verifier_id": "veritas-human-approval-verifier-v1",
         "human_approval_verifier_key_id": "local-demo-verifier-key",
+        "human_approval_verifier_lifecycle_snapshot_hash": "f48b71ec17e99dbf4785defcd6a7f2de3a51333adcb47c5739a81a969f7430fa",
         "human_approval_verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
         "human_approval_verifier_policy_id": "human-approval-verifier-policy-v1",
-        "manifest_hash": "5b1a60de9131745f4d53f91c83b021796842dc4882f16b3403844005c6dbe858",
+        "manifest_hash": "2f344ea93088bb92a5148276b94bd2eaf6c97c629f84ed96872869afc28be674",
         "manifest_id": "ecm-saas-permission-change-valid_authority_and_approval",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -685,7 +691,7 @@
           }
         ],
         "operation_id": "saas-permission-change-valid_authority_and_approval",
-        "outcome_receipt_hash": "1186d57ff77b5cd25f3031c569418941140aa5ff16d3eb537c0cc2be816cefdc",
+        "outcome_receipt_hash": "b29ecfff49a64dba77185fac997e4a543045f76e2e332274162d2781ab7587e9",
         "outcome_receipt_id": "outcome-saas-permission-change-valid_authority_and_approval",
         "refusal_basis": [],
         "requested_scope": [
@@ -709,7 +715,7 @@
         "mismatched_links": [],
         "missing_links": [],
         "operation_id": "saas-permission-change-valid_authority_and_approval",
-        "recomputed_manifest_hash": "5b1a60de9131745f4d53f91c83b021796842dc4882f16b3403844005c6dbe858",
+        "recomputed_manifest_hash": "2f344ea93088bb92a5148276b94bd2eaf6c97c629f84ed96872869afc28be674",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -768,6 +774,7 @@
           "human_approval_verification_source": "signed_human_approval_artifact",
           "human_approval_verifier_id": "veritas-human-approval-verifier-v1",
           "human_approval_verifier_key_id": "local-demo-verifier-key",
+          "human_approval_verifier_lifecycle_snapshot_hash": "f48b71ec17e99dbf4785defcd6a7f2de3a51333adcb47c5739a81a969f7430fa",
           "human_approval_verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
           "human_approval_verifier_policy_id": "human-approval-verifier-policy-v1",
           "verified_human_approval_proof_hash": "4c5825bb7e0f647e705ca280a411695d052bfb8e65382f13804e86c0f485ef0c",
@@ -782,7 +789,7 @@
           }
         ],
         "operation_id": "saas-permission-change-valid_authority_and_approval",
-        "outcome_hash": "1186d57ff77b5cd25f3031c569418941140aa5ff16d3eb537c0cc2be816cefdc",
+        "outcome_hash": "b29ecfff49a64dba77185fac997e4a543045f76e2e332274162d2781ab7587e9",
         "outcome_receipt_id": "outcome-saas-permission-change-valid_authority_and_approval",
         "post_state_fingerprint": null,
         "postcondition_status": "passed",
@@ -910,7 +917,7 @@
     }
   },
   "local_offline_only": true,
-  "packet_hash": "2622e0c2a729a9a9755fd3a232a4b11bc514b4122ce92c753bbcd9baa5d98205",
+  "packet_hash": "87b9ac0c05893c471f2df0b811509c267d559b9e8b190c75cebedec87154d1b2",
   "packet_id": "reviewer-evidence-packet-saas-permission-change-v1",
   "packet_version": "v1",
   "reviewer_notes": [

--- a/docs/en/demo/fixtures/reviewer-evidence-packet-decision-candidate-refusal-v1.json
+++ b/docs/en/demo/fixtures/reviewer-evidence-packet-decision-candidate-refusal-v1.json
@@ -34,9 +34,10 @@
         "human_approval_required": true,
         "human_approval_verifier_id": "veritas-human-approval-verifier-v1",
         "human_approval_verifier_key_id": "local-demo-verifier-key",
+        "human_approval_verifier_lifecycle_snapshot_hash": "f48b71ec17e99dbf4785defcd6a7f2de3a51333adcb47c5739a81a969f7430fa",
         "human_approval_verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
         "human_approval_verifier_policy_id": "human-approval-verifier-policy-v1",
-        "manifest_hash": "8b12d0c3f8a916f357e8311dcd1e20ad16bc3e468192016e491d86c3cbfe1f7b",
+        "manifest_hash": "e40ca589c0e46caabdd5482d3a3b49e5d4c76bd047e4e0e3ef23809b06f377be",
         "manifest_id": "ecm-saas-permission-change-missing_authority",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -47,7 +48,7 @@
         ],
         "observed_effects_summary": [],
         "operation_id": "saas-permission-change-missing_authority",
-        "outcome_receipt_hash": "8f28c45ec0f7efd2f8f4cd25b02fe46450c012b10a06ed715d9ed25f899ea71f",
+        "outcome_receipt_hash": "a8c961251d8ced5e5f3de82328150ae29f55ce1f193a7e9cbab9052e5d545923",
         "outcome_receipt_id": "outcome-saas-permission-change-missing_authority",
         "refusal_basis": [
           "authority_expired_or_missing",
@@ -77,7 +78,7 @@
           "authority_evidence_hash"
         ],
         "operation_id": "saas-permission-change-missing_authority",
-        "recomputed_manifest_hash": "8b12d0c3f8a916f357e8311dcd1e20ad16bc3e468192016e491d86c3cbfe1f7b",
+        "recomputed_manifest_hash": "e40ca589c0e46caabdd5482d3a3b49e5d4c76bd047e4e0e3ef23809b06f377be",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -143,6 +144,7 @@
           "human_approval_verification_source": "signed_human_approval_artifact",
           "human_approval_verifier_id": "veritas-human-approval-verifier-v1",
           "human_approval_verifier_key_id": "local-demo-verifier-key",
+          "human_approval_verifier_lifecycle_snapshot_hash": "f48b71ec17e99dbf4785defcd6a7f2de3a51333adcb47c5739a81a969f7430fa",
           "human_approval_verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
           "human_approval_verifier_policy_id": "human-approval-verifier-policy-v1",
           "verified_human_approval_proof_hash": "4c5825bb7e0f647e705ca280a411695d052bfb8e65382f13804e86c0f485ef0c",
@@ -150,7 +152,7 @@
         },
         "observed_effects": [],
         "operation_id": "saas-permission-change-missing_authority",
-        "outcome_hash": "8f28c45ec0f7efd2f8f4cd25b02fe46450c012b10a06ed715d9ed25f899ea71f",
+        "outcome_hash": "a8c961251d8ced5e5f3de82328150ae29f55ce1f193a7e9cbab9052e5d545923",
         "outcome_receipt_id": "outcome-saas-permission-change-missing_authority",
         "post_state_fingerprint": null,
         "postcondition_status": "skipped",
@@ -213,9 +215,10 @@
         "human_approval_required": true,
         "human_approval_verifier_id": null,
         "human_approval_verifier_key_id": null,
+        "human_approval_verifier_lifecycle_snapshot_hash": null,
         "human_approval_verifier_policy_hash": null,
         "human_approval_verifier_policy_id": null,
-        "manifest_hash": "1992a33be9389de9394ffa43291c46105f2d703485c904422a299e6834cb2a5f",
+        "manifest_hash": "f10d3a2b5eed6a79dda61b444ccbce21a95ffe2f062d749cac7ab2a69036afdd",
         "manifest_id": "ecm-saas-permission-change-missing_human_approval",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -254,7 +257,7 @@
           "human_approval_receipt_hash"
         ],
         "operation_id": "saas-permission-change-missing_human_approval",
-        "recomputed_manifest_hash": "1992a33be9389de9394ffa43291c46105f2d703485c904422a299e6834cb2a5f",
+        "recomputed_manifest_hash": "f10d3a2b5eed6a79dda61b444ccbce21a95ffe2f062d749cac7ab2a69036afdd",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -363,9 +366,10 @@
         "human_approval_required": true,
         "human_approval_verifier_id": null,
         "human_approval_verifier_key_id": null,
+        "human_approval_verifier_lifecycle_snapshot_hash": null,
         "human_approval_verifier_policy_hash": null,
         "human_approval_verifier_policy_id": null,
-        "manifest_hash": "01269f1895cd817090ea87e50df0dac9f5f8177de62ac2998154fee5d2b4d36c",
+        "manifest_hash": "60b1130324433c550d9898c1ed8e8e979508f9534267cac0e3a513daae2b0c6e",
         "manifest_id": "ecm-saas-permission-change-expired_human_approval",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -404,7 +408,7 @@
           "human_approval_receipt_hash"
         ],
         "operation_id": "saas-permission-change-expired_human_approval",
-        "recomputed_manifest_hash": "01269f1895cd817090ea87e50df0dac9f5f8177de62ac2998154fee5d2b4d36c",
+        "recomputed_manifest_hash": "60b1130324433c550d9898c1ed8e8e979508f9534267cac0e3a513daae2b0c6e",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -513,9 +517,10 @@
         "human_approval_required": true,
         "human_approval_verifier_id": null,
         "human_approval_verifier_key_id": null,
+        "human_approval_verifier_lifecycle_snapshot_hash": null,
         "human_approval_verifier_policy_hash": null,
         "human_approval_verifier_policy_id": null,
-        "manifest_hash": "88824854f29f8d6e1a7d8447d7a1d2012670a258bdc58fdcaf3d7e12be573cd0",
+        "manifest_hash": "055b5a585669f95bb7b43d217844f5e2de0bbfbb49615e9560253a6468d3b339",
         "manifest_id": "ecm-saas-permission-change-scope_mismatch",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -555,7 +560,7 @@
           "human_approval_receipt_hash"
         ],
         "operation_id": "saas-permission-change-scope_mismatch",
-        "recomputed_manifest_hash": "88824854f29f8d6e1a7d8447d7a1d2012670a258bdc58fdcaf3d7e12be573cd0",
+        "recomputed_manifest_hash": "055b5a585669f95bb7b43d217844f5e2de0bbfbb49615e9560253a6468d3b339",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -667,9 +672,10 @@
         "human_approval_required": true,
         "human_approval_verifier_id": "veritas-human-approval-verifier-v1",
         "human_approval_verifier_key_id": "local-demo-verifier-key",
+        "human_approval_verifier_lifecycle_snapshot_hash": "f48b71ec17e99dbf4785defcd6a7f2de3a51333adcb47c5739a81a969f7430fa",
         "human_approval_verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
         "human_approval_verifier_policy_id": "human-approval-verifier-policy-v1",
-        "manifest_hash": "c3a7ed2805f936c898340168d8ae693b9734c9732b517a16fa53ab5c4d7aecb9",
+        "manifest_hash": "10ea4eeb70998b113d38ff1fecd7caa328168eb12658aaae81fc47c49948dcff",
         "manifest_id": "ecm-saas-permission-change-valid_authority_and_approval",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -685,7 +691,7 @@
           }
         ],
         "operation_id": "saas-permission-change-valid_authority_and_approval",
-        "outcome_receipt_hash": "e8eb969be01b97993b20283a6f0314f5e83be4d6377e879f7b3719562e5a036a",
+        "outcome_receipt_hash": "42c75e4d6adcf3dc4c2a8a6822b945256be56b38209c5a8e99520ef45abddc7f",
         "outcome_receipt_id": "outcome-saas-permission-change-valid_authority_and_approval",
         "refusal_basis": [],
         "requested_scope": [
@@ -709,7 +715,7 @@
         "mismatched_links": [],
         "missing_links": [],
         "operation_id": "saas-permission-change-valid_authority_and_approval",
-        "recomputed_manifest_hash": "c3a7ed2805f936c898340168d8ae693b9734c9732b517a16fa53ab5c4d7aecb9",
+        "recomputed_manifest_hash": "10ea4eeb70998b113d38ff1fecd7caa328168eb12658aaae81fc47c49948dcff",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -768,6 +774,7 @@
           "human_approval_verification_source": "signed_human_approval_artifact",
           "human_approval_verifier_id": "veritas-human-approval-verifier-v1",
           "human_approval_verifier_key_id": "local-demo-verifier-key",
+          "human_approval_verifier_lifecycle_snapshot_hash": "f48b71ec17e99dbf4785defcd6a7f2de3a51333adcb47c5739a81a969f7430fa",
           "human_approval_verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
           "human_approval_verifier_policy_id": "human-approval-verifier-policy-v1",
           "verified_human_approval_proof_hash": "4c5825bb7e0f647e705ca280a411695d052bfb8e65382f13804e86c0f485ef0c",
@@ -782,7 +789,7 @@
           }
         ],
         "operation_id": "saas-permission-change-valid_authority_and_approval",
-        "outcome_hash": "e8eb969be01b97993b20283a6f0314f5e83be4d6377e879f7b3719562e5a036a",
+        "outcome_hash": "42c75e4d6adcf3dc4c2a8a6822b945256be56b38209c5a8e99520ef45abddc7f",
         "outcome_receipt_id": "outcome-saas-permission-change-valid_authority_and_approval",
         "post_state_fingerprint": null,
         "postcondition_status": "passed",
@@ -870,7 +877,7 @@
     }
   },
   "local_offline_only": true,
-  "packet_hash": "1990eecea8d17d26b1eddbb819a64bbd176a2e84daa8016626f9c1b277eb0cfe",
+  "packet_hash": "44a4b5bbc23218bc268702f0ffdf4f514a1611bc1bd8f875b89b1a292451aacc",
   "packet_id": "reviewer-evidence-packet-decision-candidate-refusal-v1",
   "packet_version": "v1",
   "reviewer_notes": [

--- a/docs/en/demo/fixtures/reviewer-evidence-packet-saas-permission-change-v1.json
+++ b/docs/en/demo/fixtures/reviewer-evidence-packet-saas-permission-change-v1.json
@@ -34,9 +34,10 @@
         "human_approval_required": true,
         "human_approval_verifier_id": "veritas-human-approval-verifier-v1",
         "human_approval_verifier_key_id": "local-demo-verifier-key",
+        "human_approval_verifier_lifecycle_snapshot_hash": "f48b71ec17e99dbf4785defcd6a7f2de3a51333adcb47c5739a81a969f7430fa",
         "human_approval_verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
         "human_approval_verifier_policy_id": "human-approval-verifier-policy-v1",
-        "manifest_hash": "0cb91e5a3cf9f83b65372210f87d68d4b75d74e57ed077e0abf228c70517faa2",
+        "manifest_hash": "1da42f577b8436ce6b07985cee18efc8b9adcd1151bfbf93a8c326cdc68b0e88",
         "manifest_id": "ecm-saas-permission-change-missing_authority",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -47,7 +48,7 @@
         ],
         "observed_effects_summary": [],
         "operation_id": "saas-permission-change-missing_authority",
-        "outcome_receipt_hash": "df7fb9870f269e6cf0f4f3edd0cdbc91ab4c4179eaea9ec629ada299db31f5fb",
+        "outcome_receipt_hash": "a8c961251d8ced5e5f3de82328150ae29f55ce1f193a7e9cbab9052e5d545923",
         "outcome_receipt_id": "outcome-saas-permission-change-missing_authority",
         "refusal_basis": [
           "authority_expired_or_missing",
@@ -77,7 +78,7 @@
           "authority_evidence_hash"
         ],
         "operation_id": "saas-permission-change-missing_authority",
-        "recomputed_manifest_hash": "0cb91e5a3cf9f83b65372210f87d68d4b75d74e57ed077e0abf228c70517faa2",
+        "recomputed_manifest_hash": "1da42f577b8436ce6b07985cee18efc8b9adcd1151bfbf93a8c326cdc68b0e88",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -143,6 +144,7 @@
           "human_approval_verification_source": "signed_human_approval_artifact",
           "human_approval_verifier_id": "veritas-human-approval-verifier-v1",
           "human_approval_verifier_key_id": "local-demo-verifier-key",
+          "human_approval_verifier_lifecycle_snapshot_hash": "f48b71ec17e99dbf4785defcd6a7f2de3a51333adcb47c5739a81a969f7430fa",
           "human_approval_verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
           "human_approval_verifier_policy_id": "human-approval-verifier-policy-v1",
           "verified_human_approval_proof_hash": "4c5825bb7e0f647e705ca280a411695d052bfb8e65382f13804e86c0f485ef0c",
@@ -150,7 +152,7 @@
         },
         "observed_effects": [],
         "operation_id": "saas-permission-change-missing_authority",
-        "outcome_hash": "df7fb9870f269e6cf0f4f3edd0cdbc91ab4c4179eaea9ec629ada299db31f5fb",
+        "outcome_hash": "a8c961251d8ced5e5f3de82328150ae29f55ce1f193a7e9cbab9052e5d545923",
         "outcome_receipt_id": "outcome-saas-permission-change-missing_authority",
         "post_state_fingerprint": null,
         "postcondition_status": "skipped",
@@ -213,9 +215,10 @@
         "human_approval_required": true,
         "human_approval_verifier_id": null,
         "human_approval_verifier_key_id": null,
+        "human_approval_verifier_lifecycle_snapshot_hash": null,
         "human_approval_verifier_policy_hash": null,
         "human_approval_verifier_policy_id": null,
-        "manifest_hash": "30d6b2a7c44ab8f641eb2fb6f0045081f44ab67d32dd60684c0dcf5bd15d1a17",
+        "manifest_hash": "f10d3a2b5eed6a79dda61b444ccbce21a95ffe2f062d749cac7ab2a69036afdd",
         "manifest_id": "ecm-saas-permission-change-missing_human_approval",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -254,7 +257,7 @@
           "human_approval_receipt_hash"
         ],
         "operation_id": "saas-permission-change-missing_human_approval",
-        "recomputed_manifest_hash": "30d6b2a7c44ab8f641eb2fb6f0045081f44ab67d32dd60684c0dcf5bd15d1a17",
+        "recomputed_manifest_hash": "f10d3a2b5eed6a79dda61b444ccbce21a95ffe2f062d749cac7ab2a69036afdd",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -363,9 +366,10 @@
         "human_approval_required": true,
         "human_approval_verifier_id": null,
         "human_approval_verifier_key_id": null,
+        "human_approval_verifier_lifecycle_snapshot_hash": null,
         "human_approval_verifier_policy_hash": null,
         "human_approval_verifier_policy_id": null,
-        "manifest_hash": "daceaf740f173da86473d4145558559ebf52afdd33e6dbd0a32a2bf4165b6121",
+        "manifest_hash": "0409620db11a3f87ae384d156a42ff056fa6e6cd4d43ef56ab466406f727045a",
         "manifest_id": "ecm-saas-permission-change-expired_human_approval",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -404,7 +408,7 @@
           "human_approval_receipt_hash"
         ],
         "operation_id": "saas-permission-change-expired_human_approval",
-        "recomputed_manifest_hash": "daceaf740f173da86473d4145558559ebf52afdd33e6dbd0a32a2bf4165b6121",
+        "recomputed_manifest_hash": "0409620db11a3f87ae384d156a42ff056fa6e6cd4d43ef56ab466406f727045a",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -513,9 +517,10 @@
         "human_approval_required": true,
         "human_approval_verifier_id": null,
         "human_approval_verifier_key_id": null,
+        "human_approval_verifier_lifecycle_snapshot_hash": null,
         "human_approval_verifier_policy_hash": null,
         "human_approval_verifier_policy_id": null,
-        "manifest_hash": "fd3f22dc3ed5cc0203e37d8e32efa151bdcf948cc83adcf65a46d0b49049a30f",
+        "manifest_hash": "a69bc8fd28af1d842d90f66340e456e0954a989649d00e00380ff42ddab7249c",
         "manifest_id": "ecm-saas-permission-change-scope_mismatch",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -555,7 +560,7 @@
           "human_approval_receipt_hash"
         ],
         "operation_id": "saas-permission-change-scope_mismatch",
-        "recomputed_manifest_hash": "fd3f22dc3ed5cc0203e37d8e32efa151bdcf948cc83adcf65a46d0b49049a30f",
+        "recomputed_manifest_hash": "a69bc8fd28af1d842d90f66340e456e0954a989649d00e00380ff42ddab7249c",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -667,9 +672,10 @@
         "human_approval_required": true,
         "human_approval_verifier_id": "veritas-human-approval-verifier-v1",
         "human_approval_verifier_key_id": "local-demo-verifier-key",
+        "human_approval_verifier_lifecycle_snapshot_hash": "f48b71ec17e99dbf4785defcd6a7f2de3a51333adcb47c5739a81a969f7430fa",
         "human_approval_verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
         "human_approval_verifier_policy_id": "human-approval-verifier-policy-v1",
-        "manifest_hash": "bad33da5884c59320c0ae88bff60c4fd0826456ce86adebca96979600fdce883",
+        "manifest_hash": "d1184945f3c7671e9f67ffcc16c5f1872b4bcbe15c623def09d35c9e4a46cd5f",
         "manifest_id": "ecm-saas-permission-change-valid_authority_and_approval",
         "metadata": {
           "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
@@ -685,7 +691,7 @@
           }
         ],
         "operation_id": "saas-permission-change-valid_authority_and_approval",
-        "outcome_receipt_hash": "e088f67d0293f1b506eeb76a8469dff567ddd4b7b9927cfc141b83b06313e758",
+        "outcome_receipt_hash": "42c75e4d6adcf3dc4c2a8a6822b945256be56b38209c5a8e99520ef45abddc7f",
         "outcome_receipt_id": "outcome-saas-permission-change-valid_authority_and_approval",
         "refusal_basis": [],
         "requested_scope": [
@@ -709,7 +715,7 @@
         "mismatched_links": [],
         "missing_links": [],
         "operation_id": "saas-permission-change-valid_authority_and_approval",
-        "recomputed_manifest_hash": "bad33da5884c59320c0ae88bff60c4fd0826456ce86adebca96979600fdce883",
+        "recomputed_manifest_hash": "d1184945f3c7671e9f67ffcc16c5f1872b4bcbe15c623def09d35c9e4a46cd5f",
         "verification_status": "verified",
         "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
@@ -768,6 +774,7 @@
           "human_approval_verification_source": "signed_human_approval_artifact",
           "human_approval_verifier_id": "veritas-human-approval-verifier-v1",
           "human_approval_verifier_key_id": "local-demo-verifier-key",
+          "human_approval_verifier_lifecycle_snapshot_hash": "f48b71ec17e99dbf4785defcd6a7f2de3a51333adcb47c5739a81a969f7430fa",
           "human_approval_verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
           "human_approval_verifier_policy_id": "human-approval-verifier-policy-v1",
           "verified_human_approval_proof_hash": "4c5825bb7e0f647e705ca280a411695d052bfb8e65382f13804e86c0f485ef0c",
@@ -782,7 +789,7 @@
           }
         ],
         "operation_id": "saas-permission-change-valid_authority_and_approval",
-        "outcome_hash": "e088f67d0293f1b506eeb76a8469dff567ddd4b7b9927cfc141b83b06313e758",
+        "outcome_hash": "42c75e4d6adcf3dc4c2a8a6822b945256be56b38209c5a8e99520ef45abddc7f",
         "outcome_receipt_id": "outcome-saas-permission-change-valid_authority_and_approval",
         "post_state_fingerprint": null,
         "postcondition_status": "passed",
@@ -838,7 +845,7 @@
     }
   },
   "local_offline_only": true,
-  "packet_hash": "a2783c7eeaddad468a5fd5e1209d56b812bdc4e3796f4366de62fa54a1335163",
+  "packet_hash": "20b7db9cfd4f22df36472b048b9d9bafc080e2f571886d381e117d12c099492f",
   "packet_id": "reviewer-evidence-packet-saas-permission-change-v1",
   "packet_version": "v1",
   "reviewer_notes": [

--- a/docs/en/demo/reviewer-evidence-packet.md
+++ b/docs/en/demo/reviewer-evidence-packet.md
@@ -72,10 +72,11 @@ Reviewer Evidence Packet validation now checks human approval proof continuity f
 - `outcome_receipt_summary.metadata.verified_human_approval_proof_hash` is present;
 - both proof hashes match;
 - reviewer summaries expose the approver, verifier, `verifier_policy_id`, `verifier_policy_hash`, and proof hash;
-- the verifier policy hash in the reviewer summary, manifest summary, and outcome metadata match; and
+- the verifier policy hash in the reviewer summary, manifest summary, and outcome metadata match;
+- when `verifier_lifecycle_summary` is non-null, `verifier_lifecycle_summary.verifier_lifecycle_snapshot_hash`, `evidence_chain_manifest_summary.human_approval_verifier_lifecycle_snapshot_hash`, and `outcome_receipt_summary.metadata.human_approval_verifier_lifecycle_snapshot_hash` match; and
 - a verified `evidence_chain_verification_summary` includes `verified_human_approval_proof_hash` in `verified_links`.
 
-For failed or incomplete evidence-chain verification caused by approval proof continuity, reviewer validation expects deterministic failure reasons from the evidence-chain verifier. This prevents reviewer-facing artifacts from presenting a committed outcome with a substituted, missing, or unverified human approval proof, or with a missing/mismatched verifier policy snapshot. No-approval-required flows may keep the proof hash and verifier policy fields absent and do not need the proof hash link in `verified_links`.
+For failed or incomplete evidence-chain verification caused by approval proof continuity, reviewer validation expects deterministic failure reasons from the evidence-chain verifier. This prevents reviewer-facing artifacts from presenting a committed outcome with a substituted, missing, or unverified human approval proof, or with a missing/mismatched verifier policy or lifecycle snapshot. No-approval-required flows may keep the proof hash, verifier policy fields, and lifecycle snapshot hash absent and do not need the proof hash link in `verified_links`.
 
 ## Local/offline boundary
 
@@ -112,4 +113,3 @@ Reviewer Evidence Packet v1 has a checked-in schema at:
 The schema documents the required packet fields, case summaries, nested evidence summaries, aggregate summary, reviewer notes, packet hash format, and optional `evaluation_governance_artifacts` reference shape. The golden fixture and generated packet are tested against this schema. Future intentional packet-shape changes should update the schema, exporter, tests, and golden fixture in the same PR.
 
 This schema is for a local/offline reviewer packet. It is not a production audit certification, regulatory approval, or proof of live deployment.
-

--- a/docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json
+++ b/docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json
@@ -498,6 +498,7 @@
         "human_approval_verifier_key_id",
         "human_approval_verifier_policy_id",
         "human_approval_verifier_policy_hash",
+        "human_approval_verifier_lifecycle_snapshot_hash",
         "human_approval_required",
         "bind_receipt_id",
         "bind_receipt_hash",
@@ -636,6 +637,9 @@
           ]
         },
         "human_approval_verifier_policy_hash": {
+          "$ref": "#/$defs/nullable_sha256_hex"
+        },
+        "human_approval_verifier_lifecycle_snapshot_hash": {
           "$ref": "#/$defs/nullable_sha256_hex"
         },
         "human_approval_required": {

--- a/samples/evidence_bundle/key_provenance_review/reviewer-evidence-packet.json
+++ b/samples/evidence_bundle/key_provenance_review/reviewer-evidence-packet.json
@@ -1,162 +1,816 @@
 {
   "aggregate_summary": {
-    "blocked_cases": 0,
+    "blocked_cases": 4,
     "committed_cases": 1,
     "failed_chains": 0,
     "incomplete_chains": 0,
     "indeterminate_chains": 0,
     "local_offline_only": true,
-    "passed_cases": 1,
-    "total_cases": 1,
-    "verified_chains": 1
+    "passed_cases": 5,
+    "total_cases": 5,
+    "verified_chains": 5
   },
-  "boundary_note": "Illustrative sample only. Not production evidence, not regulatory certification, and not completed third-party audit approval. The packet references artifacts for reviewer navigation only; it does not create trust, replace out-of-band public key trust, or prove certification.",
+  "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
   "cases": [
     {
-      "actual_outcome": "commit",
-      "authority_validation_status": "sample_authority_present",
-      "boundary_note": "Illustrative local/offline case summary only; not production evidence or audit approval.",
-      "case_id": "sample_key_provenance_review",
+      "actual_outcome": "block",
+      "authority_validation_status": "fail",
+      "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+      "case_id": "missing_authority",
       "evidence_chain_manifest_summary": {
-        "action_class": "sample.review",
-        "authority_evidence_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        "authority_evidence_id": "sample-authority-evidence",
-        "bind_coverage_operation_id": "sample-operation",
-        "bind_receipt_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-        "bind_receipt_id": "sample-bind-receipt",
-        "chain_status": "complete",
-        "decision_id": "sample-decision",
-        "execution_intent_id": "sample-execution-intent",
-        "final_outcome": "commit",
-        "generated_at": "2026-01-15T12:05:00Z",
-        "human_approval_receipt_hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
-        "human_approval_receipt_id": "sample-human-approval",
+        "action_class": "permission_change",
+        "authority_evidence_hash": null,
+        "authority_evidence_id": null,
+        "bind_coverage_operation_id": "saas_permission_change_demo",
+        "bind_receipt_hash": null,
+        "bind_receipt_id": null,
+        "chain_status": "blocked",
+        "decision_id": "decision-saas-001",
+        "execution_intent_id": "intent-saas-001",
+        "final_outcome": "block",
+        "generated_at": "2026-04-26T00:00:00+00:00",
+        "human_approval_receipt_hash": "55db4aa2686f01d6e1133b880ee85e82572957b3e0e3dd63bce692a8be4d38ba",
+        "human_approval_receipt_id": "har-saas-001",
         "human_approval_required": true,
         "human_approval_verifier_id": "veritas-human-approval-verifier-v1",
         "human_approval_verifier_key_id": "local-demo-verifier-key",
+        "human_approval_verifier_lifecycle_snapshot_hash": "f48b71ec17e99dbf4785defcd6a7f2de3a51333adcb47c5739a81a969f7430fa",
         "human_approval_verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
         "human_approval_verifier_policy_id": "human-approval-verifier-policy-v1",
-        "manifest_hash": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
-        "manifest_id": "sample-evidence-chain-manifest",
+        "manifest_hash": "e516075e6cfbb5cac895d225799df60113eddc36465d688e08968e3e6f93e1f4",
+        "manifest_id": "ecm-saas-permission-change-missing_authority",
         "metadata": {
-          "sample_context": "key provenance reviewer walkthrough"
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
         },
-        "missing_links": [],
-        "observed_effects_summary": [
-          {
-            "effect": "sample reference packet assembled"
-          }
+        "missing_links": [
+          "authority_evidence_hash"
         ],
-        "operation_id": "sample-operation",
-        "outcome_receipt_hash": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
-        "outcome_receipt_id": "sample-outcome-receipt",
-        "refusal_basis": [],
+        "observed_effects_summary": [],
+        "operation_id": "saas-permission-change-missing_authority",
+        "outcome_receipt_hash": "54a4b593be499ee0f5fe62274189479d00352646cc6676d196d07ed483b50a90",
+        "outcome_receipt_id": "outcome-saas-permission-change-missing_authority",
+        "refusal_basis": [
+          "authority_expired_or_missing",
+          "authority_invalid",
+          "authority_missing"
+        ],
         "requested_scope": [
-          "sample:review"
+          "saas:grant_admin"
         ],
-        "target_resource": "sample-evidence-bundle",
-        "target_system": "sample-review-system",
-        "verified_human_approval_proof_hash": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+        "target_resource": "synthetic_offline_resource",
+        "target_system": "mock_saas_directory",
+        "verified_human_approval_proof_hash": "4c5825bb7e0f647e705ca280a411695d052bfb8e65382f13804e86c0f485ef0c"
       },
       "evidence_chain_verification_summary": {
-        "decision_id": "sample-decision",
-        "execution_intent_id": "sample-execution-intent",
+        "decision_id": "decision-saas-001",
+        "execution_intent_id": "intent-saas-001",
         "failure_reasons": [],
         "is_valid": true,
         "manifest_hash_matches": true,
-        "manifest_id": "sample-evidence-chain-manifest",
+        "manifest_id": "ecm-saas-permission-change-missing_authority",
         "metadata": {
-          "sample_context": "key provenance reviewer walkthrough"
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
         },
         "mismatched_links": [],
-        "missing_links": [],
-        "operation_id": "sample-operation",
-        "recomputed_manifest_hash": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+        "missing_links": [
+          "authority_evidence_hash"
+        ],
+        "operation_id": "saas-permission-change-missing_authority",
+        "recomputed_manifest_hash": "e516075e6cfbb5cac895d225799df60113eddc36465d688e08968e3e6f93e1f4",
         "verification_status": "verified",
-        "verified_at": "2026-01-15T12:06:00Z",
+        "verified_at": "2026-04-26T00:00:00+00:00",
         "verified_links": [
-          "authority_evidence",
-          "human_approval_receipt",
-          "bind_receipt",
-          "outcome_receipt",
+          "bind_coverage_operation_id",
+          "human_approval_receipt_hash",
+          "manifest_hash",
+          "outcome_receipt_hash",
           "verified_human_approval_proof_hash"
         ]
       },
-      "expected_outcome": "Reviewer can follow illustrative key provenance artifact references.",
-      "failure_reasons": [],
+      "expected_outcome": "block",
+      "failure_reasons": [
+        "authority_expired_or_missing",
+        "authority_invalid",
+        "authority_missing"
+      ],
       "human_approval_summary": {
-        "approval_receipt_id": "sample-human-approval",
+        "approval_receipt_id": "har-saas-001",
         "approved": true,
         "approved_scope": [
-          "sample:review"
+          "saas:grant_admin"
         ],
-        "approver_identity": "sample-reviewer",
-        "approver_role": "sample-review-role",
+        "approver_identity": "human:synthetic_reviewer",
+        "approver_role": "synthetic_reviewer",
         "context_binding": {
-          "action_class": "sample.review",
+          "action_class": "permission_change",
           "ai_output_ref": null,
-          "authority_evidence_id": "sample-authority-evidence",
+          "authority_evidence_id": null,
           "bind_context_hash": null,
-          "decision_id": "sample-decision",
-          "execution_intent_id": "sample-execution-intent",
-          "policy_snapshot_id": null,
+          "decision_id": "decision-saas-001",
+          "execution_intent_id": "intent-saas-001",
+          "policy_snapshot_id": "policy-snapshot-saas-001",
           "request_ref": null
         },
         "failure_reasons": [],
         "receipt_hash_present": true,
-        "verification_proof_hash": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-        "verified_at": "2026-01-15T12:06:00Z",
+        "verification_proof_hash": "4c5825bb7e0f647e705ca280a411695d052bfb8e65382f13804e86c0f485ef0c",
+        "verified_at": "2026-04-26T00:00:00+00:00",
         "verifier_id": "veritas-human-approval-verifier-v1",
         "verifier_key_id": "local-demo-verifier-key",
         "verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
         "verifier_policy_id": "human-approval-verifier-policy-v1"
       },
       "outcome_receipt_summary": {
-        "action_class": "sample.review",
-        "blocked": false,
-        "committed": true,
-        "decision_id": "sample-decision",
+        "action_class": "permission_change",
+        "bind_receipt_id": null,
+        "blocked": true,
+        "committed": false,
+        "decision_id": "decision-saas-001",
         "escalated": false,
-        "evaluated_at": "2026-01-15T12:04:00Z",
-        "execution_intent_id": "sample-execution-intent",
-        "failure_reasons": [],
-        "final_outcome": "commit",
-        "intended_action": "assemble illustrative reviewer evidence packet",
+        "evaluated_at": "2026-04-26T00:00:00+00:00",
+        "execution_intent_id": "intent-saas-001",
+        "failure_reasons": [
+          "authority_expired_or_missing",
+          "authority_invalid",
+          "authority_missing"
+        ],
+        "final_outcome": "block",
+        "intended_action": "grant_admin_permission",
         "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true,
           "human_approval_verification_source": "signed_human_approval_artifact",
           "human_approval_verifier_id": "veritas-human-approval-verifier-v1",
           "human_approval_verifier_key_id": "local-demo-verifier-key",
+          "human_approval_verifier_lifecycle_snapshot_hash": "f48b71ec17e99dbf4785defcd6a7f2de3a51333adcb47c5739a81a969f7430fa",
           "human_approval_verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
           "human_approval_verifier_policy_id": "human-approval-verifier-policy-v1",
-          "sample_context": "key provenance reviewer walkthrough",
-          "verified_human_approval_proof_hash": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-          "verified_human_approval_receipt_id": "sample-human-approval"
+          "verified_human_approval_proof_hash": "4c5825bb7e0f647e705ca280a411695d052bfb8e65382f13804e86c0f485ef0c",
+          "verified_human_approval_receipt_id": "har-saas-001"
+        },
+        "observed_effects": [],
+        "operation_id": "saas-permission-change-missing_authority",
+        "outcome_hash": "54a4b593be499ee0f5fe62274189479d00352646cc6676d196d07ed483b50a90",
+        "outcome_receipt_id": "outcome-saas-permission-change-missing_authority",
+        "post_state_fingerprint": null,
+        "postcondition_status": "skipped",
+        "pre_state_fingerprint": null,
+        "requested_scope": [
+          "saas:grant_admin"
+        ],
+        "rollback_status": null,
+        "rolled_back": false,
+        "target_resource": "synthetic_offline_resource",
+        "target_system": "mock_saas_directory"
+      },
+      "passed": true,
+      "refusal_basis": [
+        "authority_expired_or_missing",
+        "authority_invalid",
+        "authority_missing"
+      ],
+      "requested_scope": [
+        "saas:grant_admin"
+      ],
+      "reviewer_interpretation": "The local/offline fixture blocked because AuthorityEvidence was missing.",
+      "runtime_recommended_outcome": "block",
+      "target_resource": "synthetic_offline_resource",
+      "target_system": "mock_saas_directory",
+      "verifier_lifecycle_summary": {
+        "failure_reasons": [],
+        "verifier_id": "veritas-human-approval-verifier-v1",
+        "verifier_key_id": "local-demo-verifier-key",
+        "verifier_lifecycle_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
+        "verifier_lifecycle_snapshot_hash": "f48b71ec17e99dbf4785defcd6a7f2de3a51333adcb47c5739a81a969f7430fa",
+        "verifier_lifecycle_status": "rotated",
+        "verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
+        "verifier_policy_id": "human-approval-verifier-policy-v1",
+        "verifier_revocation_reason": null,
+        "verifier_revoked_at": null,
+        "verifier_valid_from": "2026-01-01T00:00:00+00:00",
+        "verifier_valid_until": "2026-12-31T00:00:00+00:00"
+      }
+    },
+    {
+      "actual_outcome": "block",
+      "authority_validation_status": "fail",
+      "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+      "case_id": "missing_human_approval",
+      "evidence_chain_manifest_summary": {
+        "action_class": "permission_change",
+        "authority_evidence_hash": "86bd3a69cb781db382f94e0a87e6a36aaa203d934403a23ac36e8856a9d5e940",
+        "authority_evidence_id": "aev-saas-001",
+        "bind_coverage_operation_id": "saas_permission_change_demo",
+        "bind_receipt_hash": null,
+        "bind_receipt_id": null,
+        "chain_status": "blocked",
+        "decision_id": "decision-saas-001",
+        "execution_intent_id": "intent-saas-001",
+        "final_outcome": "block",
+        "generated_at": "2026-04-26T00:00:00+00:00",
+        "human_approval_receipt_hash": null,
+        "human_approval_receipt_id": null,
+        "human_approval_required": true,
+        "human_approval_verifier_id": null,
+        "human_approval_verifier_key_id": null,
+        "human_approval_verifier_lifecycle_snapshot_hash": null,
+        "human_approval_verifier_policy_hash": null,
+        "human_approval_verifier_policy_id": null,
+        "manifest_hash": "20b395802fcdf88e4f81bb867b0f810dcc4182530e444fdcebbe1171a4be3612",
+        "manifest_id": "ecm-saas-permission-change-missing_human_approval",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "missing_links": [
+          "human_approval_receipt_hash"
+        ],
+        "observed_effects_summary": [],
+        "operation_id": "saas-permission-change-missing_human_approval",
+        "outcome_receipt_hash": "f94d52a89c6aafd19bd2a19bba13d51e49fee1080a804d822a8699b8330c0dce",
+        "outcome_receipt_id": "outcome-saas-permission-change-missing_human_approval",
+        "refusal_basis": [
+          "human_approval_missing"
+        ],
+        "requested_scope": [
+          "saas:grant_admin"
+        ],
+        "target_resource": "synthetic_offline_resource",
+        "target_system": "mock_saas_directory",
+        "verified_human_approval_proof_hash": null
+      },
+      "evidence_chain_verification_summary": {
+        "decision_id": "decision-saas-001",
+        "execution_intent_id": "intent-saas-001",
+        "failure_reasons": [],
+        "is_valid": true,
+        "manifest_hash_matches": true,
+        "manifest_id": "ecm-saas-permission-change-missing_human_approval",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "mismatched_links": [],
+        "missing_links": [
+          "human_approval_receipt_hash"
+        ],
+        "operation_id": "saas-permission-change-missing_human_approval",
+        "recomputed_manifest_hash": "20b395802fcdf88e4f81bb867b0f810dcc4182530e444fdcebbe1171a4be3612",
+        "verification_status": "verified",
+        "verified_at": "2026-04-26T00:00:00+00:00",
+        "verified_links": [
+          "authority_evidence_hash",
+          "bind_coverage_operation_id",
+          "manifest_hash",
+          "outcome_receipt_hash"
+        ]
+      },
+      "expected_outcome": "block",
+      "failure_reasons": [
+        "human_approval_missing"
+      ],
+      "human_approval_summary": {
+        "approval_receipt_id": null,
+        "approved": false,
+        "approved_scope": [],
+        "approver_identity": null,
+        "approver_role": null,
+        "context_binding": {
+          "action_class": "permission_change",
+          "ai_output_ref": null,
+          "authority_evidence_id": "aev-saas-001",
+          "bind_context_hash": null,
+          "decision_id": "decision-saas-001",
+          "execution_intent_id": "intent-saas-001",
+          "policy_snapshot_id": null,
+          "request_ref": null
+        },
+        "failure_reasons": [
+          "human_approval_missing"
+        ],
+        "receipt_hash_present": false,
+        "verification_proof_hash": null,
+        "verified_at": null,
+        "verifier_id": null,
+        "verifier_key_id": null,
+        "verifier_policy_hash": null,
+        "verifier_policy_id": null
+      },
+      "outcome_receipt_summary": {
+        "action_class": "permission_change",
+        "bind_receipt_id": null,
+        "blocked": true,
+        "committed": false,
+        "decision_id": "decision-saas-001",
+        "escalated": false,
+        "evaluated_at": "2026-04-26T00:00:00+00:00",
+        "execution_intent_id": "intent-saas-001",
+        "failure_reasons": [
+          "human_approval_missing"
+        ],
+        "final_outcome": "block",
+        "intended_action": "grant_admin_permission",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "observed_effects": [],
+        "operation_id": "saas-permission-change-missing_human_approval",
+        "outcome_hash": "f94d52a89c6aafd19bd2a19bba13d51e49fee1080a804d822a8699b8330c0dce",
+        "outcome_receipt_id": "outcome-saas-permission-change-missing_human_approval",
+        "post_state_fingerprint": null,
+        "postcondition_status": "skipped",
+        "pre_state_fingerprint": null,
+        "requested_scope": [
+          "saas:grant_admin"
+        ],
+        "rollback_status": null,
+        "rolled_back": false,
+        "target_resource": "synthetic_offline_resource",
+        "target_system": "mock_saas_directory"
+      },
+      "passed": true,
+      "refusal_basis": [
+        "human_approval_missing"
+      ],
+      "requested_scope": [
+        "saas:grant_admin"
+      ],
+      "reviewer_interpretation": "The local/offline fixture blocked because HumanApprovalReceipt was missing.",
+      "runtime_recommended_outcome": "block",
+      "target_resource": "synthetic_offline_resource",
+      "target_system": "mock_saas_directory",
+      "verifier_lifecycle_summary": null
+    },
+    {
+      "actual_outcome": "block",
+      "authority_validation_status": "fail",
+      "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+      "case_id": "expired_human_approval",
+      "evidence_chain_manifest_summary": {
+        "action_class": "permission_change",
+        "authority_evidence_hash": "86bd3a69cb781db382f94e0a87e6a36aaa203d934403a23ac36e8856a9d5e940",
+        "authority_evidence_id": "aev-saas-001",
+        "bind_coverage_operation_id": "saas_permission_change_demo",
+        "bind_receipt_hash": null,
+        "bind_receipt_id": null,
+        "chain_status": "blocked",
+        "decision_id": "decision-saas-001",
+        "execution_intent_id": "intent-saas-001",
+        "final_outcome": "block",
+        "generated_at": "2026-04-26T00:00:00+00:00",
+        "human_approval_receipt_hash": null,
+        "human_approval_receipt_id": null,
+        "human_approval_required": true,
+        "human_approval_verifier_id": null,
+        "human_approval_verifier_key_id": null,
+        "human_approval_verifier_lifecycle_snapshot_hash": null,
+        "human_approval_verifier_policy_hash": null,
+        "human_approval_verifier_policy_id": null,
+        "manifest_hash": "14271a0d3fa310746804e3778f5f0913defe68326e1a3a63a7a0803968c6b4cf",
+        "manifest_id": "ecm-saas-permission-change-expired_human_approval",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "missing_links": [
+          "human_approval_receipt_hash"
+        ],
+        "observed_effects_summary": [],
+        "operation_id": "saas-permission-change-expired_human_approval",
+        "outcome_receipt_hash": "ee446644e9169ec5bd718a553ec6011e1f7fc2935eab44b135c610fa79206a01",
+        "outcome_receipt_id": "outcome-saas-permission-change-expired_human_approval",
+        "refusal_basis": [
+          "human_approval_expired"
+        ],
+        "requested_scope": [
+          "saas:grant_admin"
+        ],
+        "target_resource": "synthetic_offline_resource",
+        "target_system": "mock_saas_directory",
+        "verified_human_approval_proof_hash": null
+      },
+      "evidence_chain_verification_summary": {
+        "decision_id": "decision-saas-001",
+        "execution_intent_id": "intent-saas-001",
+        "failure_reasons": [],
+        "is_valid": true,
+        "manifest_hash_matches": true,
+        "manifest_id": "ecm-saas-permission-change-expired_human_approval",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "mismatched_links": [],
+        "missing_links": [
+          "human_approval_receipt_hash"
+        ],
+        "operation_id": "saas-permission-change-expired_human_approval",
+        "recomputed_manifest_hash": "14271a0d3fa310746804e3778f5f0913defe68326e1a3a63a7a0803968c6b4cf",
+        "verification_status": "verified",
+        "verified_at": "2026-04-26T00:00:00+00:00",
+        "verified_links": [
+          "authority_evidence_hash",
+          "bind_coverage_operation_id",
+          "manifest_hash",
+          "outcome_receipt_hash"
+        ]
+      },
+      "expected_outcome": "block",
+      "failure_reasons": [
+        "human_approval_expired"
+      ],
+      "human_approval_summary": {
+        "approval_receipt_id": null,
+        "approved": false,
+        "approved_scope": [],
+        "approver_identity": null,
+        "approver_role": null,
+        "context_binding": {
+          "action_class": "permission_change",
+          "ai_output_ref": null,
+          "authority_evidence_id": "aev-saas-001",
+          "bind_context_hash": null,
+          "decision_id": "decision-saas-001",
+          "execution_intent_id": "intent-saas-001",
+          "policy_snapshot_id": null,
+          "request_ref": null
+        },
+        "failure_reasons": [
+          "human_approval_expired"
+        ],
+        "receipt_hash_present": false,
+        "verification_proof_hash": null,
+        "verified_at": null,
+        "verifier_id": null,
+        "verifier_key_id": null,
+        "verifier_policy_hash": null,
+        "verifier_policy_id": null
+      },
+      "outcome_receipt_summary": {
+        "action_class": "permission_change",
+        "bind_receipt_id": null,
+        "blocked": true,
+        "committed": false,
+        "decision_id": "decision-saas-001",
+        "escalated": false,
+        "evaluated_at": "2026-04-26T00:00:00+00:00",
+        "execution_intent_id": "intent-saas-001",
+        "failure_reasons": [
+          "human_approval_expired"
+        ],
+        "final_outcome": "block",
+        "intended_action": "grant_admin_permission",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "observed_effects": [],
+        "operation_id": "saas-permission-change-expired_human_approval",
+        "outcome_hash": "ee446644e9169ec5bd718a553ec6011e1f7fc2935eab44b135c610fa79206a01",
+        "outcome_receipt_id": "outcome-saas-permission-change-expired_human_approval",
+        "post_state_fingerprint": null,
+        "postcondition_status": "skipped",
+        "pre_state_fingerprint": null,
+        "requested_scope": [
+          "saas:grant_admin"
+        ],
+        "rollback_status": null,
+        "rolled_back": false,
+        "target_resource": "synthetic_offline_resource",
+        "target_system": "mock_saas_directory"
+      },
+      "passed": true,
+      "refusal_basis": [
+        "human_approval_expired"
+      ],
+      "requested_scope": [
+        "saas:grant_admin"
+      ],
+      "reviewer_interpretation": "The local/offline fixture blocked because HumanApprovalReceipt was expired.",
+      "runtime_recommended_outcome": "block",
+      "target_resource": "synthetic_offline_resource",
+      "target_system": "mock_saas_directory",
+      "verifier_lifecycle_summary": null
+    },
+    {
+      "actual_outcome": "block",
+      "authority_validation_status": "fail",
+      "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+      "case_id": "scope_mismatch",
+      "evidence_chain_manifest_summary": {
+        "action_class": "permission_change",
+        "authority_evidence_hash": "f3ef007f0aa8236117004edd91c0abd105762b8f4d02f8b2572a5988c6c0647a",
+        "authority_evidence_id": "aev-saas-001",
+        "bind_coverage_operation_id": "saas_permission_change_demo",
+        "bind_receipt_hash": null,
+        "bind_receipt_id": null,
+        "chain_status": "blocked",
+        "decision_id": "decision-saas-001",
+        "execution_intent_id": "intent-saas-001",
+        "final_outcome": "block",
+        "generated_at": "2026-04-26T00:00:00+00:00",
+        "human_approval_receipt_hash": null,
+        "human_approval_receipt_id": null,
+        "human_approval_required": true,
+        "human_approval_verifier_id": null,
+        "human_approval_verifier_key_id": null,
+        "human_approval_verifier_lifecycle_snapshot_hash": null,
+        "human_approval_verifier_policy_hash": null,
+        "human_approval_verifier_policy_id": null,
+        "manifest_hash": "5b1329d818b576d3d8e7d8985f4fbc358776e059c0011c10cbcea8d417531f17",
+        "manifest_id": "ecm-saas-permission-change-scope_mismatch",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "missing_links": [
+          "human_approval_receipt_hash"
+        ],
+        "observed_effects_summary": [],
+        "operation_id": "saas-permission-change-scope_mismatch",
+        "outcome_receipt_hash": "95a4f24da2b9b02e20935967ce0a5bbda64c5e904e0ef6db3778b0ee14508c22",
+        "outcome_receipt_id": "outcome-saas-permission-change-scope_mismatch",
+        "refusal_basis": [
+          "authority_invalid",
+          "human_approval_scope_not_granted"
+        ],
+        "requested_scope": [
+          "saas:grant_admin"
+        ],
+        "target_resource": "synthetic_offline_resource",
+        "target_system": "mock_saas_directory",
+        "verified_human_approval_proof_hash": null
+      },
+      "evidence_chain_verification_summary": {
+        "decision_id": "decision-saas-001",
+        "execution_intent_id": "intent-saas-001",
+        "failure_reasons": [],
+        "is_valid": true,
+        "manifest_hash_matches": true,
+        "manifest_id": "ecm-saas-permission-change-scope_mismatch",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "mismatched_links": [],
+        "missing_links": [
+          "human_approval_receipt_hash"
+        ],
+        "operation_id": "saas-permission-change-scope_mismatch",
+        "recomputed_manifest_hash": "5b1329d818b576d3d8e7d8985f4fbc358776e059c0011c10cbcea8d417531f17",
+        "verification_status": "verified",
+        "verified_at": "2026-04-26T00:00:00+00:00",
+        "verified_links": [
+          "authority_evidence_hash",
+          "bind_coverage_operation_id",
+          "manifest_hash",
+          "outcome_receipt_hash"
+        ]
+      },
+      "expected_outcome": "block",
+      "failure_reasons": [
+        "authority_invalid",
+        "human_approval_scope_not_granted"
+      ],
+      "human_approval_summary": {
+        "approval_receipt_id": null,
+        "approved": false,
+        "approved_scope": [],
+        "approver_identity": null,
+        "approver_role": null,
+        "context_binding": {
+          "action_class": "permission_change",
+          "ai_output_ref": null,
+          "authority_evidence_id": "aev-saas-001",
+          "bind_context_hash": null,
+          "decision_id": "decision-saas-001",
+          "execution_intent_id": "intent-saas-001",
+          "policy_snapshot_id": null,
+          "request_ref": null
+        },
+        "failure_reasons": [
+          "human_approval_scope_not_granted"
+        ],
+        "receipt_hash_present": false,
+        "verification_proof_hash": null,
+        "verified_at": null,
+        "verifier_id": null,
+        "verifier_key_id": null,
+        "verifier_policy_hash": null,
+        "verifier_policy_id": null
+      },
+      "outcome_receipt_summary": {
+        "action_class": "permission_change",
+        "bind_receipt_id": null,
+        "blocked": true,
+        "committed": false,
+        "decision_id": "decision-saas-001",
+        "escalated": false,
+        "evaluated_at": "2026-04-26T00:00:00+00:00",
+        "execution_intent_id": "intent-saas-001",
+        "failure_reasons": [
+          "authority_invalid",
+          "human_approval_scope_not_granted"
+        ],
+        "final_outcome": "block",
+        "intended_action": "grant_admin_permission",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "observed_effects": [],
+        "operation_id": "saas-permission-change-scope_mismatch",
+        "outcome_hash": "95a4f24da2b9b02e20935967ce0a5bbda64c5e904e0ef6db3778b0ee14508c22",
+        "outcome_receipt_id": "outcome-saas-permission-change-scope_mismatch",
+        "post_state_fingerprint": null,
+        "postcondition_status": "skipped",
+        "pre_state_fingerprint": null,
+        "requested_scope": [
+          "saas:grant_admin"
+        ],
+        "rollback_status": null,
+        "rolled_back": false,
+        "target_resource": "synthetic_offline_resource",
+        "target_system": "mock_saas_directory"
+      },
+      "passed": true,
+      "refusal_basis": [
+        "authority_invalid",
+        "human_approval_scope_not_granted"
+      ],
+      "requested_scope": [
+        "saas:grant_admin"
+      ],
+      "reviewer_interpretation": "The local/offline fixture blocked because approved authority or approval scope was insufficient.",
+      "runtime_recommended_outcome": "block",
+      "target_resource": "synthetic_offline_resource",
+      "target_system": "mock_saas_directory",
+      "verifier_lifecycle_summary": null
+    },
+    {
+      "actual_outcome": "commit",
+      "authority_validation_status": "pass",
+      "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+      "case_id": "valid_authority_and_approval",
+      "evidence_chain_manifest_summary": {
+        "action_class": "permission_change",
+        "authority_evidence_hash": "6879ecdcdeded375a2e81832fe8819a698c9c5df151d7819224420f21a7a53a0",
+        "authority_evidence_id": "aev-saas-001",
+        "bind_coverage_operation_id": "saas_permission_change_demo",
+        "bind_receipt_hash": null,
+        "bind_receipt_id": null,
+        "chain_status": "complete",
+        "decision_id": "decision-saas-001",
+        "execution_intent_id": "intent-saas-001",
+        "final_outcome": "commit",
+        "generated_at": "2026-04-26T00:00:00+00:00",
+        "human_approval_receipt_hash": "55db4aa2686f01d6e1133b880ee85e82572957b3e0e3dd63bce692a8be4d38ba",
+        "human_approval_receipt_id": "har-saas-001",
+        "human_approval_required": true,
+        "human_approval_verifier_id": "veritas-human-approval-verifier-v1",
+        "human_approval_verifier_key_id": "local-demo-verifier-key",
+        "human_approval_verifier_lifecycle_snapshot_hash": "f48b71ec17e99dbf4785defcd6a7f2de3a51333adcb47c5739a81a969f7430fa",
+        "human_approval_verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
+        "human_approval_verifier_policy_id": "human-approval-verifier-policy-v1",
+        "manifest_hash": "f952b300fd698a17ca84471792364c9862560254e74bb681b05ea12fe8264a41",
+        "manifest_id": "ecm-saas-permission-change-valid_authority_and_approval",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "missing_links": [],
+        "observed_effects_summary": [
+          {
+            "effect_type": "permission_grant",
+            "fixture_only": true,
+            "permission": "saas:grant_admin",
+            "target_resource": "synthetic_offline_resource"
+          }
+        ],
+        "operation_id": "saas-permission-change-valid_authority_and_approval",
+        "outcome_receipt_hash": "b29ecfff49a64dba77185fac997e4a543045f76e2e332274162d2781ab7587e9",
+        "outcome_receipt_id": "outcome-saas-permission-change-valid_authority_and_approval",
+        "refusal_basis": [],
+        "requested_scope": [
+          "saas:grant_admin"
+        ],
+        "target_resource": "synthetic_offline_resource",
+        "target_system": "mock_saas_directory",
+        "verified_human_approval_proof_hash": "4c5825bb7e0f647e705ca280a411695d052bfb8e65382f13804e86c0f485ef0c"
+      },
+      "evidence_chain_verification_summary": {
+        "decision_id": "decision-saas-001",
+        "execution_intent_id": "intent-saas-001",
+        "failure_reasons": [],
+        "is_valid": true,
+        "manifest_hash_matches": true,
+        "manifest_id": "ecm-saas-permission-change-valid_authority_and_approval",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "mismatched_links": [],
+        "missing_links": [],
+        "operation_id": "saas-permission-change-valid_authority_and_approval",
+        "recomputed_manifest_hash": "f952b300fd698a17ca84471792364c9862560254e74bb681b05ea12fe8264a41",
+        "verification_status": "verified",
+        "verified_at": "2026-04-26T00:00:00+00:00",
+        "verified_links": [
+          "authority_evidence_hash",
+          "bind_coverage_operation_id",
+          "human_approval_receipt_hash",
+          "manifest_hash",
+          "outcome_receipt_hash",
+          "verified_human_approval_proof_hash"
+        ]
+      },
+      "expected_outcome": "commit",
+      "failure_reasons": [],
+      "human_approval_summary": {
+        "approval_receipt_id": "har-saas-001",
+        "approved": true,
+        "approved_scope": [
+          "saas:grant_admin"
+        ],
+        "approver_identity": "human:synthetic_reviewer",
+        "approver_role": "synthetic_reviewer",
+        "context_binding": {
+          "action_class": "permission_change",
+          "ai_output_ref": null,
+          "authority_evidence_id": "aev-saas-001",
+          "bind_context_hash": null,
+          "decision_id": "decision-saas-001",
+          "execution_intent_id": "intent-saas-001",
+          "policy_snapshot_id": "policy-snapshot-saas-001",
+          "request_ref": null
+        },
+        "failure_reasons": [],
+        "receipt_hash_present": true,
+        "verification_proof_hash": "4c5825bb7e0f647e705ca280a411695d052bfb8e65382f13804e86c0f485ef0c",
+        "verified_at": "2026-04-26T00:00:00+00:00",
+        "verifier_id": "veritas-human-approval-verifier-v1",
+        "verifier_key_id": "local-demo-verifier-key",
+        "verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
+        "verifier_policy_id": "human-approval-verifier-policy-v1"
+      },
+      "outcome_receipt_summary": {
+        "action_class": "permission_change",
+        "bind_receipt_id": null,
+        "blocked": false,
+        "committed": true,
+        "decision_id": "decision-saas-001",
+        "escalated": false,
+        "evaluated_at": "2026-04-26T00:00:00+00:00",
+        "execution_intent_id": "intent-saas-001",
+        "failure_reasons": [],
+        "final_outcome": "commit",
+        "intended_action": "grant_admin_permission",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true,
+          "human_approval_verification_source": "signed_human_approval_artifact",
+          "human_approval_verifier_id": "veritas-human-approval-verifier-v1",
+          "human_approval_verifier_key_id": "local-demo-verifier-key",
+          "human_approval_verifier_lifecycle_snapshot_hash": "f48b71ec17e99dbf4785defcd6a7f2de3a51333adcb47c5739a81a969f7430fa",
+          "human_approval_verifier_policy_hash": "b625a813408d3a1d6c55ff59e9661ac21c4a9017fda76e4369bd9407a743a2cd",
+          "human_approval_verifier_policy_id": "human-approval-verifier-policy-v1",
+          "verified_human_approval_proof_hash": "4c5825bb7e0f647e705ca280a411695d052bfb8e65382f13804e86c0f485ef0c",
+          "verified_human_approval_receipt_id": "har-saas-001"
         },
         "observed_effects": [
           {
-            "effect": "sample artifacts referenced"
+            "effect_type": "permission_grant",
+            "fixture_only": true,
+            "permission": "saas:grant_admin",
+            "target_resource": "synthetic_offline_resource"
           }
         ],
-        "operation_id": "sample-operation",
-        "outcome_hash": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
-        "outcome_receipt_id": "sample-outcome-receipt",
+        "operation_id": "saas-permission-change-valid_authority_and_approval",
+        "outcome_hash": "b29ecfff49a64dba77185fac997e4a543045f76e2e332274162d2781ab7587e9",
+        "outcome_receipt_id": "outcome-saas-permission-change-valid_authority_and_approval",
+        "post_state_fingerprint": null,
         "postcondition_status": "passed",
+        "pre_state_fingerprint": null,
         "requested_scope": [
-          "sample:review"
+          "saas:grant_admin"
         ],
+        "rollback_status": null,
         "rolled_back": false,
-        "target_resource": "sample-evidence-bundle",
-        "target_system": "sample-review-system"
+        "target_resource": "synthetic_offline_resource",
+        "target_system": "mock_saas_directory"
       },
       "passed": true,
       "refusal_basis": [],
       "requested_scope": [
-        "sample:review"
+        "saas:grant_admin"
       ],
-      "reviewer_interpretation": "The packet points to the key provenance artifacts; reviewers still need independent public key trust.",
-      "runtime_recommended_outcome": "sample_commit_eligible",
-      "target_resource": "sample-evidence-bundle",
-      "target_system": "sample-review-system",
+      "reviewer_interpretation": "AuthorityEvidence and HumanApprovalReceipt were sufficient for the local/offline fixture to reach a commit outcome.",
+      "runtime_recommended_outcome": "commit",
+      "target_resource": "synthetic_offline_resource",
+      "target_system": "mock_saas_directory",
       "verifier_lifecycle_summary": {
         "failure_reasons": [],
         "verifier_id": "veritas-human-approval-verifier-v1",
@@ -173,8 +827,8 @@
       }
     }
   ],
-  "demo_id": "sample-key-provenance-review",
-  "generated_at": "2026-01-15T12:07:00Z",
+  "demo_id": "saas_permission_change_governed_execution_v1",
+  "generated_at": "2026-04-26T00:00:00+00:00",
   "key_provenance": {
     "key_provenance_result_validation_report": {
       "artifact_name": "key-provenance-result-validation.json",
@@ -191,14 +845,15 @@
     }
   },
   "local_offline_only": true,
-  "packet_hash": "d02fc7e2efc97a8922ed5abf5966e11f9d0821b664258dcb0ffa7468d672135f",
+  "packet_hash": "bc311d8a56bc5e2ebd926b1b1763072cad51f0f92a7b6cadea3316a907b508b2",
   "packet_id": "reviewer-evidence-packet-saas-permission-change-v1",
   "packet_version": "v1",
   "reviewer_notes": [
-    "Illustrative sample only. Not production evidence, not regulatory certification, and not completed third-party audit approval.",
-    "This sample demonstrates verification-result.json to trusted-public-key-provenance.json to key-provenance-validation.json to key-provenance-result-validation.json to reviewer-evidence-packet.json relationships.",
-    "Samples do not create trust, do not replace out-of-band public key trust, and matching fingerprints support correlation only."
+    "This packet is generated from a local/offline fixture demo.",
+    "It does not connect to live SaaS, IAM, IdP, SSO, synthetic directory, bank, sanctions, or production approval systems.",
+    "It demonstrates bind-time governance and evidence-chain verification using deterministic artifacts.",
+    "It is not legal advice, regulatory approval, third-party certification, production audit certification, or proof of live deployment."
   ],
-  "summary": "Illustrative sample packet showing key provenance artifact references for reviewer walkthroughs.",
-  "title": "Illustrative Trusted Public Key Provenance Reviewer Evidence Packet"
+  "summary": "Deterministic local/offline reviewer packet for the SaaS permission-change governed execution demo.",
+  "title": "SaaS Permission-Change Governed Execution Reviewer Evidence Packet"
 }

--- a/samples/evidence_bundle/key_provenance_review/sample-artifact-manifest.json
+++ b/samples/evidence_bundle/key_provenance_review/sample-artifact-manifest.json
@@ -28,7 +28,7 @@
       "artifact_name": "reviewer-evidence-packet.json",
       "role": "reviewer_evidence_packet",
       "schema_id": "docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json",
-      "sha256": "6f1d9dafaa3b9cd72cdb2b14912d422b815f1f42fe55d156c2111a0541e162ed"
+      "sha256": "666aa67846318daf24123e09321d955395d8f11e78dd8f4eb0711c5ae196c87c"
     },
     {
       "artifact_name": "reviewer-handoff-review-result.json",

--- a/scripts/demo/export_context_bound_approval_replay_packet.py
+++ b/scripts/demo/export_context_bound_approval_replay_packet.py
@@ -110,6 +110,34 @@ def _case_summary(case_id: str, expected_context: dict[str, str]) -> dict[str, A
     failure_reasons = validation.failure_reasons
     actual_outcome = "commit_eligible" if validation.is_valid else "block"
     operation_id = f"operation-{case_id}"
+    human_approval_summary = {
+        "approved": validation.is_valid,
+        "approval_receipt_id": receipt.approval_receipt_id,
+        "approver_identity": receipt.approver_identity,
+        "approver_role": receipt.approver_role,
+        "approved_scope": list(receipt.approved_scope),
+        "receipt_hash_present": validation.is_valid,
+        "verifier_id": VERIFIER_ID if validation.is_valid else None,
+        "verifier_key_id": VERIFIER_KEY_ID if validation.is_valid else None,
+        "verifier_policy_id": VERIFIER_POLICY_ID if validation.is_valid else None,
+        "verifier_policy_hash": (
+            VERIFIER_POLICY_HASH if validation.is_valid else None
+        ),
+        "verification_proof_hash": (
+            VERIFIED_APPROVAL_PROOF_HASH if validation.is_valid else None
+        ),
+        "verified_at": GENERATED_AT if validation.is_valid else None,
+        "failure_reasons": list(failure_reasons),
+        "context_binding": copy.deepcopy(expected_context),
+    }
+    lifecycle_summary = verifier_lifecycle_summary_from_human_approval(
+        human_approval_summary
+    )
+    lifecycle_hash = (
+        lifecycle_summary.get("verifier_lifecycle_snapshot_hash")
+        if lifecycle_summary is not None
+        else None
+    )
     outcome = {
         "outcome_receipt_id": f"outcome-{case_id}",
         "decision_id": expected_context["decision_id"],
@@ -148,6 +176,7 @@ def _case_summary(case_id: str, expected_context: dict[str, str]) -> dict[str, A
                 "human_approval_verifier_key_id": VERIFIER_KEY_ID,
                 "human_approval_verifier_policy_id": VERIFIER_POLICY_ID,
                 "human_approval_verifier_policy_hash": VERIFIER_POLICY_HASH,
+                "human_approval_verifier_lifecycle_snapshot_hash": lifecycle_hash,
             }
         )
     outcome["outcome_hash"] = _hash_payload(outcome)
@@ -180,6 +209,9 @@ def _case_summary(case_id: str, expected_context: dict[str, str]) -> dict[str, A
         ),
         "human_approval_verifier_policy_hash": (
             VERIFIER_POLICY_HASH if validation.is_valid else None
+        ),
+        "human_approval_verifier_lifecycle_snapshot_hash": (
+            lifecycle_hash if validation.is_valid else None
         ),
         "human_approval_required": True,
         "bind_receipt_id": f"bind-{case_id}",
@@ -220,26 +252,6 @@ def _case_summary(case_id: str, expected_context: dict[str, str]) -> dict[str, A
         "verified_at": GENERATED_AT,
         "metadata": {"context_binding_valid": validation.is_valid},
     }
-    human_approval_summary = {
-        "approved": validation.is_valid,
-        "approval_receipt_id": receipt.approval_receipt_id,
-        "approver_identity": receipt.approver_identity,
-        "approver_role": receipt.approver_role,
-        "approved_scope": list(receipt.approved_scope),
-        "receipt_hash_present": validation.is_valid,
-        "verifier_id": VERIFIER_ID if validation.is_valid else None,
-        "verifier_key_id": VERIFIER_KEY_ID if validation.is_valid else None,
-        "verifier_policy_id": VERIFIER_POLICY_ID if validation.is_valid else None,
-        "verifier_policy_hash": (
-            VERIFIER_POLICY_HASH if validation.is_valid else None
-        ),
-        "verification_proof_hash": (
-            VERIFIED_APPROVAL_PROOF_HASH if validation.is_valid else None
-        ),
-        "verified_at": GENERATED_AT if validation.is_valid else None,
-        "failure_reasons": list(failure_reasons),
-        "context_binding": copy.deepcopy(expected_context),
-    }
     return {
         "case_id": case_id,
         "expected_outcome": actual_outcome,
@@ -251,9 +263,7 @@ def _case_summary(case_id: str, expected_context: dict[str, str]) -> dict[str, A
         "authority_validation_status": "valid",
         "runtime_recommended_outcome": "commit" if validation.is_valid else "block",
         "human_approval_summary": human_approval_summary,
-        "verifier_lifecycle_summary": (
-            verifier_lifecycle_summary_from_human_approval(human_approval_summary)
-        ),
+        "verifier_lifecycle_summary": lifecycle_summary,
         "refusal_basis": list(failure_reasons),
         "failure_reasons": list(failure_reasons),
         "outcome_receipt_summary": outcome,

--- a/scripts/demo/export_reviewer_evidence_packet.py
+++ b/scripts/demo/export_reviewer_evidence_packet.py
@@ -168,6 +168,17 @@ def _reviewer_interpretation(case: dict[str, Any]) -> str:
 
 def _case_summary(case: dict[str, Any]) -> dict[str, Any]:
     """Return a compact reviewer-facing case summary with nested evidence details."""
+    verifier_lifecycle = _verifier_lifecycle_summary(case)
+    lifecycle_hash = (
+        verifier_lifecycle.get("verifier_lifecycle_snapshot_hash")
+        if verifier_lifecycle is not None
+        else None
+    )
+    manifest_summary = copy.deepcopy(case["evidence_chain_manifest_summary"])
+    manifest_summary.setdefault(
+        "human_approval_verifier_lifecycle_snapshot_hash",
+        lifecycle_hash,
+    )
     return {
         "case_id": case["case_id"],
         "expected_outcome": case["expected_outcome"],
@@ -181,13 +192,11 @@ def _case_summary(case: dict[str, Any]) -> dict[str, Any]:
         "human_approval_summary": _human_approval_summary(
             case["human_approval_state"], case
         ),
-        "verifier_lifecycle_summary": _verifier_lifecycle_summary(case),
+        "verifier_lifecycle_summary": verifier_lifecycle,
         "refusal_basis": case["refusal_basis"],
         "failure_reasons": list(case["failure_reasons"]),
         "outcome_receipt_summary": copy.deepcopy(case["outcome_receipt_summary"]),
-        "evidence_chain_manifest_summary": copy.deepcopy(
-            case["evidence_chain_manifest_summary"]
-        ),
+        "evidence_chain_manifest_summary": manifest_summary,
         "evidence_chain_verification_summary": copy.deepcopy(
             case["evidence_chain_verification_summary"]
         ),

--- a/scripts/demo/generate_reviewer_evidence_packet_from_evaluation_governance_chain.py
+++ b/scripts/demo/generate_reviewer_evidence_packet_from_evaluation_governance_chain.py
@@ -366,6 +366,8 @@ def _recompute_nested_hashes(
     manifest: dict[str, Any],
     outcome: dict[str, Any],
     verification: dict[str, Any],
+    *,
+    include_verified_proof_link: bool = True,
 ) -> None:
     """Refresh nested fixture hashes after verifier evidence backfill."""
     outcome_payload = copy.deepcopy(outcome)
@@ -381,7 +383,8 @@ def _recompute_nested_hashes(
     verification["manifest_hash_matches"] = True
     verified_links = verification.setdefault("verified_links", [])
     if (
-        isinstance(verified_links, list)
+        include_verified_proof_link
+        and isinstance(verified_links, list)
         and "verified_human_approval_proof_hash" not in verified_links
     ):
         verified_links.append("verified_human_approval_proof_hash")
@@ -423,6 +426,16 @@ def _ensure_human_approval_verifier_evidence(packet: dict[str, Any]) -> None:
 
         if not _is_verified_approval_case(summary, manifest, outcome):
             case["verifier_lifecycle_summary"] = None
+            manifest.setdefault(
+                "human_approval_verifier_lifecycle_snapshot_hash",
+                None,
+            )
+            _recompute_nested_hashes(
+                manifest,
+                outcome,
+                verification,
+                include_verified_proof_link=False,
+            )
             continue
 
         metadata = outcome.setdefault("metadata", {})
@@ -507,6 +520,18 @@ def _ensure_human_approval_verifier_evidence(packet: dict[str, Any]) -> None:
         case["verifier_lifecycle_summary"] = (
             verifier_lifecycle_summary_from_human_approval(summary)
         )
+        lifecycle_summary = case["verifier_lifecycle_summary"]
+        lifecycle_hash = (
+            lifecycle_summary.get("verifier_lifecycle_snapshot_hash")
+            if isinstance(lifecycle_summary, dict)
+            else None
+        )
+        manifest[
+            "human_approval_verifier_lifecycle_snapshot_hash"
+        ] = lifecycle_hash
+        metadata[
+            "human_approval_verifier_lifecycle_snapshot_hash"
+        ] = lifecycle_hash
         _recompute_nested_hashes(manifest, outcome, verification)
 
 

--- a/scripts/demo/saas_permission_change_governed_demo.py
+++ b/scripts/demo/saas_permission_change_governed_demo.py
@@ -33,6 +33,7 @@ from scripts.demo.verifier_lifecycle import (
     VERIFIER_POLICY_HASH,
     VERIFIER_POLICY_ID,
     verifier_lifecycle_snapshot,
+    verifier_lifecycle_summary_from_human_approval,
 )
 from veritas_os.security.hash import sha256_of_canonical_json
 
@@ -272,6 +273,22 @@ def _evaluate_case(
             }
         )
 
+    verifier_lifecycle_summary = (
+        verifier_lifecycle_summary_from_human_approval(human_approval_state)
+        if verified_human_approval is not None
+        else None
+    )
+    verifier_lifecycle_snapshot_hash = (
+        verifier_lifecycle_summary.get("verifier_lifecycle_snapshot_hash")
+        if verifier_lifecycle_summary is not None
+        else None
+    )
+    outcome_metadata = {"fixture_only": True, "boundary_note": BOUNDARY_NOTE}
+    if verifier_lifecycle_snapshot_hash:
+        outcome_metadata[
+            "human_approval_verifier_lifecycle_snapshot_hash"
+        ] = verifier_lifecycle_snapshot_hash
+
     outcome_receipt = build_outcome_receipt(
         decision_id="decision-saas-001",
         execution_intent_id="intent-saas-001",
@@ -288,7 +305,7 @@ def _evaluate_case(
         failure_reasons=failure_reasons,
         rollback_status=None,
         evaluated_at=FIXED_NOW.isoformat(),
-        metadata={"fixture_only": True, "boundary_note": BOUNDARY_NOTE},
+        metadata=outcome_metadata,
         verified_human_approval=verified_human_approval,
     )
     authority_evidence_id = (
@@ -357,6 +374,9 @@ def _evaluate_case(
             verified_human_approval.verifier_policy_hash
             if verified_human_approval is not None
             else None
+        ),
+        human_approval_verifier_lifecycle_snapshot_hash=(
+            verifier_lifecycle_snapshot_hash
         ),
     )
 

--- a/scripts/demo/validate_reviewer_evidence_packet.py
+++ b/scripts/demo/validate_reviewer_evidence_packet.py
@@ -134,6 +134,9 @@ FAILURE_REASON_BY_CHECK = {
     "committed_lifecycle_status_clean": (
         "reviewer_packet_committed_lifecycle_status_not_clean"
     ),
+    "verifier_lifecycle_snapshot_hash_continuity_valid": (
+        "reviewer_packet_verifier_lifecycle_snapshot_hash_mismatch"
+    ),
     "local_offline_boundary_present": "local_offline_boundary_missing",
 }
 
@@ -516,6 +519,61 @@ def _verifier_lifecycle_snapshot_hashes_match(packet: dict[str, Any]) -> bool:
     )
 
 
+def _verifier_lifecycle_snapshot_hash_continuity_reasons(
+    packet: dict[str, Any],
+) -> list[str]:
+    """Return lifecycle snapshot hash continuity failures across artifacts."""
+    cases = packet.get("cases")
+    if not isinstance(cases, list):
+        return ["required_case_fields_missing"]
+    reasons: list[str] = []
+    for case in cases:
+        if not isinstance(case, dict):
+            continue
+        lifecycle = case.get("verifier_lifecycle_summary")
+        if not isinstance(lifecycle, dict):
+            continue
+        lifecycle_hash = str(
+            lifecycle.get("verifier_lifecycle_snapshot_hash") or ""
+        ).strip()
+        if not lifecycle_hash:
+            reason = "reviewer_packet_verifier_lifecycle_snapshot_hash_missing"
+            if reason not in reasons:
+                reasons.append(reason)
+            continue
+
+        manifest = case.get("evidence_chain_manifest_summary", {})
+        if not isinstance(manifest, dict):
+            manifest = {}
+        manifest_hash = str(
+            manifest.get("human_approval_verifier_lifecycle_snapshot_hash") or ""
+        ).strip()
+        if manifest_hash != lifecycle_hash:
+            reason = "reviewer_packet_manifest_lifecycle_snapshot_hash_mismatch"
+            if reason not in reasons:
+                reasons.append(reason)
+
+        outcome = case.get("outcome_receipt_summary", {})
+        metadata = outcome.get("metadata", {}) if isinstance(outcome, dict) else {}
+        if not isinstance(metadata, dict):
+            metadata = {}
+        outcome_hash = str(
+            metadata.get("human_approval_verifier_lifecycle_snapshot_hash") or ""
+        ).strip()
+        if outcome_hash != lifecycle_hash:
+            reason = "reviewer_packet_outcome_lifecycle_snapshot_hash_mismatch"
+            if reason not in reasons:
+                reasons.append(reason)
+    return reasons
+
+
+def _verifier_lifecycle_snapshot_hash_continuity_valid(
+    packet: dict[str, Any],
+) -> bool:
+    """Return whether lifecycle hash is bound consistently in chain artifacts."""
+    return not _verifier_lifecycle_snapshot_hash_continuity_reasons(packet)
+
+
 def _committed_lifecycle_status_clean(packet: dict[str, Any]) -> bool:
     """Return whether committed cases carry clean lifecycle evidence."""
     cases = packet.get("cases")
@@ -602,6 +660,12 @@ def _build_checks(
         "committed_lifecycle_status_clean": _committed_lifecycle_status_clean(
             generated_packet
         ),
+        "verifier_lifecycle_snapshot_hash_continuity_valid": (
+            _verifier_lifecycle_snapshot_hash_continuity_valid(generated_packet)
+        ),
+        "verifier_lifecycle_snapshot_hash_continuity_reasons": (
+            _verifier_lifecycle_snapshot_hash_continuity_reasons(generated_packet)
+        ),
         "local_offline_boundary_present": _local_offline_boundary_present(
             generated_packet
         ),
@@ -622,6 +686,11 @@ def _failure_reasons(checks: dict[str, Any]) -> list[str]:
         if reason not in reasons:
             reasons.append(reason)
     for reason in checks.get("verifier_lifecycle_reasons", []):
+        if reason not in reasons:
+            reasons.append(reason)
+    for reason in checks.get(
+        "verifier_lifecycle_snapshot_hash_continuity_reasons", []
+    ):
         if reason not in reasons:
             reasons.append(reason)
     return reasons

--- a/tests/demo/test_reviewer_evidence_packet_schema.py
+++ b/tests/demo/test_reviewer_evidence_packet_schema.py
@@ -533,7 +533,10 @@ def test_checked_in_reviewer_packets_have_lifecycle_fields() -> None:
             "docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated/"
             "reviewer-evidence-packet.generated.example.json"
         ),
-        Path("samples/evidence_bundle/key_provenance_review/reviewer-evidence-packet.json"),
+        Path(
+            "samples/evidence_bundle/key_provenance_review/"
+            "reviewer-evidence-packet.json"
+        ),
     ]
     for packet_path in packet_paths:
         packet = _load_json(packet_path)
@@ -697,7 +700,10 @@ def test_approval_proof_present_cases_carry_verifier_policy_fields() -> None:
         DECISION_CANDIDATE_REFUSAL_FIXTURE_PATH,
         EVALUATION_GOVERNANCE_EXAMPLE_PATH,
         CONTEXT_BOUND_APPROVAL_REPLAY_EXAMPLE_PATH,
-        Path("samples/evidence_bundle/key_provenance_review/reviewer-evidence-packet.json"),
+        Path(
+            "samples/evidence_bundle/key_provenance_review/"
+            "reviewer-evidence-packet.json"
+        ),
     ]
     for packet_path in packet_paths:
         packet = _load_json(packet_path)
@@ -720,6 +726,46 @@ def test_approval_proof_present_cases_carry_verifier_policy_fields() -> None:
             assert outcome_metadata["human_approval_verifier_policy_hash"] == summary[
                 "verifier_policy_hash"
             ]
+
+
+def test_all_manifest_summaries_include_lifecycle_snapshot_hash_field() -> None:
+    """Require explicit lifecycle hash nulls for no-proof manifest summaries."""
+    packet_paths = [
+        FIXTURE_PATH,
+        DECISION_CANDIDATE_REFUSAL_FIXTURE_PATH,
+        EVALUATION_GOVERNANCE_EXAMPLE_PATH,
+        CONTEXT_BOUND_APPROVAL_REPLAY_EXAMPLE_PATH,
+        Path(
+            "docs/en/demo/examples/evaluation-governance-chain-reviewer-packet-v1/"
+            "reviewer-evidence-packet.generated.example.json"
+        ),
+        Path(
+            "docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated/"
+            "reviewer-evidence-packet.generated.example.json"
+        ),
+        Path(
+            "samples/evidence_bundle/key_provenance_review/"
+            "reviewer-evidence-packet.json"
+        ),
+    ]
+
+    for packet_path in packet_paths:
+        packet = _load_json(packet_path)
+        for case in packet["cases"]:
+            manifest = case["evidence_chain_manifest_summary"]
+            lifecycle = case["verifier_lifecycle_summary"]
+
+            assert "human_approval_verifier_lifecycle_snapshot_hash" in manifest
+            if lifecycle is None:
+                assert (
+                    manifest["human_approval_verifier_lifecycle_snapshot_hash"]
+                    is None
+                )
+            else:
+                assert (
+                    manifest["human_approval_verifier_lifecycle_snapshot_hash"]
+                    == lifecycle["verifier_lifecycle_snapshot_hash"]
+                )
 
 
 def test_failed_context_bound_replay_cases_do_not_claim_verified_receipts() -> None:

--- a/tests/demo/test_reviewer_evidence_packet_validation_report.py
+++ b/tests/demo/test_reviewer_evidence_packet_validation_report.py
@@ -158,6 +158,67 @@ def test_approval_required_packet_passes_with_matching_proof_hashes() -> None:
 
     assert report["checks"]["approval_proof_continuity_valid"] is True
     assert report["checks"]["approval_proof_continuity_reasons"] == []
+    assert (
+        report["checks"]["verifier_lifecycle_snapshot_hash_continuity_valid"]
+        is True
+    )
+    assert (
+        report["checks"][
+            "verifier_lifecycle_snapshot_hash_continuity_reasons"
+        ]
+        == []
+    )
+
+
+def test_committed_verified_approval_packet_binds_lifecycle_hash() -> None:
+    packet = _valid_case_packet()
+    case = packet["cases"][0]
+    lifecycle_hash = case["verifier_lifecycle_summary"][
+        "verifier_lifecycle_snapshot_hash"
+    ]
+
+    assert (
+        case["evidence_chain_manifest_summary"][
+            "human_approval_verifier_lifecycle_snapshot_hash"
+        ]
+        == lifecycle_hash
+    )
+    assert (
+        case["outcome_receipt_summary"]["metadata"][
+            "human_approval_verifier_lifecycle_snapshot_hash"
+        ]
+        == lifecycle_hash
+    )
+
+
+def test_validation_report_fails_when_manifest_lifecycle_hash_differs() -> None:
+    packet = _valid_case_packet()
+    packet["cases"][0]["evidence_chain_manifest_summary"][
+        "human_approval_verifier_lifecycle_snapshot_hash"
+    ] = "f" * 64
+
+    report = _report_for_mutated_packet(packet)
+
+    assert report["status"] == "fail"
+    assert (
+        "reviewer_packet_manifest_lifecycle_snapshot_hash_mismatch"
+        in report["failure_reasons"]
+    )
+
+
+def test_validation_report_fails_when_outcome_lifecycle_hash_differs() -> None:
+    packet = _valid_case_packet()
+    packet["cases"][0]["outcome_receipt_summary"]["metadata"][
+        "human_approval_verifier_lifecycle_snapshot_hash"
+    ] = "f" * 64
+
+    report = _report_for_mutated_packet(packet)
+
+    assert report["status"] == "fail"
+    assert (
+        "reviewer_packet_outcome_lifecycle_snapshot_hash_mismatch"
+        in report["failure_reasons"]
+    )
 
 
 def test_approval_required_packet_fails_when_manifest_proof_hash_missing() -> None:

--- a/tests/demo/test_reviewer_verifier_policy_snapshot_continuity.py
+++ b/tests/demo/test_reviewer_verifier_policy_snapshot_continuity.py
@@ -52,6 +52,11 @@ SNAPSHOT_FIELD_MAPPINGS = (
         "verified_human_approval_proof_hash",
         "verified_human_approval_proof_hash",
     ),
+    (
+        "verifier_lifecycle_snapshot_hash",
+        "human_approval_verifier_lifecycle_snapshot_hash",
+        "human_approval_verifier_lifecycle_snapshot_hash",
+    ),
 )
 
 
@@ -117,12 +122,18 @@ def test_verifier_policy_snapshot_continuity_across_reviewer_packets(
             continue
 
         human_approval = case["human_approval_summary"]
+        lifecycle = case["verifier_lifecycle_summary"]
         manifest = case["evidence_chain_manifest_summary"]
         metadata = case["outcome_receipt_summary"]["metadata"]
         case_label = f"{fixture_path}:{_case_id(case)}"
 
         for approval_field, manifest_field, metadata_field in SNAPSHOT_FIELD_MAPPINGS:
-            approval_value = human_approval.get(approval_field)
+            approval_source = (
+                lifecycle
+                if approval_field == "verifier_lifecycle_snapshot_hash"
+                else human_approval
+            )
+            approval_value = approval_source.get(approval_field)
             manifest_value = manifest.get(manifest_field)
             metadata_value = metadata.get(metadata_field)
 

--- a/tests/governance/test_evidence_chain_manifest.py
+++ b/tests/governance/test_evidence_chain_manifest.py
@@ -29,6 +29,7 @@ def _base_manifest() -> EvidenceChainManifest:
         human_approval_verifier_key_id="verifier-key-1",
         human_approval_verifier_policy_id="verifier-policy-1",
         human_approval_verifier_policy_hash="v" * 64,
+        human_approval_verifier_lifecycle_snapshot_hash="l" * 64,
         human_approval_required=True,
         bind_receipt_id=None,
         bind_receipt_hash=None,

--- a/veritas_os/governance/evidence_chain_manifest.py
+++ b/veritas_os/governance/evidence_chain_manifest.py
@@ -39,6 +39,7 @@ class EvidenceChainManifest:
     human_approval_verifier_key_id: str | None
     human_approval_verifier_policy_id: str | None
     human_approval_verifier_policy_hash: str | None
+    human_approval_verifier_lifecycle_snapshot_hash: str | None
     human_approval_required: bool
     bind_receipt_id: str | None
     bind_receipt_hash: str | None
@@ -79,6 +80,9 @@ class EvidenceChainManifest:
             ),
             "human_approval_verifier_policy_hash": (
                 self.human_approval_verifier_policy_hash
+            ),
+            "human_approval_verifier_lifecycle_snapshot_hash": (
+                self.human_approval_verifier_lifecycle_snapshot_hash
             ),
             "human_approval_required": self.human_approval_required,
             "bind_receipt_id": self.bind_receipt_id,
@@ -204,6 +208,7 @@ def build_evidence_chain_manifest(
     human_approval_verifier_key_id: str | None = None,
     human_approval_verifier_policy_id: str | None = None,
     human_approval_verifier_policy_hash: str | None = None,
+    human_approval_verifier_lifecycle_snapshot_hash: str | None = None,
     human_approval_required: bool = True,
     bind_receipt_id: str | None = None,
     bind_receipt_hash: str | None = None,
@@ -256,6 +261,9 @@ def build_evidence_chain_manifest(
         human_approval_verifier_key_id=human_approval_verifier_key_id,
         human_approval_verifier_policy_id=human_approval_verifier_policy_id,
         human_approval_verifier_policy_hash=human_approval_verifier_policy_hash,
+        human_approval_verifier_lifecycle_snapshot_hash=(
+            human_approval_verifier_lifecycle_snapshot_hash
+        ),
         human_approval_required=human_approval_required,
         bind_receipt_id=bind_receipt_id,
         bind_receipt_hash=bind_receipt_hash,


### PR DESCRIPTION
### Motivation
- Ensure the `verifier_lifecycle_snapshot_hash` produced for a verified human approval is bound into the replayable evidence-chain artifacts (manifest and outcome receipt) rather than only shown in the reviewer packet summary. 
- Provide deterministic continuity checks so reviewers can assert the same lifecycle snapshot hash appears in the lifecycle summary, evidence-chain manifest, and outcome receipt metadata. 
- Close the remaining audit question about whether lifecycle evidence is actually bound into underlying artifacts used for replay verification. 
- Security note: this is deterministic reviewer/demo evidence only and does not introduce live KMS/HSM, revocation services, or change production verifier allowlist behavior.

### Description
- Added `human_approval_verifier_lifecycle_snapshot_hash` to the `EvidenceChainManifest` dataclass, `to_dict()` output, and the `build_evidence_chain_manifest()` builder so manifests carry the lifecycle snapshot hash when available. 
- Bound the verifier lifecycle snapshot hash into `OutcomeReceipt.metadata` for cases with a verified human approval (demo/SaaS exporter) and passed the same value into the manifest builder so the hash appears in both manifest summary and outcome metadata. 
- Implemented continuity validation in the reviewer-packet validator to assert three-way equality when a lifecycle summary is present and added clear failure reason codes for missing or mismatched lifecycle hashes (`reviewer_packet_verifier_lifecycle_snapshot_hash_missing`, `reviewer_packet_manifest_lifecycle_snapshot_hash_mismatch`, `reviewer_packet_outcome_lifecycle_snapshot_hash_mismatch`, and related continuity flags). 
- Updated reviewer packet schema, regenerated fixtures/examples/samples to include the new manifest/outcome fields and recomputed packet/manifest/outcome hashes, and added regression tests that assert lifecycle-hash binding and deterministic failure modes.

### Testing
- Ran the full targeted test suites under the local test stubs: `PYTHONPATH=/tmp/pytest_stubs:$PYTHONPATH PYENV_VERSION=3.11.15 python -m pytest [...]` which completed successfully (`133 passed, 2 skipped, 1 warning`). 
- Ran a subset on another interpreter: `PYTHONPATH=/tmp/pytest_stubs:$PYTHONPATH PYENV_VERSION=3.12.13 python -m pytest tests/demo/test_reviewer_evidence_packet_validation_report.py tests/demo/test_reviewer_verifier_policy_snapshot_continuity.py tests/demo/test_verifier_lifecycle.py` which passed (`46 passed`). 
- Executed the reviewer packet validator script `scripts/demo/validate_reviewer_evidence_packet.py` and the sample sanity checker `scripts/quality/check_key_provenance_review_samples.py`, both returned `pass` in this environment. 
- Note: test runs used a local PyYAML stub (`/tmp/pytest_stubs/yaml.py`) because the execution environment did not have PyYAML available and network package installation was not used.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f0beffd908326b09c9739fff9a117)