### PR TITLE
docs: add reviewer evidence navigation index

### DIFF
--- a/docs/en/demo/external-reviewer-artifact-index.md
+++ b/docs/en/demo/external-reviewer-artifact-index.md
@@ -2,6 +2,8 @@
 
 Key local/offline reviewer-facing artifacts:
 
+For the reviewer documentation landing page and suggested reading order, see the [Reviewer Evidence Index](reviewer-evidence-index.md).
+
 - `docs/en/demos/pre_boundary_collapse_demo.md#procedural-admissibility-vs-maneuverability-observables-v0`
   - Procedural Admissibility vs. Maneuverability Observables v0: a reviewer-facing note clarifying that a process can remain admissible, documented, inspectable, and procedurally coherent while practical maneuverability contracts upstream. The note frames visibility of that contraction as a governance function, without adding production claims or runtime behavior.
 - `docs/en/demos/pre_boundary_collapse_demo.md#governance-recognizability-conditions-v0`

--- a/docs/en/demo/reviewer-evidence-assurance-overview.md
+++ b/docs/en/demo/reviewer-evidence-assurance-overview.md
@@ -1,5 +1,7 @@
 # Reviewer Evidence Assurance Overview
 
+See also: [Reviewer Evidence Index](reviewer-evidence-index.md).
+
 This document is the reviewer-facing map of the local/offline evidence assurance model implemented across the Reviewer Evidence Packet, Evidence Chain verification, verifier continuity checks, verifier lifecycle checks, and failure reason catalog artifacts.
 
 It explains how the existing demo/reviewer artifacts fit together. It does not introduce runtime behavior, schema changes, or new failure reasons.

--- a/docs/en/demo/reviewer-evidence-bundle.md
+++ b/docs/en/demo/reviewer-evidence-bundle.md
@@ -6,6 +6,8 @@ For external auditors and design partners who want to preview strict Evidence Bu
 
 This is useful for external reviewers, investors, enterprise stakeholders, and technical evaluators who want to reproduce the CI evidence bundle locally with one command.
 
