### PR TITLE
feat: verify lifecycle snapshot continuity in evidence chains

### DIFF
--- a/docs/en/demo/examples/context-bound-approval-replay-prevention-v1.json
+++ b/docs/en/demo/examples/context-bound-approval-replay-prevention-v1.json
@@ -73,8 +73,11 @@
         "verified_at": "2026-05-10T00:00:00+00:00",
         "verified_links": [
           "human_approval_receipt_signature",
+          "human_approval_verifier_lifecycle_snapshot_hash_continuity",
           "verified_human_approval_proof_hash"
-        ]
+        ],
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": true,
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": []
       },
       "expected_outcome": "commit_eligible",
       "failure_reasons": [],
@@ -229,8 +232,11 @@
         "verification_status": "failed",
         "verified_at": "2026-05-10T00:00:00+00:00",
         "verified_links": [
-          "human_approval_receipt_signature"
-        ]
+          "human_approval_receipt_signature",
+          "human_approval_verifier_lifecycle_snapshot_hash_continuity"
+        ],
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": true,
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": []
       },
       "expected_outcome": "block",
       "failure_reasons": [
@@ -372,8 +378,11 @@
         "verification_status": "failed",
         "verified_at": "2026-05-10T00:00:00+00:00",
         "verified_links": [
-          "human_approval_receipt_signature"
-        ]
+          "human_approval_receipt_signature",
+          "human_approval_verifier_lifecycle_snapshot_hash_continuity"
+        ],
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": true,
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": []
       },
       "expected_outcome": "block",
       "failure_reasons": [
@@ -515,8 +524,11 @@
         "verification_status": "failed",
         "verified_at": "2026-05-10T00:00:00+00:00",
         "verified_links": [
-          "human_approval_receipt_signature"
-        ]
+          "human_approval_receipt_signature",
+          "human_approval_verifier_lifecycle_snapshot_hash_continuity"
+        ],
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": true,
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": []
       },
       "expected_outcome": "block",
       "failure_reasons": [
@@ -596,7 +608,7 @@
   "demo_id": "context-bound-approval-replay-prevention-v1",
   "generated_at": "2026-05-10T00:00:00+00:00",
   "local_offline_only": true,
-  "packet_hash": "bc935111791a65c80840d20ae1ceb6349e695e9984a276dd4e64463c265815d6",
+  "packet_hash": "afaafa6d6c23080d469933a73108ba6b4e080546676e17aa14479102795b447f",
   "packet_id": "reviewer-evidence-packet-approval-replay-prevention-v1",
   "packet_version": "v1",
   "reviewer_notes": [

--- a/docs/en/demo/examples/evaluation-governance-chain-reviewer-packet-v1/reviewer-evidence-packet.generated.example.json
+++ b/docs/en/demo/examples/evaluation-governance-chain-reviewer-packet-v1/reviewer-evidence-packet.generated.example.json
@@ -84,10 +84,13 @@
         "verified_links": [
           "bind_coverage_operation_id",
           "human_approval_receipt_hash",
+          "human_approval_verifier_lifecycle_snapshot_hash_continuity",
           "manifest_hash",
           "outcome_receipt_hash",
           "verified_human_approval_proof_hash"
-        ]
+        ],
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": true,
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": []
       },
       "expected_outcome": "block",
       "failure_reasons": [
@@ -263,9 +266,12 @@
         "verified_links": [
           "authority_evidence_hash",
           "bind_coverage_operation_id",
+          "human_approval_verifier_lifecycle_snapshot_hash_continuity",
           "manifest_hash",
           "outcome_receipt_hash"
-        ]
+        ],
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": true,
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": []
       },
       "expected_outcome": "block",
       "failure_reasons": [
@@ -414,9 +420,12 @@
         "verified_links": [
           "authority_evidence_hash",
           "bind_coverage_operation_id",
+          "human_approval_verifier_lifecycle_snapshot_hash_continuity",
           "manifest_hash",
           "outcome_receipt_hash"
-        ]
+        ],
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": true,
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": []
       },
       "expected_outcome": "block",
       "failure_reasons": [
@@ -566,9 +575,12 @@
         "verified_links": [
           "authority_evidence_hash",
           "bind_coverage_operation_id",
+          "human_approval_verifier_lifecycle_snapshot_hash_continuity",
           "manifest_hash",
           "outcome_receipt_hash"
-        ]
+        ],
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": true,
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": []
       },
       "expected_outcome": "block",
       "failure_reasons": [
@@ -722,10 +734,13 @@
           "authority_evidence_hash",
           "bind_coverage_operation_id",
           "human_approval_receipt_hash",
+          "human_approval_verifier_lifecycle_snapshot_hash_continuity",
           "manifest_hash",
           "outcome_receipt_hash",
           "verified_human_approval_proof_hash"
-        ]
+        ],
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": true,
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": []
       },
       "expected_outcome": "commit",
       "failure_reasons": [],
