### PR TITLE
Add generated reviewer failure reason catalog artifacts and generator

### DIFF
--- a/docs/en/demo/examples/reviewer-failure-reason-catalog-v1/reviewer-failure-reason-catalog.generated.example.json
+++ b/docs/en/demo/examples/reviewer-failure-reason-catalog-v1/reviewer-failure-reason-catalog.generated.example.json
@@ -1,0 +1,775 @@
+{
+  "catalog_version": "reviewer-failure-reason-catalog-v1",
+  "categories": [
+    "artifact_manifest",
+    "authority",
+    "demo_generation",
+    "human_approval",
+    "lifecycle_snapshot_continuity",
+    "packet_integrity",
+    "schema",
+    "taxonomy",
+    "verifier_continuity",
+    "verifier_lifecycle"
+  ],
+  "generated_at": "2026-01-01T00:00:00Z",
+  "reasons": [
+    {
+      "affected_artifacts": [
+        "artifact_manifest",
+        "reviewer_evidence_bundle"
+      ],
+      "category": "artifact_manifest",
+      "reason": "artifact_manifest_artifact_name_invalid",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Artifact manifest artifact name invalid indicates a artifact manifest validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Artifact manifest artifact name invalid",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "artifact_manifest",
+        "reviewer_evidence_bundle"
+      ],
+      "category": "artifact_manifest",
+      "reason": "artifact_manifest_file_hash_mismatch",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Artifact manifest file hash mismatch indicates a artifact manifest validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Artifact manifest file hash mismatch",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "artifact_manifest",
+        "reviewer_evidence_bundle"
+      ],
+      "category": "artifact_manifest",
+      "reason": "artifact_manifest_file_size_mismatch",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Artifact manifest file size mismatch indicates a artifact manifest validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Artifact manifest file size mismatch",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "artifact_manifest",
+        "reviewer_evidence_bundle"
+      ],
+      "category": "artifact_manifest",
+      "reason": "artifact_manifest_hash_mismatch",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Artifact manifest hash mismatch indicates a artifact manifest validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Artifact manifest hash mismatch",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "artifact_manifest",
+        "reviewer_evidence_bundle"
+      ],
+      "category": "artifact_manifest",
+      "reason": "artifact_manifest_json_unparseable",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Artifact manifest json unparseable indicates a artifact manifest validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Artifact manifest json unparseable",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "artifact_manifest",
+        "reviewer_evidence_bundle"
+      ],
+      "category": "artifact_manifest",
+      "reason": "artifact_manifest_missing",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Artifact manifest missing indicates a artifact manifest validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Artifact manifest missing",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "artifact_manifest",
+        "reviewer_evidence_bundle"
+      ],
+      "category": "artifact_manifest",
+      "reason": "artifact_manifest_required_file_missing",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Artifact manifest required file missing indicates a artifact manifest validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Artifact manifest required file missing",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "reviewer_packet",
+        "authority_summary"
+      ],
+      "category": "authority",
+      "reason": "authority_expired_or_missing",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Authority expired or missing indicates a authority validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Authority expired or missing",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "reviewer_packet",
+        "authority_summary"
+      ],
+      "category": "authority",
+      "reason": "authority_invalid",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Authority invalid indicates a authority validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Authority invalid",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "reviewer_packet",
+        "authority_summary"
+      ],
+      "category": "authority",
+      "reason": "authority_missing",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Authority missing indicates a authority validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Authority missing",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "demo_fixture",
+        "validation_report"
+      ],
+      "category": "demo_generation",
+      "reason": "blocked_case_outcome_failure_reasons_missing",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Blocked case outcome failure reasons missing indicates a demo generation validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Blocked case outcome failure reasons missing",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "demo_fixture",
+        "validation_report"
+      ],
+      "category": "demo_generation",
+      "reason": "blocked_case_refusal_basis_missing",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Blocked case refusal basis missing indicates a demo generation validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Blocked case refusal basis missing",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "demo_fixture",
+        "validation_report"
+      ],
+      "category": "demo_generation",
+      "reason": "case_expectations_failed",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Case expectations failed indicates a demo generation validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Case expectations failed",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "demo_fixture",
+        "validation_report"
+      ],
+      "category": "demo_generation",
+      "reason": "demo_mismatched_links_present",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Demo mismatched links present indicates a demo generation validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Demo mismatched links present",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "reviewer_packet",
+        "verifier_lifecycle_summary",
+        "evidence_chain_manifest",
+        "outcome_receipt"
+      ],
+      "category": "lifecycle_snapshot_continuity",
+      "reason": "evidence_chain_lifecycle_snapshot_hash_mismatch",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Evidence chain lifecycle snapshot hash mismatch indicates a lifecycle snapshot continuity validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Evidence chain lifecycle snapshot hash mismatch",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "reviewer_packet",
+        "verifier_lifecycle_summary",
+        "evidence_chain_manifest",
+        "outcome_receipt"
+      ],
+      "category": "lifecycle_snapshot_continuity",
+      "reason": "evidence_chain_manifest_lifecycle_snapshot_hash_missing",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Evidence chain manifest lifecycle snapshot hash missing indicates a lifecycle snapshot continuity validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Evidence chain manifest lifecycle snapshot hash missing",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "reviewer_packet",
+        "verifier_lifecycle_summary",
+        "evidence_chain_manifest",
+        "outcome_receipt"
+      ],
+      "category": "lifecycle_snapshot_continuity",
+      "reason": "evidence_chain_outcome_lifecycle_snapshot_hash_missing",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Evidence chain outcome lifecycle snapshot hash missing indicates a lifecycle snapshot continuity validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Evidence chain outcome lifecycle snapshot hash missing",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "reviewer_packet",
+        "evidence_chain_manifest",
+        "outcome_receipt"
+      ],
+      "category": "packet_integrity",
+      "reason": "evidence_chain_verification_missing",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Evidence chain verification missing indicates a packet integrity validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Evidence chain verification missing",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "demo_fixture",
+        "validation_report"
+      ],
+      "category": "demo_generation",
+      "reason": "generated_packet_mismatch",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Generated packet mismatch indicates a demo generation validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Generated packet mismatch",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "demo_fixture",
+        "validation_report"
+      ],
+      "category": "demo_generation",
+      "reason": "golden_fixture_json_unparseable",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Golden fixture json unparseable indicates a demo generation validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Golden fixture json unparseable",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "demo_fixture",
+        "validation_report"
+      ],
+      "category": "demo_generation",
+      "reason": "golden_fixture_missing",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Golden fixture missing indicates a demo generation validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Golden fixture missing",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "reviewer_packet",
+        "human_approval_summary"
+      ],
+      "category": "human_approval",
+      "reason": "human_approval_action_class_mismatch",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Human approval action class mismatch indicates a human approval validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Human approval action class mismatch",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "reviewer_packet",
+        "human_approval_summary"
+      ],
+      "category": "human_approval",
+      "reason": "human_approval_bind_context_hash_mismatch",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Human approval bind context hash mismatch indicates a human approval validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Human approval bind context hash mismatch",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "reviewer_packet",
+        "human_approval_summary"
+      ],
+      "category": "human_approval",
+      "reason": "human_approval_expired",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Human approval expired indicates a human approval validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Human approval expired",
+      "severity": "warning"
+    },
+    {
+      "affected_artifacts": [
+        "reviewer_packet",
+        "human_approval_summary"
+      ],
+      "category": "human_approval",
+      "reason": "human_approval_missing",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Human approval missing indicates a human approval validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Human approval missing",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "reviewer_packet",
+        "human_approval_summary"
+      ],
+      "category": "human_approval",
+      "reason": "human_approval_request_ref_mismatch",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Human approval request ref mismatch indicates a human approval validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Human approval request ref mismatch",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "reviewer_packet",
+        "human_approval_summary"
+      ],
+      "category": "human_approval",
+      "reason": "human_approval_scope_not_granted",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Human approval scope not granted indicates a human approval validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Human approval scope not granted",
+      "severity": "warning"
+    },
+    {
+      "affected_artifacts": [
+        "demo_fixture",
+        "validation_report"
+      ],
+      "category": "demo_generation",
+      "reason": "local_offline_boundary_missing",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Local offline boundary missing indicates a demo generation validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Local offline boundary missing",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "reviewer_packet",
+        "evidence_chain_manifest",
+        "outcome_receipt"
+      ],
+      "category": "packet_integrity",
+      "reason": "packet_hash_length_invalid",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Packet hash length invalid indicates a packet integrity validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Packet hash length invalid",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "reviewer_packet",
+        "evidence_chain_manifest",
+        "outcome_receipt"
+      ],
+      "category": "packet_integrity",
+      "reason": "packet_hash_missing",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Packet hash missing indicates a packet integrity validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Packet hash missing",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "reviewer_packet",
+        "evidence_chain_manifest",
+        "outcome_receipt"
+      ],
+      "category": "packet_integrity",
+      "reason": "packet_hash_recompute_mismatch",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Packet hash recompute mismatch indicates a packet integrity validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Packet hash recompute mismatch",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "reviewer_packet_schema",
+        "validation_report"
+      ],
+      "category": "schema",
+      "reason": "required_case_fields_missing",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Required case fields missing indicates a schema validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Required case fields missing",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "reviewer_packet_schema",
+        "validation_report"
+      ],
+      "category": "schema",
+      "reason": "required_top_level_fields_missing",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Required top level fields missing indicates a schema validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Required top level fields missing",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "demo_fixture",
+        "validation_report"
+      ],
+      "category": "demo_generation",
+      "reason": "reviewer_evidence_bundle_output_dir_invalid",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Reviewer evidence bundle output dir invalid indicates a demo generation validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Reviewer evidence bundle output dir invalid",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "reviewer_packet",
+        "validation_report"
+      ],
+      "category": "taxonomy",
+      "reason": "reviewer_failure_reason_taxonomy_unknown",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Reviewer failure reason taxonomy unknown indicates a taxonomy validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Reviewer failure reason taxonomy unknown",
+      "severity": "critical"
+    },
+    {
+      "affected_artifacts": [
+        "reviewer_packet",
+        "verifier_lifecycle_summary"
+      ],
+      "category": "verifier_lifecycle",
+      "reason": "reviewer_packet_committed_lifecycle_status_not_clean",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Reviewer packet committed lifecycle status not clean indicates a verifier lifecycle validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Reviewer packet committed lifecycle status not clean",
+      "severity": "warning"
+    },
+    {
+      "affected_artifacts": [
+        "reviewer_packet",
+        "human_approval_summary",
+        "evidence_chain_manifest",
+        "outcome_receipt"
+      ],
+      "category": "verifier_continuity",
+      "reason": "reviewer_packet_human_approval_proof_continuity_invalid",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Reviewer packet human approval proof continuity invalid indicates a verifier continuity validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Reviewer packet human approval proof continuity invalid",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "reviewer_packet",
+        "verifier_lifecycle_summary",
+        "evidence_chain_manifest",
+        "outcome_receipt"
+      ],
+      "category": "lifecycle_snapshot_continuity",
+      "reason": "reviewer_packet_manifest_lifecycle_snapshot_hash_mismatch",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Reviewer packet manifest lifecycle snapshot hash mismatch indicates a lifecycle snapshot continuity validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Reviewer packet manifest lifecycle snapshot hash mismatch",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "reviewer_packet",
+        "verifier_lifecycle_summary",
+        "evidence_chain_manifest",
+        "outcome_receipt"
+      ],
+      "category": "lifecycle_snapshot_continuity",
+      "reason": "reviewer_packet_outcome_lifecycle_snapshot_hash_mismatch",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Reviewer packet outcome lifecycle snapshot hash mismatch indicates a lifecycle snapshot continuity validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Reviewer packet outcome lifecycle snapshot hash mismatch",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "reviewer_packet",
+        "evidence_chain_manifest",
+        "outcome_receipt"
+      ],
+      "category": "packet_integrity",
+      "reason": "reviewer_packet_verification_proof_hash_mismatch",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Reviewer packet verification proof hash mismatch indicates a packet integrity validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Reviewer packet verification proof hash mismatch",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "reviewer_packet",
+        "human_approval_summary",
+        "evidence_chain_manifest",
+        "outcome_receipt"
+      ],
+      "category": "verifier_continuity",
+      "reason": "reviewer_packet_verified_at_mismatch",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Reviewer packet verified at mismatch indicates a verifier continuity validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Reviewer packet verified at mismatch",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "reviewer_packet",
+        "human_approval_summary",
+        "evidence_chain_manifest",
+        "outcome_receipt"
+      ],
+      "category": "verifier_continuity",
+      "reason": "reviewer_packet_verifier_expired_before_verification",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Reviewer packet verifier expired before verification indicates a verifier continuity validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Reviewer packet verifier expired before verification",
+      "severity": "critical"
+    },
+    {
+      "affected_artifacts": [
+        "reviewer_packet",
+        "human_approval_summary",
+        "evidence_chain_manifest",
+        "outcome_receipt"
+      ],
+      "category": "verifier_continuity",
+      "reason": "reviewer_packet_verifier_id_mismatch",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Reviewer packet verifier id mismatch indicates a verifier continuity validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Reviewer packet verifier id mismatch",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "reviewer_packet",
+        "human_approval_summary",
+        "evidence_chain_manifest",
+        "outcome_receipt"
+      ],
+      "category": "verifier_continuity",
+      "reason": "reviewer_packet_verifier_id_missing",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Reviewer packet verifier id missing indicates a verifier continuity validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Reviewer packet verifier id missing",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "reviewer_packet",
+        "human_approval_summary",
+        "evidence_chain_manifest",
+        "outcome_receipt"
+      ],
+      "category": "verifier_continuity",
+      "reason": "reviewer_packet_verifier_key_id_mismatch",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Reviewer packet verifier key id mismatch indicates a verifier continuity validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Reviewer packet verifier key id mismatch",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "reviewer_packet",
+        "verifier_lifecycle_summary"
+      ],
+      "category": "verifier_lifecycle",
+      "reason": "reviewer_packet_verifier_lifecycle_invalid",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Reviewer packet verifier lifecycle invalid indicates a verifier lifecycle validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Reviewer packet verifier lifecycle invalid",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "reviewer_packet",
+        "verifier_lifecycle_summary"
+      ],
+      "category": "verifier_lifecycle",
+      "reason": "reviewer_packet_verifier_lifecycle_policy_hash_mismatch",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Reviewer packet verifier lifecycle policy hash mismatch indicates a verifier lifecycle validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Reviewer packet verifier lifecycle policy hash mismatch",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "reviewer_packet",
+        "verifier_lifecycle_summary",
+        "evidence_chain_manifest",
+        "outcome_receipt"
+      ],
+      "category": "lifecycle_snapshot_continuity",
+      "reason": "reviewer_packet_verifier_lifecycle_snapshot_hash_mismatch",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Reviewer packet verifier lifecycle snapshot hash mismatch indicates a lifecycle snapshot continuity validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Reviewer packet verifier lifecycle snapshot hash mismatch",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "reviewer_packet",
+        "verifier_lifecycle_summary",
+        "evidence_chain_manifest",
+        "outcome_receipt"
+      ],
+      "category": "lifecycle_snapshot_continuity",
+      "reason": "reviewer_packet_verifier_lifecycle_snapshot_hash_missing",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Reviewer packet verifier lifecycle snapshot hash missing indicates a lifecycle snapshot continuity validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Reviewer packet verifier lifecycle snapshot hash missing",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "reviewer_packet",
+        "human_approval_summary",
+        "evidence_chain_manifest",
+        "outcome_receipt"
+      ],
+      "category": "verifier_continuity",
+      "reason": "reviewer_packet_verifier_not_yet_valid",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Reviewer packet verifier not yet valid indicates a verifier continuity validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Reviewer packet verifier not yet valid",
+      "severity": "critical"
+    },
+    {
+      "affected_artifacts": [
+        "reviewer_packet",
+        "human_approval_summary",
+        "evidence_chain_manifest",
+        "outcome_receipt"
+      ],
+      "category": "verifier_continuity",
+      "reason": "reviewer_packet_verifier_policy_hash_mismatch",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Reviewer packet verifier policy hash mismatch indicates a verifier continuity validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Reviewer packet verifier policy hash mismatch",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "reviewer_packet",
+        "human_approval_summary",
+        "evidence_chain_manifest",
+        "outcome_receipt"
+      ],
+      "category": "verifier_continuity",
+      "reason": "reviewer_packet_verifier_policy_hash_missing",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Reviewer packet verifier policy hash missing indicates a verifier continuity validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Reviewer packet verifier policy hash missing",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "reviewer_packet",
+        "human_approval_summary",
+        "evidence_chain_manifest",
+        "outcome_receipt"
+      ],
+      "category": "verifier_continuity",
+      "reason": "reviewer_packet_verifier_policy_id_missing",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Reviewer packet verifier policy id missing indicates a verifier continuity validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Reviewer packet verifier policy id missing",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "reviewer_packet",
+        "human_approval_summary",
+        "evidence_chain_manifest",
+        "outcome_receipt"
+      ],
+      "category": "verifier_continuity",
+      "reason": "reviewer_packet_verifier_revoked_before_verification",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Reviewer packet verifier revoked before verification indicates a verifier continuity validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Reviewer packet verifier revoked before verification",
+      "severity": "critical"
+    },
+    {
+      "affected_artifacts": [
+        "reviewer_packet_schema",
+        "validation_report"
+      ],
+      "category": "schema",
+      "reason": "schema_file_json_unparseable",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Schema file json unparseable indicates a schema validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Schema file json unparseable",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "reviewer_packet_schema",
+        "validation_report"
+      ],
+      "category": "schema",
+      "reason": "schema_file_missing",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Schema file missing indicates a schema validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Schema file missing",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "reviewer_packet_schema",
+        "validation_report"
+      ],
+      "category": "schema",
+      "reason": "schema_json_unparseable",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Schema json unparseable indicates a schema validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Schema json unparseable",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "reviewer_packet_schema",
+        "validation_report"
+      ],
+      "category": "schema",
+      "reason": "schema_validation_failed",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Schema validation failed indicates a schema validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Schema validation failed",
+      "severity": "error"
+    },
+    {
+      "affected_artifacts": [
+        "reviewer_packet",
+        "evidence_chain_manifest",
+        "outcome_receipt"
+      ],
+      "category": "packet_integrity",
+      "reason": "valid_case_chain_not_verified",
+      "remediation_hint": "Regenerate or repair the affected local demo artifact, then rerun the reviewer validation commands before review.",
+      "reviewer_explanation": "Valid case chain not verified indicates a packet integrity validation condition failed in the local/offline reviewer demo artifacts.",
+      "reviewer_label": "Valid case chain not verified",
+      "severity": "warning"
+    }
+  ],
+  "severities": [
+    "critical",
+    "error",
+    "info",
+    "warning"
+  ],
+  "total_reasons": 59
+}

