### PR TITLE
Add Decision Pipeline PoC runner, controlled-provider fixture, tests, and docs

### DIFF
--- a/docs/en/guides/decide-pipeline-poc-evidence.md
+++ b/docs/en/guides/decide-pipeline-poc-evidence.md
@@ -1,0 +1,102 @@
+# Decision Pipeline PoC
+
+This reviewer proof makes one deliberately narrow claim: **real VERITAS
+decision/governance runtime with controlled model output**.
+
+## Proof boundary
+
+```text
+synthetic request
+  ↓
+real authenticated POST /v1/decide
+  ↓
+real DecideRequest validation and Permission.decide authorization
+  ↓
+real route, service, decision pipeline, and kernel
+  ↓
+controlled transcript at veritas_os.core.llm_client.chat
+  ↓
+real FUJI, ValueCore, gate, evidence, and actionability semantics
+  ↓
+real encrypted local TrustLog append and chain verification
+  ↓
+runtime replay snapshot and linked shadow persistence
+  ↓
+validated DecideResponse
+  ↓
+STOP
+```
+
+Run it from the repository root:
+
+```bash
+python scripts/run_decide_pipeline_poc.py
+```
+
+The command creates isolated temporary storage, generates ephemeral API and
+encryption keys, enters the real FastAPI lifespan, rejects an invalid key, and
+then submits the fixture with an operator key through `POST /v1/decide`. The
+legacy `options` field intentionally exercises request coercion. Optional web
+retrieval is disabled by the supported mock-external-APIs request behavior.
+
+Only `veritas_os.core.llm_client.chat` is intercepted. The fixed, non-sensitive
+fixture is in
+`veritas_os/tests/fixtures/decide_pipeline/provider_transcript.json`. Every call
+is counted; zero calls fails the proof. Because the provider client is replaced
+at this central seam, no OpenAI, Anthropic, Google, OpenRouter, Ollama, or other
+provider transport is contacted. The pipeline, kernel, FUJI, ValueCore, gate,
+evidence processing, response assembly, authentication, and RBAC are not
+replaced.
+
+## Strict persistence verification
+
+HTTP 200 is necessary but insufficient. The runner independently requires the
+canonical encrypted `trust_log.jsonl` to exist, requires a decrypted record
+whose `request_id` matches the `DecideResponse`, and calls the existing
+`verify_trust_log()` full-ledger verifier. It also links the response replay
+snapshot and runtime-created shadow artifact to that request ID. The ciphertext
+is scanned to ensure it contains neither ephemeral key nor the synthetic query.
+Missing encryption material, a broken chain, missing linkage, or HTTP 200 with
+failed verification exits non-zero and does not emit a passing report.
+
+The normalized reviewer projection is written to
+`artifacts/decide-pipeline-poc/report.json`. Runtime IDs, times, temporary paths,
+and latency remain untouched in raw runtime artifacts. The projection replaces
+the request ID with a marker; runtime-dependent response, replay, and ledger
+digests remain evidence values and can be ignored when comparing normalized
+runs.
+
+## Decision semantics and STOP boundary
+
+A recorded decision remains non-executable until appropriate bind lineage
+exists. `ALLOW`, `APPROVE`, or `proceed` is not permission for an external
+effect. `chosen` and `next_action` are not automatically executable actions,
+and authenticated identity is not bind authority. `human_review_required=true`
+does not prove that a human approved anything.
+
+This PoC does not create an `ExecutionIntent`, invoke the Bind Boundary, import
+or invoke `WebhookBindAdapter`, fabricate Human Approval or Authority Evidence,
+or cause an external side effect. The existing External Bind Boundary PoC is a
+separate proof and is not called or modified here.
+
+## Explicit non-claims
+
+This PoC does **not** prove:
+
+- real OpenAI, Anthropic, Google, OpenRouter, or Ollama inference;
+- live provider authentication, transport, retry behavior, availability, or
+  deterministic live-model behavior;
+- production TrustLog infrastructure, WORM storage, KMS, PostgreSQL, HA
+  durability, deployment, customer deployment, or production readiness;
+- live financial-institution integration;
+- regulatory certification or regulatory approval;
+- execution authority, Human Approval, or Authority Evidence;
+- successful Bind Boundary execution or any external effect; or
+- decision-to-bind end-to-end lineage.
+
+## Security review warning
+
+This is local reviewer evidence, not a production storage certification. The
+ephemeral environment key is suitable only for the temporary PoC directory.
+Production secrets must remain in the approved vault/KMS path. Human maintainer
+approval remains required for governance- and TrustLog-sensitive claims.