@@ -917,7 +932,7 @@
     }
   },
   "local_offline_only": true,
-  "packet_hash": "87b9ac0c05893c471f2df0b811509c267d559b9e8b190c75cebedec87154d1b2",
+  "packet_hash": "baef4fac41b54b91281f73776018cd9519d1a17776f79c786050c1777cb97630",
   "packet_id": "reviewer-evidence-packet-saas-permission-change-v1",
   "packet_version": "v1",
   "reviewer_notes": [

--- a/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated/reviewer-evidence-packet.generated.example.json
+++ b/docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated/reviewer-evidence-packet.generated.example.json
@@ -84,10 +84,13 @@
         "verified_links": [
           "bind_coverage_operation_id",
           "human_approval_receipt_hash",
+          "human_approval_verifier_lifecycle_snapshot_hash_continuity",
           "manifest_hash",
           "outcome_receipt_hash",
           "verified_human_approval_proof_hash"
-        ]
+        ],
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": true,
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": []
       },
       "expected_outcome": "block",
       "failure_reasons": [
@@ -263,9 +266,12 @@
         "verified_links": [
           "authority_evidence_hash",
           "bind_coverage_operation_id",
+          "human_approval_verifier_lifecycle_snapshot_hash_continuity",
           "manifest_hash",
           "outcome_receipt_hash"
-        ]
+        ],
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": true,
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": []
       },
       "expected_outcome": "block",
       "failure_reasons": [
@@ -414,9 +420,12 @@
         "verified_links": [
           "authority_evidence_hash",
           "bind_coverage_operation_id",
+          "human_approval_verifier_lifecycle_snapshot_hash_continuity",
           "manifest_hash",
           "outcome_receipt_hash"
-        ]
+        ],
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": true,
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": []
       },
       "expected_outcome": "block",
       "failure_reasons": [
@@ -566,9 +575,12 @@
         "verified_links": [
           "authority_evidence_hash",
           "bind_coverage_operation_id",
+          "human_approval_verifier_lifecycle_snapshot_hash_continuity",
           "manifest_hash",
           "outcome_receipt_hash"
-        ]
+        ],
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": true,
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": []
       },
       "expected_outcome": "block",
       "failure_reasons": [
@@ -722,10 +734,13 @@
           "authority_evidence_hash",
           "bind_coverage_operation_id",
           "human_approval_receipt_hash",
+          "human_approval_verifier_lifecycle_snapshot_hash_continuity",
           "manifest_hash",
           "outcome_receipt_hash",
           "verified_human_approval_proof_hash"
-        ]
+        ],
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": true,
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": []
       },
       "expected_outcome": "commit",
       "failure_reasons": [],
@@ -917,7 +932,7 @@
     }
   },
   "local_offline_only": true,
-  "packet_hash": "87b9ac0c05893c471f2df0b811509c267d559b9e8b190c75cebedec87154d1b2",
+  "packet_hash": "baef4fac41b54b91281f73776018cd9519d1a17776f79c786050c1777cb97630",
   "packet_id": "reviewer-evidence-packet-saas-permission-change-v1",
   "packet_version": "v1",
   "reviewer_notes": [

--- a/docs/en/demo/examples/reviewer-evidence-packet-with-evaluation-governance-v1.json
+++ b/docs/en/demo/examples/reviewer-evidence-packet-with-evaluation-governance-v1.json
@@ -84,10 +84,13 @@
         "verified_links": [
           "bind_coverage_operation_id",
           "human_approval_receipt_hash",
+          "human_approval_verifier_lifecycle_snapshot_hash_continuity",
           "manifest_hash",
           "outcome_receipt_hash",
           "verified_human_approval_proof_hash"
-        ]
+        ],
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": true,
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": []
       },
       "expected_outcome": "block",
       "failure_reasons": [
@@ -263,9 +266,12 @@
         "verified_links": [
           "authority_evidence_hash",
           "bind_coverage_operation_id",
+          "human_approval_verifier_lifecycle_snapshot_hash_continuity",
           "manifest_hash",
           "outcome_receipt_hash"
-        ]
+        ],
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": true,
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": []
       },
       "expected_outcome": "block",
       "failure_reasons": [
@@ -414,9 +420,12 @@
         "verified_links": [
           "authority_evidence_hash",
           "bind_coverage_operation_id",
+          "human_approval_verifier_lifecycle_snapshot_hash_continuity",
           "manifest_hash",
           "outcome_receipt_hash"
-        ]
+        ],
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": true,
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": []
       },
       "expected_outcome": "block",
       "failure_reasons": [
@@ -566,9 +575,12 @@
         "verified_links": [
           "authority_evidence_hash",
           "bind_coverage_operation_id",
+          "human_approval_verifier_lifecycle_snapshot_hash_continuity",
           "manifest_hash",
           "outcome_receipt_hash"
-        ]
+        ],
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": true,
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": []
       },
       "expected_outcome": "block",
       "failure_reasons": [
@@ -722,10 +734,13 @@
           "authority_evidence_hash",
           "bind_coverage_operation_id",
           "human_approval_receipt_hash",
+          "human_approval_verifier_lifecycle_snapshot_hash_continuity",
           "manifest_hash",
           "outcome_receipt_hash",
           "verified_human_approval_proof_hash"
-        ]
+        ],
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": true,
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": []
       },
       "expected_outcome": "commit",
       "failure_reasons": [],
