### PR TITLE
docs(sdk): add AML/KYC Webhook Bind reference example

### DIFF
--- a/docs/en/guides/aml-kyc-sdk-webhook-example.md
+++ b/docs/en/guides/aml-kyc-sdk-webhook-example.md
@@ -25,8 +25,10 @@ does not replace bind admissibility, authority, audit, or failure controls.
 
 ## Import-safe, non-executing example
 
-The following code defines the integration steps but does not call the API or
-an external system when imported or run. An application must explicitly call
+The import-safe
+[`aml_kyc_webhook_bind.py`](../../../sdk/python/examples/aml_kyc_webhook_bind.py)
+example defines the integration steps but does not call the API or an external
+system when imported or run. An application must explicitly call
 `request_review()` to contact its configured VERITAS deployment. The
 `prepare_bind_payload()` function only constructs application data for a later
 reviewed bind flow.
@@ -113,4 +115,3 @@ effect can occur.
   integrator's responsibility.
 - Follow the `WebhookBindAdapter` guidance for target allowlisting, signing,
   idempotency, postcondition verification, and fail-closed handling.
-

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -69,6 +69,12 @@ The example is not a production-certified integration and does not define a
 new VERITAS endpoint. Use the deployed VERITAS contract and the documented
 `WebhookBindAdapter` controls when implementing a real bind path.
 
+For a domain-specific reference flow, see the import-safe
+[`examples/aml_kyc_webhook_bind.py`](examples/aml_kyc_webhook_bind.py). It
+builds a synthetic AML/KYC review request and prepares a non-executing bind
+payload; it does not contact a webhook target or use real identity, customer,
+bank, sanctions, or account data.
+
 ## Security notes
 
 - Do not commit API keys or include them in logs and error reports.

