### PR TITLE
docs: add AML/KYC SDK to Webhook Bind example

### DIFF
--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -73,6 +73,7 @@ For the bilingual correspondence table, see [../DOCUMENTATION_MAP.md](../DOCUMEN
 
 ### Guides
 - [Minimal Python SDK reference](../../sdk/python/README.md) — dependency-free `/v1/decide` client with import-safe examples and non-executing bind payload preparation; a reference integration aid, not a production-certified SDK. AI output remains a Decision Candidate, and external side effects must still cross the Bind Boundary using the `WebhookBindAdapter` reference pattern.
+- [AML/KYC SDK to Webhook Bind example](guides/aml-kyc-sdk-webhook-example.md) — placeholder-only reference flow from `/v1/decide` to preparation of a non-executing bind payload; it does not authorize or perform an external action.
 - [External Bind Adapter: WebhookBindAdapter](guides/webhook-bind-adapter.md) — first reference adapter for gating an external HTTPS side effect at the Bind Boundary; an integration pattern, not production certification.
 - [3-Minute Demo Script](guides/demo-script.md)
 - [Financial PoC Pack (1-day quickstart, EN)](guides/poc-pack-financial-quickstart.md)

--- a/docs/en/guides/aml-kyc-sdk-webhook-example.md
+++ b/docs/en/guides/aml-kyc-sdk-webhook-example.md
@@ -1,0 +1,116 @@
+# AML/KYC Decision Candidate: Python SDK to Webhook Bind
+
+This reference integration example shows how an application can ask VERITAS
+OS to review a placeholder AML/KYC case, then prepare data for a separately
+governed external bind. It does not use customer data, contact a bank, or
+perform an external action. It is not a production integration, certification,
+regulatory approval, or compliance determination.
+
+## Boundary at a glance
+
+1. The application prepares a placeholder review request.
+2. The [minimal Python SDK](../../../sdk/python/README.md) calls
+   `POST /v1/decide`.
+3. The response is retained as a **Decision Candidate / governance decision**,
+   not permission to execute.
+4. The application may prepare a non-executing bind payload for review.
+5. Any actual external action must separately cross the **Bind Boundary**. The
+   [WebhookBindAdapter](webhook-bind-adapter.md) is the reference external bind
+   adapter pattern; it applies bind adjudication and its documented external
+   execution controls rather than treating the SDK response as authorization.
+
+`/v1/decide` evaluates a request and returns a decision response. It does not
+execute an external action. The SDK only helps an application call VERITAS; it
+does not replace bind admissibility, authority, audit, or failure controls.
+
+## Import-safe, non-executing example
+
+The following code defines the integration steps but does not call the API or
+an external system when imported or run. An application must explicitly call
+`request_review()` to contact its configured VERITAS deployment. The
+`prepare_bind_payload()` function only constructs application data for a later
+reviewed bind flow.
+
+```python
+from typing import Any
+
+from veritas_client import VeritasClient
+
+
+def build_review_payload() -> dict[str, Any]:
+    """Build a fictional AML/KYC review request with no customer data."""
+    return {
+        "query": (
+            "Which review disposition should an analyst consider for the "
+            "placeholder case?"
+        ),
+        "options": [
+            "request_additional_documentation",
+            "escalate_for_human_review",
+            "record_no_further_action_candidate",
+        ],
+        "context": {
+            "case_id": "placeholder-case-001",
+            "risk_signals": [
+                "placeholder_identity_mismatch",
+                "placeholder_source_of_funds_review",
+            ],
+            "data_classification": "synthetic_example_only",
+        },
+    }
+
+
+def request_review(client: VeritasClient) -> dict[str, Any]:
+    """Request a governance decision that remains a Decision Candidate."""
+    return client.decide(build_review_payload())
+
+
+def prepare_bind_payload(
+    decision: dict[str, Any],
+) -> dict[str, Any]:
+    """Prepare, but do not execute, data for a reviewed bind workflow."""
+    return {
+        "decision_id": decision.get("decision_id"),
+        "adapter_pattern": "WebhookBindAdapter",
+        "target": "https://example.invalid/aml-kyc-review",
+        "action_payload": {
+            "case_id": "placeholder-case-001",
+            "requested_operation": "create_human_review_task",
+        },
+        "execution_status": "not_executed",
+        "requires_bind_adjudication": True,
+    }
+```
+
+For example, an application can construct a client with locally supplied
+configuration and explicitly request the review:
+
+```python
+client = VeritasClient(
+    base_url="http://localhost:8000",
+    api_key="your-local-api-key",
+)
+candidate = request_review(client)
+bind_payload = prepare_bind_payload(candidate)
+```
+
+At this point, `bind_payload` is still only application data. Do not send it
+directly to the placeholder target. A reviewed integration must map it to the
+existing bind contract and cross the Bind Boundary through the
+`WebhookBindAdapter` pattern (or another approved adapter) before any side
+effect can occur.
+
+## Integration and security notes
+
+- Use synthetic data while evaluating this example; do not copy real identity,
+  account, sanctions-screening, or customer records into source code or logs.
+- Keep API keys and webhook signing secrets outside code, use least-privilege
+  access, and use verified HTTPS for non-local deployments.
+- Validate the deployed `/v1/decide` request and response contract. Treat both
+  decision and error payloads as potentially sensitive.
+- Do not infer approval from an HTTP success response or a favorable Decision
+  Candidate. Human review and deployment-specific AML/KYC controls remain the
+  integrator's responsibility.
+- Follow the `WebhookBindAdapter` guidance for target allowlisting, signing,
+  idempotency, postcondition verification, and fail-closed handling.
+


### PR DESCRIPTION
### Motivation
- Provide a small, reviewable reference showing how an AML/KYC Decision Candidate flow can be invoked from the minimal Python SDK and prepared for an external bind without executing the bind.
- Clarify that `POST /v1/decide` returns a Decision Candidate (not permission to act) and that any external execution must cross the Bind Boundary using the `WebhookBindAdapter` reference pattern.
- Keep the change documentation-only and avoid touching governance core, bind core, runtime behavior, dependencies, or CI gates.

### Description
- Add `docs/en/guides/aml-kyc-sdk-webhook-example.md` with import-safe, non-executing Python snippets that build a placeholder AML/KYC review payload, call the minimal SDK (`VeritasClient.decide`), and prepare a non-executing bind payload for later reviewed execution. 
- Link the new guide from `docs/en/README.md` under the Guides section so it is discoverable from the English docs index. 
- Use only synthetic placeholder data and explicit disclaimers that this is a reference integration example, not a production/certification/regulatory or live-bank integration. 
- Make no runtime, CI, dependency, governance, or adapter behavior changes; this is documentation only.

### Testing
- Parsed the embedded Python examples with `ast.parse` to verify example syntax and they parsed successfully. 
- Verified local Markdown links in the changed files resolve with a local link-check routine and the check passed. 
- Ran `git diff --check` and basic repository sanity checks (commit and status) with no warnings. 
- Security verification: examples are non-executing by default, use synthetic data only, and the guide includes explicit guidance to keep API keys and webhook signing secrets out of source and logs; no networked calls were performed during tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7db505574c83268cc776db05ca494b)