@@ -917,7 +932,7 @@
     }
   },
   "local_offline_only": true,
-  "packet_hash": "87b9ac0c05893c471f2df0b811509c267d559b9e8b190c75cebedec87154d1b2",
+  "packet_hash": "baef4fac41b54b91281f73776018cd9519d1a17776f79c786050c1777cb97630",
   "packet_id": "reviewer-evidence-packet-saas-permission-change-v1",
   "packet_version": "v1",
   "reviewer_notes": [

--- a/docs/en/demo/fixtures/reviewer-evidence-packet-decision-candidate-refusal-v1.json
+++ b/docs/en/demo/fixtures/reviewer-evidence-packet-decision-candidate-refusal-v1.json
@@ -84,10 +84,13 @@
         "verified_links": [
           "bind_coverage_operation_id",
           "human_approval_receipt_hash",
+          "human_approval_verifier_lifecycle_snapshot_hash_continuity",
           "manifest_hash",
           "outcome_receipt_hash",
           "verified_human_approval_proof_hash"
-        ]
+        ],
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": true,
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": []
       },
       "expected_outcome": "block",
       "failure_reasons": [
@@ -263,9 +266,12 @@
         "verified_links": [
           "authority_evidence_hash",
           "bind_coverage_operation_id",
+          "human_approval_verifier_lifecycle_snapshot_hash_continuity",
           "manifest_hash",
           "outcome_receipt_hash"
-        ]
+        ],
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": true,
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": []
       },
       "expected_outcome": "block",
       "failure_reasons": [
@@ -414,9 +420,12 @@
         "verified_links": [
           "authority_evidence_hash",
           "bind_coverage_operation_id",
+          "human_approval_verifier_lifecycle_snapshot_hash_continuity",
           "manifest_hash",
           "outcome_receipt_hash"
-        ]
+        ],
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": true,
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": []
       },
       "expected_outcome": "block",
       "failure_reasons": [
@@ -566,9 +575,12 @@
         "verified_links": [
           "authority_evidence_hash",
           "bind_coverage_operation_id",
+          "human_approval_verifier_lifecycle_snapshot_hash_continuity",
           "manifest_hash",
           "outcome_receipt_hash"
-        ]
+        ],
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": true,
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": []
       },
       "expected_outcome": "block",
       "failure_reasons": [
@@ -722,10 +734,13 @@
           "authority_evidence_hash",
           "bind_coverage_operation_id",
           "human_approval_receipt_hash",
+          "human_approval_verifier_lifecycle_snapshot_hash_continuity",
           "manifest_hash",
           "outcome_receipt_hash",
           "verified_human_approval_proof_hash"
-        ]
+        ],
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": true,
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": []
       },
       "expected_outcome": "commit",
       "failure_reasons": [],
@@ -877,7 +892,7 @@
     }
   },
   "local_offline_only": true,
