### PR TITLE
Add fail-closed WebhookBindAdapter with docs and tests

### DIFF
--- a/docs/en/guides/webhook-bind-adapter.md
+++ b/docs/en/guides/webhook-bind-adapter.md
@@ -1,0 +1,86 @@
+# Webhook Bind Adapter
+
+`WebhookBindAdapter` is a reference external bind adapter for evaluating VERITAS OS bind execution against an HTTPS webhook target. It connects an existing `ExecutionIntent` to the existing bind adjudication flow and does not create a new bind engine, API route, UI, SDK, or decorator.
+
+## Status and purpose
+
+This adapter is currently a prototype/evaluation reference for external bind integration. It is not certification, not regulatory approval, and not evidence of production customer deployment. Deployment-specific authentication, network policy, secret management, and mTLS remain integrator responsibilities.
+
+## Required three-endpoint flow
+
+The adapter uses three HTTPS endpoints:
+
+1. **Snapshot**: `GET snapshot_url` returns the current external state as a JSON object.
+2. **Action**: `POST action_url` applies the governed action payload.
+3. **Postcondition**: `GET postcondition_url` returns a JSON object that must recursively contain the configured expected postcondition.
+
+An optional compensation endpoint can be configured. Generic external effects may be irreversible. A successful compensation response must be a 2xx JSON object containing `{"compensated": true}`. When compensation is absent, fails, or does not explicitly acknowledge compensation, rollback is not claimed.
+
+## HMAC request format
+
+Action and compensation requests are JSON `POST` requests with redirects disabled and a bounded timeout. Receivers should expect:
+
+```text
+Content-Type: application/json
+X-Veritas-Decision-Id: <decision id>
+X-Veritas-Execution-Intent-Id: <execution intent id>
+X-Veritas-Idempotency-Key: <deterministic adapter key>
+X-Veritas-Timestamp: <UTC timestamp>
+X-Veritas-Signature: sha256=<lowercase hex hmac-sha256>
+```
+
+The signature input is:
+
+```text
+X-Veritas-Timestamp + "." + canonical_json_body
+```
+
+The HMAC secret is never included in the idempotency key, target description, bind receipt, or response evidence.
+
+## Idempotency
+
+The adapter idempotency key is deterministic over the execution intent id, decision id, normalized action URL, and canonical action payload. It does not use Python `hash()`, current time, or the HMAC secret.
+
+## Sample receiver responses
+
+Snapshot response:
+
+```json
+{"account": {"status": "active", "limit": 100}}
+```
+
+Action response:
+
+```json
+{"accepted": true, "operation_id": "op-123"}
+```
+
+Postcondition response:
+
+```json
+{"account": {"status": "active", "limit": 120}}
+```
+
+With `expected_postcondition={"account": {"limit": 120}}`, the postcondition passes because the expected object is a recursive subset of the returned object.
+
+## Fail-closed behavior
+
+The adapter fails closed on timeout, connection failure, malformed JSON, non-object JSON, non-2xx responses, unverifiable postconditions, unsafe URLs, missing approval, constraint failure, or runtime-risk failure. BLOCKED and ESCALATED decisions do not execute the action webhook.
+
+Outbound URL validation is intentionally restrictive by default:
+
+- HTTPS only
+- explicit host allowlist required
+- no URL userinfo
+- no fragments
+- malformed ports rejected
+- redirects disabled
+- localhost, loopback, link-local, multicast, unspecified, private, and reserved addresses rejected unless a narrowly scoped test/deployment option is enabled
+
+## What is not yet provided
+
+This PR does not provide a separate SDK package, `@veritas.govern` decorator, public API route, UI, customer demo, production-readiness claim, certification claim, or regulatory approval claim.
+
+## Planned SDK layer
+
+A later SDK layer can wrap receiver scaffolding, secret management guidance, mTLS integration patterns, and developer ergonomics around this reference adapter without changing the bind core semantics.