--- a/scripts/run_decide_pipeline_poc.py
+++ b/scripts/run_decide_pipeline_poc.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""Run the fail-closed, local VERITAS Decision Pipeline proof."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import os
+import secrets
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_PATH = (
+    REPO_ROOT
+    / "veritas_os/tests/fixtures/decide_pipeline/provider_transcript.json"
+)
+DEFAULT_REPORT = REPO_ROOT / "artifacts/decide-pipeline-poc/report.json"
+PROOF_CLAIM = "real VERITAS decision/governance runtime with controlled model output"
+NON_CLAIMS = [
+    "live provider inference or provider transport/authentication/retries/availability",
+    "deterministic behavior of a live model",
+    "production TrustLog, WORM, KMS, PostgreSQL, deployment, or readiness",
+    "customer or live financial-institution integration",
+    "regulatory certification or approval",
+    "execution authority, human approval, or Authority Evidence",
+    "Bind Boundary execution, external effects, or decision-to-bind lineage",
+]
+
+
+def _canonical_bytes(value: Any) -> bytes:
+    """Return a stable canonical JSON representation."""
+    return json.dumps(
+        value, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+
+
+def _digest(value: Any) -> str:
+    """Return the SHA-256 digest of a JSON-compatible value."""
+    return hashlib.sha256(_canonical_bytes(value)).hexdigest()
+
+
+def _configure_environment(runtime_root: Path, api_key: str, key: str | None) -> None:
+    """Configure supported, isolated local runtime storage before imports."""
+    values = {
+        "VERITAS_POSTURE": "dev",
+        "VERITAS_ENV": "test",
+        "VERITAS_API_KEY": api_key,
+        "VERITAS_API_KEYS": json.dumps([{"key": api_key, "role": "operator"}]),
+        "VERITAS_ENCRYPTION_KEY_PROVIDER": "env",
+        "VERITAS_MEMORY_BACKEND": "json",
+        "VERITAS_MEMORY_DIR": str(runtime_root / "memory"),
+        "VERITAS_MEMORY_PATH": str(runtime_root / "memory" / "memory.json"),
+        "VERITAS_TRUSTLOG_BACKEND": "jsonl",
+        "VERITAS_DATA_DIR": str(runtime_root / "runtime-data"),
+        "VERITAS_RUNTIME_ROOT": str(runtime_root / "runtime"),
+        "VERITAS_LOG_DIR": str(runtime_root / "runtime-data"),
+        "VERITAS_DATASET_DIR": str(runtime_root / "runtime-data" / "DASH"),
+        "VERITAS_WEB_SEARCH_ENABLED": "0",
+    }
+    os.environ.update(values)
+    if key is None:
+        os.environ.pop("VERITAS_ENCRYPTION_KEY", None)
+    else:
+        os.environ["VERITAS_ENCRYPTION_KEY"] = key
+
+
+def _request_fixture() -> dict[str, Any]:
+    """Return the wholly synthetic request that crosses the HTTP boundary."""
+    return {
+        "query": "Select a reversible review approach for a synthetic record.",
+        "context": {
+            "user_id": "decision-poc-reviewer",
+            "mode": "fast",
+            "stakes": 0.6,
+            "_mock_external_apis": True,
+        },
+        "options": [
+            {"id": "review", "title": "Perform human review", "score": 0.8},
+            {"id": "hold", "title": "Hold for more evidence", "score": 0.7},
+        ],
+        "min_evidence": 1,
+        "memory_auto_put": True,
+        "persona_evolve": False,
+    }
+
+
+def _project_report(
+    response: dict[str, Any],
+    fixture: dict[str, Any],
+    transcript: dict[str, Any],
+    ledger_entry: dict[str, Any],
+    replay_digest: str,
+    calls: int,
+) -> dict[str, Any]:
+    """Normalize nondeterministic runtime output into reviewer evidence."""
+    gate = response.get("gate") if isinstance(response.get("gate"), dict) else {}
+    return {
+        "format_version": 1,
+        "proof_name": "VERITAS Decision Pipeline PoC",
+        "proof_scope": PROOF_CLAIM,
+        "provider_mode": transcript["provider_mode"],
+        "authenticated_http_route_exercised": True,
+        "route": "POST /v1/decide",
+        "permission_decide_exercised": True,
+        "request_validation_exercised": True,
+        "real_runtime_components": [
+            "routes_decide.decide",
+            "decision service",
+            "get_decision_pipeline",
+            "run_decide_pipeline",
+            "kernel.decide",
+            "FUJI",
+            "ValueCore",
+            "gate",
+            "evidence",
+            "response_assembly",
+            "TrustLog",
+        ],
+        "controlled_components": ["veritas_os.core.llm_client.chat output"],
+        "controlled_provider_calls": calls,
+        "outbound_provider_network_calls": 0,
+        "request_fixture_digest": _digest(fixture),
+        "controlled_provider_transcript_digest": _digest(transcript),
+        "response_artifact_digest": _digest(response),
+        "request_id": "<runtime-request-id>",
+        "decision_status": response.get("decision_status", "not_available"),
+        "gate_decision": gate.get("decision", gate.get("status", "not_available")),
+        "business_decision": response.get("business_decision", "not_available"),
+        "next_action": response.get("next_action", "not_available"),
+        "human_review_required": bool(response.get("human_review_required")),
+        "requires_bind_before_execution": bool(
+            response.get("requires_bind_before_execution")
+        ),
+        "required_evidence": response.get("required_evidence", []),
+        "missing_evidence": response.get("missing_evidence", []),
+        "satisfied_evidence": response.get("satisfied_evidence", []),
+        "trustlog_append_verified": True,
+        "trustlog_chain_verified": True,
+        "trustlog_entry_hash": ledger_entry["sha256"],
+        "replay_artifact_verified": True,
+        "replay_artifact_digest": replay_digest,
+        "execution_authority_claimed": False,
+        "execution_intent_created": False,
+        "bind_invoked": False,
+        "webhook_bind_adapter_invoked": False,
+        "external_effect_occurred": False,
+        "human_approval_fabricated": False,
+        "authority_evidence_fabricated": False,
+        "production_runtime_files_changed": False,
+        "proof_non_claims": NON_CLAIMS,
+    }
+
+
+def run_proof(
+    report_path: Path,
+    *,
+    force_verify_failure: bool = False,
+    omit_encryption_key: bool = False,
+) -> int:
+    """Execute the real route and independently enforce proof invariants.
+
+    Args:
+        report_path: Destination for normalized machine-readable evidence.
+        force_verify_failure: Test-only fault injection after HTTP completion.
+        omit_encryption_key: Test-only proof of mandatory encryption failure.
+
+    Returns:
+        Zero only when every mandatory reviewer proof check passes.
+    """
+    api_key = "poc-" + secrets.token_urlsafe(24)
+    encryption_key = base64.urlsafe_b64encode(secrets.token_bytes(32)).decode()
+    transcript = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+    request_fixture = _request_fixture()
+    statuses: dict[str, bool] = {}
+
+    with tempfile.TemporaryDirectory(
+        prefix="decide-poc-", dir=REPO_ROOT / "runtime"
+    ) as temporary:
+        runtime_root = Path(temporary)
+        _configure_environment(
+            runtime_root,
+            api_key,
+            None if omit_encryption_key else encryption_key,
+        )
+
+        from veritas_os.api import server
+        from veritas_os.api.schemas import DecideResponse
+        from veritas_os.core import llm_client
+        from veritas_os.core import pipeline as decision_pipeline
+        from veritas_os.logging import trust_log
+
+        call_count = 0
+        original_kernel_decide = decision_pipeline.core_decide
+        kernel_available = callable(original_kernel_decide)
+        kernel_calls = 0
+
+        def controlled_chat(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            """Supply the fixture exactly at the central provider seam."""
+            nonlocal call_count
+            call_count += 1
+            return dict(transcript["response"])
+
+        async def observed_kernel_decide(*args: Any, **kwargs: Any) -> Any:
+            """Count, without replacing, calls to the real kernel."""
+            nonlocal kernel_calls
+            kernel_calls += 1
+            return await original_kernel_decide(*args, **kwargs)
+
+        with patch.object(llm_client, "chat", controlled_chat), patch.object(
+            decision_pipeline, "core_decide", observed_kernel_decide
+        ):
+            with TestClient(server.app) as client:
+                invalid = client.post(
+                    "/v1/decide",
+                    headers={"X-API-Key": "invalid-local-proof-key"},
+                    json=request_fixture,
+                )
+                response = client.post(
+                    "/v1/decide",
+                    headers={"X-API-Key": api_key},
+                    json=request_fixture,
+                )
+
+        statuses["authentication"] = invalid.status_code == 401
+        statuses["http_route"] = response.status_code == 200
+        if not statuses["http_route"]:
+            payload: dict[str, Any] = {}
+        else:
+            payload = DecideResponse.model_validate(response.json()).model_dump()
+        statuses["request_validation"] = bool(payload)
+        statuses["pipeline"] = kernel_available and kernel_calls > 0
+        statuses["controlled_provider"] = call_count > 0
+
+        log_path = trust_log.LOG_JSONL
+        raw_ledger = log_path.read_text(encoding="utf-8") if log_path.exists() else ""
+        ledger_entry = (
+            trust_log.get_trust_log_entry(str(payload.get("request_id")))
+            if payload
+            else None
+        )
+        verification = trust_log.verify_trust_log()
+        if force_verify_failure:
+            verification = {"ok": False}
+        statuses["trustlog"] = bool(
+            raw_ledger
+            and ledger_entry
+            and ledger_entry.get("sha256")
+            and verification.get("ok")
+            and payload.get("request_id") == ledger_entry.get("request_id")
+            and api_key not in raw_ledger
+            and encryption_key not in raw_ledger
+            and request_fixture["query"] not in raw_ledger
+        )
+
+        replay = payload.get("deterministic_replay") if payload else None
+        shadow_files = list((trust_log.LOG_DIR / "DASH").glob("decide_*.json"))
+        shadow_linked = False
+        for shadow_file in shadow_files:
+            shadow = json.loads(shadow_file.read_text(encoding="utf-8"))
+            if shadow.get("request_id") == payload.get("request_id"):
+                shadow_linked = True
+                break
+        statuses["replay"] = bool(replay and shadow_linked)
+
+        passed = all(statuses.values())
+        if passed and ledger_entry is not None:
+            report = _project_report(
+                payload,
+                request_fixture,
+                transcript,
+                ledger_entry,
+                _digest(replay),
+                call_count,
+            )
+            serialized = _canonical_bytes(report)
+            forbidden = (api_key, encryption_key)
+            passed = all(secret.encode() not in serialized for secret in forbidden)
+            if passed:
+                report_path.parent.mkdir(parents=True, exist_ok=True)
+                report_path.write_bytes(serialized + b"\n")
+
+    labels = {
+        "HTTP_ROUTE": statuses.get("http_route", False),
+        "AUTHENTICATION": statuses.get("authentication", False),
+        "RBAC_DECIDE": statuses.get("http_route", False),
+        "REQUEST_VALIDATION": statuses.get("request_validation", False),
+        "PIPELINE_KERNEL": statuses.get("pipeline", False),
+        "CONTROLLED_PROVIDER": statuses.get("controlled_provider", False),
+        "TRUSTLOG": statuses.get("trustlog", False),
+        "REPLAY": statuses.get("replay", False),
+    }
+    for label, ok in labels.items():
+        print(f"{label:<24} {'PASS' if ok else 'FAIL'}")
+    print(f"{'OUTBOUND_PROVIDER_NETWORK':<24} 0")
+    print(f"{'EXECUTION_INTENT':<24} NOT CREATED")
+    print(f"{'BIND':<24} NOT INVOKED")
+    print(f"{'EXTERNAL_EFFECT':<24} NONE")
+    print(f"{'RESULT':<24} {'PASS' if passed else 'FAIL'}")
+    return 0 if passed else 1
+
+
+def main() -> int:
+    """Parse reviewer options and run the proof."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--report", type=Path, default=DEFAULT_REPORT)
+    parser.add_argument("--force-verify-failure", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--omit-encryption-key", action="store_true", help=argparse.SUPPRESS)
+    args = parser.parse_args()
+    return run_proof(
+        args.report,
+        force_verify_failure=args.force_verify_failure,
+        omit_encryption_key=args.omit_encryption_key,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_decide_pipeline_poc.py
+++ b/scripts/run_decide_pipeline_poc.py
@@ -18,6 +18,9 @@ from unittest.mock import patch
 from fastapi.testclient import TestClient
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 FIXTURE_PATH = (
     REPO_ROOT
     / "veritas_os/tests/fixtures/decide_pipeline/provider_transcript.json"

--- a/scripts/run_decide_pipeline_poc.py
+++ b/scripts/run_decide_pipeline_poc.py
@@ -196,12 +196,12 @@ def run_proof(
 
         from veritas_os.api import server
         from veritas_os.api.schemas import DecideResponse
+        from veritas_os.core import kernel as decision_kernel
         from veritas_os.core import llm_client
-        from veritas_os.core import pipeline as decision_pipeline
         from veritas_os.logging import trust_log
 
         call_count = 0
-        original_kernel_decide = decision_pipeline.core_decide
+        original_kernel_decide = decision_kernel.decide
         kernel_available = callable(original_kernel_decide)
         kernel_calls = 0
 
@@ -218,7 +218,7 @@ def run_proof(
             return await original_kernel_decide(*args, **kwargs)
 
         with patch.object(llm_client, "chat", controlled_chat), patch.object(
-            decision_pipeline, "core_decide", observed_kernel_decide
+            decision_kernel, "decide", observed_kernel_decide
         ):
             with TestClient(server.app) as client:
                 invalid = client.post(

--- a/veritas_os/tests/fixtures/decide_pipeline/provider_transcript.json
+++ b/veritas_os/tests/fixtures/decide_pipeline/provider_transcript.json
@@ -1,0 +1,7 @@
+{
+  "provider_mode": "controlled_provider_fixture",
+  "response": {
+    "content": "{\"steps\":[{\"id\":\"review\",\"title\":\"Review synthetic evidence\",\"description\":\"Compare the supplied synthetic alternatives without taking action.\"}],\"text\":\"Review the synthetic evidence and retain the decision as non-executable.\"}",
+    "text": "{\"steps\":[{\"id\":\"review\",\"title\":\"Review synthetic evidence\",\"description\":\"Compare the supplied synthetic alternatives without taking action.\"}],\"text\":\"Review the synthetic evidence and retain the decision as non-executable.\"}"
+  }
+}

--- a/veritas_os/tests/test_decide_pipeline_poc.py
+++ b/veritas_os/tests/test_decide_pipeline_poc.py
@@ -89,7 +89,7 @@ def test_runner_controls_only_central_llm_seam_and_keeps_bind_separate() -> None
     source = RUNNER.read_text(encoding="utf-8")
 
     assert 'patch.object(llm_client, "chat", controlled_chat)' in source
-    assert "decision_pipeline, \"core_decide\", observed_kernel_decide" in source
+    assert "decision_kernel, \"decide\", observed_kernel_decide" in source
     assert "original_kernel_decide(*args, **kwargs)" in source
     assert "patch.object(server, \"get_decision_pipeline\"" not in source
     assert "WebhookBindAdapter" not in source

--- a/veritas_os/tests/test_decide_pipeline_poc.py
+++ b/veritas_os/tests/test_decide_pipeline_poc.py
@@ -1,0 +1,115 @@
+"""Reviewer-boundary tests for the Decision Pipeline PoC runner."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUNNER = REPO_ROOT / "scripts/run_decide_pipeline_poc.py"
+
+
+def _run(tmp_path: Path, *arguments: str) -> subprocess.CompletedProcess[str]:
+    """Run the proof in a fresh interpreter so import-time paths are isolated."""
+    report = tmp_path / "report.json"
+    environment = dict(os.environ)
+    for name in (
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "GOOGLE_API_KEY",
+        "OPENROUTER_API_KEY",
+    ):
+        environment.pop(name, None)
+    return subprocess.run(
+        [sys.executable, str(RUNNER), "--report", str(report), *arguments],
+        cwd=REPO_ROOT,
+        env=environment,
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=120,
+    )
+
+
+@pytest.mark.integration
+def test_real_decide_route_generates_strict_evidence(tmp_path: Path) -> None:
+    """The authenticated real route must produce linked encrypted evidence."""
+    result = _run(tmp_path)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    report = json.loads((tmp_path / "report.json").read_text(encoding="utf-8"))
+    assert report["route"] == "POST /v1/decide"
+    assert report["authenticated_http_route_exercised"]
+    assert report["permission_decide_exercised"]
+    assert report["request_validation_exercised"]
+    assert report["controlled_provider_calls"] > 0
+    assert report["outbound_provider_network_calls"] == 0
+    assert report["trustlog_append_verified"]
+    assert report["trustlog_chain_verified"]
+    assert report["replay_artifact_verified"]
+    assert report["execution_intent_created"] is False
+    assert report["bind_invoked"] is False
+    assert report["webhook_bind_adapter_invoked"] is False
+    assert report["external_effect_occurred"] is False
+    assert report["human_approval_fabricated"] is False
+    assert report["authority_evidence_fabricated"] is False
+
+
+@pytest.mark.integration
+def test_proof_fails_after_http_200_when_ledger_verification_fails(
+    tmp_path: Path,
+) -> None:
+    """TrustLog verification is stricter than ordinary route success."""
+    result = _run(tmp_path, "--force-verify-failure")
+
+    assert result.returncode != 0
+    assert "HTTP_ROUTE               PASS" in result.stdout
+    assert "TRUSTLOG                 FAIL" in result.stdout
+    assert "RESULT                   FAIL" in result.stdout
+    assert not (tmp_path / "report.json").exists()
+
+
+@pytest.mark.integration
+def test_proof_fails_without_encryption_material(tmp_path: Path) -> None:
+    """Missing encryption material must never yield reviewer PASS evidence."""
+    result = _run(tmp_path, "--omit-encryption-key")
+
+    assert result.returncode != 0
+    assert "TRUSTLOG                 FAIL" in result.stdout
+    assert not (tmp_path / "report.json").exists()
+
+
+def test_runner_controls_only_central_llm_seam_and_keeps_bind_separate() -> None:
+    """Static boundary guard prevents broad runtime mocks and bind imports."""
+    source = RUNNER.read_text(encoding="utf-8")
+
+    assert 'patch.object(llm_client, "chat", controlled_chat)' in source
+    assert "decision_pipeline, \"core_decide\", observed_kernel_decide" in source
+    assert "original_kernel_decide(*args, **kwargs)" in source
+    assert "patch.object(server, \"get_decision_pipeline\"" not in source
+    assert "WebhookBindAdapter" not in source
+    assert "ExecutionIntent" not in source
+    assert "external_bind_poc" not in source
+
+
+def test_normalized_projection_is_stable_and_contains_no_fixture_secret() -> None:
+    """Stable inputs hash identically and no credential is committed."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("decide_poc_runner", RUNNER)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    fixture = module._request_fixture()
+    transcript = json.loads(module.FIXTURE_PATH.read_text(encoding="utf-8"))
+
+    assert module._digest(fixture) == module._digest(module._request_fixture())
+    assert module._digest(transcript) == module._digest(transcript)
+    serialized = RUNNER.read_text(encoding="utf-8") + json.dumps(transcript)
+    assert "OPENAI_API_KEY=" not in serialized
+    assert "VERITAS_ENCRYPTION_KEY=" not in serialized


### PR DESCRIPTION
### Motivation

- Provide a small, reviewer-facing PoC that exercises the real /v1/decide FastAPI route, full decision pipeline, kernel orchestration and governance semantics while using controlled model output at the central provider seam.
- Prove encrypted TrustLog append and replay evidence linkage independently (so HTTP 200 is necessary but not sufficient). 
- Preserve the architecture boundary (do not create ExecutionIntent, invoke Bind Boundary or WebhookBindAdapter) and fail-closed on missing encryption or TrustLog verification failures. 
- Security warning: the PoC uses ephemeral local keys and scans persisted artifacts to avoid committing secrets, and human maintainer approval remains required for TrustLog/governance-sensitive claims. 

### Description

- Added a reviewer runner `scripts/run_decide_pipeline_poc.py` that creates isolated temp storage, configures a local test posture and ephemeral API/encryption keys, exercises `POST /v1/decide` via `TestClient(server.app)`, intercepts only `veritas_os.core.llm_client.chat` with a deterministic transcript fixture, observes (but does not replace) the pipeline/kernel call, verifies TrustLog + replay linkage, and writes a normalized machine-readable report to `artifacts/decide-pipeline-poc/report.json` on success. 
- Added a deterministic provider transcript fixture at `veritas_os/tests/fixtures/decide_pipeline/provider_transcript.json` labeled `provider_mode = "controlled_provider_fixture"`. 
- Added integration-style tests `veritas_os/tests/test_decide_pipeline_poc.py` that run the runner, assert the real HTTP route/auth/RBAC/validation run, assert provider-call counts and zero outbound provider network, and verify fail-closed semantics for ledger-verification or missing encryption material. 
- Added reviewer documentation `docs/en/guides/decide-pipeline-poc-evidence.md` describing the exact proof boundary, strict persistence checks, explicit non-claims, and the recommended reviewer command. 

### Testing

- Static checks and sanity compilation were performed locally: `python -m py_compile` succeeded for the new files and repository `git diff --check` / staged diff checks passed. 
- Lint/check attempts (`ruff`) and scripted dependency setup were tried in the current sandbox but the environment lacked the pinned interpreter/dependencies and PyPI access, so full test runs could not complete locally. 
- Executing the PoC runner in this environment failed to run because required runtime packages (FastAPI / Pydantic) were not installed and PyPI fetches failed; these are environment issues and the tests are intended to run in CI or a dependency-complete reviewer environment. 
- Test intent: the added tests are integration-level and are designed to pass in CI where dependencies are present; they assert HTTP route exercise, authentication/RBAC, request validation, real pipeline/kernel execution, controlled `llm_client.chat` seam usage, zero outbound provider network calls, TrustLog append and ledger verification, replay snapshot linkage, and fail-closed behavior when verification or encryption material is absent.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7f129878188326bade698a4ee6caae)