-  "packet_hash": "44a4b5bbc23218bc268702f0ffdf4f514a1611bc1bd8f875b89b1a292451aacc",
+  "packet_hash": "de124ce235fab93ea9e277fa76537145d3b30ca76aa614ea54f3d0aead9a8ed0",
   "packet_id": "reviewer-evidence-packet-decision-candidate-refusal-v1",
   "packet_version": "v1",
   "reviewer_notes": [

--- a/docs/en/demo/fixtures/reviewer-evidence-packet-saas-permission-change-v1.json
+++ b/docs/en/demo/fixtures/reviewer-evidence-packet-saas-permission-change-v1.json
@@ -84,10 +84,13 @@
         "verified_links": [
           "bind_coverage_operation_id",
           "human_approval_receipt_hash",
+          "human_approval_verifier_lifecycle_snapshot_hash_continuity",
           "manifest_hash",
           "outcome_receipt_hash",
           "verified_human_approval_proof_hash"
-        ]
+        ],
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": true,
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": []
       },
       "expected_outcome": "block",
       "failure_reasons": [
@@ -263,9 +266,12 @@
         "verified_links": [
           "authority_evidence_hash",
           "bind_coverage_operation_id",
+          "human_approval_verifier_lifecycle_snapshot_hash_continuity",
           "manifest_hash",
           "outcome_receipt_hash"
-        ]
+        ],
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": true,
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": []
       },
       "expected_outcome": "block",
       "failure_reasons": [
@@ -414,9 +420,12 @@
         "verified_links": [
           "authority_evidence_hash",
           "bind_coverage_operation_id",
+          "human_approval_verifier_lifecycle_snapshot_hash_continuity",
           "manifest_hash",
           "outcome_receipt_hash"
-        ]
+        ],
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": true,
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": []
       },
       "expected_outcome": "block",
       "failure_reasons": [
@@ -566,9 +575,12 @@
         "verified_links": [
           "authority_evidence_hash",
           "bind_coverage_operation_id",
+          "human_approval_verifier_lifecycle_snapshot_hash_continuity",
           "manifest_hash",
           "outcome_receipt_hash"
-        ]
+        ],
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": true,
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": []
       },
       "expected_outcome": "block",
       "failure_reasons": [
@@ -722,10 +734,13 @@
           "authority_evidence_hash",
           "bind_coverage_operation_id",
           "human_approval_receipt_hash",
+          "human_approval_verifier_lifecycle_snapshot_hash_continuity",
           "manifest_hash",
           "outcome_receipt_hash",
           "verified_human_approval_proof_hash"
-        ]
+        ],
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": true,
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": []
       },
       "expected_outcome": "commit",
       "failure_reasons": [],
@@ -845,7 +860,7 @@
     }
   },
   "local_offline_only": true,
-  "packet_hash": "20b7db9cfd4f22df36472b048b9d9bafc080e2f571886d381e117d12c099492f",
+  "packet_hash": "3d4df29c13955f0c6d51d36f2380f5d5957ca9618675d06bbc7cb08332b44ab3",
   "packet_id": "reviewer-evidence-packet-saas-permission-change-v1",
   "packet_version": "v1",
   "reviewer_notes": [

--- a/docs/en/demo/fixtures/reviewer-evidence-packet-saas-permission-change-v1.json
+++ b/docs/en/demo/fixtures/reviewer-evidence-packet-saas-permission-change-v1.json
@@ -66,6 +66,8 @@
         "decision_id": "decision-saas-001",
         "execution_intent_id": "intent-saas-001",
         "failure_reasons": [],
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": [],
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": true,
         "is_valid": true,
         "manifest_hash_matches": true,
         "manifest_id": "ecm-saas-permission-change-missing_authority",
@@ -88,9 +90,7 @@
           "manifest_hash",
           "outcome_receipt_hash",
           "verified_human_approval_proof_hash"
-        ],
-        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": true,
-        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": []
+        ]
       },
       "expected_outcome": "block",
       "failure_reasons": [
@@ -248,6 +248,8 @@
         "decision_id": "decision-saas-001",
         "execution_intent_id": "intent-saas-001",
         "failure_reasons": [],
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": [],
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": true,
         "is_valid": true,
         "manifest_hash_matches": true,
         "manifest_id": "ecm-saas-permission-change-missing_human_approval",
@@ -269,9 +271,7 @@
           "human_approval_verifier_lifecycle_snapshot_hash_continuity",
           "manifest_hash",
           "outcome_receipt_hash"
-        ],
-        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": true,
-        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": []
+        ]
       },
       "expected_outcome": "block",
       "failure_reasons": [
@@ -402,6 +402,8 @@
         "decision_id": "decision-saas-001",
         "execution_intent_id": "intent-saas-001",
         "failure_reasons": [],
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": [],
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": true,
         "is_valid": true,
         "manifest_hash_matches": true,
         "manifest_id": "ecm-saas-permission-change-expired_human_approval",
@@ -423,9 +425,7 @@
           "human_approval_verifier_lifecycle_snapshot_hash_continuity",
           "manifest_hash",
           "outcome_receipt_hash"
-        ],
-        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": true,
-        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": []
+        ]
       },
       "expected_outcome": "block",
       "failure_reasons": [
@@ -557,6 +557,8 @@
         "decision_id": "decision-saas-001",
         "execution_intent_id": "intent-saas-001",
         "failure_reasons": [],
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": [],
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": true,
         "is_valid": true,
         "manifest_hash_matches": true,
         "manifest_id": "ecm-saas-permission-change-scope_mismatch",
@@ -578,9 +580,7 @@
           "human_approval_verifier_lifecycle_snapshot_hash_continuity",
           "manifest_hash",
           "outcome_receipt_hash"
-        ],
-        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": true,
-        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": []
+        ]
       },
       "expected_outcome": "block",
       "failure_reasons": [
@@ -717,6 +717,8 @@
         "decision_id": "decision-saas-001",
         "execution_intent_id": "intent-saas-001",
         "failure_reasons": [],
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": [],
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": true,
         "is_valid": true,
         "manifest_hash_matches": true,
         "manifest_id": "ecm-saas-permission-change-valid_authority_and_approval",
@@ -738,9 +740,7 @@
           "manifest_hash",
           "outcome_receipt_hash",
           "verified_human_approval_proof_hash"
-        ],
-        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": true,
-        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": []
+        ]
       },
       "expected_outcome": "commit",
       "failure_reasons": [],

