### PR TITLE
feat(sdk): add minimal Python reference client

### DIFF
--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,0 +1,79 @@
+# Minimal Python SDK reference
+
+This directory provides a small, synchronous reference client for starting a
+VERITAS OS integration. It uses only the Python standard library and calls the
+existing `POST /v1/decide` endpoint. Copy `veritas_client.py` into an
+application or place this directory on `PYTHONPATH`; this reference is not a
+packaged distribution.
+
+## Scope and claims
+
+- This is a minimal reference SDK, **not** a full production SDK.
+- It does not claim certification, regulatory compliance, or a live customer
+  integration.
+- AI output remains a **Decision Candidate**, not authorization to act.
+- External execution must separately cross the **Bind Boundary**, including
+  the applicable admissibility, authority, audit, and failure controls.
+- The bind example only prepares application data. It does not invoke,
+  reproduce, or bypass `WebhookBindAdapter` or bind adjudication.
+
+## Requirements
+
+- Python 3.11 or newer
+- A running VERITAS OS API and an API key authorized for `/v1/decide`
+- No third-party Python dependencies
+
+## Decision example
+
+Run from this directory:
+
+```bash
+export VERITAS_BASE_URL="http://localhost:8000"
+export VERITAS_API_KEY="your-local-api-key"
+PYTHONPATH=. python examples/decide.py
+```
+
+Or use the client directly:
+
+```python
+from veritas_client import VeritasClient
+
+client = VeritasClient(
+    base_url="http://localhost:8000",
+    api_key="your-local-api-key",
+    timeout=30.0,
+)
+candidate = client.decide(
+    {
+        "query": "Which maintenance window should an operator review?",
+        "options": ["Saturday 02:00 UTC", "Sunday 02:00 UTC"],
+    }
+)
+```
+
+`VeritasAPIError` exposes `status_code` and `response_body` for non-2xx API
+responses. Network failures, timeouts, invalid JSON, and non-object JSON raise
+`VeritasTransportError`.
+
+## Bind-related call pattern
+
+`examples/webhook_bind.py` prepares a deliberately non-executing payload that
+an external application could carry into its own reviewed bind workflow. Run
+it without credentials:
+
+```bash
+PYTHONPATH=. python examples/webhook_bind.py
+```
+
+The example is not a production-certified integration and does not define a
+new VERITAS endpoint. Use the deployed VERITAS contract and the documented
+`WebhookBindAdapter` controls when implementing a real bind path.
+
+## Security notes
+
+- Do not commit API keys or include them in logs and error reports.
+- Use HTTPS with certificate verification for non-local deployments.
+- Treat decision and error payloads as potentially sensitive application data.
+- Validate the deployed API contract and apply least-privilege credentials.
+- Never treat a successful decision response as permission to perform a side
+  effect; complete the governed Bind Boundary flow first.

