### PR TITLE
feat: add reviewer failure reason metadata catalog

### DIFF
--- a/docs/en/demo/reviewer-evidence-packet.md
+++ b/docs/en/demo/reviewer-evidence-packet.md
@@ -80,6 +80,12 @@ For failed or incomplete evidence-chain verification caused by approval proof co
 
 Reviewer-facing failure reasons are stable machine-readable strings intended for audit and reviewer automation. The deterministic taxonomy in `scripts/demo/reviewer_failure_reasons.py` allowlists the strings that may appear in reviewer packet cases, evidence-chain verification summaries, verifier lifecycle summaries, tamper fixtures, and validation reports; unknown or misspelled strings fail the local taxonomy guard.
 
+### Failure reason metadata catalog
+
+The local/offline catalog in `scripts/demo/reviewer_failure_reasons.py` maps each stable failure reason code to reviewer-facing metadata: category, severity, label, explanation, remediation hint, and affected artifacts. Reviewer UI, audit reports, and deterministic automation can use this catalog to explain why a packet, fixture, or validation report failed without changing the underlying machine-readable reason string.
+
+The catalog is demo/reviewer validation scope only. It does not change runtime admissibility, bind/admissibility logic, governance policy behavior, FUJI fail-closed behavior, TrustLog persistence, or the Reviewer Evidence Packet schema.
+
 ## Local/offline boundary
 
 Reviewer Evidence Packet v1 is a local/offline fixture export only.

--- a/scripts/demo/reviewer_failure_reasons.py
+++ b/scripts/demo/reviewer_failure_reasons.py
@@ -6,7 +6,7 @@ reviewer/demo artifacts. It does not change runtime admissibility behavior.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from typing import Any, Iterable
 
 EVIDENCE_CHAIN_MANIFEST_LIFECYCLE_SNAPSHOT_HASH_MISSING = (
@@ -105,6 +105,25 @@ REVIEWER_FAILURE_REASONS = frozenset(
     }
 )
 
+REVIEWER_FAILURE_REASON_CATEGORIES = frozenset(
+    {
+        "schema",
+        "artifact_manifest",
+        "authority",
+        "human_approval",
+        "verifier_lifecycle",
+        "verifier_continuity",
+        "lifecycle_snapshot_continuity",
+        "packet_integrity",
+        "demo_generation",
+        "taxonomy",
+    }
+)
+
+REVIEWER_FAILURE_REASON_SEVERITIES = frozenset(
+    {"info", "warning", "error", "critical"}
+)
+
 
 @dataclass(frozen=True, order=True)
 class UnknownFailureReason:
@@ -112,6 +131,145 @@ class UnknownFailureReason:
 
     path: str
     reason: str
