### PR TITLE
docs: surface minimal Python SDK reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ For deeper reviewer evidence context, see the [Reviewer Evidence Index](docs/en/
 
 This is a reference integration pattern, not production certification, regulatory approval, or proof of a production deployment. When compensation is absent or cannot be verified, the adapter does not claim rollback.
 
+### Minimal Python SDK reference
+
+The [minimal Python SDK reference](sdk/python/README.md) is a dependency-free Python client for calling VERITAS `/v1/decide`, with import-safe examples and a non-executing bind payload preparation pattern. This is a reference integration aid, not a production-certified SDK: AI output remains a Decision Candidate, `/v1/decide` does not authorize external side effects, and external execution must still cross the Bind Boundary. `WebhookBindAdapter` remains the reference external bind adapter pattern.
+
 Official Website: https://veritas-website-navy.vercel.app/
 
 This project is not only about running agents.

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -72,6 +72,7 @@ For the bilingual correspondence table, see [../DOCUMENTATION_MAP.md](../DOCUMEN
 - [Recent Hardening Notes](development/recent-hardening.md) — compact summary of recent auditability, observability, CI gate, and compatibility hardening work.
 
 ### Guides
+- [Minimal Python SDK reference](../../sdk/python/README.md) — dependency-free `/v1/decide` client with import-safe examples and non-executing bind payload preparation; a reference integration aid, not a production-certified SDK. AI output remains a Decision Candidate, and external side effects must still cross the Bind Boundary using the `WebhookBindAdapter` reference pattern.
 - [External Bind Adapter: WebhookBindAdapter](guides/webhook-bind-adapter.md) — first reference adapter for gating an external HTTPS side effect at the Bind Boundary; an integration pattern, not production certification.
 - [3-Minute Demo Script](guides/demo-script.md)
 - [Financial PoC Pack (1-day quickstart, EN)](guides/poc-pack-financial-quickstart.md)


### PR DESCRIPTION
### Motivation

- Make the newly merged minimal Python SDK easier to discover from the main README and English developer/reviewer docs while keeping this change documentation-only and preserving the Decision Candidate / Bind Boundary model and non-certification posture.

### Description

- Add a short SDK link/section to `README.md` and an SDK entry to `docs/en/README.md` pointing to `sdk/python/README.md`, and explicitly state the SDK is a minimal, dependency-free reference (no runtime, test, dependency, CI, or governance changes were made). 

### Testing

- Ran the bilingual docs check and local validation: `PYENV_VERSION=3.12.13 python scripts/quality/check_bilingual_docs.py` (passed), `git diff --check` (passed), and confirmed only `README.md` and `docs/en/README.md` were changed (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7db0e67d988326b4dbedf874370b7a)