### PR TITLE
feat(bind): add fail-closed external webhook adapter

### DIFF
--- a/docs/en/guides/webhook-bind-adapter.md
+++ b/docs/en/guides/webhook-bind-adapter.md
@@ -1,0 +1,86 @@
+# Webhook Bind Adapter
+
+`WebhookBindAdapter` is a reference external bind adapter for evaluating VERITAS OS bind execution against an HTTPS webhook target. It connects an existing `ExecutionIntent` to the existing bind adjudication flow and does not create a new bind engine, API route, UI, SDK, or decorator.
+
+## Status and purpose
+
+This adapter is currently a prototype/evaluation reference for external bind integration. It is not certification, not regulatory approval, and not evidence of production customer deployment. Deployment-specific authentication, network policy, secret management, and mTLS remain integrator responsibilities.
+
+## Required three-endpoint flow
+
+The adapter uses three HTTPS endpoints:
+
+1. **Snapshot**: `GET snapshot_url` returns the current external state as a JSON object.
+2. **Action**: `POST action_url` applies the governed action payload.
+3. **Postcondition**: `GET postcondition_url` returns a JSON object that must recursively contain the configured expected postcondition.
+
+An optional compensation endpoint can be configured. Generic external effects may be irreversible. When compensation is absent, fails, or cannot be verified, rollback is not claimed.
+
+## HMAC request format
+
+Action and compensation requests are JSON `POST` requests with redirects disabled and a bounded timeout. Receivers should expect:
+
+```text
+Content-Type: application/json
+X-Veritas-Decision-Id: <decision id>
+X-Veritas-Execution-Intent-Id: <execution intent id>
+X-Veritas-Idempotency-Key: <deterministic adapter key>
+X-Veritas-Timestamp: <UTC timestamp>
+X-Veritas-Signature: sha256=<lowercase hex hmac-sha256>
+```
+
+The signature input is:
+
+```text
+X-Veritas-Timestamp + "." + canonical_json_body
+```
+
+The HMAC secret is never included in the idempotency key, target description, bind receipt, or response evidence.
+
+## Idempotency
+
+The adapter idempotency key is deterministic over the execution intent id, decision id, normalized action URL, and canonical action payload. It does not use Python `hash()`, current time, or the HMAC secret.
+
+## Sample receiver responses
+
+Snapshot response:
+
+```json
+{"account": {"status": "active", "limit": 100}}
+```
+
+Action response:
+
+```json
+{"accepted": true, "operation_id": "op-123"}
+```
+
+Postcondition response:
+
+```json
+{"account": {"status": "active", "limit": 120}}
+```
+
+With `expected_postcondition={"account": {"limit": 120}}`, the postcondition passes because the expected object is a recursive subset of the returned object.
+
+## Fail-closed behavior
+
+The adapter fails closed on timeout, connection failure, malformed JSON, non-object JSON, non-2xx responses, unverifiable postconditions, unsafe URLs, missing approval, constraint failure, or runtime-risk failure. BLOCKED and ESCALATED decisions do not execute the action webhook.
+
+Outbound URL validation is intentionally restrictive by default:
+
+- HTTPS only
+- explicit host allowlist required
+- no URL userinfo
+- no fragments
+- malformed ports rejected
+- redirects disabled
+- localhost, loopback, link-local, multicast, unspecified, private, and reserved addresses rejected unless a narrowly scoped test/deployment option is enabled
+
+## What is not yet provided
+
+This PR does not provide a separate SDK package, `@veritas.govern` decorator, public API route, UI, customer demo, production-readiness claim, certification claim, or regulatory approval claim.
+
+## Planned SDK layer
+
+A later SDK layer can wrap receiver scaffolding, secret management guidance, mTLS integration patterns, and developer ergonomics around this reference adapter without changing the bind core semantics.

--- a/docs/en/guides/webhook-bind-adapter.md
+++ b/docs/en/guides/webhook-bind-adapter.md
@@ -16,6 +16,11 @@ The adapter uses three HTTPS endpoints:
 
 An optional compensation endpoint can be configured. Generic external effects may be irreversible. When compensation is absent, fails, or cannot be verified, rollback is not claimed.
 
+Drift-sensitive execution requires the `ExecutionIntent` to carry the
+decision-time `expected_state_fingerprint`. The adapter fingerprints the live
+snapshot with canonical JSON and SHA-256; a missing or mismatched expected
+fingerprint fails closed before the action endpoint is called.
+
 ## HMAC request format
 
 Action and compensation requests are JSON `POST` requests with redirects disabled and a bounded timeout. Receivers should expect:
@@ -67,6 +72,11 @@ With `expected_postcondition={"account": {"limit": 120}}`, the postcondition pas
 
 The adapter fails closed on timeout, connection failure, malformed JSON, non-object JSON, non-2xx responses, unverifiable postconditions, unsafe URLs, missing approval, constraint failure, or runtime-risk failure. BLOCKED and ESCALATED decisions do not execute the action webhook.
 
+Rollback is claimed only after a successful compensation response is followed
+by a fresh snapshot whose canonical fingerprint exactly matches the original
+pre-bind snapshot. A successful compensation HTTP response alone is not proof
+that an external effect was restored.
+
 Outbound URL validation is intentionally restrictive by default:
 
 - HTTPS only
@@ -75,7 +85,11 @@ Outbound URL validation is intentionally restrictive by default:
 - no fragments
 - malformed ports rejected
 - redirects disabled
-- localhost, loopback, link-local, multicast, unspecified, private, and reserved addresses rejected unless a narrowly scoped test/deployment option is enabled
+- localhost, loopback, link-local, multicast, unspecified, private, and reserved addresses rejected
+
+These controls reduce common outbound request and SSRF risks, but they are not
+a claim of complete SSRF resistance. Integrators must also enforce
+deployment-specific egress and DNS policy.
 
 ## What is not yet provided
 

--- a/tests/policy/test_webhook_bind_adapter.py
+++ b/tests/policy/test_webhook_bind_adapter.py
@@ -2,16 +2,22 @@
 
 from __future__ import annotations
 
+import hashlib
+import hmac
 import json
 from dataclasses import dataclass, field
 from typing import Any, Mapping
 
 import pytest
 
-from veritas_os.policy.bind_artifacts import ExecutionIntent, FinalOutcome, canonical_bind_receipt_json
+from veritas_os.policy.bind_artifacts import (
+    ExecutionIntent,
+    FinalOutcome,
+    canonical_bind_receipt_json,
+)
 from veritas_os.policy.bind_core import BindAdapterContract, execute_bind_adjudication
 from veritas_os.policy.webhook_bind_adapter import WebhookBindAdapter, WebhookResponse
-from veritas_os.security.hash import sha256_of_canonical_json
+from veritas_os.security.hash import canonical_json_dumps, sha256_of_canonical_json
 
 
 class TransportError(RuntimeError):
@@ -52,7 +58,9 @@ class FakeTransport:
         return response
 
     def count(self, method: str, url: str) -> int:
-        return sum(1 for call in self.calls if call["method"] == method and call["url"] == url)
+        return sum(
+            1 for call in self.calls if call["method"] == method and call["url"] == url
+        )
 
 
 PUBLIC_IP = ["93.184.216.34"]
@@ -74,6 +82,7 @@ def intent(**overrides: Any) -> ExecutionIntent:
         "intended_action": "external_webhook_action",
         "decision_hash": "a" * 64,
         "decision_ts": "2026-07-13T00:00:00Z",
+        "expected_state_fingerprint": sha256_of_canonical_json({"state": "before"}),
         "approval_context": {"external_webhook_action_approved": True},
     }
     values.update(overrides)
@@ -83,14 +92,21 @@ def intent(**overrides: Any) -> ExecutionIntent:
 def transport_for_success() -> FakeTransport:
     return FakeTransport(
         {
-            ("GET", SNAPSHOT_URL): [WebhookResponse(200, {"state": "before"}), WebhookResponse(200, {"state": "after"})],
+            ("GET", SNAPSHOT_URL): [
+                WebhookResponse(200, {"state": "before"}),
+                WebhookResponse(200, {"state": "after"}),
+            ],
             ("POST", ACTION_URL): [WebhookResponse(200, {"accepted": True})],
-            ("GET", POSTCONDITION_URL): [WebhookResponse(200, {"state": "after", "nested": {"ok": True}})],
+            ("GET", POSTCONDITION_URL): [
+                WebhookResponse(200, {"state": "after", "nested": {"ok": True}})
+            ],
         }
     )
 
 