--- a/docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json
+++ b/docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json
@@ -664,7 +664,9 @@
         "recomputed_manifest_hash",
         "manifest_hash_matches",
         "verified_at",
-        "metadata"
+        "metadata",
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified",
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons"
       ],
       "properties": {
         "is_valid": {
@@ -718,6 +720,12 @@
         },
         "metadata": {
           "type": "object"
+        },
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": {
+          "type": "boolean"
+        },
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": {
+          "$ref": "#/$defs/string_array"
         }
       }
     },

--- a/samples/evidence_bundle/key_provenance_review/reviewer-evidence-packet.json
+++ b/samples/evidence_bundle/key_provenance_review/reviewer-evidence-packet.json
@@ -84,10 +84,13 @@
         "verified_links": [
           "bind_coverage_operation_id",
           "human_approval_receipt_hash",
+          "human_approval_verifier_lifecycle_snapshot_hash_continuity",
           "manifest_hash",
           "outcome_receipt_hash",
           "verified_human_approval_proof_hash"
-        ]
+        ],
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": true,
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": []
       },
       "expected_outcome": "block",
       "failure_reasons": [
@@ -263,9 +266,12 @@
         "verified_links": [
           "authority_evidence_hash",
           "bind_coverage_operation_id",
+          "human_approval_verifier_lifecycle_snapshot_hash_continuity",
           "manifest_hash",
           "outcome_receipt_hash"
-        ]
+        ],
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": true,
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": []
       },
       "expected_outcome": "block",
       "failure_reasons": [
@@ -414,9 +420,12 @@
         "verified_links": [
           "authority_evidence_hash",
           "bind_coverage_operation_id",
+          "human_approval_verifier_lifecycle_snapshot_hash_continuity",
           "manifest_hash",
           "outcome_receipt_hash"
-        ]
+        ],
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": true,
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": []
       },
       "expected_outcome": "block",
       "failure_reasons": [
@@ -566,9 +575,12 @@
         "verified_links": [
           "authority_evidence_hash",
           "bind_coverage_operation_id",
+          "human_approval_verifier_lifecycle_snapshot_hash_continuity",
           "manifest_hash",
           "outcome_receipt_hash"
-        ]
+        ],
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": true,
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": []
       },
       "expected_outcome": "block",
       "failure_reasons": [
@@ -722,10 +734,13 @@
           "authority_evidence_hash",
           "bind_coverage_operation_id",
           "human_approval_receipt_hash",
+          "human_approval_verifier_lifecycle_snapshot_hash_continuity",
           "manifest_hash",
           "outcome_receipt_hash",
           "verified_human_approval_proof_hash"
-        ]
+        ],
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": true,
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": []
       },
       "expected_outcome": "commit",
       "failure_reasons": [],
@@ -845,7 +860,7 @@
     }
   },
   "local_offline_only": true,
