### PR TITLE
docs: external bind integration milestone (reviewer-facing update)

### DIFF
--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -70,6 +70,7 @@ For the bilingual correspondence table, see [../DOCUMENTATION_MAP.md](../DOCUMEN
 - [AI-Assisted Development Guardrails](development/ai-assisted-development.md) — auditable workflow rules for using assistant tools during development.
 - [AI Review Matrix](development/ai-review-matrix.md) — role and authority matrix for AI-assisted development reviews.
 - [Recent Hardening Notes](development/recent-hardening.md) — compact summary of recent auditability, observability, CI gate, and compatibility hardening work.
+- [External Bind Integration Milestone](development/external-bind-integration-update.md) — reviewer-facing summary of the reference adapter, minimal Python SDK, AML/KYC example, traceable bind path, and explicit non-claims.
 
 ### Guides
 - [External Bind Integration Path](guides/external-bind-integration-path.md) — concise reviewer path from a Decision Candidate through `/v1/decide`, non-executing payload preparation, the Bind Boundary, and verified external outcomes.

--- a/docs/en/development/external-bind-integration-update.md
+++ b/docs/en/development/external-bind-integration-update.md
@@ -1,0 +1,25 @@
+# External Bind Integration Milestone
+
+This milestone brings the recently merged external bind reference assets into
+one reviewer-traceable path:
+
+- `WebhookBindAdapter` is now the reference external bind adapter pattern.
+- A minimal Python SDK is available under [`sdk/python/`](../../../sdk/python/README.md).
+- An import-safe, synthetic [AML/KYC reference example](../../../sdk/python/examples/aml_kyc_webhook_bind.py)
+  demonstrates SDK use and non-executing bind-payload preparation.
+- The [External Bind Integration Path](../guides/external-bind-integration-path.md)
+  connects these assets, with supporting guides for the
+  [WebhookBindAdapter](../guides/webhook-bind-adapter.md) and the
+  [AML/KYC SDK-to-webhook flow](../guides/aml-kyc-sdk-webhook-example.md).
+
+## What reviewers can trace
+
+Reviewers can follow a Decision Candidate through the SDK call, preparation of
+a non-executing bind payload, separate Bind Boundary adjudication, and outcome
+verification. The SDK response and prepared payload do not authorize or
+perform an external action.
+
+## Boundaries and non-claims
+
+These reference assets do **not** claim production certification, a live bank
+integration, regulatory approval, or a customer deployment.


### PR DESCRIPTION
### Motivation
- Provide a concise, reviewer-facing summary that ties together the newly merged reference assets for external bind integration and clarifies what they enable and do not claim.

### Description
- Add `docs/en/development/external-bind-integration-update.md` summarizing the `WebhookBindAdapter` reference pattern, the minimal Python SDK (`sdk/python/`), the import-safe AML/KYC example, and the External Bind Integration Path, and add a link to this summary from `docs/en/README.md`.

### Testing
- Ran `PYENV_VERSION=3.12.13 python scripts/quality/check_bilingual_docs.py`, local Markdown link-target validation for the changed files, and `git diff --check`, all of which passed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7df21afc2c83268b870d7bc577df41)