+For the reviewer documentation landing page and suggested reading order, see the [Reviewer Evidence Index](reviewer-evidence-index.md).
+
 ## Usage
 
 ```text

--- a/docs/en/demo/reviewer-evidence-index.md
+++ b/docs/en/demo/reviewer-evidence-index.md
@@ -1,0 +1,81 @@
+# Reviewer Evidence Index
+
+This page is the landing page for local/offline Reviewer Evidence documentation. It groups the reviewer-facing overview, packet contract, generated examples, schemas, and validation references so reviewers can follow the evidence model without jumping between unrelated docs.
+
+See also: [Reviewer Evidence Assurance Overview](reviewer-evidence-assurance-overview.md) and [Reviewer Evidence Packet v1](reviewer-evidence-packet.md).
+
+## Overview
+
+Reviewer Evidence documentation explains how deterministic demo artifacts help reviewers inspect governed outcomes, evidence-chain continuity, packet validation, and catalog-backed failure explanations.
+
+The reviewer evidence layer is documentation and validation only. It does not change runtime admissibility, governance policy behavior, FUJI fail-closed behavior, TrustLog persistence, schemas, validators, or generated artifacts.
+
+## Quick architecture summary
+
+```text
+Reviewer Evidence
+  ↓
+Evidence Chain
+  ↓
+Packet Validation
+  ↓
+Failure Reason Catalog
+  ↓
+Validation Report
+```
+
+## Reviewer Evidence Assurance Overview
+
+Start with the [Reviewer Evidence Assurance Overview](reviewer-evidence-assurance-overview.md) to understand the assurance boundary, layered model, component mapping, tamper coverage, and non-goals for reviewer evidence.
+
+## Reviewer Evidence Packet
+
+Use [Reviewer Evidence Packet v1](reviewer-evidence-packet.md) for the packet purpose, included evidence summaries, optional Evaluation Governance attachments, approval proof continuity rules, local/offline boundary, usage, and golden fixture guidance.
+
+## Failure Reason Catalog
+
+Failure reasons are stable machine-readable strings with reviewer-facing metadata. Use these catalog docs and examples when explaining validation failures:
+
+- [Generated failure reason catalog Markdown](examples/reviewer-failure-reason-catalog-v1/reviewer-failure-reason-catalog.generated.example.md)
+- [Generated failure reason catalog JSON](examples/reviewer-failure-reason-catalog-v1/reviewer-failure-reason-catalog.generated.example.json)
+- [Failure reason catalog schema](schemas/reviewer-failure-reason-catalog-v1.schema.json)
+
+## Validation
+
+Reviewer validation references are:
+
+- [Reviewer Evidence Packet Validation Report](reviewer-evidence-packet-validation-report.md)
+- [Reviewer Evidence Packet schema](schemas/reviewer-evidence-packet-v1.schema.json)
+- [Failure reason catalog schema](schemas/reviewer-failure-reason-catalog-v1.schema.json)
+
+## Generated Examples
+
+Generated examples are checked in for review and deterministic validation. This navigation PR does not regenerate them.
+
+- [Reviewer Evidence Packet generated example](examples/evaluation-governance-chain-reviewer-packet-v1/reviewer-evidence-packet.generated.example.json)
+- [Failure reason catalog Markdown example](examples/reviewer-failure-reason-catalog-v1/reviewer-failure-reason-catalog.generated.example.md)
+- [Failure reason catalog JSON example](examples/reviewer-failure-reason-catalog-v1/reviewer-failure-reason-catalog.generated.example.json)
+
+## Schemas
+
+Schema references for reviewer evidence artifacts are:
+
+- [Reviewer Evidence Packet v1 schema](schemas/reviewer-evidence-packet-v1.schema.json)
+- [Reviewer Failure Reason Catalog v1 schema](schemas/reviewer-failure-reason-catalog-v1.schema.json)
+
+## Suggested reading order
+
+1. [Reviewer Evidence Assurance Overview](reviewer-evidence-assurance-overview.md)
+2. [Reviewer Evidence Packet v1](reviewer-evidence-packet.md)
+3. [Reviewer failure reason catalog Markdown example](examples/reviewer-failure-reason-catalog-v1/reviewer-failure-reason-catalog.generated.example.md)
+4. [Reviewer failure reason catalog JSON example](examples/reviewer-failure-reason-catalog-v1/reviewer-failure-reason-catalog.generated.example.json)
+5. [Reviewer Evidence Packet generated example](examples/evaluation-governance-chain-reviewer-packet-v1/reviewer-evidence-packet.generated.example.json)
+6. [Reviewer Evidence Packet v1 schema](schemas/reviewer-evidence-packet-v1.schema.json)
+7. [Reviewer Failure Reason Catalog v1 schema](schemas/reviewer-failure-reason-catalog-v1.schema.json)
+8. [Reviewer Evidence Packet Validation Report](reviewer-evidence-packet-validation-report.md)
+
+## Related reviewer docs
+
+- [Reviewer Evidence Bundle v1](reviewer-evidence-bundle.md)
+- [External Reviewer Artifact Index v1](external-reviewer-artifact-index.md)
+- [External Reviewer Quickstart](external-reviewer-quickstart.md)

--- a/docs/en/demo/reviewer-evidence-packet.md
+++ b/docs/en/demo/reviewer-evidence-packet.md
@@ -1,5 +1,7 @@
 # Reviewer Evidence Packet v1
 
+See also: [Reviewer Evidence Index](reviewer-evidence-index.md) and [Reviewer Evidence Assurance Overview](reviewer-evidence-assurance-overview.md).
+
 Reviewer Evidence Packet v1 is a deterministic local/offline JSON-friendly export for the SaaS permission-change governed execution demo.
 
 It packages the existing demo output into one reviewer-facing artifact so external reviewers, investors, and enterprise stakeholders can inspect the main governance evidence without opening every internal artifact separately.


### PR DESCRIPTION
### Motivation

- Improve discoverability of scattered reviewer evidence documentation by providing a single landing/index that groups overview, packet contract, generated examples, schemas, validation references, and a suggested reading order. 
- This is a documentation-only change that must not alter runtime behavior, validators, schemas, or generated artifacts.

### Description

- Add a new landing page at `docs/en/demo/reviewer-evidence-index.md` containing an overview, a compact architecture summary diagram, generated examples, schema references, and a suggested reading order. 
- Add cross-links from `docs/en/demo/reviewer-evidence-assurance-overview.md` and `docs/en/demo/reviewer-evidence-packet.md` to the new index. 
- Add nearby navigation links from `docs/en/demo/reviewer-evidence-bundle.md` and `docs/en/demo/external-reviewer-artifact-index.md` pointing to the new index. 
- No runtime, schema, validator, or generated artifact changes were made; this PR only modifies documentation files.

### Testing

- Attempted to run `python scripts/check_relative_doc_links.py` but the repository pins `3.12.12` which was not available in the environment so the check could not be executed. 
- Attempted `PYENV_VERSION=3.12.13 python scripts/check_relative_doc_links.py` but the script path was not present in this checkout, so the canonical script did not run. 
- Ran an inline `python3` relative-link existence check over the touched Markdown files which passed and confirmed all internal links resolve to existing targets. 
- Ran `git diff --check` which passed with no whitespace or diff errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41ebb37c7c832688c8023a1eefdb6f)