--- a/sdk/python/examples/aml_kyc_webhook_bind.py
+++ b/sdk/python/examples/aml_kyc_webhook_bind.py
@@ -1,0 +1,76 @@
+"""Prepare a synthetic AML/KYC Decision Candidate for a bind review.
+
+The SDK only calls VERITAS; ``/v1/decide`` does not authorize external side
+effects. This example never contacts a webhook target. Any external execution
+must separately cross the Bind Boundary, where ``WebhookBindAdapter`` remains
+the reference external bind adapter pattern.
+
+This example is not production certification, regulatory approval, or a live
+bank integration. All case details are fictional and contain no customer data.
+"""
+
+import json
+from typing import Any
+
+from veritas_client import VeritasClient
+
+
+def build_review_payload() -> dict[str, Any]:
+    """Build a fictional AML/KYC review request with no customer data."""
+    return {
+        "query": (
+            "Which review disposition should an analyst consider for this "
+            "synthetic AML/KYC case?"
+        ),
+        "options": [
+            "request_additional_documentation",
+            "escalate_for_human_review",
+            "record_no_further_action_candidate",
+        ],
+        "context": {
+            "case_id": "synthetic-case-001",
+            "risk_signals": [
+                "synthetic_identity_mismatch",
+                "synthetic_source_of_funds_review",
+            ],
+            "data_classification": "synthetic_example_only",
+        },
+    }
+
+
+def request_review(client: VeritasClient) -> dict[str, Any]:
+    """Call VERITAS for a Decision Candidate, not execution authority."""
+    return client.decide(build_review_payload())
+
+
+def prepare_bind_payload(decision: dict[str, Any]) -> dict[str, Any]:
+    """Prepare, without sending, data for later Bind Boundary adjudication."""
+    return {
+        "decision_id": decision.get("decision_id"),
+        "adapter_pattern": "WebhookBindAdapter",
+        "target": "https://example.invalid/aml-kyc-review",
+        "action_payload": {
+            "case_id": "synthetic-case-001",
+            "requested_operation": "create_human_review_task",
+        },
+        "execution_status": "not_executed",
+        "requires_bind_adjudication": True,
+    }
+
+
+def main() -> None:
+    """Display synthetic review and non-executing bind payloads locally."""
+    review_payload = build_review_payload()
+    bind_payload = prepare_bind_payload(
+        {"decision_id": "replace-with-reviewed-decision-id"}
+    )
+    print(
+        json.dumps(
+            {"review_payload": review_payload, "bind_payload": bind_payload},
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/sdk/python/tests/test_aml_kyc_webhook_bind.py
+++ b/sdk/python/tests/test_aml_kyc_webhook_bind.py
@@ -1,0 +1,50 @@
+"""Tests for the import-safe AML/KYC webhook bind SDK example."""
+
+import unittest
+from unittest import mock
+
+from examples.aml_kyc_webhook_bind import (
+    build_review_payload,
+    prepare_bind_payload,
+    request_review,
+)
+
+
+class AMLKYCWebhookBindExampleTests(unittest.TestCase):
+    """Verify the example stays synthetic and non-executing."""
+
+    def test_build_review_payload_is_synthetic(self) -> None:
+        """The review request identifies all case context as synthetic."""
+        payload = build_review_payload()
+
+        self.assertEqual(
+            payload["context"]["data_classification"],
+            "synthetic_example_only",
+        )
+        self.assertEqual(payload["context"]["case_id"], "synthetic-case-001")
+
+    def test_request_review_only_calls_supplied_client(self) -> None:
+        """The optional API step delegates to the supplied SDK client."""
+        client = mock.Mock()
+        client.decide.return_value = {"decision_id": "synthetic-decision"}
+
+        result = request_review(client)
+
+        client.decide.assert_called_once_with(build_review_payload())
+        self.assertEqual(result, {"decision_id": "synthetic-decision"})
+
+    def test_prepare_bind_payload_is_not_executed(self) -> None:
+        """The bind data explicitly requires later adjudication."""
+        payload = prepare_bind_payload({"decision_id": "synthetic-decision"})
+
+        self.assertEqual(payload["execution_status"], "not_executed")
+        self.assertIs(payload["requires_bind_adjudication"], True)
+        self.assertEqual(payload["adapter_pattern"], "WebhookBindAdapter")
+        self.assertEqual(
+            payload["target"],
+            "https://example.invalid/aml-kyc-review",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Move the AML/KYC SDK Webhook Bind walkthrough from docs-only into a small, import-safe SDK example so integrators have a runnable reference flow.
- Keep the change minimal and example-focused while preserving the Bind Boundary and existing `WebhookBindAdapter` reference semantics.
- Provide a synthetic, non-executing example that demonstrates how to build a Decision Candidate and prepare bind payloads without granting external execution authority.

### Description

- Add `sdk/python/examples/aml_kyc_webhook_bind.py`, an import-safe example that builds a synthetic AML/KYC review payload, exposes `request_review()` that calls `VeritasClient.decide()` only when explicitly invoked, and prepares a bind payload with `execution_status` set to `"not_executed"` and `requires_bind_adjudication: True` while using an `.invalid` target.
- Add lightweight unit tests in `sdk/python/tests/test_aml_kyc_webhook_bind.py` verifying the payload is synthetic, `request_review()` delegates to the supplied client, and the bind payload explicitly requires adjudication.
- Update `sdk/python/README.md` to link to the new import-safe example and update `docs/en/guides/aml-kyc-sdk-webhook-example.md` to point to the executable example without changing any runtime, governance, or bind core behavior.
- Ensure the example contains no real customer/bank/identity/sanctions/account data, does not contact external webhooks, and preserves the documented claims that `/v1/decide` does not authorize external side effects and the Bind Boundary must be crossed separately.

### Testing

- Ran `PYENV_VERSION=3.12.13 python -m compileall -q sdk/python` and compilation succeeded with the installed interpreter (note: repository pins `3.12.12` which was not present, so verification used `3.12.13`).
- Ran `PYENV_VERSION=3.12.13 PYTHONPATH=sdk/python python -m unittest discover -s sdk/python/tests -v` and all SDK tests passed (6 tests OK), and root-level discover without `PYTHONPATH` will not import the SDK as documented.
- Ran `PYENV_VERSION=3.12.13 ruff check sdk/python` and lint checks passed for the SDK files.
- Ran `git diff --check` and executed the example locally with `PYTHONPATH=sdk/python` to confirm it only prints synthetic, non-executing payloads; no CI gates, dependencies, or production runtime behavior were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7dbb1090c8832689d80b8596d0df4a)