--- a/docs/en/demo/examples/reviewer-failure-reason-catalog-v1/reviewer-failure-reason-catalog.generated.example.md
+++ b/docs/en/demo/examples/reviewer-failure-reason-catalog-v1/reviewer-failure-reason-catalog.generated.example.md
@@ -1,0 +1,71 @@
+# Reviewer Failure Reason Catalog v1
+
+Generated deterministic local/offline reviewer documentation.
+
+- catalog_version: `reviewer-failure-reason-catalog-v1`
+- generated_at: `2026-01-01T00:00:00Z`
+- total_reasons: `59`
+
+| reason | category | severity | reviewer label | affected artifacts |
+|---|---|---|---|---|
+| artifact_manifest_artifact_name_invalid | artifact_manifest | error | Artifact manifest artifact name invalid | artifact_manifest, reviewer_evidence_bundle |
+| artifact_manifest_file_hash_mismatch | artifact_manifest | error | Artifact manifest file hash mismatch | artifact_manifest, reviewer_evidence_bundle |
+| artifact_manifest_file_size_mismatch | artifact_manifest | error | Artifact manifest file size mismatch | artifact_manifest, reviewer_evidence_bundle |
+| artifact_manifest_hash_mismatch | artifact_manifest | error | Artifact manifest hash mismatch | artifact_manifest, reviewer_evidence_bundle |
+| artifact_manifest_json_unparseable | artifact_manifest | error | Artifact manifest json unparseable | artifact_manifest, reviewer_evidence_bundle |
+| artifact_manifest_missing | artifact_manifest | error | Artifact manifest missing | artifact_manifest, reviewer_evidence_bundle |
+| artifact_manifest_required_file_missing | artifact_manifest | error | Artifact manifest required file missing | artifact_manifest, reviewer_evidence_bundle |
+| authority_expired_or_missing | authority | error | Authority expired or missing | reviewer_packet, authority_summary |
+| authority_invalid | authority | error | Authority invalid | reviewer_packet, authority_summary |
+| authority_missing | authority | error | Authority missing | reviewer_packet, authority_summary |
+| blocked_case_outcome_failure_reasons_missing | demo_generation | error | Blocked case outcome failure reasons missing | demo_fixture, validation_report |
+| blocked_case_refusal_basis_missing | demo_generation | error | Blocked case refusal basis missing | demo_fixture, validation_report |
+| case_expectations_failed | demo_generation | error | Case expectations failed | demo_fixture, validation_report |
+| demo_mismatched_links_present | demo_generation | error | Demo mismatched links present | demo_fixture, validation_report |
+| evidence_chain_lifecycle_snapshot_hash_mismatch | lifecycle_snapshot_continuity | error | Evidence chain lifecycle snapshot hash mismatch | reviewer_packet, verifier_lifecycle_summary, evidence_chain_manifest, outcome_receipt |
+| evidence_chain_manifest_lifecycle_snapshot_hash_missing | lifecycle_snapshot_continuity | error | Evidence chain manifest lifecycle snapshot hash missing | reviewer_packet, verifier_lifecycle_summary, evidence_chain_manifest, outcome_receipt |
+| evidence_chain_outcome_lifecycle_snapshot_hash_missing | lifecycle_snapshot_continuity | error | Evidence chain outcome lifecycle snapshot hash missing | reviewer_packet, verifier_lifecycle_summary, evidence_chain_manifest, outcome_receipt |
+| evidence_chain_verification_missing | packet_integrity | error | Evidence chain verification missing | reviewer_packet, evidence_chain_manifest, outcome_receipt |
+| generated_packet_mismatch | demo_generation | error | Generated packet mismatch | demo_fixture, validation_report |
+| golden_fixture_json_unparseable | demo_generation | error | Golden fixture json unparseable | demo_fixture, validation_report |
+| golden_fixture_missing | demo_generation | error | Golden fixture missing | demo_fixture, validation_report |
+| human_approval_action_class_mismatch | human_approval | error | Human approval action class mismatch | reviewer_packet, human_approval_summary |
+| human_approval_bind_context_hash_mismatch | human_approval | error | Human approval bind context hash mismatch | reviewer_packet, human_approval_summary |
+| human_approval_expired | human_approval | warning | Human approval expired | reviewer_packet, human_approval_summary |
+| human_approval_missing | human_approval | error | Human approval missing | reviewer_packet, human_approval_summary |
+| human_approval_request_ref_mismatch | human_approval | error | Human approval request ref mismatch | reviewer_packet, human_approval_summary |
+| human_approval_scope_not_granted | human_approval | warning | Human approval scope not granted | reviewer_packet, human_approval_summary |
+| local_offline_boundary_missing | demo_generation | error | Local offline boundary missing | demo_fixture, validation_report |
+| packet_hash_length_invalid | packet_integrity | error | Packet hash length invalid | reviewer_packet, evidence_chain_manifest, outcome_receipt |
+| packet_hash_missing | packet_integrity | error | Packet hash missing | reviewer_packet, evidence_chain_manifest, outcome_receipt |
+| packet_hash_recompute_mismatch | packet_integrity | error | Packet hash recompute mismatch | reviewer_packet, evidence_chain_manifest, outcome_receipt |
+| required_case_fields_missing | schema | error | Required case fields missing | reviewer_packet_schema, validation_report |
+| required_top_level_fields_missing | schema | error | Required top level fields missing | reviewer_packet_schema, validation_report |
+| reviewer_evidence_bundle_output_dir_invalid | demo_generation | error | Reviewer evidence bundle output dir invalid | demo_fixture, validation_report |
+| reviewer_failure_reason_taxonomy_unknown | taxonomy | critical | Reviewer failure reason taxonomy unknown | reviewer_packet, validation_report |
+| reviewer_packet_committed_lifecycle_status_not_clean | verifier_lifecycle | warning | Reviewer packet committed lifecycle status not clean | reviewer_packet, verifier_lifecycle_summary |
+| reviewer_packet_human_approval_proof_continuity_invalid | verifier_continuity | error | Reviewer packet human approval proof continuity invalid | reviewer_packet, human_approval_summary, evidence_chain_manifest, outcome_receipt |
+| reviewer_packet_manifest_lifecycle_snapshot_hash_mismatch | lifecycle_snapshot_continuity | error | Reviewer packet manifest lifecycle snapshot hash mismatch | reviewer_packet, verifier_lifecycle_summary, evidence_chain_manifest, outcome_receipt |
+| reviewer_packet_outcome_lifecycle_snapshot_hash_mismatch | lifecycle_snapshot_continuity | error | Reviewer packet outcome lifecycle snapshot hash mismatch | reviewer_packet, verifier_lifecycle_summary, evidence_chain_manifest, outcome_receipt |
+| reviewer_packet_verification_proof_hash_mismatch | packet_integrity | error | Reviewer packet verification proof hash mismatch | reviewer_packet, evidence_chain_manifest, outcome_receipt |
+| reviewer_packet_verified_at_mismatch | verifier_continuity | error | Reviewer packet verified at mismatch | reviewer_packet, human_approval_summary, evidence_chain_manifest, outcome_receipt |
+| reviewer_packet_verifier_expired_before_verification | verifier_continuity | critical | Reviewer packet verifier expired before verification | reviewer_packet, human_approval_summary, evidence_chain_manifest, outcome_receipt |
+| reviewer_packet_verifier_id_mismatch | verifier_continuity | error | Reviewer packet verifier id mismatch | reviewer_packet, human_approval_summary, evidence_chain_manifest, outcome_receipt |
+| reviewer_packet_verifier_id_missing | verifier_continuity | error | Reviewer packet verifier id missing | reviewer_packet, human_approval_summary, evidence_chain_manifest, outcome_receipt |
+| reviewer_packet_verifier_key_id_mismatch | verifier_continuity | error | Reviewer packet verifier key id mismatch | reviewer_packet, human_approval_summary, evidence_chain_manifest, outcome_receipt |
+| reviewer_packet_verifier_lifecycle_invalid | verifier_lifecycle | error | Reviewer packet verifier lifecycle invalid | reviewer_packet, verifier_lifecycle_summary |
+| reviewer_packet_verifier_lifecycle_policy_hash_mismatch | verifier_lifecycle | error | Reviewer packet verifier lifecycle policy hash mismatch | reviewer_packet, verifier_lifecycle_summary |
+| reviewer_packet_verifier_lifecycle_snapshot_hash_mismatch | lifecycle_snapshot_continuity | error | Reviewer packet verifier lifecycle snapshot hash mismatch | reviewer_packet, verifier_lifecycle_summary, evidence_chain_manifest, outcome_receipt |
+| reviewer_packet_verifier_lifecycle_snapshot_hash_missing | lifecycle_snapshot_continuity | error | Reviewer packet verifier lifecycle snapshot hash missing | reviewer_packet, verifier_lifecycle_summary, evidence_chain_manifest, outcome_receipt |
+| reviewer_packet_verifier_not_yet_valid | verifier_continuity | critical | Reviewer packet verifier not yet valid | reviewer_packet, human_approval_summary, evidence_chain_manifest, outcome_receipt |
+| reviewer_packet_verifier_policy_hash_mismatch | verifier_continuity | error | Reviewer packet verifier policy hash mismatch | reviewer_packet, human_approval_summary, evidence_chain_manifest, outcome_receipt |
+| reviewer_packet_verifier_policy_hash_missing | verifier_continuity | error | Reviewer packet verifier policy hash missing | reviewer_packet, human_approval_summary, evidence_chain_manifest, outcome_receipt |
+| reviewer_packet_verifier_policy_id_missing | verifier_continuity | error | Reviewer packet verifier policy id missing | reviewer_packet, human_approval_summary, evidence_chain_manifest, outcome_receipt |
+| reviewer_packet_verifier_revoked_before_verification | verifier_continuity | critical | Reviewer packet verifier revoked before verification | reviewer_packet, human_approval_summary, evidence_chain_manifest, outcome_receipt |
+| schema_file_json_unparseable | schema | error | Schema file json unparseable | reviewer_packet_schema, validation_report |
+| schema_file_missing | schema | error | Schema file missing | reviewer_packet_schema, validation_report |
+| schema_json_unparseable | schema | error | Schema json unparseable | reviewer_packet_schema, validation_report |
+| schema_validation_failed | schema | error | Schema validation failed | reviewer_packet_schema, validation_report |
+| valid_case_chain_not_verified | packet_integrity | warning | Valid case chain not verified | reviewer_packet, evidence_chain_manifest, outcome_receipt |
+
+Explanations and remediation hints are available in the generated JSON catalog.

