### PR TITLE
Add reviewer failure reason catalog schema and deterministic validator

### DIFF
--- a/docs/en/demo/reviewer-evidence-packet.md
+++ b/docs/en/demo/reviewer-evidence-packet.md
@@ -86,7 +86,9 @@ Reviewer-facing failure reasons are stable machine-readable codes. The local/off
 
 Generated reviewer documentation is checked in at `docs/en/demo/examples/reviewer-failure-reason-catalog-v1/reviewer-failure-reason-catalog.generated.example.json` and `docs/en/demo/examples/reviewer-failure-reason-catalog-v1/reviewer-failure-reason-catalog.generated.example.md`. These artifacts are derived from the Python metadata source of truth by `scripts/demo/generate_reviewer_failure_reason_catalog.py`, are deterministic, and can be regenerated locally/offline without credentials or network access.
 
-The generated catalog is demo/reviewer documentation only. It does not change runtime admissibility, bind/admissibility logic, governance policy behavior, FUJI fail-closed behavior, TrustLog persistence, emitted failure reason strings, or the Reviewer Evidence Packet schema.
+The generated catalog JSON has a checked-in schema at `docs/en/demo/schemas/reviewer-failure-reason-catalog-v1.schema.json`. The local/offline validator at `scripts/demo/validate_reviewer_failure_reason_catalog.py` checks schema validity, deterministic artifact freshness, taxonomy coverage, one-entry-per-reason uniqueness, stable sorting, and exact metadata fidelity against the Python source of truth.
+
+The generated catalog remains demo/reviewer documentation only. It does not change runtime admissibility, bind/admissibility logic, governance policy behavior, FUJI fail-closed behavior, TrustLog persistence, emitted failure reason strings, or the Reviewer Evidence Packet schema.
 
 ## Local/offline boundary
 