-  "packet_hash": "bc311d8a56bc5e2ebd926b1b1763072cad51f0f92a7b6cadea3316a907b508b2",
+  "packet_hash": "f662ed7059e4453009199b816f0f03855551ea962f8224e700bbe1baa51777b5",
   "packet_id": "reviewer-evidence-packet-saas-permission-change-v1",
   "packet_version": "v1",
   "reviewer_notes": [

--- a/samples/evidence_bundle/key_provenance_review/sample-artifact-manifest.json
+++ b/samples/evidence_bundle/key_provenance_review/sample-artifact-manifest.json
@@ -28,7 +28,7 @@
       "artifact_name": "reviewer-evidence-packet.json",
       "role": "reviewer_evidence_packet",
       "schema_id": "docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json",
-      "sha256": "666aa67846318daf24123e09321d955395d8f11e78dd8f4eb0711c5ae196c87c"
+      "sha256": "773e745e88cc59134c63c5a6199399292250f34ecafaf7d6eeef17338109fa51"
     },
     {
       "artifact_name": "reviewer-handoff-review-result.json",

--- a/tests/governance/test_evidence_chain_verifier.py
+++ b/tests/governance/test_evidence_chain_verifier.py
@@ -20,6 +20,7 @@ AUTHORITY_HASH = "a" * 64
 APPROVAL_HASH = "b" * 64
 OUTCOME_HASH = "c" * 64
 PROOF_HASH = "p" * 64
+LIFECYCLE_HASH = "1" * 64
 
 
 @dataclass(frozen=True)
@@ -52,6 +53,7 @@ def _complete_manifest() -> EvidenceChainManifest:
         human_approval_receipt_id="har-1",
         human_approval_receipt_hash=APPROVAL_HASH,
         verified_human_approval_proof_hash=PROOF_HASH,
+        human_approval_verifier_lifecycle_snapshot_hash=LIFECYCLE_HASH,
         outcome_receipt_id="outcome-1",
         outcome_receipt_hash=OUTCOME_HASH,
         bind_coverage_operation_id="saas_permission_change_demo",
@@ -67,7 +69,10 @@ def _verify_complete(**overrides: object) -> EvidenceChainVerificationResult:
         "human_approval_receipt": {"receipt_hash": APPROVAL_HASH},
         "outcome_receipt": {
             "outcome_hash": OUTCOME_HASH,
-            "metadata": {"verified_human_approval_proof_hash": PROOF_HASH},
+            "metadata": {
+                "verified_human_approval_proof_hash": PROOF_HASH,
+                "human_approval_verifier_lifecycle_snapshot_hash": LIFECYCLE_HASH,
+            },
         },
         "verified_human_approval": SimpleNamespace(verification_proof_hash=PROOF_HASH),
         "approval_required": True,
@@ -94,11 +99,20 @@ def test_valid_complete_chain_verifies_successfully() -> None:
         "authority_evidence_hash",
         "bind_coverage_operation_id",
         "human_approval_receipt_hash",
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity",
         "manifest_hash",
         "outcome_receipt_hash",
         "verified_human_approval_proof_hash",
     ]
     assert result.failure_reasons == []
+    assert (
+        result.human_approval_verifier_lifecycle_snapshot_hash_continuity_verified
+        is True
+    )
+    assert (
+        result.human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons
+        == []
+    )
 
 
 def test_manifest_hash_mismatch_fails_verification() -> None:
@@ -189,7 +203,14 @@ def test_approval_required_verifies_proof_hash_continuity() -> None:
 
 
 def test_approval_required_fails_when_outcome_proof_hash_missing() -> None:
-    result = _verify_complete(outcome_receipt={"outcome_hash": OUTCOME_HASH})
+    result = _verify_complete(
+        outcome_receipt={
+            "outcome_hash": OUTCOME_HASH,
+            "metadata": {
+                "human_approval_verifier_lifecycle_snapshot_hash": LIFECYCLE_HASH,
+            },
+        }
+    )
     assert result.verification_status == "incomplete"
     assert "human_approval_proof_hash_missing" in result.failure_reasons
 
@@ -208,7 +229,10 @@ def test_outcome_proof_hash_mismatch_fails_verification() -> None:
     result = _verify_complete(
         outcome_receipt={
             "outcome_hash": OUTCOME_HASH,
-            "metadata": {"verified_human_approval_proof_hash": "x" * 64},
+            "metadata": {
+                "verified_human_approval_proof_hash": "x" * 64,
+                "human_approval_verifier_lifecycle_snapshot_hash": LIFECYCLE_HASH,
+            },
         }
     )
     assert result.verification_status == "failed"
@@ -248,3 +272,88 @@ def test_no_approval_required_path_allows_missing_proof_hash() -> None:
         verified_at=VERIFIED_AT,
     )
     assert result.verification_status == "verified"
