### PR TITLE
docs: add Reviewer Evidence Documentation links to top-level READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ It is about making AI decisions **reviewable, traceable, replayable, auditable, 
 
 For external reviewers, start with `docs/REVIEWER_ENTRYPOINT.md`.
 
+## Reviewer Evidence Documentation
+
+For reviewer-facing evidence assurance, validation, failure reason taxonomy, generated catalogs, and demo validation reports, start here:
+
+- [Reviewer Evidence Index](docs/en/demo/reviewer-evidence-index.md)
+- [Reviewer Evidence Assurance Overview](docs/en/demo/reviewer-evidence-assurance-overview.md)
+- [Reviewer Evidence Packet](docs/en/demo/reviewer-evidence-packet.md)
+
 ## External reviewer fast path
 
 For a 10-minute implementation snapshot, start here:

--- a/README_JP.md
+++ b/README_JP.md
@@ -27,6 +27,14 @@ VERITAS OS は **Decision Governance and Bind-Boundary Control Plane for AI Agen
 
 外部レビュー担当者向けの入口は `docs/REVIEWER_ENTRYPOINT.md` を参照してください。
 
+## Reviewer Evidence Documentation
+
+Reviewer向けの証跡保証、検証、failure reason taxonomy、生成catalog、demo validation reportについては、以下から確認できます。
+
+- [Reviewer Evidence Index](docs/en/demo/reviewer-evidence-index.md)
+- [Reviewer Evidence Assurance Overview](docs/en/demo/reviewer-evidence-assurance-overview.md)
+- [Reviewer Evidence Packet](docs/en/demo/reviewer-evidence-packet.md)
+
 - **性能メトリクス**: [日本語補助](docs/ja/benchmarks/performance-metrics.md) / [英語正本](docs/en/benchmarks/performance-metrics.md)
 - **最新ローカル性能メトリクスartifact**: [日本語補助](docs/ja/benchmarks/local-performance-metrics.latest.md) / [英語正本](docs/en/benchmarks/local-performance-metrics.latest.md) / [JSON](docs/en/benchmarks/local-performance-metrics.latest.json)
 - **One-Day PoC証跡パック**: [日本語補助](docs/ja/poc/one-day-poc-evidence-pack.md) / [英語正本](docs/en/poc/one-day-poc-evidence-pack.md)


### PR DESCRIPTION
### Motivation
- Make the reviewer evidence documentation discoverable from the repository entrypoint so first-time visitors and external reviewers can find reviewer-facing assurance and validation docs quickly.

### Description
- Add a concise "Reviewer Evidence Documentation" section to `README.md` and `README_JP.md` that links to `docs/en/demo/reviewer-evidence-index.md`, `docs/en/demo/reviewer-evidence-assurance-overview.md`, and `docs/en/demo/reviewer-evidence-packet.md`.

### Testing
- Ran `git diff --check` and `PYTHONPATH=. python3 scripts/check_bilingual_docs.py`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a423ca927d88326a41347428a05ed95)