--- a/tests/policy/test_webhook_bind_adapter.py
+++ b/tests/policy/test_webhook_bind_adapter.py
@@ -1,0 +1,447 @@
+"""Tests for the fail-closed webhook bind adapter."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+import pytest
+
+from veritas_os.policy.bind_artifacts import (
+    ExecutionIntent,
+    FinalOutcome,
+    canonical_bind_receipt_json,
+)
+from veritas_os.policy.bind_core import BindAdapterContract, execute_bind_adjudication
+from veritas_os.policy.webhook_bind_adapter import WebhookBindAdapter, WebhookResponse
+from veritas_os.security.hash import sha256_of_canonical_json
+
+
+class TransportError(RuntimeError):
+    pass
+
+
+@dataclass
+class FakeTransport:
+    responses: dict[tuple[str, str], list[WebhookResponse | Exception]]
+    calls: list[dict[str, Any]] = field(default_factory=list)
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: Mapping[str, str] | None = None,
+        json_body: Mapping[str, Any] | None = None,
+        timeout: float,
+        allow_redirects: bool = False,
+    ) -> WebhookResponse:
+        self.calls.append(
+            {
+                "method": method,
+                "url": url,
+                "headers": dict(headers or {}),
+                "json_body": dict(json_body or {}),
+                "timeout": timeout,
+                "allow_redirects": allow_redirects,
+            }
+        )
+        queued = self.responses.get((method, url), [])
+        if not queued:
+            raise TransportError(f"unexpected call: {method} {url}")
+        response = queued.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    def count(self, method: str, url: str) -> int:
+        return sum(
+            1 for call in self.calls if call["method"] == method and call["url"] == url
+        )
+
+
+PUBLIC_IP = ["93.184.216.34"]
+SNAPSHOT_URL = "https://hooks.example.test/snapshot?token=secret"
+ACTION_URL = "https://hooks.example.test/action?token=secret"
+POSTCONDITION_URL = "https://hooks.example.test/postcondition?token=secret"
+COMPENSATION_URL = "https://hooks.example.test/compensate?token=secret"
+
+
+def intent(**overrides: Any) -> ExecutionIntent:
+    values = {
+        "execution_intent_id": "ei-1",
+        "decision_id": "dec-1",
+        "request_id": "req-1",
+        "policy_snapshot_id": "snap-1",
+        "actor_identity": "ops",
+        "target_system": "external_webhook",
+        "target_resource": "hooks.example.test/action",
+        "intended_action": "external_webhook_action",
+        "decision_hash": "a" * 64,
+        "decision_ts": "2026-07-13T00:00:00Z",
+        "expected_state_fingerprint": sha256_of_canonical_json({"state": "before"}),
+        "approval_context": {"external_webhook_action_approved": True},
+    }
+    values.update(overrides)
+    return ExecutionIntent(**values)
+
+
+def transport_for_success() -> FakeTransport:
+    return FakeTransport(
+        {
+            ("GET", SNAPSHOT_URL): [
+                WebhookResponse(200, {"state": "before"}),
+                WebhookResponse(200, {"state": "after"}),
+            ],
+            ("POST", ACTION_URL): [WebhookResponse(200, {"accepted": True})],
+            ("GET", POSTCONDITION_URL): [
+                WebhookResponse(200, {"state": "after", "nested": {"ok": True}})
+            ],
+        }
+    )
+
+
+def adapter(
+    transport: FakeTransport | None = None, **overrides: Any
+) -> WebhookBindAdapter:
+    values = {
+        "snapshot_url": SNAPSHOT_URL,
+        "action_url": ACTION_URL,
+        "postcondition_url": POSTCONDITION_URL,
+        "action_payload": {"op": "set", "value": 1},
+        "expected_postcondition": {"nested": {"ok": True}},
+        "allowed_hosts": {"hooks.example.test"},
+        "hmac_secret": "super-secret",
+        "transport": transport or transport_for_success(),
+        "dns_resolver": lambda hostname: PUBLIC_IP,
+    }
+    values.update(overrides)
+    return WebhookBindAdapter(**values)
+
+
+def test_contract_fingerprint_and_sanitized_description() -> None:
+    subject = adapter()
+    assert isinstance(subject, BindAdapterContract)
+    snapshot = {"b": 2, "a": 1}
+    assert subject.fingerprint_state(snapshot) == sha256_of_canonical_json(snapshot)
+    assert "token=secret" not in subject.describe_target()
+    assert "super-secret" not in repr(subject)
+
+
+def test_authority_requires_explicit_true() -> None:
+    subject = adapter()
+    assert subject.validate_authority(intent(), {}) is True
+    assert (
+        subject.validate_authority(
+            intent(approval_context={"external_webhook_action_approved": False}), {}
+        )
+        is False
+    )
+    assert subject.validate_authority(intent(approval_context={}), {}) is False
+    assert subject.validate_authority(intent(approval_context=None), {}) is False
+
+
+@pytest.mark.parametrize(
+    "approval_context",
+    [
+        {"external_webhook_action_approved": False},
+        {},
+        None,
+    ],
+)
+def test_authority_failure_prevents_action_post(approval_context: Any) -> None:
+    fake = transport_for_success()
+    receipt = execute_bind_adjudication(
+        execution_intent=intent(approval_context=approval_context),
+        adapter=adapter(fake),
+        append_trustlog=False,
+    )
+    assert receipt.final_outcome is FinalOutcome.BLOCKED
+    assert fake.count("POST", ACTION_URL) == 0
+
+
+def test_successful_governed_execution_commits_and_posts_once() -> None:
+    fake = transport_for_success()
+    receipt = execute_bind_adjudication(
+        execution_intent=intent(),
+        adapter=adapter(fake),
+        append_trustlog=False,
+    )
+    assert receipt.final_outcome is FinalOutcome.COMMITTED
+    assert fake.count("POST", ACTION_URL) == 1
+    call = next(call for call in fake.calls if call["method"] == "POST")
+    assert call["allow_redirects"] is False
+    assert call["headers"]["X-Veritas-Decision-Id"] == "dec-1"
+    assert call["headers"]["X-Veritas-Execution-Intent-Id"] == "ei-1"
+    assert call["headers"]["X-Veritas-Signature"].startswith("sha256=")
+    assert "super-secret" not in json.dumps(call)
+
+
+def test_constraint_and_runtime_risk_failures_prevent_action_post() -> None:
+    for subject in [
+        adapter(action_payload=[]),
+        adapter(action_url="https://evil.example.test/action"),
+    ]:
+        fake = subject.transport
+        receipt = execute_bind_adjudication(
+            execution_intent=intent(),
+            adapter=subject,
+            append_trustlog=False,
+        )
+        assert receipt.final_outcome is FinalOutcome.BLOCKED
+        assert fake.count("POST", ACTION_URL) == 0
+
+
+@pytest.mark.parametrize(
+    "responses,expected",
+    [
+        (
+            {("GET", SNAPSHOT_URL): [TransportError("timeout")]},
+            FinalOutcome.SNAPSHOT_FAILED,
+        ),
+        (
+            {("GET", SNAPSHOT_URL): [WebhookResponse(200, [])]},
+            FinalOutcome.SNAPSHOT_FAILED,
+        ),
+        (
+            {("GET", SNAPSHOT_URL): [WebhookResponse(500, {})]},
+            FinalOutcome.SNAPSHOT_FAILED,
+        ),
+    ],
+)
+def test_snapshot_failures_fail_closed(
+    responses: dict[tuple[str, str], list[Any]], expected: FinalOutcome
+) -> None:
+    fake = FakeTransport(responses)
+    receipt = execute_bind_adjudication(
+        execution_intent=intent(),
+        adapter=adapter(fake),
+        append_trustlog=False,
+    )
+    assert receipt.final_outcome is expected
+    assert fake.count("POST", ACTION_URL) == 0
+
+
+@pytest.mark.parametrize(
+    "action_response",
+    [
+        TransportError("timeout"),
+        WebhookResponse(500, {}),
+        WebhookResponse(302, {"redirect": True}),
+        WebhookResponse(200, []),
+    ],
+)
+def test_action_failures_are_not_committed_and_do_not_retry(
+    action_response: Any,
+) -> None:
+    fake = FakeTransport(
+        {
+            ("GET", SNAPSHOT_URL): [WebhookResponse(200, {"state": "before"})],
+            ("POST", ACTION_URL): [action_response],
+        }
+    )
+    receipt = execute_bind_adjudication(
+        execution_intent=intent(),
+        adapter=adapter(fake),
+        append_trustlog=False,
+    )
+    assert receipt.final_outcome is FinalOutcome.APPLY_FAILED
+    assert fake.count("POST", ACTION_URL) == 1
+
+
+@pytest.mark.parametrize(
+    "postcondition_response",
+    [
+        TransportError("timeout"),
+        WebhookResponse(500, {}),
+        WebhookResponse(200, []),
+        WebhookResponse(200, {"nested": {"ok": False}}),
+    ],
+)
+def test_postcondition_failures_do_not_commit_without_compensation(
+    postcondition_response: Any,
+) -> None:
+    fake = FakeTransport(
+        {
+            ("GET", SNAPSHOT_URL): [WebhookResponse(200, {"state": "before"})],
+            ("POST", ACTION_URL): [WebhookResponse(200, {"accepted": True})],
+            ("GET", POSTCONDITION_URL): [postcondition_response],
+        }
+    )
+    receipt = execute_bind_adjudication(
+        execution_intent=intent(),
+        adapter=adapter(fake),
+        append_trustlog=False,
+    )
+    assert receipt.final_outcome is FinalOutcome.ESCALATED
+    assert receipt.rollback_status == "rollback_failed"
+
+
+def test_idempotency_key_is_deterministic_and_excludes_secret() -> None:
+    first = adapter(hmac_secret="secret-a")
+    second = adapter(hmac_secret="secret-b")
+    changed = adapter(hmac_secret="secret-a", action_payload={"op": "set", "value": 2})
+    assert first.build_idempotency_key(intent()) == second.build_idempotency_key(
+        intent()
+    )
+    assert first.build_idempotency_key(intent()) != changed.build_idempotency_key(
+        intent()
+    )
+
+
+def test_replay_does_not_duplicate_external_post(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import veritas_os.policy.bind_core.core as core
+
+    first_fake = transport_for_success()
+    first = execute_bind_adjudication(
+        execution_intent=intent(),
+        adapter=adapter(first_fake),
+        append_trustlog=False,
+    )
+    monkeypatch.setattr(core, "_idempotency_replay_enabled", lambda **_: True)
+    monkeypatch.setattr(core, "_find_duplicate_bind_receipt", lambda **_: first)
+    replay_fake = transport_for_success()
+    replay = execute_bind_adjudication(
+        execution_intent=intent(),
+        adapter=adapter(replay_fake),
+        append_trustlog=True,
+    )
+    assert replay.idempotency_status == "replayed"
+    assert replay_fake.count("POST", ACTION_URL) == 0
+
+
+def test_successful_compensation_reports_rolled_back() -> None:
+    fake = FakeTransport(
+        {
+            ("GET", SNAPSHOT_URL): [
+                WebhookResponse(200, {"state": "before"}),
+                WebhookResponse(200, {"state": "compensated"}),
+            ],
+            ("POST", ACTION_URL): [WebhookResponse(200, {"accepted": True})],
+            ("GET", POSTCONDITION_URL): [
+                WebhookResponse(200, {"nested": {"ok": False}})
+            ],
+            ("POST", COMPENSATION_URL): [WebhookResponse(200, {"compensated": True})],
+        }
+    )
+    receipt = execute_bind_adjudication(
+        execution_intent=intent(),
+        adapter=adapter(
+            fake, compensation_url=COMPENSATION_URL, compensation_payload={"undo": True}
+        ),
+        append_trustlog=False,
+    )
+    assert receipt.final_outcome is FinalOutcome.ROLLED_BACK
+    assert fake.count("POST", COMPENSATION_URL) == 1
+
+
+def test_failed_compensation_does_not_claim_rollback() -> None:
+    fake = FakeTransport(
+        {
+            ("GET", SNAPSHOT_URL): [WebhookResponse(200, {"state": "before"})],
+            ("POST", ACTION_URL): [WebhookResponse(200, {"accepted": True})],
+            ("GET", POSTCONDITION_URL): [
+                WebhookResponse(200, {"nested": {"ok": False}})
+            ],
+            ("POST", COMPENSATION_URL): [WebhookResponse(500, {})],
+        }
+    )
+    receipt = execute_bind_adjudication(
+        execution_intent=intent(),
+        adapter=adapter(fake, compensation_url=COMPENSATION_URL),
+        append_trustlog=False,
+    )
+    assert receipt.final_outcome is FinalOutcome.ESCALATED
+    assert receipt.rollback_status == "rollback_failed"
+
+
+def test_unacknowledged_compensation_does_not_claim_rollback() -> None:
+    fake = FakeTransport(
+        {
+            ("GET", SNAPSHOT_URL): [WebhookResponse(200, {"state": "before"})],
+            ("POST", ACTION_URL): [WebhookResponse(200, {"accepted": True})],
+            ("GET", POSTCONDITION_URL): [
+                WebhookResponse(200, {"nested": {"ok": False}})
+            ],
+            ("POST", COMPENSATION_URL): [WebhookResponse(200, {"accepted": True})],
+        }
+    )
+    receipt = execute_bind_adjudication(
+        execution_intent=intent(),
+        adapter=adapter(fake, compensation_url=COMPENSATION_URL),
+        append_trustlog=False,
+    )
+    assert receipt.final_outcome is FinalOutcome.ESCALATED
+    assert receipt.rollback_status == "rollback_failed"
+
+
+def test_invalid_action_configuration_is_blocked_without_escaping_bind_core() -> None:
+    for subject in [
+        adapter(action_url="https://hooks.example.test:invalid/action"),
+        adapter(action_payload={"invalid": object()}),
+    ]:
+        fake = subject.transport
+        receipt = execute_bind_adjudication(
+            execution_intent=intent(),
+            adapter=subject,
+            append_trustlog=False,
+        )
+        assert receipt.final_outcome is FinalOutcome.BLOCKED
+        assert fake.count("POST", ACTION_URL) == 0
+
+
+def test_resolver_exception_is_a_runtime_deny() -> None:
+    def failing_resolver(hostname: str) -> list[str]:
+        del hostname
+        raise ValueError("resolver failed")
+
+    fake = transport_for_success()
+    receipt = execute_bind_adjudication(
+        execution_intent=intent(),
+        adapter=adapter(fake, dns_resolver=failing_resolver),
+        append_trustlog=False,
+    )
+    assert receipt.final_outcome is FinalOutcome.SNAPSHOT_FAILED
+    assert fake.count("POST", ACTION_URL) == 0
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"action_url": "http://hooks.example.test/action"},
+        {"action_url": "https://evil.example.test/action"},
+        {"action_url": "https://user:pass@hooks.example.test/action"},
+        {"action_url": "https://hooks.example.test/action#frag"},
+        {"dns_resolver": lambda hostname: ["127.0.0.1"]},
+        {"dns_resolver": lambda hostname: ["10.0.0.1"]},
+        {"dns_resolver": lambda hostname: ["169.254.1.1"]},
+    ],
+)
+def test_url_security_rejections_prevent_action(kwargs: dict[str, Any]) -> None:
+    subject = adapter(**kwargs)
+    fake = subject.transport
+    receipt = execute_bind_adjudication(
+        execution_intent=intent(),
+        adapter=subject,
+        append_trustlog=False,
+    )
+    assert receipt.final_outcome in {FinalOutcome.BLOCKED, FinalOutcome.SNAPSHOT_FAILED}
+    assert fake.count("POST", ACTION_URL) == 0
+
+
+def test_secret_absent_from_errors_and_receipt() -> None:
+    fake = FakeTransport({("GET", SNAPSHOT_URL): [TransportError("super-secret")]})
+    receipt = execute_bind_adjudication(
+        execution_intent=intent(),
+        adapter=adapter(fake),
+        append_trustlog=False,
+    )
+    serialized = canonical_bind_receipt_json(receipt)
+    assert "super-secret" not in serialized
+    with pytest.raises(RuntimeError) as excinfo:
+        adapter(fake)._request("GET", SNAPSHOT_URL, headers={}, json_body=None)
+    assert "super-secret" not in str(excinfo.value)
+    assert excinfo.value.__cause__ is None

--- a/veritas_os/policy/__init__.py
+++ b/veritas_os/policy/__init__.py
@@ -18,6 +18,7 @@ from .bind_artifacts import (
     hash_execution_intent,
 )
 from .bind_boundary_adapters import PolicyBundlePromotionAdapter
+from .webhook_bind_adapter import WebhookBindAdapter
 from .bind_core import (
     BIND_OUTCOME_VALUES,
     BindAdapterContract,
@@ -94,6 +95,7 @@ __all__ = [
     "BindBoundaryAdapter",
     "ReferenceBindAdapter",
     "PolicyBundlePromotionAdapter",
+    "WebhookBindAdapter",
     "promote_policy_bundle_with_bind_boundary",
     "execute_bind_boundary",
     "promote_decision_candidate_to_execution_intent",

--- a/veritas_os/policy/webhook_bind_adapter.py
+++ b/veritas_os/policy/webhook_bind_adapter.py
@@ -1,0 +1,448 @@
+"""Fail-closed HTTPS webhook bind adapter.
+
+WebhookBindAdapter is a reference external bind adapter.  It sends a
+three-endpoint bind flow (snapshot, action, postcondition) through the existing
+bind core and compensates only when an explicitly configured compensation
+webhook verifies success.  Generic external side effects may be irreversible;
+when compensation is absent or unverified, rollback is not claimed.
+
+Receiver contract
+-----------------
+Action and compensation receivers get JSON POST requests with these headers:
+``Content-Type``, ``X-Veritas-Decision-Id``,
+``X-Veritas-Execution-Intent-Id``, ``X-Veritas-Idempotency-Key``,
+``X-Veritas-Timestamp``, and ``X-Veritas-Signature``.  The signature is
+``sha256=<hex hmac-sha256>`` over ``timestamp + "." + canonical_json_body``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+import hashlib
+import hmac
+import ipaddress
+import json
+import socket
+from typing import Any, Callable, Mapping, Protocol
+from urllib.error import HTTPError, URLError
+from urllib.parse import ParseResult, urlparse, urlunparse
+from urllib.request import Request, build_opener, HTTPRedirectHandler
+
+from veritas_os.policy.bind_artifacts import ExecutionIntent
+from veritas_os.policy.bind_core.contracts import BindAdapterContract
+from veritas_os.security.hash import canonical_json_dumps, sha256_of_canonical_json
+
+
+class WebhookTransport(Protocol):
+    """Synchronous transport contract used by WebhookBindAdapter."""
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: Mapping[str, str] | None = None,
+        json_body: Mapping[str, Any] | None = None,
+        timeout: float,
+        allow_redirects: bool = False,
+    ) -> "WebhookResponse":
+        """Return an HTTP response without following redirects."""
+
+
+@dataclass(frozen=True)
+class WebhookResponse:
+    """Minimal sanitized HTTP response shape for webhook calls."""
+
+    status_code: int
+    json_data: Any
+    headers: Mapping[str, str] = field(default_factory=dict, repr=False)
+
+
+@dataclass(frozen=True, repr=False)
+class WebhookBindAdapter(BindAdapterContract):
+    """Bind adapter that executes governed changes through HTTPS webhooks."""
+
+    snapshot_url: str
+    action_url: str
+    postcondition_url: str
+    action_payload: dict[str, Any]
+    expected_postcondition: dict[str, Any]
+    allowed_hosts: set[str] | frozenset[str]
+    hmac_secret: bytes | str
+    timeout_seconds: float = 5.0
+    required_approval_key: str = "external_webhook_action_approved"
+    compensation_url: str | None = None
+    compensation_payload: dict[str, Any] | None = None
+    transport: WebhookTransport | None = field(default=None, repr=False, compare=False)
+    dns_resolver: Callable[[str], list[str]] | None = field(
+        default=None, repr=False, compare=False
+    )
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "allowed_hosts", frozenset(self.allowed_hosts))
+        if isinstance(self.hmac_secret, str):
+            object.__setattr__(self, "hmac_secret", self.hmac_secret.encode("utf-8"))
+
+    def __repr__(self) -> str:
+        return (
+            "WebhookBindAdapter("
+            f"snapshot_url={self._describe_url(self.snapshot_url)!r}, "
+            f"action_url={self._describe_url(self.action_url)!r}, "
+            f"postcondition_url={self._describe_url(self.postcondition_url)!r}, "
+            f"compensation_url={self._describe_url(self.compensation_url)!r}, "
+            f"allowed_hosts={sorted(self.allowed_hosts)!r}, "
+            f"timeout_seconds={self.timeout_seconds!r})"
+        )
+
+    def snapshot(self) -> dict[str, Any]:
+        return self._get_json_object(self.snapshot_url, "BIND_WEBHOOK_SNAPSHOT_FAILED")
+
+    def fingerprint_state(self, snapshot: Any) -> str:
+        if not isinstance(snapshot, dict):
+            raise ValueError("BIND_WEBHOOK_SNAPSHOT_INVALID")
+        return sha256_of_canonical_json(snapshot)
+
+    def validate_authority(self, intent: ExecutionIntent, snapshot: Any) -> bool | None:
+        del snapshot
+        if not isinstance(intent.approval_context, dict):
+            return False
+        return intent.approval_context.get(self.required_approval_key) is True
+
+    def validate_constraints(
+        self,
+        intent: ExecutionIntent,
+        snapshot: Any,
+    ) -> dict[str, bool] | None:
+        del intent
+        results = {
+            "action_payload_is_object": isinstance(self.action_payload, dict),
+            "action_payload_is_canonical_json": _is_canonical_json(self.action_payload),
+            "expected_postcondition_is_object": isinstance(
+                self.expected_postcondition, dict
+            ),
+            "expected_postcondition_is_canonical_json": _is_canonical_json(
+                self.expected_postcondition
+            ),
+            "snapshot_is_object": isinstance(snapshot, dict),
+            "snapshot_url_allowed": self._url_allowed(self.snapshot_url),
+            "action_url_allowed": self._url_allowed(self.action_url),
+            "postcondition_url_allowed": self._url_allowed(self.postcondition_url),
+            "hmac_secret_present": isinstance(self.hmac_secret, bytes)
+            and bool(self.hmac_secret),
+            "timeout_is_valid": isinstance(self.timeout_seconds, (int, float))
+            and 0 < self.timeout_seconds <= 60,
+        }
+        if self.compensation_url is not None:
+            results["compensation_url_allowed"] = self._url_allowed(
+                self.compensation_url
+            )
+            compensation_payload = self.compensation_payload or {}
+            results["compensation_payload_is_object"] = isinstance(
+                compensation_payload, dict
+            )
+            results["compensation_payload_is_canonical_json"] = _is_canonical_json(
+                compensation_payload
+            )
+        return results
+
+    def assess_runtime_risk(
+        self, intent: ExecutionIntent, snapshot: Any
+    ) -> bool | None:
+        del intent, snapshot
+        urls = [self.snapshot_url, self.action_url, self.postcondition_url]
+        if self.compensation_url:
+            urls.append(self.compensation_url)
+        return all(self._url_allowed(url) for url in urls)
+
+    def apply(self, intent: ExecutionIntent, snapshot: Any) -> bool:
+        del snapshot
+        self._post_json_object(
+            self.action_url,
+            self.action_payload,
+            intent,
+            "BIND_WEBHOOK_ACTION_FAILED",
+        )
+        return True
+
+    def verify_postconditions(self, intent: ExecutionIntent, snapshot: Any) -> bool:
+        del intent, snapshot
+        try:
+            actual = self._get_json_object(
+                self.postcondition_url,
+                "BIND_WEBHOOK_POSTCONDITION_FAILED",
+            )
+        except RuntimeError:
+            return False
+        return _recursive_subset(self.expected_postcondition, actual)
+
+    def revert(self, intent: ExecutionIntent, snapshot: Any) -> bool:
+        del snapshot
+        if not self.compensation_url:
+            return False
+        try:
+            response = self._post_json_object(
+                self.compensation_url,
+                self.compensation_payload or {},
+                intent,
+                "BIND_WEBHOOK_COMPENSATION_FAILED",
+            )
+        except RuntimeError:
+            return False
+        return response.get("compensated") is True
+
+    def describe_target(self) -> str:
+        return "webhook:" + ",".join(
+            part
+            for part in [
+                self._describe_url(self.action_url),
+                self._describe_url(self.postcondition_url),
+            ]
+            if part
+        )
+
+    def build_idempotency_key(self, intent: ExecutionIntent) -> str:
+        """Build a stable key without allowing invalid configuration to escape.
+
+        Bind core asks for the key before it enters its adapter error boundary.
+        Invalid URLs or non-JSON payloads therefore use explicit invalid
+        sentinels here and are rejected later by adapter constraints.
+        """
+        try:
+            action_url = self._normalized_url(self.action_url)
+        except (TypeError, ValueError):
+            action_url = "<invalid-action-url>"
+        action_payload: Any = self.action_payload
+        if not _is_canonical_json(action_payload):
+            action_payload = "<invalid-action-payload>"
+        payload = {
+            "execution_intent_id": intent.execution_intent_id,
+            "decision_id": intent.decision_id,
+            "action_url": action_url,
+            "action_payload": action_payload,
+        }
+        return sha256_of_canonical_json(payload)
+
+    def _get_json_object(self, url: str, error_code: str) -> dict[str, Any]:
+        response = self._request("GET", url, headers={}, json_body=None)
+        return self._require_json_object(response, error_code)
+
+    def _post_json_object(
+        self,
+        url: str,
+        body: dict[str, Any],
+        intent: ExecutionIntent,
+        error_code: str,
+    ) -> dict[str, Any]:
+        idempotency_key = self.build_idempotency_key(intent)
+        canonical_body = canonical_json_dumps(body)
+        timestamp = (
+            datetime.now(timezone.utc)
+            .isoformat(timespec="seconds")
+            .replace("+00:00", "Z")
+        )
+        signature_input = f"{timestamp}.{canonical_body}".encode("utf-8")
+        signature = hmac.new(
+            self.hmac_secret, signature_input, hashlib.sha256
+        ).hexdigest()
+        headers = {
+            "Content-Type": "application/json",
+            "X-Veritas-Decision-Id": intent.decision_id,
+            "X-Veritas-Execution-Intent-Id": intent.execution_intent_id,
+            "X-Veritas-Idempotency-Key": idempotency_key,
+            "X-Veritas-Timestamp": timestamp,
+            "X-Veritas-Signature": f"sha256={signature}",
+        }
+        response = self._request("POST", url, headers=headers, json_body=body)
+        return self._require_json_object(response, error_code)
+
+    def _request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: Mapping[str, str] | None,
+        json_body: Mapping[str, Any] | None,
+    ) -> WebhookResponse:
+        if not self._url_allowed(url):
+            raise RuntimeError("BIND_WEBHOOK_URL_NOT_ALLOWED")
+        transport = self.transport or _UrllibWebhookTransport()
+        try:
+            return transport.request(
+                method,
+                self._normalized_url(url),
+                headers=headers,
+                json_body=json_body,
+                timeout=float(self.timeout_seconds),
+                allow_redirects=False,
+            )
+        except Exception:
+            # Do not preserve transport exception text or chaining: injected
+            # clients can include request headers or secret material in errors.
+            raise RuntimeError("BIND_WEBHOOK_REQUEST_FAILED") from None
+
+    @staticmethod
+    def _require_json_object(
+        response: WebhookResponse, error_code: str
+    ) -> dict[str, Any]:
+        if not 200 <= int(response.status_code) <= 299:
+            raise RuntimeError(error_code)
+        if not isinstance(response.json_data, dict):
+            raise RuntimeError(error_code)
+        return dict(response.json_data)
+
+    def _url_allowed(self, url: str | None) -> bool:
+        try:
+            parsed = _parse_https_url(url)
+        except ValueError:
+            return False
+        hostname = parsed.hostname or ""
+        if hostname not in self.allowed_hosts:
+            return False
+        return self._hostname_addresses_are_safe(hostname)
+
+    def _hostname_addresses_are_safe(self, hostname: str) -> bool:
+        try:
+            addresses = (
+                self.dns_resolver(hostname)
+                if self.dns_resolver
+                else _resolve_host(hostname)
+            )
+        except Exception:
+            # Resolver implementations are untrusted boundaries. Any unknown
+            # resolver behavior must become a deny signal, not escape bind core.
+            return False
+        return bool(addresses) and all(
+            _address_is_safe(address) for address in addresses
+        )
+
+    @staticmethod
+    def _normalized_url(url: str) -> str:
+        parsed = _parse_https_url(url)
+        host = parsed.hostname or ""
+        netloc = host if parsed.port in (None, 443) else f"{host}:{parsed.port}"
+        return urlunparse(("https", netloc, parsed.path or "/", "", parsed.query, ""))
+
+    @staticmethod
+    def _describe_url(url: str | None) -> str:
+        if not url:
+            return ""
+        try:
+            parsed = _parse_https_url(url)
+        except ValueError:
+            return "invalid-url"
+        host = parsed.hostname or ""
+        netloc = host if parsed.port in (None, 443) else f"{host}:{parsed.port}"
+        return urlunparse(("https", netloc, "", "", "", ""))
+
+
+class _NoRedirectHandler(HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: ANN001
+        return None
+
+
+class _UrllibWebhookTransport:
+    """Default transport using urllib with redirects disabled."""
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: Mapping[str, str] | None = None,
+        json_body: Mapping[str, Any] | None = None,
+        timeout: float,
+        allow_redirects: bool = False,
+    ) -> WebhookResponse:
+        del allow_redirects
+        data = None
+        if json_body is not None:
+            data = canonical_json_dumps(json_body).encode("utf-8")
+        request = Request(url, data=data, headers=dict(headers or {}), method=method)
+        opener = build_opener(_NoRedirectHandler)
+        try:
+            with opener.open(request, timeout=timeout) as response:
+                raw = response.read().decode("utf-8")
+                parsed = json.loads(raw) if raw else {}
+                return WebhookResponse(
+                    response.status, parsed, dict(response.headers.items())
+                )
+        except HTTPError as exc:
+            try:
+                parsed = json.loads(exc.read().decode("utf-8"))
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                parsed = None
+            return WebhookResponse(exc.code, parsed, dict(exc.headers.items()))
+        except (
+            TimeoutError,
+            URLError,
+            json.JSONDecodeError,
+            UnicodeDecodeError,
+        ) as exc:
+            raise RuntimeError("BIND_WEBHOOK_TRANSPORT_FAILED") from exc
+
+
+def _parse_https_url(url: str | None) -> ParseResult:
+    if not isinstance(url, str) or not url.strip():
+        raise ValueError("BIND_WEBHOOK_URL_INVALID")
+    try:
+        parsed = urlparse(url)
+        _ = parsed.port
+    except ValueError as exc:
+        raise ValueError("BIND_WEBHOOK_URL_INVALID") from exc
+    if parsed.scheme != "https":
+        raise ValueError("BIND_WEBHOOK_URL_SCHEME_INVALID")
+    if not parsed.hostname:
+        raise ValueError("BIND_WEBHOOK_URL_HOST_MISSING")
+    if parsed.username or parsed.password:
+        raise ValueError("BIND_WEBHOOK_URL_USERINFO_FORBIDDEN")
+    if parsed.fragment:
+        raise ValueError("BIND_WEBHOOK_URL_FRAGMENT_FORBIDDEN")
+    return parsed
+
+
+def _resolve_host(hostname: str) -> list[str]:
+    return sorted({item[4][0] for item in socket.getaddrinfo(hostname, None)})
+
+
+def _address_is_safe(address: str) -> bool:
+    try:
+        ip = ipaddress.ip_address(address)
+    except ValueError:
+        return False
+    return not (
+        ip.is_loopback
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_unspecified
+        or ip.is_reserved
+        or ip.is_private
+    )
+
+
+def _recursive_subset(expected: dict[str, Any], actual: dict[str, Any]) -> bool:
+    for key, value in expected.items():
+        if key not in actual:
+            return False
+        actual_value = actual[key]
+        if isinstance(value, dict):
+            if not isinstance(actual_value, dict):
+                return False
+            if not _recursive_subset(value, actual_value):
+                return False
+            continue
+        if actual_value != value:
+            return False
+    return True
+
+
+def _is_canonical_json(value: Any) -> bool:
+    """Return whether a value can be serialized by canonical JSON helpers."""
+    try:
+        canonical_json_dumps(value)
+    except (OverflowError, RecursionError, TypeError, ValueError):
+        return False
+    return True
+
+
+__all__ = ["WebhookBindAdapter", "WebhookResponse", "WebhookTransport"]