+
+
+def test_lifecycle_snapshot_hash_missing_from_outcome_fails_verification() -> None:
+    result = _verify_complete(
+        outcome_receipt={
+            "outcome_hash": OUTCOME_HASH,
+            "metadata": {"verified_human_approval_proof_hash": PROOF_HASH},
+        }
+    )
+    assert result.verification_status == "failed"
+    assert "human_approval_verifier_lifecycle_snapshot_hash" in result.mismatched_links
+    assert (
+        "evidence_chain_outcome_lifecycle_snapshot_hash_missing"
+        in result.failure_reasons
+    )
+    assert (
+        result.human_approval_verifier_lifecycle_snapshot_hash_continuity_verified
+        is False
+    )
+
+
+def test_lifecycle_snapshot_hash_missing_from_manifest_fails_verification() -> None:
+    manifest = _complete_manifest()
+    manifest = type(manifest)(
+        **{
+            **manifest.to_dict(),
+            "human_approval_verifier_lifecycle_snapshot_hash": None,
+        }
+    )
+    result = _verify_complete(manifest=manifest)
+    assert result.verification_status == "failed"
+    assert "human_approval_verifier_lifecycle_snapshot_hash" in result.mismatched_links
+    assert (
+        "evidence_chain_manifest_lifecycle_snapshot_hash_missing"
+        in result.failure_reasons
+    )
+
+
+def test_lifecycle_snapshot_hash_mismatch_fails_verification() -> None:
+    result = _verify_complete(
+        outcome_receipt={
+            "outcome_hash": OUTCOME_HASH,
+            "metadata": {
+                "verified_human_approval_proof_hash": PROOF_HASH,
+                "human_approval_verifier_lifecycle_snapshot_hash": "2" * 64,
+            },
+        }
+    )
+    assert result.verification_status == "failed"
+    assert "human_approval_verifier_lifecycle_snapshot_hash" in result.mismatched_links
+    assert "evidence_chain_lifecycle_snapshot_hash_mismatch" in result.failure_reasons
+    assert result.to_dict()[
+        "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons"
+    ] == ["evidence_chain_lifecycle_snapshot_hash_mismatch"]
+
+
+def test_no_approval_path_allows_absent_lifecycle_snapshot_hashes() -> None:
+    manifest = build_evidence_chain_manifest(
+        decision_id="decision-1",
+        execution_intent_id="intent-1",
+        operation_id="operation-1",
+        action_class="read_only",
+        target_system="mock_saas",
+        target_resource="user:alice",
+        requested_scope=["saas:read"],
+        final_outcome="commit",
+        authority_evidence_hash=AUTHORITY_HASH,
+        outcome_receipt_hash=OUTCOME_HASH,
+        bind_coverage_operation_id="saas_read_demo",
+        human_approval_required=False,
+        generated_at=VERIFIED_AT,
+    )
+    result = verify_evidence_chain_manifest(
+        manifest=manifest,
+        authority_evidence={"evidence_hash": AUTHORITY_HASH},
+        outcome_receipt={"outcome_hash": OUTCOME_HASH},
+        bind_coverage_operation_id="saas_read_demo",
+        approval_required=False,
+        verified_at=VERIFIED_AT,
+    )
+    assert result.verification_status == "verified"
+    assert (
+        result.human_approval_verifier_lifecycle_snapshot_hash_continuity_verified
+        is True
+    )

--- a/veritas_os/governance/evidence_chain_verifier.py
+++ b/veritas_os/governance/evidence_chain_verifier.py
@@ -41,6 +41,10 @@ class EvidenceChainVerificationResult:
     manifest_hash_matches: bool = False
     verified_at: str = ""
     metadata: dict[str, Any] = field(default_factory=dict)
+    human_approval_verifier_lifecycle_snapshot_hash_continuity_verified: bool = False
+    human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons: (
+        list[str]
+    ) = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
         """Return a deterministic JSON-friendly verification summary."""
@@ -59,6 +63,14 @@ class EvidenceChainVerificationResult:
             "manifest_hash_matches": self.manifest_hash_matches,
             "verified_at": self.verified_at,
             "metadata": dict(self.metadata),
+            "human_approval_verifier_lifecycle_snapshot_hash_continuity_verified": (
+                self.human_approval_verifier_lifecycle_snapshot_hash_continuity_verified
+            ),
+            "human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons": (
+                sorted(
+                    self.human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons
+                )
+            ),
         }
 
 
@@ -107,6 +119,12 @@ def verify_evidence_chain_manifest(
             manifest_hash_matches=False,
             verified_at=verified_at,
             metadata=dict(metadata or {}),
+            human_approval_verifier_lifecycle_snapshot_hash_continuity_verified=(
+                False
+            ),
+            human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons=(
+                []
+            ),
         )
 
     missing_links.extend(str(link) for link in manifest.missing_links if str(link).strip())
@@ -158,6 +176,20 @@ def verify_evidence_chain_manifest(
         indeterminate_links=indeterminate_links,
         failure_reasons=failure_reasons,
     )
