### PR TITLE
docs: surface WebhookBindAdapter in README and reviewer docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ Validation Report
 
 For deeper reviewer evidence context, see the [Reviewer Evidence Index](docs/en/demo/reviewer-evidence-index.md), [Reviewer Evidence Assurance Overview](docs/en/demo/reviewer-evidence-assurance-overview.md), and [Reviewer Evidence Packet](docs/en/demo/reviewer-evidence-packet.md).
 
+### External bind adapter reference
+
+[WebhookBindAdapter](docs/en/guides/webhook-bind-adapter.md) is the first reference adapter for external bind execution. It demonstrates how VERITAS can treat AI output as a Decision Candidate and gate an external HTTPS side effect at the Bind Boundary through snapshot, governed action, postcondition verification, deterministic idempotency, HMAC signing, and fail-closed compensation semantics before claiming a committed outcome.
+
+This is a reference integration pattern, not production certification, regulatory approval, or proof of a production deployment. When compensation is absent or cannot be verified, the adapter does not claim rollback.
+
 Official Website: https://veritas-website-navy.vercel.app/
 
 This project is not only about running agents.

--- a/docs/REVIEWER_ENTRYPOINT.md
+++ b/docs/REVIEWER_ENTRYPOINT.md
@@ -41,6 +41,7 @@ This entry point is organized around the current enterprise review path: busines
 15. [Provider Support Matrix](en/operations/provider-support-matrix.md)
 16. [Regulated Action Governance Kernel](en/architecture/regulated-action-governance-kernel.md)
 17. [Bind Boundary Governance Artifacts](en/architecture/bind-boundary-governance-artifacts.md)
+18. [External Bind Adapter: WebhookBindAdapter](en/guides/webhook-bind-adapter.md) — first reference adapter for reviewing how an external HTTPS side effect crosses the Bind Boundary; this is a reference integration pattern, not production certification.
 
 ## What VERITAS OS is
 

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -72,6 +72,7 @@ For the bilingual correspondence table, see [../DOCUMENTATION_MAP.md](../DOCUMEN
 - [Recent Hardening Notes](development/recent-hardening.md) — compact summary of recent auditability, observability, CI gate, and compatibility hardening work.
 
 ### Guides
+- [External Bind Adapter: WebhookBindAdapter](guides/webhook-bind-adapter.md) — first reference adapter for gating an external HTTPS side effect at the Bind Boundary; an integration pattern, not production certification.
 - [3-Minute Demo Script](guides/demo-script.md)
 - [Financial PoC Pack (1-day quickstart, EN)](guides/poc-pack-financial-quickstart.md)
 - [Financial PoC Success Criteria](guides/financial-poc-success-criteria.md)


### PR DESCRIPTION
### Motivation
- Make the newly merged `WebhookBindAdapter` easy to discover from the main README and reviewer/developer navigation while explicitly positioning it as a reference integration pattern (not production certification) and preserving the Decision Candidate / Bind Boundary model.

### Description
- Documentation-only changes: add an "External bind adapter reference" section to `README.md`, add a `WebhookBindAdapter` entry under `Guides` in `docs/en/README.md`, and add an `External Bind Adapter: WebhookBindAdapter` entry to the reviewer path in `docs/REVIEWER_ENTRYPOINT.md`; no runtime code, tests, dependencies, CI, or governance behavior were modified.

### Testing
- Verified the modified files exist with `test -f docs/en/guides/webhook-bind-adapter.md` and ran `git diff --check` (no issues);
- Ran bilingual docs checks with `python -m scripts.quality.check_bilingual_docs` (invoked with `PYENV_VERSION=3.12.13`) which passed;
- Attempted to run `pytest -q veritas_os/tests/test_reviewer_entrypoint_current_path.py` but test collection failed in this environment due to a missing runtime dependency (`pydantic`), so full test execution is left to CI where the repository test matrix will run the standard checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7cc34aafbc8326a3f97673bf32311b)