--- a/docs/en/demo/reviewer-evidence-packet.md
+++ b/docs/en/demo/reviewer-evidence-packet.md
@@ -82,9 +82,11 @@ Reviewer-facing failure reasons are stable machine-readable strings intended for
 
 ### Failure reason metadata catalog
 
-The local/offline catalog in `scripts/demo/reviewer_failure_reasons.py` maps each stable failure reason code to reviewer-facing metadata: category, severity, label, explanation, remediation hint, and affected artifacts. Reviewer UI, audit reports, and deterministic automation can use this catalog to explain why a packet, fixture, or validation report failed without changing the underlying machine-readable reason string.
+Reviewer-facing failure reasons are stable machine-readable codes. The local/offline catalog in `scripts/demo/reviewer_failure_reasons.py` maps each stable code to reviewer-facing metadata: category, severity, label, explanation, remediation hint, and affected artifacts. Reviewer UI, audit reports, and deterministic automation can use this catalog to explain why a packet, fixture, or validation report failed without changing the underlying machine-readable reason string.
 
-The catalog is demo/reviewer validation scope only. It does not change runtime admissibility, bind/admissibility logic, governance policy behavior, FUJI fail-closed behavior, TrustLog persistence, or the Reviewer Evidence Packet schema.
+Generated reviewer documentation is checked in at `docs/en/demo/examples/reviewer-failure-reason-catalog-v1/reviewer-failure-reason-catalog.generated.example.json` and `docs/en/demo/examples/reviewer-failure-reason-catalog-v1/reviewer-failure-reason-catalog.generated.example.md`. These artifacts are derived from the Python metadata source of truth by `scripts/demo/generate_reviewer_failure_reason_catalog.py`, are deterministic, and can be regenerated locally/offline without credentials or network access.
+
+The generated catalog is demo/reviewer documentation only. It does not change runtime admissibility, bind/admissibility logic, governance policy behavior, FUJI fail-closed behavior, TrustLog persistence, emitted failure reason strings, or the Reviewer Evidence Packet schema.
 
 ## Local/offline boundary
 