-def adapter(transport: FakeTransport | None = None, **overrides: Any) -> WebhookBindAdapter:
+def adapter(
+    transport: FakeTransport | None = None, **overrides: Any
+) -> WebhookBindAdapter:
     values = {
         "snapshot_url": SNAPSHOT_URL,
         "action_url": ACTION_URL,
@@ -118,7 +134,12 @@ def test_contract_fingerprint_and_sanitized_description() -> None:
 def test_authority_requires_explicit_true() -> None:
     subject = adapter()
     assert subject.validate_authority(intent(), {}) is True
-    assert subject.validate_authority(intent(approval_context={"external_webhook_action_approved": False}), {}) is False
+    assert (
+        subject.validate_authority(
+            intent(approval_context={"external_webhook_action_approved": False}), {}
+        )
+        is False
+    )
     assert subject.validate_authority(intent(approval_context={}), {}) is False
     assert subject.validate_authority(intent(approval_context=None), {}) is False
 
@@ -155,8 +176,28 @@ def test_successful_governed_execution_commits_and_posts_once() -> None:
     assert call["allow_redirects"] is False
     assert call["headers"]["X-Veritas-Decision-Id"] == "dec-1"
     assert call["headers"]["X-Veritas-Execution-Intent-Id"] == "ei-1"
-    assert call["headers"]["X-Veritas-Signature"].startswith("sha256=")
+    timestamp = call["headers"]["X-Veritas-Timestamp"]
+    signed = f"{timestamp}.{canonical_json_dumps(call['json_body'])}".encode()
+    expected_signature = hmac.new(b"super-secret", signed, hashlib.sha256).hexdigest()
+    assert call["headers"]["X-Veritas-Signature"] == f"sha256={expected_signature}"
     assert "super-secret" not in json.dumps(call)
+
+
+@pytest.mark.parametrize(
+    "expected_fingerprint",
+    [None, sha256_of_canonical_json({"state": "different"})],
+)
+def test_missing_or_mismatched_drift_fingerprint_blocks_action(
+    expected_fingerprint: str | None,
+) -> None:
+    fake = transport_for_success()
+    receipt = execute_bind_adjudication(
+        execution_intent=intent(expected_state_fingerprint=expected_fingerprint),
+        adapter=adapter(fake),
+        append_trustlog=False,
+    )
+    assert receipt.final_outcome is FinalOutcome.BLOCKED
+    assert fake.count("POST", ACTION_URL) == 0
 
 
 def test_constraint_and_runtime_risk_failures_prevent_action_post() -> None:
@@ -174,15 +215,42 @@ def test_constraint_and_runtime_risk_failures_prevent_action_post() -> None:
         assert fake.count("POST", ACTION_URL) == 0
 
 
+def test_non_dict_compensation_payload_blocks_before_action() -> None:
+    fake = transport_for_success()
+    subject = adapter(
+        fake,
+        compensation_url=COMPENSATION_URL,
+        compensation_payload=[],  # type: ignore[arg-type]
+    )
+    receipt = execute_bind_adjudication(
+        execution_intent=intent(),
+        adapter=subject,
+        append_trustlog=False,
+    )
+    assert receipt.final_outcome is FinalOutcome.BLOCKED
+    assert fake.count("POST", ACTION_URL) == 0
+
+
 @pytest.mark.parametrize(
     "responses,expected",
     [
-        ({("GET", SNAPSHOT_URL): [TransportError("timeout")]}, FinalOutcome.SNAPSHOT_FAILED),
-        ({("GET", SNAPSHOT_URL): [WebhookResponse(200, [])]}, FinalOutcome.SNAPSHOT_FAILED),
-        ({("GET", SNAPSHOT_URL): [WebhookResponse(500, {})]}, FinalOutcome.SNAPSHOT_FAILED),
+        (
+            {("GET", SNAPSHOT_URL): [TransportError("timeout")]},
+            FinalOutcome.SNAPSHOT_FAILED,
+        ),
+        (
+            {("GET", SNAPSHOT_URL): [WebhookResponse(200, [])]},
+            FinalOutcome.SNAPSHOT_FAILED,
+        ),
+        (
+            {("GET", SNAPSHOT_URL): [WebhookResponse(500, {})]},
+            FinalOutcome.SNAPSHOT_FAILED,
+        ),
     ],
 )
-def test_snapshot_failures_fail_closed(responses: dict[tuple[str, str], list[Any]], expected: FinalOutcome) -> None:
+def test_snapshot_failures_fail_closed(
+    responses: dict[tuple[str, str], list[Any]], expected: FinalOutcome
+) -> None:
     fake = FakeTransport(responses)
     receipt = execute_bind_adjudication(
         execution_intent=intent(),
@@ -195,9 +263,16 @@ def test_snapshot_failures_fail_closed(responses: dict[tuple[str, str], list[Any
 
 @pytest.mark.parametrize(
     "action_response",
-    [TransportError("timeout"), WebhookResponse(500, {}), WebhookResponse(302, {"redirect": True}), WebhookResponse(200, [])],
+    [
+        TransportError("timeout"),
+        WebhookResponse(500, {}),
+        WebhookResponse(302, {"redirect": True}),
+        WebhookResponse(200, []),
+    ],
 )
-def test_action_failures_are_not_committed_and_do_not_retry(action_response: Any) -> None:
+def test_action_failures_are_not_committed_and_do_not_retry(
+    action_response: Any,
+) -> None:
     fake = FakeTransport(
         {
             ("GET", SNAPSHOT_URL): [WebhookResponse(200, {"state": "before"})],
@@ -215,9 +290,16 @@ def test_action_failures_are_not_committed_and_do_not_retry(action_response: Any
 
 @pytest.mark.parametrize(
     "postcondition_response",
-    [TransportError("timeout"), WebhookResponse(500, {}), WebhookResponse(200, []), WebhookResponse(200, {"nested": {"ok": False}})],
+    [
+        TransportError("timeout"),
+        WebhookResponse(500, {}),
+        WebhookResponse(200, []),
+        WebhookResponse(200, {"nested": {"ok": False}}),
+    ],
 )
-def test_postcondition_failures_do_not_commit_without_compensation(postcondition_response: Any) -> None:
+def test_postcondition_failures_do_not_commit_without_compensation(
+    postcondition_response: Any,
+) -> None:
     fake = FakeTransport(
         {
             ("GET", SNAPSHOT_URL): [WebhookResponse(200, {"state": "before"})],
@@ -231,18 +313,24 @@ def test_postcondition_failures_do_not_commit_without_compensation(postcondition
         append_trustlog=False,
     )
     assert receipt.final_outcome is FinalOutcome.ESCALATED
-    assert receipt.rollback_status == "manual_intervention_required"
+    assert receipt.rollback_status != "rolled_back"
 
 
 def test_idempotency_key_is_deterministic_and_excludes_secret() -> None:
     first = adapter(hmac_secret="secret-a")
     second = adapter(hmac_secret="secret-b")
     changed = adapter(hmac_secret="secret-a", action_payload={"op": "set", "value": 2})
-    assert first.build_idempotency_key(intent()) == second.build_idempotency_key(intent())
-    assert first.build_idempotency_key(intent()) != changed.build_idempotency_key(intent())
+    assert first.build_idempotency_key(intent()) == second.build_idempotency_key(
+        intent()
+    )
+    assert first.build_idempotency_key(intent()) != changed.build_idempotency_key(
+        intent()
+    )
 
 
-def test_replay_does_not_duplicate_external_post(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_replay_does_not_duplicate_external_post(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     import veritas_os.policy.bind_core.core as core
 
     first_fake = transport_for_success()
@@ -266,19 +354,49 @@ def test_replay_does_not_duplicate_external_post(monkeypatch: pytest.MonkeyPatch
 def test_successful_compensation_reports_rolled_back() -> None:
     fake = FakeTransport(
         {
-            ("GET", SNAPSHOT_URL): [WebhookResponse(200, {"state": "before"}), WebhookResponse(200, {"state": "compensated"})],
+            ("GET", SNAPSHOT_URL): [
+                WebhookResponse(200, {"state": "before"}),
+                WebhookResponse(200, {"state": "before"}),
+            ],
             ("POST", ACTION_URL): [WebhookResponse(200, {"accepted": True})],
-            ("GET", POSTCONDITION_URL): [WebhookResponse(200, {"nested": {"ok": False}})],
+            ("GET", POSTCONDITION_URL): [
+                WebhookResponse(200, {"nested": {"ok": False}})
+            ],
             ("POST", COMPENSATION_URL): [WebhookResponse(200, {"compensated": True})],
         }
     )
     receipt = execute_bind_adjudication(
         execution_intent=intent(),
-        adapter=adapter(fake, compensation_url=COMPENSATION_URL, compensation_payload={"undo": True}),
+        adapter=adapter(
+            fake, compensation_url=COMPENSATION_URL, compensation_payload={"undo": True}
+        ),
         append_trustlog=False,
     )
     assert receipt.final_outcome is FinalOutcome.ROLLED_BACK
     assert fake.count("POST", COMPENSATION_URL) == 1
+
+
+def test_unverified_compensation_does_not_claim_rollback() -> None:
+    fake = FakeTransport(
+        {
+            ("GET", SNAPSHOT_URL): [
+                WebhookResponse(200, {"state": "before"}),
+                WebhookResponse(200, {"state": "compensated"}),
+            ],
+            ("POST", ACTION_URL): [WebhookResponse(200, {"accepted": True})],
+            ("GET", POSTCONDITION_URL): [
+                WebhookResponse(200, {"nested": {"ok": False}})
+            ],
+            ("POST", COMPENSATION_URL): [WebhookResponse(200, {"compensated": True})],
+        }
+    )
+    receipt = execute_bind_adjudication(
+        execution_intent=intent(),
+        adapter=adapter(fake, compensation_url=COMPENSATION_URL),
+        append_trustlog=False,
+    )
+    assert receipt.final_outcome is FinalOutcome.ESCALATED
+    assert receipt.rollback_status != "rolled_back"
 
 
 def test_failed_compensation_does_not_claim_rollback() -> None:
@@ -286,7 +404,9 @@ def test_failed_compensation_does_not_claim_rollback() -> None:
         {
             ("GET", SNAPSHOT_URL): [WebhookResponse(200, {"state": "before"})],
             ("POST", ACTION_URL): [WebhookResponse(200, {"accepted": True})],
-            ("GET", POSTCONDITION_URL): [WebhookResponse(200, {"nested": {"ok": False}})],
+            ("GET", POSTCONDITION_URL): [
+                WebhookResponse(200, {"nested": {"ok": False}})
+            ],
             ("POST", COMPENSATION_URL): [WebhookResponse(500, {})],
         }
     )
@@ -296,7 +416,62 @@ def test_failed_compensation_does_not_claim_rollback() -> None:
         append_trustlog=False,
     )
     assert receipt.final_outcome is FinalOutcome.ESCALATED
-    assert receipt.rollback_status == "manual_intervention_required"
+    assert receipt.rollback_status != "rolled_back"
+
+
+@pytest.mark.parametrize(
+    "compensation_response",
+    [TransportError("timeout"), WebhookResponse(500, {}), WebhookResponse(200, [])],
+)
+def test_compensation_transport_failures_do_not_claim_rollback(
+    compensation_response: WebhookResponse | Exception,
+) -> None:
+    fake = FakeTransport(
+        {
+            ("GET", SNAPSHOT_URL): [WebhookResponse(200, {"state": "before"})],
+            ("POST", ACTION_URL): [WebhookResponse(200, {"accepted": True})],
+            ("GET", POSTCONDITION_URL): [
+                WebhookResponse(200, {"nested": {"ok": False}})
+            ],
+            ("POST", COMPENSATION_URL): [compensation_response],
+        }
+    )
+    receipt = execute_bind_adjudication(
+        execution_intent=intent(),
+        adapter=adapter(fake, compensation_url=COMPENSATION_URL),
+        append_trustlog=False,
+    )
+    assert receipt.final_outcome is FinalOutcome.ESCALATED
+    assert receipt.rollback_status != "rolled_back"
+
+
+@pytest.mark.parametrize(
+    "verification_response",
+    [TransportError("timeout"), WebhookResponse(500, {}), WebhookResponse(200, [])],
+)
+def test_compensation_verification_failures_do_not_claim_rollback(
+    verification_response: WebhookResponse | Exception,
+) -> None:
+    fake = FakeTransport(
+        {
+            ("GET", SNAPSHOT_URL): [
+                WebhookResponse(200, {"state": "before"}),
+                verification_response,
+            ],
+            ("POST", ACTION_URL): [WebhookResponse(200, {"accepted": True})],
+            ("GET", POSTCONDITION_URL): [
+                WebhookResponse(200, {"nested": {"ok": False}})
+            ],
+            ("POST", COMPENSATION_URL): [WebhookResponse(200, {"compensated": True})],
+        }
+    )
+    receipt = execute_bind_adjudication(
+        execution_intent=intent(),
+        adapter=adapter(fake, compensation_url=COMPENSATION_URL),
+        append_trustlog=False,
+    )
+    assert receipt.final_outcome is FinalOutcome.ESCALATED
+    assert receipt.rollback_status != "rolled_back"
 
 
 @pytest.mark.parametrize(
@@ -306,6 +481,7 @@ def test_failed_compensation_does_not_claim_rollback() -> None:
         {"action_url": "https://evil.example.test/action"},
         {"action_url": "https://user:pass@hooks.example.test/action"},
         {"action_url": "https://hooks.example.test/action#frag"},
+        {"action_url": "https://hooks.example.test:invalid/action"},
         {"dns_resolver": lambda hostname: ["127.0.0.1"]},
         {"dns_resolver": lambda hostname: ["10.0.0.1"]},
         {"dns_resolver": lambda hostname: ["169.254.1.1"]},
@@ -314,12 +490,40 @@ def test_failed_compensation_does_not_claim_rollback() -> None:
 def test_url_security_rejections_prevent_action(kwargs: dict[str, Any]) -> None:
     subject = adapter(**kwargs)
     fake = subject.transport
+    assert subject.build_idempotency_key(intent()) == subject.build_idempotency_key(
+        intent()
+    )
     receipt = execute_bind_adjudication(
         execution_intent=intent(),
         adapter=subject,
         append_trustlog=False,
     )
     assert receipt.final_outcome in {FinalOutcome.BLOCKED, FinalOutcome.SNAPSHOT_FAILED}
+    assert fake.count("POST", ACTION_URL) == 0
+
+
+@pytest.mark.parametrize(
+    "decision_context",
+    [
+        {"external_webhook_action_approved": True, "business_decision": "block"},
+        {"external_webhook_action_approved": True, "bind_decision": "escalate"},
+    ],
+)
+def test_decision_precedence_prevents_action(
+    decision_context: dict[str, Any],
+) -> None:
+    fake = transport_for_success()
+    receipt = execute_bind_adjudication(
+        execution_intent=intent(approval_context=decision_context),
+        adapter=adapter(fake),
+        append_trustlog=False,
+    )
+    expected = (
+        FinalOutcome.ESCALATED
+        if decision_context.get("bind_decision") == "escalate"
+        else FinalOutcome.BLOCKED
+    )
+    assert receipt.final_outcome is expected
     assert fake.count("POST", ACTION_URL) == 0
 
 

--- a/tests/policy/test_webhook_bind_adapter.py
+++ b/tests/policy/test_webhook_bind_adapter.py
@@ -1,0 +1,337 @@
+"""Tests for the fail-closed webhook bind adapter."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+import pytest
+
+from veritas_os.policy.bind_artifacts import ExecutionIntent, FinalOutcome, canonical_bind_receipt_json
+from veritas_os.policy.bind_core import BindAdapterContract, execute_bind_adjudication
+from veritas_os.policy.webhook_bind_adapter import WebhookBindAdapter, WebhookResponse
+from veritas_os.security.hash import sha256_of_canonical_json
+
+
+class TransportError(RuntimeError):
+    pass
+
+
+@dataclass
+class FakeTransport:
+    responses: dict[tuple[str, str], list[WebhookResponse | Exception]]
+    calls: list[dict[str, Any]] = field(default_factory=list)
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: Mapping[str, str] | None = None,
+        json_body: Mapping[str, Any] | None = None,
+        timeout: float,
+        allow_redirects: bool = False,
+    ) -> WebhookResponse:
+        self.calls.append(
+            {
+                "method": method,
+                "url": url,
+                "headers": dict(headers or {}),
+                "json_body": dict(json_body or {}),
+                "timeout": timeout,
+                "allow_redirects": allow_redirects,
+            }
+        )
+        queued = self.responses.get((method, url), [])
+        if not queued:
+            raise TransportError(f"unexpected call: {method} {url}")
+        response = queued.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    def count(self, method: str, url: str) -> int:
+        return sum(1 for call in self.calls if call["method"] == method and call["url"] == url)
+
+
+PUBLIC_IP = ["93.184.216.34"]
+SNAPSHOT_URL = "https://hooks.example.test/snapshot?token=secret"
+ACTION_URL = "https://hooks.example.test/action?token=secret"
+POSTCONDITION_URL = "https://hooks.example.test/postcondition?token=secret"
+COMPENSATION_URL = "https://hooks.example.test/compensate?token=secret"
+
+
+def intent(**overrides: Any) -> ExecutionIntent:
+    values = {
+        "execution_intent_id": "ei-1",
+        "decision_id": "dec-1",
+        "request_id": "req-1",
+        "policy_snapshot_id": "snap-1",
+        "actor_identity": "ops",
+        "target_system": "external_webhook",
+        "target_resource": "hooks.example.test/action",
+        "intended_action": "external_webhook_action",
+        "decision_hash": "a" * 64,
+        "decision_ts": "2026-07-13T00:00:00Z",
+        "approval_context": {"external_webhook_action_approved": True},
+    }
+    values.update(overrides)
+    return ExecutionIntent(**values)
+
+
+def transport_for_success() -> FakeTransport:
+    return FakeTransport(
+        {
+            ("GET", SNAPSHOT_URL): [WebhookResponse(200, {"state": "before"}), WebhookResponse(200, {"state": "after"})],
+            ("POST", ACTION_URL): [WebhookResponse(200, {"accepted": True})],
+            ("GET", POSTCONDITION_URL): [WebhookResponse(200, {"state": "after", "nested": {"ok": True}})],
+        }
+    )
+
+
+def adapter(transport: FakeTransport | None = None, **overrides: Any) -> WebhookBindAdapter:
+    values = {
+        "snapshot_url": SNAPSHOT_URL,
+        "action_url": ACTION_URL,
+        "postcondition_url": POSTCONDITION_URL,
+        "action_payload": {"op": "set", "value": 1},
+        "expected_postcondition": {"nested": {"ok": True}},
+        "allowed_hosts": {"hooks.example.test"},
+        "hmac_secret": "super-secret",
+        "transport": transport or transport_for_success(),
+        "dns_resolver": lambda hostname: PUBLIC_IP,
+    }
+    values.update(overrides)
+    return WebhookBindAdapter(**values)
+
+
+def test_contract_fingerprint_and_sanitized_description() -> None:
+    subject = adapter()
+    assert isinstance(subject, BindAdapterContract)
+    snapshot = {"b": 2, "a": 1}
+    assert subject.fingerprint_state(snapshot) == sha256_of_canonical_json(snapshot)
+    assert "token=secret" not in subject.describe_target()
+    assert "super-secret" not in repr(subject)
+
+
+def test_authority_requires_explicit_true() -> None:
+    subject = adapter()
+    assert subject.validate_authority(intent(), {}) is True
+    assert subject.validate_authority(intent(approval_context={"external_webhook_action_approved": False}), {}) is False
+    assert subject.validate_authority(intent(approval_context={}), {}) is False
+    assert subject.validate_authority(intent(approval_context=None), {}) is False
+
+
+@pytest.mark.parametrize(
+    "approval_context",
+    [
+        {"external_webhook_action_approved": False},
+        {},
+        None,
+    ],
+)
+def test_authority_failure_prevents_action_post(approval_context: Any) -> None:
+    fake = transport_for_success()
+    receipt = execute_bind_adjudication(
+        execution_intent=intent(approval_context=approval_context),
+        adapter=adapter(fake),
+        append_trustlog=False,
+    )
+    assert receipt.final_outcome is FinalOutcome.BLOCKED
+    assert fake.count("POST", ACTION_URL) == 0
+
+
+def test_successful_governed_execution_commits_and_posts_once() -> None:
+    fake = transport_for_success()
+    receipt = execute_bind_adjudication(
+        execution_intent=intent(),
+        adapter=adapter(fake),
+        append_trustlog=False,
+    )
+    assert receipt.final_outcome is FinalOutcome.COMMITTED
+    assert fake.count("POST", ACTION_URL) == 1
+    call = next(call for call in fake.calls if call["method"] == "POST")
+    assert call["allow_redirects"] is False
+    assert call["headers"]["X-Veritas-Decision-Id"] == "dec-1"
+    assert call["headers"]["X-Veritas-Execution-Intent-Id"] == "ei-1"
+    assert call["headers"]["X-Veritas-Signature"].startswith("sha256=")
+    assert "super-secret" not in json.dumps(call)
+
+
+def test_constraint_and_runtime_risk_failures_prevent_action_post() -> None:
+    for subject in [
+        adapter(action_payload=[]),
+        adapter(action_url="https://evil.example.test/action"),
+    ]:
+        fake = subject.transport
+        receipt = execute_bind_adjudication(
+            execution_intent=intent(),
+            adapter=subject,
+            append_trustlog=False,
+        )
+        assert receipt.final_outcome is FinalOutcome.BLOCKED
+        assert fake.count("POST", ACTION_URL) == 0
+
+
+@pytest.mark.parametrize(
+    "responses,expected",
+    [
+        ({("GET", SNAPSHOT_URL): [TransportError("timeout")]}, FinalOutcome.SNAPSHOT_FAILED),
+        ({("GET", SNAPSHOT_URL): [WebhookResponse(200, [])]}, FinalOutcome.SNAPSHOT_FAILED),
+        ({("GET", SNAPSHOT_URL): [WebhookResponse(500, {})]}, FinalOutcome.SNAPSHOT_FAILED),
+    ],
+)
+def test_snapshot_failures_fail_closed(responses: dict[tuple[str, str], list[Any]], expected: FinalOutcome) -> None:
+    fake = FakeTransport(responses)
+    receipt = execute_bind_adjudication(
+        execution_intent=intent(),
+        adapter=adapter(fake),
+        append_trustlog=False,
+    )
+    assert receipt.final_outcome is expected
+    assert fake.count("POST", ACTION_URL) == 0
+
+
+@pytest.mark.parametrize(
+    "action_response",
+    [TransportError("timeout"), WebhookResponse(500, {}), WebhookResponse(302, {"redirect": True}), WebhookResponse(200, [])],
+)
+def test_action_failures_are_not_committed_and_do_not_retry(action_response: Any) -> None:
+    fake = FakeTransport(
+        {
+            ("GET", SNAPSHOT_URL): [WebhookResponse(200, {"state": "before"})],
+            ("POST", ACTION_URL): [action_response],
+        }
+    )
+    receipt = execute_bind_adjudication(
+        execution_intent=intent(),
+        adapter=adapter(fake),
+        append_trustlog=False,
+    )
+    assert receipt.final_outcome is FinalOutcome.APPLY_FAILED
+    assert fake.count("POST", ACTION_URL) == 1
+
+
+@pytest.mark.parametrize(
+    "postcondition_response",
+    [TransportError("timeout"), WebhookResponse(500, {}), WebhookResponse(200, []), WebhookResponse(200, {"nested": {"ok": False}})],
+)
+def test_postcondition_failures_do_not_commit_without_compensation(postcondition_response: Any) -> None:
+    fake = FakeTransport(
+        {
+            ("GET", SNAPSHOT_URL): [WebhookResponse(200, {"state": "before"})],
+            ("POST", ACTION_URL): [WebhookResponse(200, {"accepted": True})],
+            ("GET", POSTCONDITION_URL): [postcondition_response],
+        }
+    )
+    receipt = execute_bind_adjudication(
+        execution_intent=intent(),
+        adapter=adapter(fake),
+        append_trustlog=False,
+    )
+    assert receipt.final_outcome is FinalOutcome.ESCALATED
+    assert receipt.rollback_status == "manual_intervention_required"
+
+
+def test_idempotency_key_is_deterministic_and_excludes_secret() -> None:
+    first = adapter(hmac_secret="secret-a")
+    second = adapter(hmac_secret="secret-b")
+    changed = adapter(hmac_secret="secret-a", action_payload={"op": "set", "value": 2})
+    assert first.build_idempotency_key(intent()) == second.build_idempotency_key(intent())
+    assert first.build_idempotency_key(intent()) != changed.build_idempotency_key(intent())
+
+
+def test_replay_does_not_duplicate_external_post(monkeypatch: pytest.MonkeyPatch) -> None:
+    import veritas_os.policy.bind_core.core as core
+
+    first_fake = transport_for_success()
+    first = execute_bind_adjudication(
+        execution_intent=intent(),
+        adapter=adapter(first_fake),
+        append_trustlog=False,
+    )
+    monkeypatch.setattr(core, "_idempotency_replay_enabled", lambda **_: True)
+    monkeypatch.setattr(core, "_find_duplicate_bind_receipt", lambda **_: first)
+    replay_fake = transport_for_success()
+    replay = execute_bind_adjudication(
+        execution_intent=intent(),
+        adapter=adapter(replay_fake),
+        append_trustlog=True,
+    )
+    assert replay.idempotency_status == "replayed"
+    assert replay_fake.count("POST", ACTION_URL) == 0
+
+
+def test_successful_compensation_reports_rolled_back() -> None:
+    fake = FakeTransport(
+        {
+            ("GET", SNAPSHOT_URL): [WebhookResponse(200, {"state": "before"}), WebhookResponse(200, {"state": "compensated"})],
+            ("POST", ACTION_URL): [WebhookResponse(200, {"accepted": True})],
+            ("GET", POSTCONDITION_URL): [WebhookResponse(200, {"nested": {"ok": False}})],
+            ("POST", COMPENSATION_URL): [WebhookResponse(200, {"compensated": True})],
+        }
+    )
+    receipt = execute_bind_adjudication(
+        execution_intent=intent(),
+        adapter=adapter(fake, compensation_url=COMPENSATION_URL, compensation_payload={"undo": True}),
+        append_trustlog=False,
+    )
+    assert receipt.final_outcome is FinalOutcome.ROLLED_BACK
+    assert fake.count("POST", COMPENSATION_URL) == 1
+
+
+def test_failed_compensation_does_not_claim_rollback() -> None:
+    fake = FakeTransport(
+        {
+            ("GET", SNAPSHOT_URL): [WebhookResponse(200, {"state": "before"})],
+            ("POST", ACTION_URL): [WebhookResponse(200, {"accepted": True})],
+            ("GET", POSTCONDITION_URL): [WebhookResponse(200, {"nested": {"ok": False}})],
+            ("POST", COMPENSATION_URL): [WebhookResponse(500, {})],
+        }
+    )
+    receipt = execute_bind_adjudication(
+        execution_intent=intent(),
+        adapter=adapter(fake, compensation_url=COMPENSATION_URL),
+        append_trustlog=False,
+    )
+    assert receipt.final_outcome is FinalOutcome.ESCALATED
+    assert receipt.rollback_status == "manual_intervention_required"
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"action_url": "http://hooks.example.test/action"},
+        {"action_url": "https://evil.example.test/action"},
+        {"action_url": "https://user:pass@hooks.example.test/action"},
+        {"action_url": "https://hooks.example.test/action#frag"},
+        {"dns_resolver": lambda hostname: ["127.0.0.1"]},
+        {"dns_resolver": lambda hostname: ["10.0.0.1"]},
+        {"dns_resolver": lambda hostname: ["169.254.1.1"]},
+    ],
+)
+def test_url_security_rejections_prevent_action(kwargs: dict[str, Any]) -> None:
+    subject = adapter(**kwargs)
+    fake = subject.transport
+    receipt = execute_bind_adjudication(
+        execution_intent=intent(),
+        adapter=subject,
+        append_trustlog=False,
+    )
+    assert receipt.final_outcome in {FinalOutcome.BLOCKED, FinalOutcome.SNAPSHOT_FAILED}
+    assert fake.count("POST", ACTION_URL) == 0
+
+
+def test_secret_absent_from_errors_and_receipt() -> None:
+    fake = FakeTransport({("GET", SNAPSHOT_URL): [TransportError("super-secret")]})
+    receipt = execute_bind_adjudication(
+        execution_intent=intent(),
+        adapter=adapter(fake),
+        append_trustlog=False,
+    )
+    serialized = canonical_bind_receipt_json(receipt)
+    assert "super-secret" not in serialized
+    with pytest.raises(RuntimeError) as excinfo:
+        adapter(fake)._request("GET", SNAPSHOT_URL, headers={}, json_body=None)
+    assert "super-secret" not in str(excinfo.value)

--- a/veritas_os/policy/__init__.py
+++ b/veritas_os/policy/__init__.py
@@ -18,6 +18,7 @@ from .bind_artifacts import (
     hash_execution_intent,
 )
 from .bind_boundary_adapters import PolicyBundlePromotionAdapter
+from .webhook_bind_adapter import WebhookBindAdapter
 from .bind_core import (
     BIND_OUTCOME_VALUES,
     BindAdapterContract,
@@ -94,6 +95,7 @@ __all__ = [
     "BindBoundaryAdapter",
     "ReferenceBindAdapter",
     "PolicyBundlePromotionAdapter",
+    "WebhookBindAdapter",
     "promote_policy_bundle_with_bind_boundary",
     "execute_bind_boundary",
     "promote_decision_candidate_to_execution_intent",

--- a/veritas_os/policy/webhook_bind_adapter.py
+++ b/veritas_os/policy/webhook_bind_adapter.py
@@ -75,8 +75,9 @@ class WebhookBindAdapter(BindAdapterContract):
     compensation_url: str | None = None
     compensation_payload: dict[str, Any] | None = None
     transport: WebhookTransport | None = field(default=None, repr=False, compare=False)
-    dns_resolver: Callable[[str], list[str]] | None = field(default=None, repr=False, compare=False)
-    allow_unsafe_test_addresses: bool = False
+    dns_resolver: Callable[[str], list[str]] | None = field(
+        default=None, repr=False, compare=False
+    )
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "allowed_hosts", frozenset(self.allowed_hosts))
@@ -95,6 +96,10 @@ class WebhookBindAdapter(BindAdapterContract):
         )
 
     def snapshot(self) -> dict[str, Any]:
+        verified_snapshot = getattr(self, "_verified_revert_snapshot", None)
+        if isinstance(verified_snapshot, dict):
+            object.__setattr__(self, "_verified_revert_snapshot", None)
+            return dict(verified_snapshot)
         return self._get_json_object(self.snapshot_url, "BIND_WEBHOOK_SNAPSHOT_FAILED")
 
     def fingerprint_state(self, snapshot: Any) -> str:
@@ -116,7 +121,9 @@ class WebhookBindAdapter(BindAdapterContract):
         del intent
         results = {
             "action_payload_is_object": isinstance(self.action_payload, dict),
-            "expected_postcondition_is_object": isinstance(self.expected_postcondition, dict),
+            "expected_postcondition_is_object": isinstance(
+                self.expected_postcondition, dict
+            ),
             "snapshot_is_object": isinstance(snapshot, dict),
             "snapshot_url_allowed": self._url_allowed(self.snapshot_url),
             "action_url_allowed": self._url_allowed(self.action_url),
@@ -126,13 +133,18 @@ class WebhookBindAdapter(BindAdapterContract):
             and 0 < self.timeout_seconds <= 60,
         }
         if self.compensation_url is not None:
-            results["compensation_url_allowed"] = self._url_allowed(self.compensation_url)
-            results["compensation_payload_is_object"] = isinstance(
-                self.compensation_payload or {}, dict
+            results["compensation_url_allowed"] = self._url_allowed(
+                self.compensation_url
+            )
+            results["compensation_payload_is_object"] = (
+                self.compensation_payload is None
+                or isinstance(self.compensation_payload, dict)
             )
         return results
 
-    def assess_runtime_risk(self, intent: ExecutionIntent, snapshot: Any) -> bool | None:
+    def assess_runtime_risk(
+        self, intent: ExecutionIntent, snapshot: Any
+    ) -> bool | None:
         del intent, snapshot
         urls = [self.snapshot_url, self.action_url, self.postcondition_url]
         if self.compensation_url:
@@ -162,8 +174,12 @@ class WebhookBindAdapter(BindAdapterContract):
         return _recursive_subset(self.expected_postcondition, actual)
 
     def revert(self, intent: ExecutionIntent, snapshot: Any) -> bool:
-        del snapshot
-        if not self.compensation_url:
+        """Compensate and verify restoration of the exact pre-bind snapshot."""
+        if not self.compensation_url or not isinstance(snapshot, dict):
+            return False
+        if self.compensation_payload is not None and not isinstance(
+            self.compensation_payload, dict
+        ):
             return False
         try:
             self._post_json_object(
@@ -172,8 +188,19 @@ class WebhookBindAdapter(BindAdapterContract):
                 intent,
                 "BIND_WEBHOOK_COMPENSATION_FAILED",
             )
-        except RuntimeError:
+            restored_snapshot = self._get_json_object(
+                self.snapshot_url,
+                "BIND_WEBHOOK_COMPENSATION_VERIFICATION_FAILED",
+            )
+            restored_fingerprint = self.fingerprint_state(restored_snapshot)
+            original_fingerprint = self.fingerprint_state(snapshot)
+        except (RuntimeError, TypeError, ValueError):
             return False
+        if restored_fingerprint != original_fingerprint:
+            return False
+        # Bind core takes its own post-revert snapshot before reporting rollback.
+        # Reuse the exact state already verified to avoid a second network race.
+        object.__setattr__(self, "_verified_revert_snapshot", restored_snapshot)
         return True
 
     def describe_target(self) -> str:
@@ -187,10 +214,11 @@ class WebhookBindAdapter(BindAdapterContract):
         )
 
     def build_idempotency_key(self, intent: ExecutionIntent) -> str:
+        """Build a deterministic key without allowing malformed URLs to escape."""
         payload = {
             "execution_intent_id": intent.execution_intent_id,
             "decision_id": intent.decision_id,
-            "action_url": self._normalized_url(self.action_url),
+            "action_url": self._safe_normalized_url(self.action_url),
             "action_payload": self.action_payload,
         }
         return sha256_of_canonical_json(payload)
@@ -208,11 +236,15 @@ class WebhookBindAdapter(BindAdapterContract):
     ) -> dict[str, Any]:
         idempotency_key = self.build_idempotency_key(intent)
         canonical_body = canonical_json_dumps(body)
-        timestamp = datetime.now(timezone.utc).isoformat(timespec="seconds").replace(
-            "+00:00", "Z"
+        timestamp = (
+            datetime.now(timezone.utc)
+            .isoformat(timespec="seconds")
+            .replace("+00:00", "Z")
         )
         signature_input = f"{timestamp}.{canonical_body}".encode("utf-8")
-        signature = hmac.new(self.hmac_secret, signature_input, hashlib.sha256).hexdigest()
+        signature = hmac.new(
+            self.hmac_secret, signature_input, hashlib.sha256
+        ).hexdigest()
         headers = {
             "Content-Type": "application/json",
             "X-Veritas-Decision-Id": intent.decision_id,
@@ -248,7 +280,9 @@ class WebhookBindAdapter(BindAdapterContract):
             raise RuntimeError("BIND_WEBHOOK_REQUEST_FAILED") from exc
 
     @staticmethod
-    def _require_json_object(response: WebhookResponse, error_code: str) -> dict[str, Any]:
+    def _require_json_object(
+        response: WebhookResponse, error_code: str
+    ) -> dict[str, Any]:
         if not 200 <= int(response.status_code) <= 299:
             raise RuntimeError(error_code)
         if not isinstance(response.json_data, dict):
@@ -267,14 +301,20 @@ class WebhookBindAdapter(BindAdapterContract):
         hostname = parsed.hostname or ""
         if hostname not in self.allowed_hosts:
             return False
-        return self.allow_unsafe_test_addresses or self._hostname_addresses_are_safe(hostname)
+        return self._hostname_addresses_are_safe(hostname)
 
     def _hostname_addresses_are_safe(self, hostname: str) -> bool:
         try:
-            addresses = self.dns_resolver(hostname) if self.dns_resolver else _resolve_host(hostname)
+            addresses = (
+                self.dns_resolver(hostname)
+                if self.dns_resolver
+                else _resolve_host(hostname)
+            )
         except OSError:
             return False
-        return bool(addresses) and all(_address_is_safe(address) for address in addresses)
+        return bool(addresses) and all(
+            _address_is_safe(address) for address in addresses
+        )
 
     @staticmethod
     def _normalized_url(url: str) -> str:
@@ -282,6 +322,15 @@ class WebhookBindAdapter(BindAdapterContract):
         host = parsed.hostname or ""
         netloc = host if parsed.port in (None, 443) else f"{host}:{parsed.port}"
         return urlunparse(("https", netloc, parsed.path or "/", "", parsed.query, ""))
+
+    @staticmethod
+    def _safe_normalized_url(url: Any) -> str:
+        """Normalize a URL or return a non-sensitive deterministic sentinel."""
+        try:
+            return WebhookBindAdapter._normalized_url(url)
+        except (AttributeError, TypeError, ValueError):
+            raw_digest = sha256_of_canonical_json({"raw_url": str(url)})
+            return f"invalid-url:sha256:{raw_digest}"
 
     @staticmethod
     def _describe_url(url: str | None) -> str:
@@ -324,14 +373,21 @@ class _UrllibWebhookTransport:
             with opener.open(request, timeout=timeout) as response:
                 raw = response.read().decode("utf-8")
                 parsed = json.loads(raw) if raw else {}
-                return WebhookResponse(response.status, parsed, dict(response.headers.items()))
+                return WebhookResponse(
+                    response.status, parsed, dict(response.headers.items())
+                )
         except HTTPError as exc:
             try:
                 parsed = json.loads(exc.read().decode("utf-8"))
             except (json.JSONDecodeError, UnicodeDecodeError):
                 parsed = None
             return WebhookResponse(exc.code, parsed, dict(exc.headers.items()))
-        except (TimeoutError, URLError, json.JSONDecodeError, UnicodeDecodeError) as exc:
+        except (
+            TimeoutError,
+            URLError,
+            json.JSONDecodeError,
+            UnicodeDecodeError,
+        ) as exc:
             raise RuntimeError("BIND_WEBHOOK_TRANSPORT_FAILED") from exc
 
 

--- a/veritas_os/policy/webhook_bind_adapter.py
+++ b/veritas_os/policy/webhook_bind_adapter.py
@@ -1,0 +1,392 @@
+"""Fail-closed HTTPS webhook bind adapter.
+
+WebhookBindAdapter is a reference external bind adapter.  It sends a
+three-endpoint bind flow (snapshot, action, postcondition) through the existing
+bind core and compensates only when an explicitly configured compensation
+webhook verifies success.  Generic external side effects may be irreversible;
+when compensation is absent or unverified, rollback is not claimed.
+
+Receiver contract
+-----------------
+Action and compensation receivers get JSON POST requests with these headers:
+``Content-Type``, ``X-Veritas-Decision-Id``,
+``X-Veritas-Execution-Intent-Id``, ``X-Veritas-Idempotency-Key``,
+``X-Veritas-Timestamp``, and ``X-Veritas-Signature``.  The signature is
+``sha256=<hex hmac-sha256>`` over ``timestamp + "." + canonical_json_body``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+import hashlib
+import hmac
+import ipaddress
+import json
+import socket
+from typing import Any, Callable, Mapping, Protocol
+from urllib.error import HTTPError, URLError
+from urllib.parse import ParseResult, urlparse, urlunparse
+from urllib.request import Request, build_opener, HTTPRedirectHandler
+
+from veritas_os.policy.bind_artifacts import ExecutionIntent
+from veritas_os.policy.bind_core.contracts import BindAdapterContract
+from veritas_os.security.hash import canonical_json_dumps, sha256_of_canonical_json
+
+
+class WebhookTransport(Protocol):
+    """Synchronous transport contract used by WebhookBindAdapter."""
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: Mapping[str, str] | None = None,
+        json_body: Mapping[str, Any] | None = None,
+        timeout: float,
+        allow_redirects: bool = False,
+    ) -> "WebhookResponse":
+        """Return an HTTP response without following redirects."""
+
+
+@dataclass(frozen=True)
+class WebhookResponse:
+    """Minimal sanitized HTTP response shape for webhook calls."""
+
+    status_code: int
+    json_data: Any
+    headers: Mapping[str, str] = field(default_factory=dict, repr=False)
+
+
+@dataclass(frozen=True, repr=False)
+class WebhookBindAdapter(BindAdapterContract):
+    """Bind adapter that executes governed changes through HTTPS webhooks."""
+
+    snapshot_url: str
+    action_url: str
+    postcondition_url: str
+    action_payload: dict[str, Any]
+    expected_postcondition: dict[str, Any]
+    allowed_hosts: set[str] | frozenset[str]
+    hmac_secret: bytes | str
+    timeout_seconds: float = 5.0
+    required_approval_key: str = "external_webhook_action_approved"
+    compensation_url: str | None = None
+    compensation_payload: dict[str, Any] | None = None
+    transport: WebhookTransport | None = field(default=None, repr=False, compare=False)
+    dns_resolver: Callable[[str], list[str]] | None = field(default=None, repr=False, compare=False)
+    allow_unsafe_test_addresses: bool = False
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "allowed_hosts", frozenset(self.allowed_hosts))
+        if isinstance(self.hmac_secret, str):
+            object.__setattr__(self, "hmac_secret", self.hmac_secret.encode("utf-8"))
+
+    def __repr__(self) -> str:
+        return (
+            "WebhookBindAdapter("
+            f"snapshot_url={self._describe_url(self.snapshot_url)!r}, "
+            f"action_url={self._describe_url(self.action_url)!r}, "
+            f"postcondition_url={self._describe_url(self.postcondition_url)!r}, "
+            f"compensation_url={self._describe_url(self.compensation_url)!r}, "
+            f"allowed_hosts={sorted(self.allowed_hosts)!r}, "
+            f"timeout_seconds={self.timeout_seconds!r})"
+        )
+
+    def snapshot(self) -> dict[str, Any]:
+        return self._get_json_object(self.snapshot_url, "BIND_WEBHOOK_SNAPSHOT_FAILED")
+
+    def fingerprint_state(self, snapshot: Any) -> str:
+        if not isinstance(snapshot, dict):
+            raise ValueError("BIND_WEBHOOK_SNAPSHOT_INVALID")
+        return sha256_of_canonical_json(snapshot)
+
+    def validate_authority(self, intent: ExecutionIntent, snapshot: Any) -> bool | None:
+        del snapshot
+        if not isinstance(intent.approval_context, dict):
+            return False
+        return intent.approval_context.get(self.required_approval_key) is True
+
+    def validate_constraints(
+        self,
+        intent: ExecutionIntent,
+        snapshot: Any,
+    ) -> dict[str, bool] | None:
+        del intent
+        results = {
+            "action_payload_is_object": isinstance(self.action_payload, dict),
+            "expected_postcondition_is_object": isinstance(self.expected_postcondition, dict),
+            "snapshot_is_object": isinstance(snapshot, dict),
+            "snapshot_url_allowed": self._url_allowed(self.snapshot_url),
+            "action_url_allowed": self._url_allowed(self.action_url),
+            "postcondition_url_allowed": self._url_allowed(self.postcondition_url),
+            "hmac_secret_present": bool(self.hmac_secret),
+            "timeout_is_valid": isinstance(self.timeout_seconds, (int, float))
+            and 0 < self.timeout_seconds <= 60,
+        }
+        if self.compensation_url is not None:
+            results["compensation_url_allowed"] = self._url_allowed(self.compensation_url)
+            results["compensation_payload_is_object"] = isinstance(
+                self.compensation_payload or {}, dict
+            )
+        return results
+
+    def assess_runtime_risk(self, intent: ExecutionIntent, snapshot: Any) -> bool | None:
+        del intent, snapshot
+        urls = [self.snapshot_url, self.action_url, self.postcondition_url]
+        if self.compensation_url:
+            urls.append(self.compensation_url)
+        return all(self._url_allowed(url) for url in urls)
+
+    def apply(self, intent: ExecutionIntent, snapshot: Any) -> bool:
+        del snapshot
+        data = self._post_json_object(
+            self.action_url,
+            self.action_payload,
+            intent,
+            "BIND_WEBHOOK_ACTION_FAILED",
+        )
+        object.__setattr__(self, "_last_action_metadata", self._response_metadata(data))
+        return True
+
+    def verify_postconditions(self, intent: ExecutionIntent, snapshot: Any) -> bool:
+        del intent, snapshot
+        try:
+            actual = self._get_json_object(
+                self.postcondition_url,
+                "BIND_WEBHOOK_POSTCONDITION_FAILED",
+            )
+        except RuntimeError:
+            return False
+        return _recursive_subset(self.expected_postcondition, actual)
+
+    def revert(self, intent: ExecutionIntent, snapshot: Any) -> bool:
+        del snapshot
+        if not self.compensation_url:
+            return False
+        try:
+            self._post_json_object(
+                self.compensation_url,
+                self.compensation_payload or {},
+                intent,
+                "BIND_WEBHOOK_COMPENSATION_FAILED",
+            )
+        except RuntimeError:
+            return False
+        return True
+
+    def describe_target(self) -> str:
+        return "webhook:" + ",".join(
+            part
+            for part in [
+                self._describe_url(self.action_url),
+                self._describe_url(self.postcondition_url),
+            ]
+            if part
+        )
+
+    def build_idempotency_key(self, intent: ExecutionIntent) -> str:
+        payload = {
+            "execution_intent_id": intent.execution_intent_id,
+            "decision_id": intent.decision_id,
+            "action_url": self._normalized_url(self.action_url),
+            "action_payload": self.action_payload,
+        }
+        return sha256_of_canonical_json(payload)
+
+    def _get_json_object(self, url: str, error_code: str) -> dict[str, Any]:
+        response = self._request("GET", url, headers={}, json_body=None)
+        return self._require_json_object(response, error_code)
+
+    def _post_json_object(
+        self,
+        url: str,
+        body: dict[str, Any],
+        intent: ExecutionIntent,
+        error_code: str,
+    ) -> dict[str, Any]:
+        idempotency_key = self.build_idempotency_key(intent)
+        canonical_body = canonical_json_dumps(body)
+        timestamp = datetime.now(timezone.utc).isoformat(timespec="seconds").replace(
+            "+00:00", "Z"
+        )
+        signature_input = f"{timestamp}.{canonical_body}".encode("utf-8")
+        signature = hmac.new(self.hmac_secret, signature_input, hashlib.sha256).hexdigest()
+        headers = {
+            "Content-Type": "application/json",
+            "X-Veritas-Decision-Id": intent.decision_id,
+            "X-Veritas-Execution-Intent-Id": intent.execution_intent_id,
+            "X-Veritas-Idempotency-Key": idempotency_key,
+            "X-Veritas-Timestamp": timestamp,
+            "X-Veritas-Signature": f"sha256={signature}",
+        }
+        response = self._request("POST", url, headers=headers, json_body=body)
+        return self._require_json_object(response, error_code)
+
+    def _request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: Mapping[str, str] | None,
+        json_body: Mapping[str, Any] | None,
+    ) -> WebhookResponse:
+        if not self._url_allowed(url):
+            raise RuntimeError("BIND_WEBHOOK_URL_NOT_ALLOWED")
+        transport = self.transport or _UrllibWebhookTransport()
+        try:
+            return transport.request(
+                method,
+                self._normalized_url(url),
+                headers=headers,
+                json_body=json_body,
+                timeout=float(self.timeout_seconds),
+                allow_redirects=False,
+            )
+        except Exception as exc:
+            raise RuntimeError("BIND_WEBHOOK_REQUEST_FAILED") from exc
+
+    @staticmethod
+    def _require_json_object(response: WebhookResponse, error_code: str) -> dict[str, Any]:
+        if not 200 <= int(response.status_code) <= 299:
+            raise RuntimeError(error_code)
+        if not isinstance(response.json_data, dict):
+            raise RuntimeError(error_code)
+        return dict(response.json_data)
+
+    @staticmethod
+    def _response_metadata(data: dict[str, Any]) -> dict[str, Any]:
+        return {"response_keys": sorted(str(key) for key in data.keys())[:20]}
+
+    def _url_allowed(self, url: str | None) -> bool:
+        try:
+            parsed = _parse_https_url(url)
+        except ValueError:
+            return False
+        hostname = parsed.hostname or ""
+        if hostname not in self.allowed_hosts:
+            return False
+        return self.allow_unsafe_test_addresses or self._hostname_addresses_are_safe(hostname)
+
+    def _hostname_addresses_are_safe(self, hostname: str) -> bool:
+        try:
+            addresses = self.dns_resolver(hostname) if self.dns_resolver else _resolve_host(hostname)
+        except OSError:
+            return False
+        return bool(addresses) and all(_address_is_safe(address) for address in addresses)
+
+    @staticmethod
+    def _normalized_url(url: str) -> str:
+        parsed = _parse_https_url(url)
+        host = parsed.hostname or ""
+        netloc = host if parsed.port in (None, 443) else f"{host}:{parsed.port}"
+        return urlunparse(("https", netloc, parsed.path or "/", "", parsed.query, ""))
+
+    @staticmethod
+    def _describe_url(url: str | None) -> str:
+        if not url:
+            return ""
+        try:
+            parsed = _parse_https_url(url)
+        except ValueError:
+            return "invalid-url"
+        host = parsed.hostname or ""
+        netloc = host if parsed.port in (None, 443) else f"{host}:{parsed.port}"
+        return urlunparse(("https", netloc, "", "", "", ""))
+
+
+class _NoRedirectHandler(HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: ANN001
+        return None
+
+
+class _UrllibWebhookTransport:
+    """Default transport using urllib with redirects disabled."""
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: Mapping[str, str] | None = None,
+        json_body: Mapping[str, Any] | None = None,
+        timeout: float,
+        allow_redirects: bool = False,
+    ) -> WebhookResponse:
+        del allow_redirects
+        data = None
+        if json_body is not None:
+            data = canonical_json_dumps(json_body).encode("utf-8")
+        request = Request(url, data=data, headers=dict(headers or {}), method=method)
+        opener = build_opener(_NoRedirectHandler)
+        try:
+            with opener.open(request, timeout=timeout) as response:
+                raw = response.read().decode("utf-8")
+                parsed = json.loads(raw) if raw else {}
+                return WebhookResponse(response.status, parsed, dict(response.headers.items()))
+        except HTTPError as exc:
+            try:
+                parsed = json.loads(exc.read().decode("utf-8"))
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                parsed = None
+            return WebhookResponse(exc.code, parsed, dict(exc.headers.items()))
+        except (TimeoutError, URLError, json.JSONDecodeError, UnicodeDecodeError) as exc:
+            raise RuntimeError("BIND_WEBHOOK_TRANSPORT_FAILED") from exc
+
+
+def _parse_https_url(url: str | None) -> ParseResult:
+    if not isinstance(url, str) or not url.strip():
+        raise ValueError("BIND_WEBHOOK_URL_INVALID")
+    try:
+        parsed = urlparse(url)
+        _ = parsed.port
+    except ValueError as exc:
+        raise ValueError("BIND_WEBHOOK_URL_INVALID") from exc
+    if parsed.scheme != "https":
+        raise ValueError("BIND_WEBHOOK_URL_SCHEME_INVALID")
+    if not parsed.hostname:
+        raise ValueError("BIND_WEBHOOK_URL_HOST_MISSING")
+    if parsed.username or parsed.password:
+        raise ValueError("BIND_WEBHOOK_URL_USERINFO_FORBIDDEN")
+    if parsed.fragment:
+        raise ValueError("BIND_WEBHOOK_URL_FRAGMENT_FORBIDDEN")
+    return parsed
+
+
+def _resolve_host(hostname: str) -> list[str]:
+    return sorted({item[4][0] for item in socket.getaddrinfo(hostname, None)})
+
+
+def _address_is_safe(address: str) -> bool:
+    try:
+        ip = ipaddress.ip_address(address)
+    except ValueError:
+        return False
+    return not (
+        ip.is_loopback
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_unspecified
+        or ip.is_reserved
+        or ip.is_private
+    )
+
+
+def _recursive_subset(expected: dict[str, Any], actual: dict[str, Any]) -> bool:
+    for key, value in expected.items():
+        if key not in actual:
+            return False
+        actual_value = actual[key]
+        if isinstance(value, dict):
+            if not isinstance(actual_value, dict):
+                return False
+            if not _recursive_subset(value, actual_value):
+                return False
+            continue
+        if actual_value != value:
+            return False
+    return True
+
+
+__all__ = ["WebhookBindAdapter", "WebhookResponse", "WebhookTransport"]


### PR DESCRIPTION
### Motivation
- Add a reference customer-facing external execution adapter that connects an existing `ExecutionIntent` and the existing bind adjudication flow to an HTTPS webhook while preserving VERITAS fail-closed semantics and without introducing new SDKs, decorators, API routes, or UI.
- Provide a deterministically idempotent, HMAC-signed, redirect-disabled three-endpoint flow (snapshot -> action -> postcondition) suitable for integration testing and later SDK layering, with an optional compensation path that is verified before rollback is claimed.

### Description
- Implement `WebhookBindAdapter` in `veritas_os/policy/webhook_bind_adapter.py` as a `BindAdapterContract` implementation with `snapshot`, `fingerprint_state`, `validate_authority`, `validate_constraints`, `assess_runtime_risk`, `apply`, `verify_postconditions`, `revert`, `describe_target`, and `build_idempotency_key` semantics, deterministic canonical JSON hashing, and strict fail-closed error handling.
- Add secure outbound URL validation and helpers (`_parse_https_url`, host allowlist, DNS resolver injection, address-safety checks), a default urllib-based transport with redirects disabled, and an HMAC signing scheme for POSTs that uses `timestamp + "." + canonical_json_body` and `sha256=<hex>` header semantics while ensuring the HMAC secret is never present in `repr`, receipts, logs, or errors.
- Add unit tests in `tests/policy/test_webhook_bind_adapter.py` using a `FakeTransport` to cover contract conformance, authority gating, committed/blocked outcomes, failure modes (timeouts, non-2xx, malformed JSON, redirects), idempotency/replay, compensation behavior, and URL/security rejections without making real network calls.
- Export `WebhookBindAdapter` through the existing package surface by updating `veritas_os/policy/__init__.py` and add documentation `docs/en/guides/webhook-bind-adapter.md` describing purpose, three-endpoint flow, HMAC contract, idempotency, fail-closed model, and limitations (explicitly noting this is a reference/evaluation adapter and not production certification).

### Testing
- Static/lint/type checks: `ruff` check and `py_compile` for the new module and tests passed successfully in the environment.
- Repository tests: attempted `pytest` for the new focused tests (`tests/policy/test_webhook_bind_adapter.py`) and broader bind tests, but automated collection/execution was unavailable in this environment due to missing runtime dependency `pydantic` and failure to install optional test dependencies from PyPI (network/tunnel error); therefore full pytest runs are deferred until CI or a dev environment with dependencies installed.
- The newly added tests exercise the adapter contract and the required acceptance criteria (authority gating, single action POST on successful admissible path, zero external calls on BLOCKED/ESCALATED, HMAC/idempotency semantics, URL safety, fail-closed behavior, and compensation semantics) and are deterministic via injected `transport`/`dns_resolver` mocks; these tests are included and ready to run in CI when test dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a545a170ad083269c9bb0dad41f4851)