### PR TITLE
docs: add External Bind Integration Path guide

### DIFF
--- a/docs/REVIEWER_ENTRYPOINT.md
+++ b/docs/REVIEWER_ENTRYPOINT.md
@@ -41,7 +41,8 @@ This entry point is organized around the current enterprise review path: busines
 15. [Provider Support Matrix](en/operations/provider-support-matrix.md)
 16. [Regulated Action Governance Kernel](en/architecture/regulated-action-governance-kernel.md)
 17. [Bind Boundary Governance Artifacts](en/architecture/bind-boundary-governance-artifacts.md)
-18. [External Bind Adapter: WebhookBindAdapter](en/guides/webhook-bind-adapter.md) — first reference adapter for reviewing how an external HTTPS side effect crosses the Bind Boundary; this is a reference integration pattern, not production certification.
+18. [External Bind Integration Path](en/guides/external-bind-integration-path.md) — concise path from a Decision Candidate through SDK-assisted review and the Bind Boundary to a verified external outcome.
+19. [External Bind Adapter: WebhookBindAdapter](en/guides/webhook-bind-adapter.md) — first reference adapter for reviewing how an external HTTPS side effect crosses the Bind Boundary; this is a reference integration pattern, not production certification.
 
 ## What VERITAS OS is
 

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -72,6 +72,7 @@ For the bilingual correspondence table, see [../DOCUMENTATION_MAP.md](../DOCUMEN
 - [Recent Hardening Notes](development/recent-hardening.md) — compact summary of recent auditability, observability, CI gate, and compatibility hardening work.
 
 ### Guides
+- [External Bind Integration Path](guides/external-bind-integration-path.md) — concise reviewer path from a Decision Candidate through `/v1/decide`, non-executing payload preparation, the Bind Boundary, and verified external outcomes.
 - [Minimal Python SDK reference](../../sdk/python/README.md) — dependency-free `/v1/decide` client with import-safe examples and non-executing bind payload preparation; a reference integration aid, not a production-certified SDK. AI output remains a Decision Candidate, and external side effects must still cross the Bind Boundary using the `WebhookBindAdapter` reference pattern.
 - [AML/KYC SDK to Webhook Bind example](guides/aml-kyc-sdk-webhook-example.md) — placeholder-only reference flow from `/v1/decide` to preparation of a non-executing bind payload; it does not authorize or perform an external action.
 - [External Bind Adapter: WebhookBindAdapter](guides/webhook-bind-adapter.md) — first reference adapter for gating an external HTTPS side effect at the Bind Boundary; an integration pattern, not production certification.

--- a/docs/en/guides/external-bind-integration-path.md
+++ b/docs/en/guides/external-bind-integration-path.md
@@ -1,0 +1,37 @@
+# External Bind Integration Path
+
+This is the shortest reviewer path through the current reference integration
+assets. It describes boundaries between decision review, payload preparation,
+and external execution; it is not a deployment recipe.
+
+## Path at a glance
+
+1. Treat AI or application output as a **Decision Candidate**, not authority to
+   act.
+2. An integrator may use the [minimal Python SDK](../../../sdk/python/README.md)
+   to submit that candidate context to `POST /v1/decide`.
+3. Treat the `/v1/decide` response as a governance decision. The endpoint does
+   **not** authorize or execute an external side effect.
+4. The application may prepare a non-executing bind payload. The import-safe
+   [AML/KYC example](../../../sdk/python/examples/aml_kyc_webhook_bind.py)
+   demonstrates this separation with synthetic data.
+5. Before any real external effect, the proposed action must separately cross
+   the **Bind Boundary**, including applicable admissibility, authority, audit,
+   and failure controls.
+6. [WebhookBindAdapter](webhook-bind-adapter.md) is the reference external bind
+   adapter pattern. It uses snapshot, action, and postcondition endpoints; it
+   must not be bypassed by sending a prepared payload directly to a target.
+7. Verify the postcondition and recorded bind outcome before claiming an action
+   **committed**. Claim **rolled back** only when compensation is configured,
+   attempted, and explicitly verified; otherwise report the failure without a
+   rollback claim.
+
+For a domain-oriented walkthrough, see the
+[AML/KYC SDK to Webhook Bind guide](aml-kyc-sdk-webhook-example.md).
+
+## Boundaries and non-claims
+
+These assets are reference integration aids. They do not establish production
+certification, a live bank integration, regulatory approval, or a customer
+deployment. Integrators remain responsible for deployment-specific security,
+human review, data handling, and external-system controls.


### PR DESCRIPTION
### Motivation
- Add a concise, reviewer-facing guide that summarizes the external integration path enabled by the recently merged `WebhookBindAdapter`, minimal Python SDK, and AML/KYC SDK example, and that clarifies Decision Candidate vs external execution without changing runtime behavior. 
- Reinforce integrator responsibility for deployment-specific security, human review, data handling, and non-claims (no production certification, bank integration, or regulatory approval). 

### Description
- Add `docs/en/guides/external-bind-integration-path.md` describing the flow from AI/application output as a Decision Candidate through use of the minimal Python SDK (`POST /v1/decide`), preparation of a non-executing bind payload, the requirement to cross the Bind Boundary, the `WebhookBindAdapter` reference pattern, and verification rules for `COMMITTED` vs `ROLLED_BACK` outcomes. 
- Update `docs/en/README.md` to include the new guide in the Guides index. 
- Update `docs/REVIEWER_ENTRYPOINT.md` to add the new guide into the reviewer technical-review path. 
- This is a documentation-only change and does not modify runtime code, SDK code, tests, dependencies, CI, or governance behavior. 

### Testing
- Ran the bilingual/documentation link checks via `python -m scripts.quality.check_bilingual_docs`, and the check passed. 
- Ran `git diff --check` and found no whitespace/link errors. 
- Verified the new guide file and README/REVIEWER_ENTRYPOINT updates are present and syntactically valid Markdown with local link checks passed by the repository docs checker.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7dc003bd14832682b81b91f976142e)