### PR TITLE
docs: add concise architecture overview to README(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,44 @@
 VERITAS OS is a **Decision Governance and Bind-Boundary Control Plane** for AI agents.
 Instead of passing model output directly to execution, VERITAS routes each decision through a **reproducible, fail-closed, safety-gated, hash-chained governance pipeline** with an operator-facing governance surface in **Mission Control** and governance APIs.
 
+## Architecture at a Glance
+
+```text
+AI / Agent Output
+  ↓
+Decision Candidate
+  ↓
+Governance Evaluation
+  ↓
+Human Approval / Authority Evidence
+  ↓
+Evidence Chain
+  ↓
+Bind Boundary
+  ↓
+Execution Intent
+  ↓
+Outcome Receipt
+  ↓
+Reviewer Evidence Packet
+  ↓
+Validation Report
+```
+
+| Layer | Purpose |
+| --- | --- |
+| Decision Candidate | Structured pre-execution decision object. |
+| Governance Evaluation | Policy, authority, evidence, and approval checks. |
+| Human Approval / Authority Evidence | Binds human authority and approval proof. |
+| Evidence Chain | Preserves hashes, manifests, and verification links. |
+| Bind Boundary | Final pre-execution control point. |
+| Execution Intent | Allowed action after governance checks. |
+| Outcome Receipt | Records the observed outcome. |
+| Reviewer Evidence Packet | Reviewer-facing evidence bundle. |
+| Validation Report | Deterministic validation result and failure reasons. |
+
+For deeper reviewer evidence context, see the [Reviewer Evidence Index](docs/en/demo/reviewer-evidence-index.md), [Reviewer Evidence Assurance Overview](docs/en/demo/reviewer-evidence-assurance-overview.md), and [Reviewer Evidence Packet](docs/en/demo/reviewer-evidence-packet.md).
+
 Official Website: https://veritas-website-navy.vercel.app/
 
 This project is not only about running agents.

--- a/README_JP.md
+++ b/README_JP.md
@@ -21,6 +21,44 @@
 VERITAS OS は **Decision Governance and Bind-Boundary Control Plane for AI Agents**（AIエージェント向け意思決定ガバナンス / bind-boundary 制御プレーン）です。
 エージェント実行の前段に **governance layer before execution** を置き、現実世界に影響する前に意思決定を制御します。これは、AIエージェントの意思決定と実行境界を統治するコントロールプレーンという現在のプロダクトポジショニングを示します。
 
+## アーキテクチャ概要
+
+```text
+AI / Agent Output
+  ↓
+Decision Candidate
+  ↓
+Governance Evaluation
+  ↓
+Human Approval / Authority Evidence
+  ↓
+Evidence Chain
+  ↓
+Bind Boundary
+  ↓
+Execution Intent
+  ↓
+Outcome Receipt
+  ↓
+Reviewer Evidence Packet
+  ↓
+Validation Report
+```
+
+| レイヤー | 目的 |
+| --- | --- |
+| Decision Candidate | 実行前の構造化された意思決定オブジェクト。 |
+| Governance Evaluation | ポリシー、権限、証跡、承認を確認する。 |
+| Human Approval / Authority Evidence | 人間の権限と承認証明を bind する。 |
+| Evidence Chain | ハッシュ、manifest、検証リンクを保持する。 |
+| Bind Boundary | 実行前の最終制御点。 |
+| Execution Intent | ガバナンス確認後に許可されたアクション。 |
+| Outcome Receipt | 観測された結果を記録する。 |
+| Reviewer Evidence Packet | レビュアー向けの証跡 bundle。 |
+| Validation Report | 決定論的な検証結果と failure reason。 |
+
+レビュアー向け証跡の詳細は、[Reviewer Evidence Index](docs/en/demo/reviewer-evidence-index.md)、[Reviewer Evidence Assurance Overview](docs/en/demo/reviewer-evidence-assurance-overview.md)、[Reviewer Evidence Packet](docs/en/demo/reviewer-evidence-packet.md) を参照してください。
+
 公式Webサイト: https://veritas-website-navy.vercel.app/
 
 > メンタルモデル: **LLM = CPU**、**VERITAS OS = その上に載る Decision Governance OS**


### PR DESCRIPTION
### Motivation
- Make the VERITAS architecture understandable from the repository top page and align README messaging with reviewer evidence docs and the public website.
- Provide a compact, scannable flow and short layer explanations to help reviewers and newcomers quickly locate deeper evidence artifacts.
- Security: this is a documentation-only change with no runtime/schema/validator modifications, but maintainers should verify that reviewer-facing links do not expose any sensitive material.

### Description
- Add an `## Architecture at a Glance` section to `README.md` containing the requested flow text block and a short `Layer | Purpose` table.
- Add the equivalent `## アーキテクチャ概要` section and Japanese table to `README_JP.md` to preserve bilingual parity.
- Link the architecture section to deeper reviewer-evidence docs: `docs/en/demo/reviewer-evidence-index.md`, `docs/en/demo/reviewer-evidence-assurance-overview.md`, and `docs/en/demo/reviewer-evidence-packet.md`.
- Files changed: `README.md` and `README_JP.md` (documentation-only changes, no code/schema/validator/artefact regeneration).

### Testing
- Ran `git diff --check` to validate whitespace and diff hygiene and it passed.
- Ran the local relative link / bilingual docs checker via `python3 scripts/quality/check_bilingual_docs.py` and it reported all checks passed.
- Scope validation: confirmed the change is documentation-only and did not modify runtime code, schemas, validators, or generated artifacts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a426f67cb808326bb92e315568775eb)