--- a/scripts/demo/generate_reviewer_failure_reason_catalog.py
+++ b/scripts/demo/generate_reviewer_failure_reason_catalog.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Generate deterministic reviewer failure reason catalog artifacts.
+
+This local/offline helper derives JSON and Markdown reviewer documentation from
+``scripts.demo.reviewer_failure_reasons``. It does not change emitted failure
+reason strings, reviewer packet schemas, runtime admissibility, or governance
+behavior.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.demo.reviewer_failure_reasons import (  # noqa: E402
+    REVIEWER_FAILURE_REASON_CATEGORIES,
+    REVIEWER_FAILURE_REASON_METADATA,
+    REVIEWER_FAILURE_REASON_SEVERITIES,
+    REVIEWER_FAILURE_REASONS,
+)
+
+CATALOG_VERSION = "reviewer-failure-reason-catalog-v1"
+GENERATED_AT = "2026-01-01T00:00:00Z"
+CATALOG_DIR = (
+    REPO_ROOT
+    / "docs/en/demo/examples/reviewer-failure-reason-catalog-v1"
+)
+JSON_OUTPUT_PATH = (
+    CATALOG_DIR / "reviewer-failure-reason-catalog.generated.example.json"
+)
+MARKDOWN_OUTPUT_PATH = (
+    CATALOG_DIR / "reviewer-failure-reason-catalog.generated.example.md"
+)
+
+
+def build_catalog() -> dict[str, Any]:
+    """Build the deterministic catalog payload from metadata source data."""
+    reasons = [
+        asdict(REVIEWER_FAILURE_REASON_METADATA[reason])
+        for reason in sorted(REVIEWER_FAILURE_REASONS)
+    ]
+    return {
+        "catalog_version": CATALOG_VERSION,
+        "generated_at": GENERATED_AT,
+        "total_reasons": len(REVIEWER_FAILURE_REASONS),
+        "categories": sorted(REVIEWER_FAILURE_REASON_CATEGORIES),
+        "severities": sorted(REVIEWER_FAILURE_REASON_SEVERITIES),
+        "reasons": reasons,
+    }
+
+
+def render_json(catalog: dict[str, Any]) -> str:
+    """Render catalog JSON with stable key ordering and trailing newline."""
+    return json.dumps(
+        catalog,
+        ensure_ascii=False,
+        indent=2,
+        sort_keys=True,
+    ) + "\n"
+
+
+def _markdown_escape(value: str) -> str:
+    """Escape Markdown table separators in generated cell content."""
+    return value.replace("|", "\\|")
+
+
+def render_markdown(catalog: dict[str, Any]) -> str:
+    """Render compact reviewer-facing Markdown from a catalog payload."""
+    lines = [
+        "# Reviewer Failure Reason Catalog v1",
+        "",
+        "Generated deterministic local/offline reviewer documentation.",
+        "",
+        f"- catalog_version: `{catalog['catalog_version']}`",
+        f"- generated_at: `{catalog['generated_at']}`",
+        f"- total_reasons: `{catalog['total_reasons']}`",
+        "",
+        "| reason | category | severity | reviewer label | affected artifacts |",
+        "|---|---|---|---|---|",
+    ]
+    for entry in catalog["reasons"]:
+        artifacts = ", ".join(entry["affected_artifacts"])
+        lines.append(
+            "| "
+            + " | ".join(
+                _markdown_escape(str(value))
+                for value in (
+                    entry["reason"],
+                    entry["category"],
+                    entry["severity"],
+                    entry["reviewer_label"],
+                    artifacts,
+                )
+            )
+            + " |"
+        )
+    lines.extend(
+        [
+            "",
+            "Explanations and remediation hints are available in the generated JSON catalog.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def write_catalog() -> None:
+    """Write generated catalog artifacts to the repository docs tree."""
+    catalog = build_catalog()
+    CATALOG_DIR.mkdir(parents=True, exist_ok=True)
+    JSON_OUTPUT_PATH.write_text(render_json(catalog), encoding="utf-8")
+    MARKDOWN_OUTPUT_PATH.write_text(render_markdown(catalog), encoding="utf-8")
+
+
+def check_catalog() -> int:
+    """Return zero when checked-in generated artifacts are current."""
+    catalog = build_catalog()
+    expected = {
+        JSON_OUTPUT_PATH: render_json(catalog),
+        MARKDOWN_OUTPUT_PATH: render_markdown(catalog),
+    }
+    stale = [
+        path
+        for path, content in expected.items()
+        if not path.is_file() or path.read_text(encoding="utf-8") != content
+    ]
+    if stale:
+        for path in stale:
+            print(f"stale generated artifact: {path.relative_to(REPO_ROOT)}")
+        return 1
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Generate reviewer failure reason catalog artifacts."
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="verify generated artifacts are current without writing files",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """CLI entry point."""
+    args = parse_args()
+    if args.check:
+        return check_catalog()
+    write_catalog()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/demo/test_reviewer_failure_reasons.py
+++ b/tests/demo/test_reviewer_failure_reasons.py
@@ -91,3 +91,70 @@ def test_centralized_failure_reason_literals_stay_in_taxonomy_module() -> None:
                 offenders.append(f"{path.relative_to(Path.cwd())}: {value}")
 
     assert offenders == []
+
+
+def test_generated_failure_reason_catalog_json_matches_metadata() -> None:
+    """Generated JSON catalog must exactly mirror metadata source of truth."""
+    import json
+
+    from scripts.demo.generate_reviewer_failure_reason_catalog import (
+        JSON_OUTPUT_PATH,
+        build_catalog,
+        render_json,
+    )
+
+    catalog = build_catalog()
+    assert JSON_OUTPUT_PATH.read_text(encoding="utf-8") == render_json(catalog)
+    assert json.loads(JSON_OUTPUT_PATH.read_text(encoding="utf-8")) == json.loads(
+        render_json(catalog)
+    )
+    reasons = catalog["reasons"]
+
+    assert catalog["total_reasons"] == len(taxonomy.REVIEWER_FAILURE_REASONS)
+    assert catalog["categories"] == sorted(
+        taxonomy.REVIEWER_FAILURE_REASON_CATEGORIES
+    )
+    assert catalog["severities"] == sorted(
+        taxonomy.REVIEWER_FAILURE_REASON_SEVERITIES
+    )
+    assert [entry["reason"] for entry in reasons] == sorted(
+        taxonomy.REVIEWER_FAILURE_REASONS
+    )
+    assert reasons == [
+        {
+            "reason": metadata.reason,
+            "category": metadata.category,
+            "severity": metadata.severity,
+            "reviewer_label": metadata.reviewer_label,
+            "reviewer_explanation": metadata.reviewer_explanation,
+            "remediation_hint": metadata.remediation_hint,
+            "affected_artifacts": metadata.affected_artifacts,
+        }
+        for reason, metadata in sorted(
+            taxonomy.REVIEWER_FAILURE_REASON_METADATA.items()
+        )
+    ]
+
+
+def test_generated_failure_reason_catalog_markdown_contains_taxonomy() -> None:
+    """Generated Markdown catalog must include every stable reason code."""
+    from scripts.demo.generate_reviewer_failure_reason_catalog import (
+        build_catalog,
+        render_markdown,
+    )
+
+    markdown = render_markdown(build_catalog())
+
+    for reason in taxonomy.REVIEWER_FAILURE_REASONS:
+        assert f"| {reason} |" in markdown
+
+
+def test_generated_failure_reason_catalog_values_are_allowlisted() -> None:
+    """Generated catalog facets must stay in taxonomy allowlists."""
+    from scripts.demo.generate_reviewer_failure_reason_catalog import (
+        build_catalog,
+    )
+
+    for entry in build_catalog()["reasons"]:
+        assert entry["category"] in taxonomy.REVIEWER_FAILURE_REASON_CATEGORIES
+        assert entry["severity"] in taxonomy.REVIEWER_FAILURE_REASON_SEVERITIES


### PR DESCRIPTION
### Motivation
- Provide a deterministic, reviewable machine-readable catalog for reviewer/demo failure reasons so UI prototypes, audit reports, and demos can inspect taxonomy metadata without reading Python source. 
- Keep the metadata as a single source of truth in `scripts/demo/reviewer_failure_reasons.py` while exposing reviewer-facing documentation artifacts for offline/local review. 

### Description
- Add a deterministic generator `scripts/demo/generate_reviewer_failure_reason_catalog.py` that derives JSON and Markdown artifacts from `REVIEWER_FAILURE_REASON_METADATA` and supports a `--check` mode. 
- Add generated artifacts `docs/en/demo/examples/reviewer-failure-reason-catalog-v1/reviewer-failure-reason-catalog.generated.example.json` and `...generated.example.md` with `catalog_version`, `generated_at`, `total_reasons`, sorted `categories`/`severities`, and reasons sorted by reason string. 
- Add tests in `tests/demo/test_reviewer_failure_reasons.py` that assert the generated JSON exactly matches the metadata, that Markdown contains every taxonomy reason, that reasons are deterministically sorted, and that category/severity values use allowlists. 
- Update `docs/en/demo/reviewer-evidence-packet.md` to reference the generated catalog and clarify this is local/offline reviewer documentation that does not change runtime admissibility or emitted failure reason strings. 

### Testing
- Ran `python -m pytest tests/demo/test_reviewer_failure_reasons.py -q` and the extended tests passed. 
- Ran the generator check `python scripts/demo/generate_reviewer_failure_reason_catalog.py --check` and it reported artifacts are current (OK). 
- Ran `python -m pytest tests/demo/test_evaluation_governance_chain_reviewer_packet.py -q` and `python scripts/demo/validate_evaluation_governance_reviewer_demo.py --demo-dir docs/en/demo/examples/evaluation-governance-reviewer-demo-v1/generated` and both validations passed. 
- `python -m pytest tests/demo/test_reviewer_evidence_packet_schema.py -q` and `python scripts/demo/validate_reviewer_evidence_packet.py` failed in this environment due to a missing `PyYAML` dependency (`ModuleNotFoundError: No module named 'yaml'`), and installing `PyYAML==6.0.3` was blocked by the container's PyPI access; this is an environment limitation and not caused by the code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a415181f080832697cb8afac8785319)