### PR TITLE
Centralize reviewer/demo failure reason constants

### DIFF
--- a/scripts/demo/generate_reviewer_evidence_packet_from_evaluation_governance_chain.py
+++ b/scripts/demo/generate_reviewer_evidence_packet_from_evaluation_governance_chain.py
@@ -34,6 +34,16 @@ REVIEWER_PACKET_TEMPLATE_PATH = (
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from scripts.demo.reviewer_failure_reasons import (  # noqa: E402
+    EVIDENCE_CHAIN_LIFECYCLE_SNAPSHOT_HASH_MISMATCH,
+    EVIDENCE_CHAIN_MANIFEST_LIFECYCLE_SNAPSHOT_HASH_MISSING,
+    EVIDENCE_CHAIN_OUTCOME_LIFECYCLE_SNAPSHOT_HASH_MISSING,
+    REVIEWER_PACKET_VERIFICATION_PROOF_HASH_MISMATCH,
+    REVIEWER_PACKET_VERIFIED_AT_MISMATCH,
+    REVIEWER_PACKET_VERIFIER_ID_MISMATCH,
+    REVIEWER_PACKET_VERIFIER_KEY_ID_MISMATCH,
+    REVIEWER_PACKET_VERIFIER_POLICY_HASH_MISMATCH,
+)
 from scripts.demo.reviewer_key_provenance_metadata import key_provenance_metadata  # noqa: E402
 from scripts.demo.verifier_lifecycle import (  # noqa: E402
     verifier_lifecycle_summary_from_human_approval,
@@ -123,19 +133,19 @@ LIFECYCLE_HASH_FIELD = "human_approval_verifier_lifecycle_snapshot_hash"
 LIFECYCLE_TAMPER_CASES = (
     (
         "lifecycle_snapshot_manifest_hash_outcome_missing",
-        "evidence_chain_outcome_lifecycle_snapshot_hash_missing",
+        EVIDENCE_CHAIN_OUTCOME_LIFECYCLE_SNAPSHOT_HASH_MISSING,
         "Outcome metadata is missing the lifecycle snapshot hash while the "
         "manifest still carries it.",
     ),
     (
         "lifecycle_snapshot_outcome_hash_manifest_missing",
-        "evidence_chain_manifest_lifecycle_snapshot_hash_missing",
+        EVIDENCE_CHAIN_MANIFEST_LIFECYCLE_SNAPSHOT_HASH_MISSING,
         "Manifest is missing the lifecycle snapshot hash while outcome "
         "metadata still carries it.",
     ),
     (
         "lifecycle_snapshot_hash_mismatch",
-        "evidence_chain_lifecycle_snapshot_hash_mismatch",
+        EVIDENCE_CHAIN_LIFECYCLE_SNAPSHOT_HASH_MISMATCH,
         "Manifest and outcome metadata carry different lifecycle snapshot "
         "hash values.",
     ),
@@ -143,7 +153,7 @@ LIFECYCLE_TAMPER_CASES = (
 VERIFIER_CONTINUITY_TAMPER_CASES = (
     (
         "verifier_id_mismatch",
-        "reviewer_packet_verifier_id_mismatch",
+        REVIEWER_PACKET_VERIFIER_ID_MISMATCH,
         "human_approval_verifier_id",
         "verifier_id",
         "Human approval summary carries a different verifier identity than "
@@ -151,7 +161,7 @@ VERIFIER_CONTINUITY_TAMPER_CASES = (
     ),
     (
         "verifier_key_id_mismatch",
-        "reviewer_packet_verifier_key_id_mismatch",
+        REVIEWER_PACKET_VERIFIER_KEY_ID_MISMATCH,
         "human_approval_verifier_key_id",
         "verifier_key_id",
         "Human approval summary carries a different verifier key identity "
@@ -159,7 +169,7 @@ VERIFIER_CONTINUITY_TAMPER_CASES = (
     ),
     (
         "verifier_policy_hash_mismatch",
-        "reviewer_packet_verifier_policy_hash_mismatch",
+        REVIEWER_PACKET_VERIFIER_POLICY_HASH_MISMATCH,
         "human_approval_verifier_policy_hash",
         "verifier_policy_hash",
         "Human approval summary carries a different verifier policy hash "
@@ -167,7 +177,7 @@ VERIFIER_CONTINUITY_TAMPER_CASES = (
     ),
     (
         "verification_proof_hash_mismatch",
-        "reviewer_packet_verification_proof_hash_mismatch",
+        REVIEWER_PACKET_VERIFICATION_PROOF_HASH_MISMATCH,
         "verification_proof_hash",
         "verification_proof_hash",
         "Human approval summary carries a different proof hash than the "
@@ -175,7 +185,7 @@ VERIFIER_CONTINUITY_TAMPER_CASES = (
     ),
     (
         "verified_at_mismatch",
-        "reviewer_packet_verified_at_mismatch",
+        REVIEWER_PACKET_VERIFIED_AT_MISMATCH,
         "verified_at",
         "verified_at",
         "Human approval summary carries a different verified_at timestamp "
@@ -651,11 +661,11 @@ def _tamper_lifecycle_hash_fields(case: dict[str, Any], failure_reason: str) -> 
         metadata = {}
         outcome["metadata"] = metadata
 
-    if failure_reason == "evidence_chain_outcome_lifecycle_snapshot_hash_missing":
+    if failure_reason == EVIDENCE_CHAIN_OUTCOME_LIFECYCLE_SNAPSHOT_HASH_MISSING:
         metadata.pop(LIFECYCLE_HASH_FIELD, None)
-    elif failure_reason == "evidence_chain_manifest_lifecycle_snapshot_hash_missing":
+    elif failure_reason == EVIDENCE_CHAIN_MANIFEST_LIFECYCLE_SNAPSHOT_HASH_MISSING:
         manifest[LIFECYCLE_HASH_FIELD] = None
-    elif failure_reason == "evidence_chain_lifecycle_snapshot_hash_mismatch":
+    elif failure_reason == EVIDENCE_CHAIN_LIFECYCLE_SNAPSHOT_HASH_MISMATCH:
         metadata[LIFECYCLE_HASH_FIELD] = "2" * 64
 
     _mark_lifecycle_continuity_failure(case, failure_reason)

--- a/scripts/demo/reviewer_failure_reasons.py
+++ b/scripts/demo/reviewer_failure_reasons.py
@@ -9,6 +9,30 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Iterable
 
+EVIDENCE_CHAIN_MANIFEST_LIFECYCLE_SNAPSHOT_HASH_MISSING = (
+    "evidence_chain_manifest_lifecycle_snapshot_hash_missing"
+)
+EVIDENCE_CHAIN_OUTCOME_LIFECYCLE_SNAPSHOT_HASH_MISSING = (
+    "evidence_chain_outcome_lifecycle_snapshot_hash_missing"
+)
+EVIDENCE_CHAIN_LIFECYCLE_SNAPSHOT_HASH_MISMATCH = (
+    "evidence_chain_lifecycle_snapshot_hash_mismatch"
+)
+REVIEWER_PACKET_VERIFIER_ID_MISMATCH = "reviewer_packet_verifier_id_mismatch"
+REVIEWER_PACKET_VERIFIER_KEY_ID_MISMATCH = (
+    "reviewer_packet_verifier_key_id_mismatch"
+)
+REVIEWER_PACKET_VERIFIER_POLICY_HASH_MISMATCH = (
+    "reviewer_packet_verifier_policy_hash_mismatch"
+)
+REVIEWER_PACKET_VERIFICATION_PROOF_HASH_MISMATCH = (
+    "reviewer_packet_verification_proof_hash_mismatch"
+)
+REVIEWER_PACKET_VERIFIED_AT_MISMATCH = "reviewer_packet_verified_at_mismatch"
+REVIEWER_FAILURE_REASON_TAXONOMY_UNKNOWN = (
+    "reviewer_failure_reason_taxonomy_unknown"
+)
+
 _FAILURE_REASON_FIELDS = frozenset(
     {
         "failure_reasons",
@@ -33,9 +57,9 @@ REVIEWER_FAILURE_REASONS = frozenset(
         "blocked_case_refusal_basis_missing",
         "case_expectations_failed",
         "demo_mismatched_links_present",
-        "evidence_chain_lifecycle_snapshot_hash_mismatch",
-        "evidence_chain_manifest_lifecycle_snapshot_hash_missing",
-        "evidence_chain_outcome_lifecycle_snapshot_hash_missing",
+        EVIDENCE_CHAIN_LIFECYCLE_SNAPSHOT_HASH_MISMATCH,
+        EVIDENCE_CHAIN_MANIFEST_LIFECYCLE_SNAPSHOT_HASH_MISSING,
+        EVIDENCE_CHAIN_OUTCOME_LIFECYCLE_SNAPSHOT_HASH_MISSING,
         "evidence_chain_verification_missing",
         "generated_packet_mismatch",
         "golden_fixture_json_unparseable",
@@ -53,23 +77,23 @@ REVIEWER_FAILURE_REASONS = frozenset(
         "required_case_fields_missing",
         "required_top_level_fields_missing",
         "reviewer_evidence_bundle_output_dir_invalid",
-        "reviewer_failure_reason_taxonomy_unknown",
+        REVIEWER_FAILURE_REASON_TAXONOMY_UNKNOWN,
         "reviewer_packet_committed_lifecycle_status_not_clean",
         "reviewer_packet_human_approval_proof_continuity_invalid",
         "reviewer_packet_manifest_lifecycle_snapshot_hash_mismatch",
         "reviewer_packet_outcome_lifecycle_snapshot_hash_mismatch",
-        "reviewer_packet_verification_proof_hash_mismatch",
-        "reviewer_packet_verified_at_mismatch",
+        REVIEWER_PACKET_VERIFICATION_PROOF_HASH_MISMATCH,
+        REVIEWER_PACKET_VERIFIED_AT_MISMATCH,
         "reviewer_packet_verifier_expired_before_verification",
-        "reviewer_packet_verifier_id_mismatch",
+        REVIEWER_PACKET_VERIFIER_ID_MISMATCH,
         "reviewer_packet_verifier_id_missing",
-        "reviewer_packet_verifier_key_id_mismatch",
+        REVIEWER_PACKET_VERIFIER_KEY_ID_MISMATCH,
         "reviewer_packet_verifier_lifecycle_invalid",
         "reviewer_packet_verifier_lifecycle_policy_hash_mismatch",
         "reviewer_packet_verifier_lifecycle_snapshot_hash_missing",
         "reviewer_packet_verifier_lifecycle_snapshot_hash_mismatch",
         "reviewer_packet_verifier_not_yet_valid",
-        "reviewer_packet_verifier_policy_hash_mismatch",
+        REVIEWER_PACKET_VERIFIER_POLICY_HASH_MISMATCH,
         "reviewer_packet_verifier_policy_hash_missing",
         "reviewer_packet_verifier_policy_id_missing",
         "reviewer_packet_verifier_revoked_before_verification",

--- a/scripts/demo/validate_reviewer_evidence_packet.py
+++ b/scripts/demo/validate_reviewer_evidence_packet.py
@@ -15,6 +15,8 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from scripts.demo.reviewer_failure_reasons import (  # noqa: E402
+    REVIEWER_FAILURE_REASON_TAXONOMY_UNKNOWN,
+    REVIEWER_PACKET_VERIFIER_POLICY_HASH_MISMATCH,
     unknown_failure_reasons,
 )
 from scripts.demo.verifier_lifecycle import (  # noqa: E402
@@ -142,7 +144,7 @@ FAILURE_REASON_BY_CHECK = {
     ),
     "local_offline_boundary_present": "local_offline_boundary_missing",
     "reviewer_failure_reason_taxonomy_valid": (
-        "reviewer_failure_reason_taxonomy_unknown"
+        REVIEWER_FAILURE_REASON_TAXONOMY_UNKNOWN
     ),
 }
 
@@ -392,13 +394,13 @@ def _case_approval_proof_continuity_reasons(case: dict[str, Any]) -> list[str]:
         and manifest_policy_hash
         and proof_policy_hash != manifest_policy_hash
     ):
-        reasons.append("reviewer_packet_verifier_policy_hash_mismatch")
+        reasons.append(REVIEWER_PACKET_VERIFIER_POLICY_HASH_MISMATCH)
     if (
         outcome_policy_hash
         and manifest_policy_hash
         and outcome_policy_hash != manifest_policy_hash
     ):
-        reasons.append("reviewer_packet_verifier_policy_hash_mismatch")
+        reasons.append(REVIEWER_PACKET_VERIFIER_POLICY_HASH_MISMATCH)
 
     if isinstance(verification, dict):
         status = verification.get("verification_status")

--- a/tests/demo/test_reviewer_failure_reasons.py
+++ b/tests/demo/test_reviewer_failure_reasons.py
@@ -1,0 +1,54 @@
+"""Tests for reviewer/demo failure reason taxonomy constants."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.demo import reviewer_failure_reasons as taxonomy
+
+CENTRALIZED_FAILURE_REASON_CONSTANTS = {
+    name: value
+    for name, value in vars(taxonomy).items()
+    if name.isupper()
+    and isinstance(value, str)
+    and name != "REVIEWER_FAILURE_REASONS"
+}
+
+CENTRALIZED_FAILURE_REASON_VALUES = frozenset(
+    CENTRALIZED_FAILURE_REASON_CONSTANTS.values()
+)
+
+
+def test_exported_failure_reason_constants_are_in_taxonomy() -> None:
+    """Every centralized string constant must remain part of the taxonomy."""
+    assert CENTRALIZED_FAILURE_REASON_CONSTANTS
+    assert CENTRALIZED_FAILURE_REASON_VALUES <= taxonomy.REVIEWER_FAILURE_REASONS
+
+
+def test_exported_failure_reason_constants_have_unique_values() -> None:
+    """Centralized failure reason constants must not alias duplicate values."""
+    values = tuple(CENTRALIZED_FAILURE_REASON_CONSTANTS.values())
+    assert len(values) == len(set(values))
+
+
+def test_reviewer_failure_reasons_have_no_duplicate_equivalent_values() -> None:
+    """The public taxonomy must remain a unique set of string values."""
+    values = tuple(taxonomy.REVIEWER_FAILURE_REASONS)
+    assert len(values) == len(set(values))
+
+
+def test_centralized_failure_reason_literals_stay_in_taxonomy_module() -> None:
+    """Prevent reintroducing centralized reviewer/demo reason literals."""
+    taxonomy_path = Path(taxonomy.__file__).resolve()
+    scripts_demo_dir = taxonomy_path.parent
+    offenders: list[str] = []
+
+    for path in sorted(scripts_demo_dir.glob("*.py")):
+        if path.resolve() == taxonomy_path:
+            continue
+        source = path.read_text(encoding="utf-8")
+        for value in sorted(CENTRALIZED_FAILURE_REASON_VALUES):
+            if repr(value) in source or f'"{value}"' in source:
+                offenders.append(f"{path.relative_to(Path.cwd())}: {value}")
+
+    assert offenders == []


### PR DESCRIPTION
### Motivation

- Reduce drift and accidental typos in reviewer/demo failure reason strings by centralizing commonly emitted literals as named constants. 
- Replace ad hoc inline literals in demo producer and validator helpers with imports from the centralized taxonomy so producers emit the same stable values via constants. 
- Add lightweight consistency and source-hygiene checks to catch regressions where literals are reintroduced outside the taxonomy module.

### Description

- Add named constants to `scripts/demo/reviewer_failure_reasons.py` for core reviewer/demo failure reasons and keep `REVIEWER_FAILURE_REASONS` as a `frozenset` backed by those constants. 
- Replace inline string literals with the new constants in `scripts/demo/generate_reviewer_evidence_packet_from_evaluation_governance_chain.py` for lifecycle and verifier continuity tamper cases. 
- Replace inline literals in `scripts/demo/validate_reviewer_evidence_packet.py` for taxonomy-unknown and verifier-policy-hash mismatch checks with imported constants. 
- Add `tests/demo/test_reviewer_failure_reasons.py`, a small test suite that asserts exported constants are present in `REVIEWER_FAILURE_REASONS`, that constant values are unique, that the taxonomy has no duplicate-equivalent values, and that centralized literal values are not reintroduced in other `scripts/demo` modules.
- No runtime admissibility, schema, packet outputs, or tamper-case semantics were changed; only references to the existing string values were converted to constants.

### Testing

- Ran `python -m pytest tests/demo/test_reviewer_failure_reasons.py -q` and the new test file passed (4 tests). 
- Ran `python -m py_compile scripts/demo/reviewer_failure_reasons.py scripts/demo/generate_reviewer_evidence_packet_from_evaluation_governance_chain.py scripts/demo/validate_reviewer_evidence_packet.py` and compilation succeeded. 
- Ran `python -m pytest tests/demo/test_evaluation_governance_chain_reviewer_packet.py -q` and `python -m pytest tests/demo/test_reviewer_verifier_lifecycle_commit_consistency.py -q`, both of which passed in the local environment. 
- Ran `python scripts/demo/validate_evaluation_governance_reviewer_demo.py --demo-dir docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated` and validation completed successfully. 
- A subset of tests (`python -m pytest tests/demo/test_reviewer_evidence_packet_schema.py -q`) and `python scripts/demo/validate_reviewer_evidence_packet.py` failed in this environment due to a missing `yaml` / PyYAML dependency (network install blocked by environment), not due to the change; these failures are environmental and not caused by the code changes. 
- Security note: this change centralizes static taxonomy strings only and does not introduce new secrets, runtime permission changes, or tamper cases; reviewers should still verify CI on clean runners (py3.11/py3.12) before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fa8af46c48326bbc6c38e24994348)