### PR DESCRIPTION
### Motivation

- Provide a reference external bind adapter to evaluate VERITAS OS bind execution against an HTTPS webhook target with a fail-closed model and strong security constraints.
- Offer integrators a prototype pattern for idempotent HMAC-signed requests, URL/hostname validation, and optional compensation semantics without changing bind core semantics.

### Description

- Add `veritas_os.policy.webhook_bind_adapter.WebhookBindAdapter`, a `BindAdapterContract` implementation that performs a three-endpoint flow (`snapshot`, `action`, `postcondition`) with HMAC signing, deterministic idempotency keys, strict URL and address validation, and optional compensation support.
- Introduce a transport abstraction `WebhookTransport` and a default `_UrllibWebhookTransport` implementation that disables redirects and sanitizes responses, plus `WebhookResponse` shape for tests and consumers.
- Add security utilities for canonical JSON checks, recursive postcondition subset matching, safe IP/address checks, DNS resolution hooks, and secret-free error handling.
- Export `WebhookBindAdapter` from `veritas_os.policy.__init__` and add user-facing docs at `docs/en/guides/webhook-bind-adapter.md` describing contract, headers, idempotency, and security posture.
- Add comprehensive unit tests at `tests/policy/test_webhook_bind_adapter.py` covering snapshot/apply/postcondition flows, compensation, idempotency, URL safety, error handling, and secret redaction.

### Testing

- Ran the new unit test module with `pytest tests/policy/test_webhook_bind_adapter.py` and the tests for the adapter passed.
- Tests exercised success and failure scenarios including snapshot failures, action failures, postcondition verification, compensation success/failure, idempotency replay protection, URL and resolver rejections, and secret absence in errors, all passing in the run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a545a170ad083269c9bb0dad41f4851)