+
+    lifecycle_failure_reasons = (
+        _human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons(
+            manifest=manifest,
+            outcome_receipt=outcome_receipt,
+        )
+    )
+    if lifecycle_failure_reasons:
+        failure_reasons.extend(lifecycle_failure_reasons)
+        mismatched_links.append("human_approval_verifier_lifecycle_snapshot_hash")
+    else:
+        verified_links.append(
+            "human_approval_verifier_lifecycle_snapshot_hash_continuity"
+        )
 
     _verify_human_approval_proof_hash_binding(
         approval_required=approval_required,
@@ -221,7 +253,51 @@ def verify_evidence_chain_manifest(
         manifest_hash_matches=manifest_hash_matches,
         verified_at=verified_at,
         metadata=dict(metadata or {}),
+        human_approval_verifier_lifecycle_snapshot_hash_continuity_verified=(
+            not lifecycle_failure_reasons
+        ),
+        human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons=(
+            sorted(set(lifecycle_failure_reasons))
+        ),
     )
+
+
+def _human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons(
+    *,
+    manifest: EvidenceChainManifest,
+    outcome_receipt: Any | None,
+) -> list[str]:
+    """Return lifecycle snapshot hash continuity failures for manifest/outcome.
+
+    Evidence-chain verification treats both absent values as valid for
+    no-approval and no-proof paths, but fails deterministically when exactly
+    one side is present or when both present values differ.
+    """
+    manifest_hash = str(
+        getattr(
+            manifest,
+            "human_approval_verifier_lifecycle_snapshot_hash",
+            "",
+        )
+        or ""
+    ).strip()
+    outcome_hash = str(
+        _metadata_value(
+            outcome_receipt,
+            "human_approval_verifier_lifecycle_snapshot_hash",
+        )
+        or ""
+    ).strip()
+
+    if not manifest_hash and not outcome_hash:
+        return []
+    if manifest_hash and not outcome_hash:
+        return ["evidence_chain_outcome_lifecycle_snapshot_hash_missing"]
+    if outcome_hash and not manifest_hash:
+        return ["evidence_chain_manifest_lifecycle_snapshot_hash_missing"]
+    if manifest_hash != outcome_hash:
+        return ["evidence_chain_lifecycle_snapshot_hash_mismatch"]
+    return []
 
 
 def _extract_artifact_hash(artifact: Any) -> str | None:


### PR DESCRIPTION
### Motivation
- Ensure the evidence-chain verification layer detects mismatched human-approval verifier lifecycle snapshot hashes between the manifest and outcome (so continuity is caught before reviewer-packet packaging). 
- Provide machine-readable continuity results so downstream consumers and automated reviewers can reason deterministically about lifecycle snapshot continuity. 

### Description
- Add deterministic manifest ↔ outcome lifecycle snapshot continuity check in `verify_evidence_chain_manifest` that fails when exactly one side is present or when both values differ, and treats both-absent as valid for no-approval/no-proof cases. 
- Expose two new fields in `EvidenceChainVerificationResult` and its `to_dict()` output: `human_approval_verifier_lifecycle_snapshot_hash_continuity_verified` (boolean) and `human_approval_verifier_lifecycle_snapshot_hash_continuity_failure_reasons` (string array), with failure reasons such as `evidence_chain_manifest_lifecycle_snapshot_hash_missing`, `evidence_chain_outcome_lifecycle_snapshot_hash_missing`, and `evidence_chain_lifecycle_snapshot_hash_mismatch`. 
- Keep existing reviewer-packet validation intact (this change does not remove or replace the reviewer-layer three-way checks from prior binding PRs). 
- Add unit tests covering the negative cases and the preserved null/no-approval path, and update reviewer packet schema, fixtures, and sample artifact manifest checksums to include and reflect the new verification summary fields and verified links. 

### Testing
- Successfully type-checked/compiled changed modules with targeted byte-compile: `python -m py_compile veritas_os/governance/evidence_chain_verifier.py tests/governance/test_evidence_chain_verifier.py` on Python 3.11 and 3.12. 
- Lint check passed: `ruff check veritas_os/governance/evidence_chain_verifier.py tests/governance/test_evidence_chain_verifier.py`. 
- Added/updated unit tests in `tests/governance/test_evidence_chain_verifier.py` for: missing outcome lifecycle hash, missing manifest lifecycle hash, lifecycle hash mismatch, and no-approval null path. 
- Attempted `pytest` runs were blocked in this environment due to missing runtime dependencies (`yaml`) and lack of network access to install packages; these prevented full local pytest execution here but the added tests are present and runnable in CI where dependencies are available. 

Security note: No KMS/HSM, external revocation services, secrets, or production verifier allowlist behavior were added; this change is deterministic and local/offline only, but reviewers should be aware verification logic affects chain-level validation and is fail-closed for mismatches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f26a28cf8832699ba001a1e07ea1b)