+
+
+@dataclass(frozen=True)
+class FailureReasonMetadata:
+    """Reviewer-facing metadata for a stable demo failure reason code."""
+
+    reason: str
+    category: str
+    severity: str
+    reviewer_label: str
+    reviewer_explanation: str
+    remediation_hint: str
+    affected_artifacts: tuple[str, ...]
+
+
+_CATEGORY_BY_PREFIX = {
+    "artifact_manifest_": "artifact_manifest",
+    "authority_": "authority",
+    "blocked_case_": "demo_generation",
+    "case_expectations_": "demo_generation",
+    "demo_": "demo_generation",
+    "evidence_chain_lifecycle_snapshot_": "lifecycle_snapshot_continuity",
+    "evidence_chain_manifest_lifecycle_snapshot_": (
+        "lifecycle_snapshot_continuity"
+    ),
+    "evidence_chain_outcome_lifecycle_snapshot_": (
+        "lifecycle_snapshot_continuity"
+    ),
+    "evidence_chain_": "packet_integrity",
+    "generated_packet_": "demo_generation",
+    "golden_fixture_": "demo_generation",
+    "human_approval_": "human_approval",
+    "local_offline_": "demo_generation",
+    "packet_hash_": "packet_integrity",
+    "required_case_fields_": "schema",
+    "required_top_level_fields_": "schema",
+    "reviewer_evidence_bundle_": "demo_generation",
+    "reviewer_failure_reason_taxonomy_": "taxonomy",
+    "reviewer_packet_committed_lifecycle_": "verifier_lifecycle",
+    "reviewer_packet_human_approval_proof_": "verifier_continuity",
+    "reviewer_packet_manifest_lifecycle_snapshot_": (
+        "lifecycle_snapshot_continuity"
+    ),
+    "reviewer_packet_outcome_lifecycle_snapshot_": (
+        "lifecycle_snapshot_continuity"
+    ),
+    "reviewer_packet_verification_proof_": "packet_integrity",
+    "reviewer_packet_verified_at_": "verifier_continuity",
+    "reviewer_packet_verifier_lifecycle_snapshot_": (
+        "lifecycle_snapshot_continuity"
+    ),
+    "reviewer_packet_verifier_lifecycle_": "verifier_lifecycle",
+    "reviewer_packet_verifier_": "verifier_continuity",
+    "schema_": "schema",
+    "valid_case_chain_": "packet_integrity",
+}
+
+_AFFECTED_ARTIFACTS_BY_CATEGORY = {
+    "schema": ("reviewer_packet_schema", "validation_report"),
+    "artifact_manifest": ("artifact_manifest", "reviewer_evidence_bundle"),
+    "authority": ("reviewer_packet", "authority_summary"),
+    "human_approval": ("reviewer_packet", "human_approval_summary"),
+    "verifier_lifecycle": ("reviewer_packet", "verifier_lifecycle_summary"),
+    "verifier_continuity": (
+        "reviewer_packet",
+        "human_approval_summary",
+        "evidence_chain_manifest",
+        "outcome_receipt",
+    ),
+    "lifecycle_snapshot_continuity": (
+        "reviewer_packet",
+        "verifier_lifecycle_summary",
+        "evidence_chain_manifest",
+        "outcome_receipt",
+    ),
+    "packet_integrity": (
+        "reviewer_packet",
+        "evidence_chain_manifest",
+        "outcome_receipt",
+    ),
+    "demo_generation": ("demo_fixture", "validation_report"),
+    "taxonomy": ("reviewer_packet", "validation_report"),
+}
+
+
+def _category_for_reason(reason: str) -> str:
+    """Return the reviewer metadata category for a taxonomy reason."""
+    for prefix, category in _CATEGORY_BY_PREFIX.items():
+        if reason.startswith(prefix):
+            return category
+    return "taxonomy"
+
+
+def _severity_for_reason(reason: str, category: str) -> str:
+    """Return a deterministic reviewer severity for a taxonomy reason."""
+    if "taxonomy_unknown" in reason:
+        return "critical"
+    if any(token in reason for token in ("mismatch", "invalid", "failed")):
+        return "error"
+    if any(token in reason for token in ("missing", "unparseable")):
+        return "error"
+    if category in {"verifier_lifecycle", "verifier_continuity"} and any(
+        token in reason for token in ("expired", "revoked", "not_yet_valid")
+    ):
+        return "critical"
+    return "warning"
+
+
+def _label_for_reason(reason: str) -> str:
+    """Return a compact title-case reviewer label for a taxonomy reason."""
+    return reason.replace("_", " ").capitalize()
+
+
+def _metadata_for_reason(reason: str) -> FailureReasonMetadata:
+    """Build metadata for a stable reviewer/demo failure reason."""
+    category = _category_for_reason(reason)
+    severity = _severity_for_reason(reason, category)
+    label = _label_for_reason(reason)
+    return FailureReasonMetadata(
+        reason=reason,
+        category=category,
+        severity=severity,
+        reviewer_label=label,
+        reviewer_explanation=(
+            f"{label} indicates a {category.replace('_', ' ')} validation "
+            "condition failed in the local/offline reviewer demo artifacts."
+        ),
+        remediation_hint=(
+            "Regenerate or repair the affected local demo artifact, then rerun "
+            "the reviewer validation commands before review."
+        ),
+        affected_artifacts=_AFFECTED_ARTIFACTS_BY_CATEGORY[category],
+    )
+
+
+REVIEWER_FAILURE_REASON_METADATA = {
+    reason: _metadata_for_reason(reason)
+    for reason in sorted(REVIEWER_FAILURE_REASONS)
+}
 
 
 def _format_path(path: Iterable[str]) -> str:
@@ -153,3 +311,42 @@ def assert_known_failure_reasons(payload: Any) -> None:
     if unknown:
         details = ", ".join(f"{item.path}={item.reason}" for item in unknown)
         raise AssertionError(f"Unknown reviewer/demo failure reasons: {details}")
+
+
+def get_failure_reason_metadata(reason: str) -> FailureReasonMetadata | None:
+    """Return reviewer-facing metadata for a stable failure reason code."""
+    return REVIEWER_FAILURE_REASON_METADATA.get(reason)
+
+
+def failure_reason_metadata_for_payload(
+    payload: Any,
+) -> dict[str, FailureReasonMetadata]:
+    """Return metadata for known failure reasons found in a payload."""
+    reasons_seen = {
+        reason
+        for _, reason in iter_failure_reasons(payload)
+        if reason in REVIEWER_FAILURE_REASON_METADATA
+    }
+    return {
+        reason: REVIEWER_FAILURE_REASON_METADATA[reason]
+        for reason in sorted(reasons_seen)
+    }
+
+
+def failure_reason_metadata_summary_for_payload(payload: Any) -> dict[str, Any]:
+    """Return a compact reviewer metadata summary for reasons in a payload."""
+    metadata = failure_reason_metadata_for_payload(payload)
+    unknown = unknown_failure_reasons(payload)
+    categories_seen = sorted({item.category for item in metadata.values()})
+    severities_seen = sorted({item.severity for item in metadata.values()})
+    return {
+        "unknown_reasons": [
+            {"path": item.path, "reason": item.reason} for item in unknown
+        ],
+        "known_reasons_seen": sorted(metadata),
+        "categories_seen": categories_seen,
+        "severities_seen": severities_seen,
+        "metadata": {
+            reason: asdict(entry) for reason, entry in metadata.items()
+        },
+    }