--- a/sdk/python/examples/decide.py
+++ b/sdk/python/examples/decide.py
@@ -1,0 +1,25 @@
+"""Call the VERITAS decision endpoint with a minimal example payload."""
+
+import json
+import os
+
+from veritas_client import VeritasClient
+
+
+def main() -> None:
+    """Load local configuration and submit a Decision Candidate."""
+    client = VeritasClient(
+        base_url=os.environ.get("VERITAS_BASE_URL", "http://localhost:8000"),
+        api_key=os.environ["VERITAS_API_KEY"],
+    )
+    response = client.decide(
+        {
+            "query": "Which maintenance window should an operator review?",
+            "options": ["Saturday 02:00 UTC", "Sunday 02:00 UTC"],
+        }
+    )
+    print(json.dumps(response, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/sdk/python/examples/webhook_bind.py
+++ b/sdk/python/examples/webhook_bind.py
@@ -1,0 +1,38 @@
+"""Prepare a reference payload for a separately governed webhook bind flow."""
+
+import json
+from typing import Any
+
+
+def prepare_bind_payload(
+    decision_id: str,
+    target_url: str,
+    action_payload: dict[str, Any],
+) -> dict[str, Any]:
+    """Prepare application data for review at a Bind Boundary.
+
+    This helper neither adjudicates nor executes a bind. Integrators must map
+    this data to their reviewed bind interface and production controls.
+    """
+    return {
+        "decision_id": decision_id,
+        "adapter": "webhook",
+        "target_url": target_url,
+        "action_payload": action_payload,
+        "execution_status": "not_executed",
+        "requires_bind_adjudication": True,
+    }
+
+
+def main() -> None:
+    """Display a non-executing bind payload example."""
+    payload = prepare_bind_payload(
+        decision_id="replace-with-reviewed-decision-id",
+        target_url="https://example.invalid/reviewed-webhook",
+        action_payload={"operation": "schedule_maintenance"},
+    )
+    print(json.dumps(payload, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/sdk/python/tests/test_veritas_client.py
+++ b/sdk/python/tests/test_veritas_client.py
@@ -1,0 +1,83 @@
+"""Unit tests for the dependency-free VERITAS reference client."""
+
+import io
+import json
+import unittest
+from unittest import mock
+from urllib import error
+
+from veritas_client import (
+    VeritasAPIError,
+    VeritasClient,
+    VeritasTransportError,
+)
+
+
+class _Response:
+    """Minimal context-managed urllib response test double."""
+
+    def __init__(self, payload: object) -> None:
+        self.body = json.dumps(payload).encode("utf-8")
+
+    def __enter__(self) -> "_Response":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self.body
+
+
+class VeritasClientTests(unittest.TestCase):
+    """Verify request construction and explicit failure behavior."""
+
+    def setUp(self) -> None:
+        """Create a client used by each test."""
+        self.client = VeritasClient("https://veritas.example/", "test-key", 5)
+
+    @mock.patch("veritas_client.request.urlopen")
+    def test_decide_posts_authenticated_json(self, urlopen: mock.Mock) -> None:
+        """The decision helper posts JSON to the existing endpoint."""
+        urlopen.return_value = _Response({"status": "candidate"})
+
+        result = self.client.decide({"query": "review this"})
+
+        self.assertEqual(result, {"status": "candidate"})
+        sent_request = urlopen.call_args.args[0]
+        self.assertEqual(sent_request.full_url, "https://veritas.example/v1/decide")
+        self.assertEqual(sent_request.get_header("X-api-key"), "test-key")
+        self.assertEqual(json.loads(sent_request.data), {"query": "review this"})
+        urlopen.assert_called_once_with(sent_request, timeout=5)
+
+    @mock.patch("veritas_client.request.urlopen")
+    def test_non_2xx_response_raises_api_error(self, urlopen: mock.Mock) -> None:
+        """HTTP failures preserve the status and response body."""
+        urlopen.side_effect = error.HTTPError(
+            self.client.base_url,
+            403,
+            "Forbidden",
+            {},
+            io.BytesIO(b'{"detail":"denied"}'),
+        )
+
+        with self.assertRaises(VeritasAPIError) as raised:
+            self.client.decide({"query": "review this"})
+
+        self.assertEqual(raised.exception.status_code, 403)
+        self.assertEqual(raised.exception.response_body, '{"detail":"denied"}')
+
+    @mock.patch("veritas_client.request.urlopen")
+    def test_non_object_response_raises_transport_error(
+        self,
+        urlopen: mock.Mock,
+    ) -> None:
+        """A JSON response must match the SDK's object return contract."""
+        urlopen.return_value = _Response(["unexpected"])
+
+        with self.assertRaises(VeritasTransportError):
+            self.client.decide({"query": "review this"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdk/python/veritas_client.py
+++ b/sdk/python/veritas_client.py
@@ -1,0 +1,141 @@
+"""Dependency-free reference client for the VERITAS OS HTTP API."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from urllib import error, request
+
+
+class VeritasClientError(Exception):
+    """Base error raised by the reference VERITAS client."""
+
+
+class VeritasAPIError(VeritasClientError):
+    """Represent a non-successful response from the VERITAS API."""
+
+    def __init__(self, status_code: int, response_body: str) -> None:
+        """Initialize an API response error.
+
+        Args:
+            status_code: HTTP response status code.
+            response_body: Response body decoded as text.
+        """
+        self.status_code = status_code
+        self.response_body = response_body
+        super().__init__(
+            f"VERITAS API returned HTTP {status_code}: {response_body}"
+        )
+
+
+class VeritasTransportError(VeritasClientError):
+    """Represent a network or response-decoding failure."""
+
+
+class VeritasClient:
+    """Small synchronous client for JSON VERITAS API calls."""
+
+    def __init__(
+        self,
+        base_url: str,
+        api_key: str,
+        timeout: float = 30.0,
+    ) -> None:
+        """Initialize the client.
+
+        Args:
+            base_url: VERITAS API origin, such as ``http://localhost:8000``.
+            api_key: Value sent in the ``X-API-Key`` header.
+            timeout: Request timeout in seconds.
+
+        Raises:
+            ValueError: If an argument is empty or timeout is not positive.
+        """
+        if not base_url.strip():
+            raise ValueError("base_url must not be empty")
+        if not api_key.strip():
+            raise ValueError("api_key must not be empty")
+        if timeout <= 0:
+            raise ValueError("timeout must be positive")
+
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self.timeout = timeout
+
+    def request_json(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+        """POST a JSON object and return a decoded JSON object.
+
+        Args:
+            path: Absolute API path beginning with ``/``.
+            payload: JSON-serializable request object.
+
+        Returns:
+            The response JSON object.
+
+        Raises:
+            ValueError: If path is not absolute.
+            TypeError: If payload is not a dictionary.
+            VeritasAPIError: If the API returns a non-2xx response.
+            VeritasTransportError: If transport or JSON decoding fails.
+        """
+        if not path.startswith("/"):
+            raise ValueError("path must begin with '/'")
+        if not isinstance(payload, dict):
+            raise TypeError("payload must be a dictionary")
+
+        body = json.dumps(payload).encode("utf-8")
+        http_request = request.Request(
+            f"{self.base_url}{path}",
+            data=body,
+            headers={
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+                "X-API-Key": self.api_key,
+            },
+            method="POST",
+        )
+
+        try:
+            with request.urlopen(http_request, timeout=self.timeout) as response:
+                response_body = response.read().decode("utf-8")
+        except error.HTTPError as exc:
+            response_body = exc.read().decode("utf-8", errors="replace")
+            raise VeritasAPIError(exc.code, response_body) from exc
+        except (error.URLError, TimeoutError) as exc:
+            raise VeritasTransportError(
+                f"VERITAS API request failed: {exc}"
+            ) from exc
+
+        try:
+            decoded = json.loads(response_body)
+        except json.JSONDecodeError as exc:
+            raise VeritasTransportError(
+                "VERITAS API response was not valid JSON"
+            ) from exc
+        if not isinstance(decoded, dict):
+            raise VeritasTransportError(
+                "VERITAS API response JSON must be an object"
+            )
+        return decoded
+
+    def decide(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Submit a Decision Candidate request to ``POST /v1/decide``.
+
+        The returned decision is not permission to execute an external action.
+        Any execution must separately cross the VERITAS Bind Boundary.
+
+        Args:
+            payload: Request body matching the deployed ``/v1/decide`` contract.
+
+        Returns:
+            The decoded decision response.
+        """
+        return self.request_json("/v1/decide", payload)
+
+
+__all__ = [
+    "VeritasAPIError",
+    "VeritasClient",
+    "VeritasClientError",
+    "VeritasTransportError",
+]


### PR DESCRIPTION
### Motivation

- Provide a minimal, dependency-free Python entrypoint that demonstrates how external developers can call VERITAS decision and bind-related endpoints without changing runtime or governance behavior. 

### Description

- Add a small synchronous reference client `VeritasClient` with `base_url`, `api_key`, `timeout`, JSON request/response handling, clear transport and API error types, and a `decide(payload: dict) -> dict` helper. 
- Add non-executing examples `examples/decide.py` and `examples/webhook_bind.py` that are import-safe and show a bind payload preparation pattern without performing any bind execution. 
- Add `README.md` documenting scope, limits (reference-only, not production-certified), Decision Candidate semantics, Bind Boundary requirements, and security guidance. 
- Add focused stdlib unit tests for request construction, non-2xx handling, and response-shape validation in `tests/test_veritas_client.py`.

### Testing

- Ran unit tests: `python -m unittest discover -s sdk/python/tests -v` and they passed. 
- Performed bytecode compile and linter checks: `python -m compileall -q sdk/python` and `ruff check sdk/python` and they passed. 
- Verified examples can be safely imported: `PYTHONPATH=sdk/python python -c 'import examples.decide, examples.webhook_bind'` and it succeeded. 
- Ran repository checks: `git diff --check` and staged-diff checks; no issues found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d894a98b0832686a4333b4cbd3069)