--- a/docs/en/demo/schemas/reviewer-failure-reason-catalog-v1.schema.json
+++ b/docs/en/demo/schemas/reviewer-failure-reason-catalog-v1.schema.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://veritas-os.local/schemas/reviewer-failure-reason-catalog-v1.schema.json",
+  "title": "Reviewer Failure Reason Catalog v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "catalog_version",
+    "generated_at",
+    "total_reasons",
+    "categories",
+    "severities",
+    "reasons"
+  ],
+  "properties": {
+    "catalog_version": {
+      "const": "reviewer-failure-reason-catalog-v1"
+    },
+    "generated_at": {
+      "type": "string",
+      "minLength": 1
+    },
+    "total_reasons": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "categories": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "severities": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "reasons": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "reason",
+          "category",
+          "severity",
+          "reviewer_label",
+          "reviewer_explanation",
+          "remediation_hint",
+          "affected_artifacts"
+        ],
+        "properties": {
+          "reason": {
+            "type": "string",
+            "minLength": 1
+          },
+          "category": {
+            "type": "string",
+            "minLength": 1
+          },
+          "severity": {
+            "type": "string",
+            "minLength": 1
+          },
+          "reviewer_label": {
+            "type": "string",
+            "minLength": 1
+          },
+          "reviewer_explanation": {
+            "type": "string",
+            "minLength": 1
+          },
+          "remediation_hint": {
+            "type": "string",
+            "minLength": 1
+          },
+          "affected_artifacts": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/demo/validate_reviewer_failure_reason_catalog.py
+++ b/scripts/demo/validate_reviewer_failure_reason_catalog.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Validate reviewer failure reason catalog artifacts locally/offline.
+
+The validator treats the generated JSON and Markdown catalog files as a stable
+reviewer documentation contract. It validates schema shape, taxonomy coverage,
+metadata fidelity, deterministic sorting, and freshness against the generator.
+It does not change runtime admissibility or emitted failure reason strings.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.demo.generate_reviewer_failure_reason_catalog import (  # noqa: E402
+    JSON_OUTPUT_PATH,
+    MARKDOWN_OUTPUT_PATH,
+    build_catalog,
+    render_json,
+    render_markdown,
+)
+from scripts.demo.reviewer_failure_reasons import (  # noqa: E402
+    REVIEWER_FAILURE_REASON_CATEGORIES,
+    REVIEWER_FAILURE_REASON_METADATA,
+    REVIEWER_FAILURE_REASON_SEVERITIES,
+    REVIEWER_FAILURE_REASONS,
+)
+
+SCHEMA_PATH = (
+    REPO_ROOT
+    / "docs/en/demo/schemas/reviewer-failure-reason-catalog-v1.schema.json"
+)
+
+
+class CatalogValidationError(ValueError):
+    """Raised when the checked-in reviewer catalog is invalid."""
+
+
+def _display_path(path: Path) -> str:
+    """Return a stable repository-relative path when possible."""
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def _load_json_object(path: Path) -> dict[str, Any]:
+    """Load a local JSON object or raise a deterministic validation error."""
+    if not path.is_file():
+        raise CatalogValidationError(f"missing file: {_display_path(path)}")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        message = f"invalid JSON in {_display_path(path)}: {exc}"
+        raise CatalogValidationError(message) from exc
+    if not isinstance(payload, dict):
+        raise CatalogValidationError(
+            f"expected JSON object in {_display_path(path)}"
+        )
+    return payload
+
+
+def _validate_schema_subset(
+    payload: Any,
+    schema: dict[str, Any],
+    path: str = "$",
+) -> None:
+    """Validate catalog JSON with the local JSON Schema subset it uses."""
+    if "const" in schema and payload != schema["const"]:
+        raise CatalogValidationError(
+            f"{path} did not match const {schema['const']!r}"
+        )
+
+    expected_type = schema.get("type")
+    if expected_type == "object":
+        _validate_object(payload, schema, path)
+    elif expected_type == "array":
+        _validate_array(payload, schema, path)
+    elif expected_type == "string":
+        _validate_string(payload, schema, path)
+    elif expected_type == "integer":
+        _validate_integer(payload, schema, path)
+
+
+def _validate_object(payload: Any, schema: dict[str, Any], path: str) -> None:
+    """Validate object keywords used by the catalog schema."""
+    if not isinstance(payload, dict):
+        raise CatalogValidationError(f"{path} is not an object")
+
+    missing = [
+        field for field in schema.get("required", []) if field not in payload
+    ]
+    if missing:
+        raise CatalogValidationError(f"{path} missing required fields: {missing}")
+
+    properties = schema.get("properties", {})
+    if schema.get("additionalProperties") is False:
+        extra = set(payload) - set(properties)
+        if extra:
+            raise CatalogValidationError(
+                f"{path} has unexpected fields: {sorted(extra)}"
+            )
+
+    for field, value in payload.items():
+        if field in properties:
+            _validate_schema_subset(
+                value, properties[field], f"{path}.{field}"
+            )
+
+
+def _validate_array(payload: Any, schema: dict[str, Any], path: str) -> None:
+    """Validate array keywords used by the catalog schema."""
+    if not isinstance(payload, list):
+        raise CatalogValidationError(f"{path} is not an array")
+    min_items = schema.get("minItems")
+    if min_items is not None and len(payload) < min_items:
+        raise CatalogValidationError(f"{path} has too few items")
+    item_schema = schema.get("items")
+    if item_schema is not None:
+        for index, item in enumerate(payload):
+            _validate_schema_subset(item, item_schema, f"{path}[{index}]")
+
+
+def _validate_string(payload: Any, schema: dict[str, Any], path: str) -> None:
+    """Validate string keywords used by the catalog schema."""
+    if not isinstance(payload, str):
+        raise CatalogValidationError(f"{path} is not a string")
+    min_length = schema.get("minLength")
+    if min_length is not None and len(payload) < min_length:
+        raise CatalogValidationError(f"{path} is too short")
+
+
+def _validate_integer(payload: Any, schema: dict[str, Any], path: str) -> None:
+    """Validate integer keywords used by the catalog schema."""
+    if not isinstance(payload, int) or isinstance(payload, bool):
+        raise CatalogValidationError(f"{path} is not an integer")
+    minimum = schema.get("minimum")
+    if minimum is not None and payload < minimum:
+        raise CatalogValidationError(f"{path} is below minimum {minimum}")
+
+
+def validate_catalog_payload(catalog: dict[str, Any], markdown: str) -> None:
+    """Validate catalog content against taxonomy and metadata source of truth."""
+    schema = _load_json_object(SCHEMA_PATH)
+    _validate_schema_subset(catalog, schema)
+
+    reasons = catalog["reasons"]
+    reason_codes = [entry["reason"] for entry in reasons]
+    taxonomy_reasons = sorted(REVIEWER_FAILURE_REASONS)
+
+    if catalog["total_reasons"] != len(REVIEWER_FAILURE_REASONS):
+        raise CatalogValidationError("total_reasons does not match taxonomy")
+    if reason_codes != sorted(reason_codes):
+        raise CatalogValidationError("catalog reasons are not sorted")
+    if len(reason_codes) != len(set(reason_codes)):
+        raise CatalogValidationError("catalog contains duplicate reason entries")
+
+    unknown = sorted(set(reason_codes) - REVIEWER_FAILURE_REASONS)
+    if unknown:
+        raise CatalogValidationError(f"catalog contains unknown reasons: {unknown}")
+
+    missing = sorted(REVIEWER_FAILURE_REASONS - set(reason_codes))
+    if missing:
+        raise CatalogValidationError(f"catalog missing taxonomy reasons: {missing}")
+    if reason_codes != taxonomy_reasons:
+        raise CatalogValidationError("catalog reasons do not match taxonomy order")
+
+    expected_categories = sorted(REVIEWER_FAILURE_REASON_CATEGORIES)
+    if catalog["categories"] != expected_categories:
+        raise CatalogValidationError("catalog categories do not match taxonomy")
+
+    expected_severities = sorted(REVIEWER_FAILURE_REASON_SEVERITIES)
+    if catalog["severities"] != expected_severities:
+        raise CatalogValidationError("catalog severities do not match taxonomy")
+
+    for entry in reasons:
+        reason = entry["reason"]
+        if entry["category"] not in REVIEWER_FAILURE_REASON_CATEGORIES:
+            raise CatalogValidationError(f"invalid category for {reason}")
+        if entry["severity"] not in REVIEWER_FAILURE_REASON_SEVERITIES:
+            raise CatalogValidationError(f"invalid severity for {reason}")
+        expected = json.loads(
+            json.dumps(asdict(REVIEWER_FAILURE_REASON_METADATA[reason]))
+        )
+        if entry != expected:
+            raise CatalogValidationError(f"metadata mismatch for {reason}")
+        if reason not in markdown:
+            raise CatalogValidationError(f"Markdown missing reason {reason}")
+
+
+def validate_catalog_files() -> None:
+    """Validate checked-in catalog files and generator freshness."""
+    catalog = _load_json_object(JSON_OUTPUT_PATH)
+    if not MARKDOWN_OUTPUT_PATH.is_file():
+        raise CatalogValidationError(
+            f"missing file: {_display_path(MARKDOWN_OUTPUT_PATH)}"
+        )
+    markdown = MARKDOWN_OUTPUT_PATH.read_text(encoding="utf-8")
+    validate_catalog_payload(catalog, markdown)
+
+    expected_catalog = build_catalog()
+    expected_json = render_json(expected_catalog)
+    if JSON_OUTPUT_PATH.read_text(encoding="utf-8") != expected_json:
+        raise CatalogValidationError("generated JSON catalog is stale")
+    if markdown != render_markdown(expected_catalog):
+        raise CatalogValidationError("generated Markdown catalog is stale")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Validate reviewer failure reason catalog artifacts."
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="accepted for parity; validation is always check-only",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for deterministic local/offline validation."""
+    parse_args(argv)
+    try:
+        validate_catalog_files()
+    except CatalogValidationError as exc:
+        print(f"Reviewer failure reason catalog validation failed: {exc}")
+        return 1
+    print("Reviewer failure reason catalog validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/demo/test_reviewer_failure_reason_catalog.py
+++ b/tests/demo/test_reviewer_failure_reason_catalog.py
@@ -1,0 +1,122 @@
+"""Tests for reviewer failure reason catalog validation."""
+
+from __future__ import annotations
+
+import copy
+import json
+
+import pytest
+
+from scripts.demo import reviewer_failure_reasons as taxonomy
+from scripts.demo.generate_reviewer_failure_reason_catalog import (
+    JSON_OUTPUT_PATH,
+    MARKDOWN_OUTPUT_PATH,
+    build_catalog,
+    render_json,
+    render_markdown,
+)
+from scripts.demo.validate_reviewer_failure_reason_catalog import (
+    CatalogValidationError,
+    SCHEMA_PATH,
+    _load_json_object,
+    _validate_schema_subset,
+    main,
+    validate_catalog_payload,
+)
+
+
+def _catalog_with_json_shapes() -> dict[str, object]:
+    """Return generated catalog with JSON list shapes for helper tests."""
+    return json.loads(render_json(build_catalog()))
+
+
+def test_checked_in_catalog_json_passes_schema_validation() -> None:
+    """Checked-in catalog JSON must satisfy the local schema contract."""
+    schema = _load_json_object(SCHEMA_PATH)
+    catalog = _load_json_object(JSON_OUTPUT_PATH)
+
+    _validate_schema_subset(catalog, schema)
+
+
+def test_catalog_validator_succeeds_on_current_generated_artifacts() -> None:
+    """CI-facing validator must pass for checked-in generated artifacts."""
+    assert main([]) == 0
+
+
+def test_generated_json_matches_metadata_source_of_truth() -> None:
+    """Generated JSON must exactly match reviewer metadata source data."""
+    catalog = _catalog_with_json_shapes()
+    markdown = render_markdown(build_catalog())
+
+    validate_catalog_payload(catalog, markdown)
+    assert JSON_OUTPUT_PATH.read_text(encoding="utf-8") == render_json(
+        build_catalog()
+    )
+
+
+def test_generated_markdown_contains_every_taxonomy_reason() -> None:
+    """Generated Markdown must include every stable taxonomy reason."""
+    markdown = MARKDOWN_OUTPUT_PATH.read_text(encoding="utf-8")
+
+    for reason in taxonomy.REVIEWER_FAILURE_REASONS:
+        assert reason in markdown
+
+
+def test_missing_taxonomy_reason_fails_deterministically() -> None:
+    """Catalog validation must reject missing taxonomy reasons."""
+    catalog = _catalog_with_json_shapes()
+    removed = catalog["reasons"].pop()
+    markdown = render_markdown(build_catalog())
+
+    with pytest.raises(CatalogValidationError, match="missing taxonomy"):
+        validate_catalog_payload(catalog, markdown)
+    assert removed["reason"] in taxonomy.REVIEWER_FAILURE_REASONS
+
+
+def test_unknown_catalog_reason_fails_deterministically() -> None:
+    """Catalog validation must reject reason codes outside taxonomy."""
+    catalog = _catalog_with_json_shapes()
+    catalog["reasons"][0] = copy.deepcopy(catalog["reasons"][0])
+    catalog["reasons"][0]["reason"] = "not_a_taxonomy_reason"
+    catalog["reasons"] = sorted(
+        catalog["reasons"], key=lambda item: item["reason"]
+    )
+    markdown = render_markdown(build_catalog()) + "\nnot_a_taxonomy_reason\n"
+
+    with pytest.raises(CatalogValidationError, match="unknown reasons"):
+        validate_catalog_payload(catalog, markdown)
+
+
+def test_category_outside_allowlist_fails_deterministically() -> None:
+    """Catalog validation must reject non-taxonomy categories."""
+    catalog = _catalog_with_json_shapes()
+    catalog["reasons"][0] = copy.deepcopy(catalog["reasons"][0])
+    catalog["reasons"][0]["category"] = "not_allowed"
+    markdown = render_markdown(build_catalog())
+
+    with pytest.raises(CatalogValidationError, match="invalid category"):
+        validate_catalog_payload(catalog, markdown)
+
+
+def test_severity_outside_allowlist_fails_deterministically() -> None:
+    """Catalog validation must reject non-taxonomy severities."""
+    catalog = _catalog_with_json_shapes()
+    catalog["reasons"][0] = copy.deepcopy(catalog["reasons"][0])
+    catalog["reasons"][0]["severity"] = "not_allowed"
+    markdown = render_markdown(build_catalog())
+
+    with pytest.raises(CatalogValidationError, match="invalid severity"):
+        validate_catalog_payload(catalog, markdown)
+
+
+def test_duplicate_reason_entry_fails_deterministically() -> None:
+    """Catalog validation must reject duplicate reason entries."""
+    catalog = _catalog_with_json_shapes()
+    catalog["reasons"][1] = copy.deepcopy(catalog["reasons"][0])
+    catalog["reasons"] = sorted(
+        catalog["reasons"], key=lambda item: item["reason"]
+    )
+    markdown = render_markdown(build_catalog())
+
+    with pytest.raises(CatalogValidationError, match="duplicate"):
+        validate_catalog_payload(catalog, markdown)


### PR DESCRIPTION
### Motivation
- Lock the generated reviewer failure reason catalog artifact shape so downstream reviewer UI, reports, and automation can consume it reliably.
- Provide a deterministic local/offline validator to ensure checked-in JSON/Markdown artifacts remain current, unique, and faithful to the canonical Python metadata without requiring network access.

### Description
- Add the JSON Schema at `docs/en/demo/schemas/reviewer-failure-reason-catalog-v1.schema.json` to validate top-level fields, reason entry required fields, non-empty arrays, `total_reasons >= 1`, and `catalog_version == "reviewer-failure-reason-catalog-v1"` with `additionalProperties: false` where practical.
- Add a deterministic, local/offline validator at `scripts/demo/validate_reviewer_failure_reason_catalog.py` that loads the checked-in JSON/Markdown artifacts, validates schema shape with a local subset, verifies `total_reasons == len(REVIEWER_FAILURE_REASONS)`, checks taxonomy coverage and one-entry-per-reason uniqueness, enforces deterministic sorting, validates `categories` and `severities` against allowlists, compares each entry against `REVIEWER_FAILURE_REASON_METADATA`, and ensures Markdown coverage and generator freshness.
- Add CI-facing tests in `tests/demo/test_reviewer_failure_reason_catalog.py` that assert schema validation, validator success on current artifacts, JSON fidelity to `REVIEWER_FAILURE_REASON_METADATA`, Markdown coverage, and deterministic negative cases for missing, unknown, invalid category, invalid severity, and duplicate entries.
- Update `docs/en/demo/reviewer-evidence-packet.md` to document the checked-in schema and the local/offline validator and to reiterate that runtime admissibility and emitted failure-reason strings are unchanged.

### Testing
- Ran `PYENV_VERSION=3.11.15 python -m pytest tests/demo/test_reviewer_failure_reasons.py tests/demo/test_reviewer_failure_reason_catalog.py` and `PYENV_VERSION=3.12.13 python -m pytest tests/demo/test_reviewer_failure_reasons.py tests/demo/test_reviewer_failure_reason_catalog.py`, and all tests passed (19 passed, 1 warning).
- Ran the generator and validator checks with `python scripts/demo/generate_reviewer_failure_reason_catalog.py --check` and `python scripts/demo/validate_reviewer_failure_reason_catalog.py --check`, both of which printed success and exited zero.
- Compiled the validator with `python -m py_compile scripts/demo/validate_reviewer_failure_reason_catalog.py` and confirmed no syntax errors, and ran `git diff --check` with no issues.
- Note: `python scripts/demo/validate_reviewer_evidence_packet.py` could not be executed in this environment due to a missing optional dev dependency (`PyYAML`), which is unrelated to the added schema/validator and does not affect offline catalog validation.

Security note: the change is local/offline documentation and validation only, introduces no network calls, secrets, KMS/HSM, or runtime policy changes, and preserves all existing emitted failure reason strings and runtime admissibility.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41ada7063c8326bf390df1dd3b0ca6)