--- a/scripts/demo/validate_reviewer_evidence_packet.py
+++ b/scripts/demo/validate_reviewer_evidence_packet.py
@@ -17,6 +17,7 @@ if str(REPO_ROOT) not in sys.path:
 from scripts.demo.reviewer_failure_reasons import (  # noqa: E402
     REVIEWER_FAILURE_REASON_TAXONOMY_UNKNOWN,
     REVIEWER_PACKET_VERIFIER_POLICY_HASH_MISMATCH,
+    failure_reason_metadata_summary_for_payload,
     unknown_failure_reasons,
 )
 from scripts.demo.verifier_lifecycle import (  # noqa: E402
@@ -747,6 +748,10 @@ def _build_report_for_packet(
         _approval_proof_continuity_reasons(packet)
     )
     failure_reasons = _failure_reasons(checks)
+    failure_reason_payload = {
+        "packet": copy.deepcopy(packet),
+        "failure_reasons": failure_reasons,
+    }
     return {
         "report_id": REPORT_ID,
         "report_version": REPORT_VERSION,
@@ -758,6 +763,9 @@ def _build_report_for_packet(
         "checks": checks,
         "aggregate_summary": _aggregate_summary(packet),
         "failure_reasons": failure_reasons,
+        "failure_reason_metadata_summary": (
+            failure_reason_metadata_summary_for_payload(failure_reason_payload)
+        ),
         "reviewer_notes": list(REVIEWER_NOTES),
         "boundary_note": packet.get("boundary_note", BOUNDARY_NOTE),
     }

--- a/tests/demo/test_reviewer_failure_reasons.py
+++ b/tests/demo/test_reviewer_failure_reasons.py
@@ -37,6 +37,45 @@ def test_reviewer_failure_reasons_have_no_duplicate_equivalent_values() -> None:
     assert len(values) == len(set(values))
 
 
+def test_failure_reason_metadata_catalog_covers_taxonomy() -> None:
+    """Every stable failure reason must have reviewer-facing metadata."""
+    assert (
+        frozenset(taxonomy.REVIEWER_FAILURE_REASON_METADATA)
+        == taxonomy.REVIEWER_FAILURE_REASONS
+    )
+
+
+def test_failure_reason_metadata_catalog_has_allowed_values() -> None:
+    """Metadata entries must be complete and use allowlisted facets."""
+    for reason, metadata in taxonomy.REVIEWER_FAILURE_REASON_METADATA.items():
+        assert metadata.reason == reason
+        assert metadata.category in taxonomy.REVIEWER_FAILURE_REASON_CATEGORIES
+        assert metadata.severity in taxonomy.REVIEWER_FAILURE_REASON_SEVERITIES
+        assert metadata.reviewer_label
+        assert metadata.reviewer_explanation
+        assert metadata.remediation_hint
+        assert metadata.affected_artifacts
+
+
+def test_failure_reason_metadata_lookup_helpers_are_deterministic() -> None:
+    """Lookup helpers expose metadata only for known taxonomy reasons."""
+    payload = {
+        "cases": [
+            {"failure_reasons": ["human_approval_missing"]},
+            {"expected_failure_reasons": ["authority_missing"]},
+        ]
+    }
+
+    metadata = taxonomy.get_failure_reason_metadata("human_approval_missing")
+    assert metadata is not None
+    assert metadata.reason == "human_approval_missing"
+    assert taxonomy.get_failure_reason_metadata("not_in_taxonomy") is None
+    assert tuple(taxonomy.failure_reason_metadata_for_payload(payload)) == (
+        "authority_missing",
+        "human_approval_missing",
+    )
+
+
 def test_centralized_failure_reason_literals_stay_in_taxonomy_module() -> None:
     """Prevent reintroducing centralized reviewer/demo reason literals."""
     taxonomy_path = Path(taxonomy.__file__).resolve()


### PR DESCRIPTION
### Motivation

- Provide a deterministic, local/offline machine-readable catalog that maps every stable reviewer/demo failure reason to reviewer-facing metadata (category, severity, label, explanation, remediation hint, affected artifacts) so UI, audit reports, and deterministic automation can explain failures without changing the underlying taxonomy.

### Description

- Add a metadata catalog and helpers in `scripts/demo/reviewer_failure_reasons.py`: `FailureReasonMetadata` dataclass, allowlisted `REVIEWER_FAILURE_REASON_CATEGORIES` and `REVIEWER_FAILURE_REASON_SEVERITIES`, computed `REVIEWER_FAILURE_REASON_METADATA`, and lookup helpers `get_failure_reason_metadata`, `failure_reason_metadata_for_payload`, and `failure_reason_metadata_summary_for_payload` (no failure reason strings were changed).
- Enrich validation report generation in `scripts/demo/validate_reviewer_evidence_packet.py` with a compact `failure_reason_metadata_summary` section derived from the new helpers.
- Add tests in `tests/demo/test_reviewer_failure_reasons.py` that assert the catalog covers the entire taxonomy, metadata completeness, allowlisted category/severity values, and deterministic lookup behavior.
- Document the catalog in `docs/en/demo/reviewer-evidence-packet.md` and explicitly state the catalog is local/offline reviewer-validation scope only and does not change runtime admissibility or packet schema.

### Testing

- `PYENV_VERSION=3.11.15 python -m pytest tests/demo/test_reviewer_failure_reasons.py -q` — passed (7 tests).
- `PYENV_VERSION=3.11.15 python -m pytest tests/demo/test_evaluation_governance_chain_reviewer_packet.py -q` — passed (32 tests).
- `PYENV_VERSION=3.11.15 python scripts/demo/validate_evaluation_governance_reviewer_demo.py --demo-dir docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated` — passed.
- Attempted `PYENV_VERSION=3.11.15 python -m pytest tests/demo/test_reviewer_evidence_packet_schema.py -q` and `PYENV_VERSION=3.11.15 python scripts/demo/validate_reviewer_evidence_packet.py` but these failed in the local environment due to a missing dependency (`ModuleNotFoundError: No module named 'yaml'`), which is an environment/PyYAML installation issue and not caused by these code changes.
- All taxonomy invariants and newly added metadata coverage tests passed, and no emitted failure reason strings were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fc7b49d488326ac898ffbe06aecc1)