### PR TITLE
ci: add Runtime Proof Evidence workflow and verification tooling

### DIFF
--- a/.github/workflows/runtime-proof-evidence.yml
+++ b/.github/workflows/runtime-proof-evidence.yml
@@ -1,0 +1,154 @@
+name: Runtime Proof Evidence
+
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  runtime-proof-evidence:
+    name: runtime-proof-evidence
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install proof runtime dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r veritas_os/requirements-core.txt
+
+      - name: Clean proof artifact directories
+        run: |
+          rm -rf artifacts/decide-pipeline-poc artifacts/external-bind-poc artifacts/runtime-proof-evidence
+          mkdir -p artifacts/decide-pipeline-poc artifacts/external-bind-poc artifacts/runtime-proof-evidence
+
+      - name: Run Decision Pipeline PoC
+        run: |
+          python scripts/run_decide_pipeline_poc.py
+          test -f artifacts/decide-pipeline-poc/report.json
+
+      - name: Run External Bind Boundary PoC
+        run: python scripts/demo/run_external_bind_poc.py
+
+      - name: Verify independent proof evidence
+        run: |
+          python scripts/demo/verify_runtime_proof_evidence.py \
+            --decision-report artifacts/decide-pipeline-poc/report.json \
+            --bind-dir artifacts/external-bind-poc \
+            --output artifacts/runtime-proof-evidence/verification-report.json
+
+      - name: Assemble Runtime Proof bundle
+        run: |
+          mkdir -p artifacts/runtime-proof-evidence/decision-pipeline artifacts/runtime-proof-evidence/external-bind
+          cp artifacts/decide-pipeline-poc/report.json artifacts/runtime-proof-evidence/decision-pipeline/report.json
+          cp artifacts/external-bind-poc/*.json artifacts/runtime-proof-evidence/external-bind/
+
+      - name: Write CI provenance context
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+          REPOSITORY: ${{ github.repository }}
+          REF: ${{ github.ref }}
+          EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW: ${{ github.workflow }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          context = {
+              "metadata_type": "ci_provenance_only",
+              "generated_by": "github_actions",
+              "repository": os.environ["REPOSITORY"],
+              "commit_sha": os.environ["COMMIT_SHA"],
+              "ref": os.environ["REF"],
+              "event_name": os.environ["EVENT_NAME"],
+              "workflow": os.environ["WORKFLOW"],
+              "run_id": os.environ["RUN_ID"],
+              "run_attempt": os.environ["RUN_ATTEMPT"],
+          }
+          Path("artifacts/runtime-proof-evidence/ci-context.json").write_text(
+              json.dumps(context, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+          )
+          PY
+
+      - name: Build reviewer summary
+        run: |
+          cat > artifacts/runtime-proof-evidence/reviewer-summary.md <<EOF
+          # VERITAS Runtime Proof Evidence
+
+          Commit: `${GITHUB_SHA}`
+
+          The Decision Pipeline and External Bind Boundary are independent proof paths.
+          No Decision Pipeline -> ExecutionIntent -> Bind handoff is claimed.
+
+          Decision: authenticated POST /v1/decide, controlled provider fixture, real
+          governance runtime, TrustLog/replay verified, then STOP. Bind: synthetic
+          decision fixture, real bind adjudication and WebhookBindAdapter, with
+          COMMITTED, BLOCKED, and ROLLED_BACK verified.
+
+          This local CI bundle does not prove live providers, production TrustLog,
+          PostgreSQL, KMS/WORM, execution authority, Human Approval, Authority Evidence,
+          decision-to-bind lineage, live financial integrations, customer deployment,
+          regulatory approval/certification, or production readiness.
+          EOF
+
+      - name: Run proof-bundle secret hygiene check
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          from scripts.demo.verify_runtime_proof_evidence import verify_secret_hygiene
+
+          verify_secret_hygiene(Path("artifacts/runtime-proof-evidence"))
+          PY
+
+      - name: Build SHA-256 manifest
+        run: |
+          python scripts/demo/build_runtime_proof_evidence_manifest.py \
+            artifacts/runtime-proof-evidence --commit-sha "$GITHUB_SHA"
+
+      - name: Verify SHA-256 manifest
+        run: python scripts/demo/verify_runtime_proof_evidence_manifest.py artifacts/runtime-proof-evidence
+
+      - name: Build GitHub step summary
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          # VERITAS Runtime Proof Evidence
+          Commit: `${GITHUB_SHA}`
+
+          ## Decision Pipeline Proof
+          - authenticated `/v1/decide`: PASS
+          - real decision/governance runtime: PASS
+          - provider mode: `controlled_provider_fixture`
+          - TrustLog and replay verification: PASS
+          - ExecutionIntent created / Bind invoked: NO / NO
+
+          ## External Bind Boundary Proof
+          - decision stage: `synthetic_fixture`
+          - COMMITTED / BLOCKED / ROLLED_BACK: PASS / PASS / PASS
+
+          ## Boundary
+          These are two independent proof paths. No Decision Pipeline -> ExecutionIntent -> Bind handoff is claimed.
+
+          Artifact: `veritas-runtime-proof-evidence`
+          EOF
+
+      - name: Upload Runtime Proof Evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: veritas-runtime-proof-evidence
+          path: artifacts/runtime-proof-evidence/
+          retention-days: 14
+

--- a/.github/workflows/runtime-proof-evidence.yml
+++ b/.github/workflows/runtime-proof-evidence.yml
@@ -26,6 +26,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r veritas_os/requirements-core.txt
+          python -m pip install ".[signing]"
 
       - name: Clean proof artifact directories
         run: |
@@ -151,4 +152,3 @@ jobs:
           name: veritas-runtime-proof-evidence
           path: artifacts/runtime-proof-evidence/
           retention-days: 14
-

--- a/.github/workflows/runtime-proof-evidence.yml
+++ b/.github/workflows/runtime-proof-evidence.yml
@@ -28,6 +28,9 @@ jobs:
           python -m pip install -r veritas_os/requirements-core.txt
           python -m pip install ".[signing]"
 
+      - name: Smoke import supported Decision Pipeline server path
+        run: python -c "import veritas_os.api.server"
+
       - name: Clean proof artifact directories
         run: |
           rm -rf artifacts/decide-pipeline-poc artifacts/external-bind-poc artifacts/runtime-proof-evidence

--- a/.github/workflows/runtime-proof-evidence.yml
+++ b/.github/workflows/runtime-proof-evidence.yml
@@ -59,7 +59,8 @@ jobs:
 
       - name: Write CI provenance context
         env:
-          COMMIT_SHA: ${{ github.sha }}
+          TESTED_SHA: ${{ github.sha }}
+          SOURCE_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           REPOSITORY: ${{ github.repository }}
           REF: ${{ github.ref }}
           EVENT_NAME: ${{ github.event_name }}
@@ -76,7 +77,9 @@ jobs:
               "metadata_type": "ci_provenance_only",
               "generated_by": "github_actions",
               "repository": os.environ["REPOSITORY"],
-              "commit_sha": os.environ["COMMIT_SHA"],
+              "commit_sha": os.environ["TESTED_SHA"],
+              "tested_sha": os.environ["TESTED_SHA"],
+              "source_head_sha": os.environ["SOURCE_HEAD_SHA"],
               "ref": os.environ["REF"],
               "event_name": os.environ["EVENT_NAME"],
               "workflow": os.environ["WORKFLOW"],
@@ -89,25 +92,14 @@ jobs:
           PY
 
       - name: Build reviewer summary
-        run: |
-          cat > artifacts/runtime-proof-evidence/reviewer-summary.md <<EOF
-          # VERITAS Runtime Proof Evidence
-
-          Commit: `${GITHUB_SHA}`
-
-          The Decision Pipeline and External Bind Boundary are independent proof paths.
-          No Decision Pipeline -> ExecutionIntent -> Bind handoff is claimed.
-
-          Decision: authenticated POST /v1/decide, controlled provider fixture, real
-          governance runtime, TrustLog/replay verified, then STOP. Bind: synthetic
-          decision fixture, real bind adjudication and WebhookBindAdapter, with
-          COMMITTED, BLOCKED, and ROLLED_BACK verified.
-
-          This local CI bundle does not prove live providers, production TrustLog,
-          PostgreSQL, KMS/WORM, execution authority, Human Approval, Authority Evidence,
-          decision-to-bind lineage, live financial integrations, customer deployment,
-          regulatory approval/certification, or production readiness.
-          EOF
+        env:
+          TESTED_SHA: ${{ github.sha }}
+          SOURCE_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: >
+          python scripts/demo/build_runtime_proof_summary.py
+          --tested-sha "$TESTED_SHA"
+          --source-head-sha "$SOURCE_HEAD_SHA"
+          --output artifacts/runtime-proof-evidence/reviewer-summary.md
 
       - name: Run proof-bundle secret hygiene check
         run: |
@@ -121,33 +113,23 @@ jobs:
       - name: Build SHA-256 manifest
         run: |
           python scripts/demo/build_runtime_proof_evidence_manifest.py \
-            artifacts/runtime-proof-evidence --commit-sha "$GITHUB_SHA"
+            artifacts/runtime-proof-evidence \
+            --tested-sha "${{ github.sha }}" \
+            --source-head-sha "${{ github.event.pull_request.head.sha || github.sha }}"
 
       - name: Verify SHA-256 manifest
         run: python scripts/demo/verify_runtime_proof_evidence_manifest.py artifacts/runtime-proof-evidence
 
       - name: Build GitHub step summary
-        run: |
-          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
-          # VERITAS Runtime Proof Evidence
-          Commit: `${GITHUB_SHA}`
-
-          ## Decision Pipeline Proof
-          - authenticated `/v1/decide`: PASS
-          - real decision/governance runtime: PASS
-          - provider mode: `controlled_provider_fixture`
-          - TrustLog and replay verification: PASS
-          - ExecutionIntent created / Bind invoked: NO / NO
-
-          ## External Bind Boundary Proof
-          - decision stage: `synthetic_fixture`
-          - COMMITTED / BLOCKED / ROLLED_BACK: PASS / PASS / PASS
-
-          ## Boundary
-          These are two independent proof paths. No Decision Pipeline -> ExecutionIntent -> Bind handoff is claimed.
-
-          Artifact: `veritas-runtime-proof-evidence`
-          EOF
+        env:
+          TESTED_SHA: ${{ github.sha }}
+          SOURCE_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: >
+          python scripts/demo/build_runtime_proof_summary.py
+          --tested-sha "$TESTED_SHA"
+          --source-head-sha "$SOURCE_HEAD_SHA"
+          --output artifacts/runtime-proof-evidence/reviewer-summary.md
+          --github-summary "$GITHUB_STEP_SUMMARY"
 
       - name: Upload Runtime Proof Evidence
         uses: actions/upload-artifact@v4

--- a/docs/en/guides/runtime-proof-ci-evidence.md
+++ b/docs/en/guides/runtime-proof-ci-evidence.md
@@ -38,7 +38,9 @@ manifest enumerates all other bundle files and excludes itself to avoid a
 recursive self-hash.
 
 Proof evidence retains the PoCs' existing deterministic behavior. CI provenance
-(`commit_sha`, ref, workflow run ID, and attempt) naturally varies, so the
+records `tested_sha` (the checked-out PR merge or push SHA) and
+`source_head_sha` (the PR head SHA, or the same SHA for non-PR events), plus the
+ref, workflow run ID, and attempt. This metadata naturally varies, so the
 downloaded ZIP is not claimed to be byte-identical across runs.
 
 ## Non-claims
@@ -49,4 +51,3 @@ or readiness; execution authority from `/v1/decide`; Human Approval or Authority
 Evidence; Decision Pipeline → Bind Boundary lineage; live bank or financial
 institution integration; customer deployment; or regulatory approval or
 certification.
-

--- a/docs/en/guides/runtime-proof-ci-evidence.md
+++ b/docs/en/guides/runtime-proof-ci-evidence.md
@@ -1,0 +1,52 @@
+# Runtime Proof Evidence from CI
+
+The **Runtime Proof Evidence** workflow creates downloadable, commit-linked
+reviewer evidence for two independent proof boundaries. It does not join them
+into an end-to-end execution chain.
+
+## Proof boundaries
+
+**Decision Pipeline PoC:** authenticated `POST /v1/decide` → controlled model
+output at the central client seam → real decision/governance runtime → verified
+encrypted TrustLog and replay → `DecideResponse` → **STOP**. It creates no
+`ExecutionIntent`, invokes no Bind Boundary, and causes no external effect.
+
+**External Bind Boundary PoC:** synthetic Decision Candidate → real bind
+adjudication → real `WebhookBindAdapter` → simulated external effect → verified
+`COMMITTED`, `BLOCKED`, and `ROLLED_BACK` evidence. Its decision stage is
+`synthetic_fixture`; it does not claim that `/v1/decide` ran.
+
+## Reviewer procedure
+
+1. Open the GitHub Actions run for the repository commit.
+2. Select **Runtime Proof Evidence**.
+3. Download the `veritas-runtime-proof-evidence` artifact.
+4. Inspect `decision-pipeline/report.json`, `external-bind/*`,
+   `verification-report.json`, `ci-context.json`, `reviewer-summary.md`, and
+   `runtime-proof-evidence-manifest.json`.
+5. From the extracted artifact directory, verify every size and SHA-256 hash
+   offline:
+
+   ```bash
+   python scripts/demo/verify_runtime_proof_evidence_manifest.py \
+     artifacts/runtime-proof-evidence
+   ```
+
+The manifest's `manifest_hash` is SHA-256 over canonical JSON (sorted keys and
+compact separators) of the manifest object with `manifest_hash` omitted. The
+manifest enumerates all other bundle files and excludes itself to avoid a
+recursive self-hash.
+
+Proof evidence retains the PoCs' existing deterministic behavior. CI provenance
+(`commit_sha`, ref, workflow run ID, and attempt) naturally varies, so the
+downloaded ZIP is not claimed to be byte-identical across runs.
+
+## Non-claims
+
+This local CI bundle does **not** prove live model inference or live provider
+behavior; production TrustLog infrastructure, PostgreSQL, KMS/WORM, deployment,
+or readiness; execution authority from `/v1/decide`; Human Approval or Authority
+Evidence; Decision Pipeline → Bind Boundary lineage; live bank or financial
+institution integration; customer deployment; or regulatory approval or
+certification.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
   # --- LLM integration (required) ---
   "openai==1.53.0",
   "httpx==0.28.1",
+  "requests==2.34.2",
   # Fixed CVE-2026-45409 in IDNA URL handling.
   "idna==3.15",
   # --- Numerical core (required by memory subsystem) ---

--- a/scripts/demo/build_runtime_proof_evidence_manifest.py
+++ b/scripts/demo/build_runtime_proof_evidence_manifest.py
@@ -27,7 +27,11 @@ def file_role(path: str) -> str:
     return {"verification-report.json": "combined_verification", "ci-context.json": "ci_provenance", "reviewer-summary.md": "reviewer_summary"}.get(path, "supporting_evidence")
 
 
-def build_manifest(root: Path, commit_sha: str) -> dict[str, Any]:
+def build_manifest(
+    root: Path,
+    tested_sha: str,
+    source_head_sha: str | None = None,
+) -> dict[str, Any]:
     """Hash every regular bundled file except the self-referential manifest."""
     files = []
     for path in sorted(item for item in root.rglob("*") if item.is_file() and item.name != MANIFEST_NAME):
@@ -38,7 +42,9 @@ def build_manifest(root: Path, commit_sha: str) -> dict[str, Any]:
         "format_version": 1,
         "manifest_id": "veritas-runtime-proof-evidence-v1",
         "artifact_name": ARTIFACT_NAME,
-        "commit_sha": commit_sha,
+        "commit_sha": tested_sha,
+        "tested_sha": tested_sha,
+        "source_head_sha": source_head_sha or tested_sha,
         "local_ci_proof_only": True,
         "proofs_independent": True,
         "decision_to_bind_connection_claimed": False,
@@ -54,9 +60,10 @@ def main() -> int:
     """Write a manifest for a bundle directory."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("bundle", type=Path)
-    parser.add_argument("--commit-sha", required=True)
+    parser.add_argument("--tested-sha", required=True)
+    parser.add_argument("--source-head-sha")
     args = parser.parse_args()
-    manifest = build_manifest(args.bundle, args.commit_sha)
+    manifest = build_manifest(args.bundle, args.tested_sha, args.source_head_sha)
     (args.bundle / MANIFEST_NAME).write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return 0
 

--- a/scripts/demo/build_runtime_proof_evidence_manifest.py
+++ b/scripts/demo/build_runtime_proof_evidence_manifest.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Build the deterministic SHA-256 manifest for Runtime Proof Evidence."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+MANIFEST_NAME = "runtime-proof-evidence-manifest.json"
+ARTIFACT_NAME = "veritas-runtime-proof-evidence"
+
+
+def canonical_bytes(value: Any) -> bytes:
+    """Return canonical UTF-8 JSON used by the aggregate hash procedure."""
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode()
+
+
+def file_role(path: str) -> str:
+    """Return a stable reviewer-facing role for a bundled relative path."""
+    if path.startswith("decision-pipeline/"):
+        return "decision_pipeline_proof"
+    if path.startswith("external-bind/"):
+        return "external_bind_proof"
+    return {"verification-report.json": "combined_verification", "ci-context.json": "ci_provenance", "reviewer-summary.md": "reviewer_summary"}.get(path, "supporting_evidence")
+
+
+def build_manifest(root: Path, commit_sha: str) -> dict[str, Any]:
+    """Hash every regular bundled file except the self-referential manifest."""
+    files = []
+    for path in sorted(item for item in root.rglob("*") if item.is_file() and item.name != MANIFEST_NAME):
+        relative = path.relative_to(root).as_posix()
+        content = path.read_bytes()
+        files.append({"path": relative, "role": file_role(relative), "sha256": hashlib.sha256(content).hexdigest(), "size_bytes": len(content)})
+    manifest: dict[str, Any] = {
+        "format_version": 1,
+        "manifest_id": "veritas-runtime-proof-evidence-v1",
+        "artifact_name": ARTIFACT_NAME,
+        "commit_sha": commit_sha,
+        "local_ci_proof_only": True,
+        "proofs_independent": True,
+        "decision_to_bind_connection_claimed": False,
+        "hash_algorithm": "SHA-256",
+        "manifest_hash_procedure": "SHA-256 of canonical JSON for this object with manifest_hash omitted",
+        "files": files,
+    }
+    manifest["manifest_hash"] = hashlib.sha256(canonical_bytes(manifest)).hexdigest()
+    return manifest
+
+
+def main() -> int:
+    """Write a manifest for a bundle directory."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("bundle", type=Path)
+    parser.add_argument("--commit-sha", required=True)
+    args = parser.parse_args()
+    manifest = build_manifest(args.bundle, args.commit_sha)
+    (args.bundle / MANIFEST_NAME).write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/demo/build_runtime_proof_summary.py
+++ b/scripts/demo/build_runtime_proof_summary.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Write safe Markdown summaries for verified independent runtime proofs."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def build_summary(tested_sha: str, source_head_sha: str) -> str:
+    """Return reviewer Markdown with explicit, non-empty CI provenance."""
+    if not tested_sha.strip() or not source_head_sha.strip():
+        raise ValueError("tested and source head SHA values must be non-empty")
+    return f"""# VERITAS Runtime Proof Evidence
+
+Tested checkout SHA: `{tested_sha}`
+Source head SHA: `{source_head_sha}`
+
+## Decision Pipeline Proof
+- authenticated `/v1/decide`: PASS
+- real decision/governance runtime: PASS
+- real `kernel.decide` successful return: PASS
+- provider mode: `controlled_provider_fixture`
+- TrustLog and replay verification: PASS
+- ExecutionIntent created / Bind invoked: NO / NO
+
+## External Bind Boundary Proof
+- decision stage: `synthetic_fixture`
+- COMMITTED / BLOCKED / ROLLED_BACK: PASS / PASS / PASS
+
+## Boundary
+These are two independent proof paths. No Decision Pipeline -> ExecutionIntent
+-> Bind handoff is claimed.
+
+Artifact: `veritas-runtime-proof-evidence`
+
+This local CI bundle does not prove live providers, production TrustLog,
+PostgreSQL, KMS/WORM, execution authority, Human Approval, Authority Evidence,
+decision-to-bind lineage, live financial integrations, customer deployment,
+regulatory approval/certification, or production readiness.
+"""
+
+
+def main() -> int:
+    """Parse provenance and write reviewer and optional GitHub summaries."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tested-sha", required=True)
+    parser.add_argument("--source-head-sha", required=True)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--github-summary", type=Path)
+    args = parser.parse_args()
+    try:
+        summary = build_summary(args.tested_sha, args.source_head_sha)
+    except ValueError as exc:
+        parser.error(str(exc))
+    args.output.write_text(summary, encoding="utf-8")
+    if args.github_summary:
+        with args.github_summary.open("a", encoding="utf-8") as stream:
+            stream.write(summary)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/demo/verify_runtime_proof_evidence.py
+++ b/scripts/demo/verify_runtime_proof_evidence.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Fail-closed validation of two independent runtime proof outputs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+DECISION_SCOPE = "real VERITAS decision/governance runtime with controlled model output"
+DECISION_COMPONENTS = {
+    "routes_decide.decide", "run_decide_pipeline", "kernel.decide",
+    "FUJI", "ValueCore", "TrustLog",
+}
+BIND_COMPONENTS = {"execute_bind_adjudication", "WebhookBindAdapter"}
+BIND_FILES = ("committed.json", "blocked.json", "rolled-back.json", "manifest.json")
+
+
+def load_object(path: Path) -> dict[str, Any]:
+    """Load a JSON object, rejecting missing, malformed, or non-object input."""
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"cannot load JSON object {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return value
+
+
+def verify_decision_report(report: dict[str, Any]) -> None:
+    """Validate the existing Decision Pipeline PoC report contract."""
+    expected = {
+        "proof_scope": DECISION_SCOPE,
+        "provider_mode": "controlled_provider_fixture",
+        "authenticated_http_route_exercised": True,
+        "route": "POST /v1/decide",
+        "permission_decide_exercised": True,
+        "request_validation_exercised": True,
+        "outbound_provider_network_calls": 0,
+        "trustlog_append_verified": True,
+        "trustlog_chain_verified": True,
+        "replay_artifact_verified": True,
+        "execution_authority_claimed": False,
+        "execution_intent_created": False,
+        "bind_invoked": False,
+        "webhook_bind_adapter_invoked": False,
+        "external_effect_occurred": False,
+        "human_approval_fabricated": False,
+        "authority_evidence_fabricated": False,
+    }
+    failures = [key for key, value in expected.items() if report.get(key) != value]
+    calls = report.get("controlled_provider_calls")
+    if isinstance(calls, bool) or not isinstance(calls, int) or calls < 1:
+        failures.append("controlled_provider_calls")
+    components = report.get("real_runtime_components")
+    if not isinstance(components, list) or not DECISION_COMPONENTS.issubset(components):
+        failures.append("real_runtime_components")
+    if failures:
+        raise ValueError("invalid decision evidence: " + ", ".join(sorted(set(failures))))
+
+
+def verify_bind_directory(bind_dir: Path) -> dict[str, dict[str, Any]]:
+    """Validate the bind PoC manifest and all three scenario artifacts."""
+    for name in BIND_FILES:
+        if not (bind_dir / name).is_file():
+            raise ValueError(f"missing bind proof file: {name}")
+    manifest = load_object(bind_dir / "manifest.json")
+    if manifest.get("synthetic_data_only") is not True:
+        raise ValueError("bind manifest must disclose synthetic-only data")
+    scenarios = {name: load_object(bind_dir / f"{name}.json") for name in ("committed", "blocked", "rolled-back")}
+    requirements = {
+        "committed": ("COMMITTED", 1, 0, True),
+        "blocked": ("BLOCKED", 0, 0, False),
+        "rolled-back": ("ROLLED_BACK", 1, 1, False),
+    }
+    for name, evidence in scenarios.items():
+        outcome, actions, compensations, postcondition = requirements[name]
+        verification = evidence.get("verification_result")
+        components = evidence.get("real_veritas_runtime")
+        path = evidence.get("path")
+        valid = (
+            evidence.get("scenario") == name
+            and evidence.get("decision_stage") == "synthetic_fixture"
+            and evidence.get("final_outcome") == outcome
+            and evidence.get("action_post_count") == actions
+            and evidence.get("compensation_post_count") == compensations
+            and evidence.get("external_post_occurred") is (actions > 0)
+            and isinstance(verification, dict)
+            and verification.get("postcondition_satisfied") is postcondition
+            and isinstance(components, list)
+            and BIND_COMPONENTS.issubset(components)
+            and isinstance(path, list)
+            and all("/v1/decide" not in str(item) for item in path)
+            and isinstance(evidence.get("receipt_hash"), str)
+            and len(evidence["receipt_hash"]) == 64
+            and isinstance(evidence.get("idempotency_status"), str)
+        )
+        if name == "rolled-back":
+            valid = valid and verification.get("compensation_verified") is True
+        if not valid:
+            raise ValueError(f"invalid bind evidence: {name}")
+    return scenarios
+
+
+def verify_secret_hygiene(root: Path) -> None:
+    """Reject obvious secret-bearing fields or authorization headers in a bundle."""
+    forbidden = (b"authorization: bearer", b"x-veritas-signature", b'"api_key"', b'"encryption_key"', b"test-only-external-bind-poc-secret")
+    for path in root.rglob("*"):
+        if path.is_file():
+            lowered = path.read_bytes().lower()
+            if any(token in lowered for token in forbidden):
+                raise ValueError(f"proof-bundle secret hygiene failure: {path.relative_to(root)}")
+
+
+def build_report(decision_path: Path, bind_dir: Path) -> dict[str, Any]:
+    """Verify both inputs and return an explicit independent-proof report."""
+    verify_decision_report(load_object(decision_path))
+    scenarios = verify_bind_directory(bind_dir)
+    verify_secret_hygiene(decision_path.parent)
+    verify_secret_hygiene(bind_dir)
+    return {
+        "format_version": 1,
+        "verification_type": "independent_runtime_proof_bundle_verification",
+        "decision_proof": {"verified": True, "connected_to_bind_proof": False},
+        "bind_proof": {
+            "verified": True,
+            "decision_stage": "synthetic_fixture",
+            "scenario_outcomes": {key: value["final_outcome"] for key, value in scenarios.items()},
+        },
+        "proofs_independent": True,
+        "cross_proof_connection_claimed": False,
+        "decision_to_bind_connection_claimed": False,
+        "execution_authority_claimed_from_decide": False,
+        "proof_bundle_secret_hygiene_verified": True,
+        "overall_verified": True,
+    }
+
+
+def main() -> int:
+    """Validate arguments and write the machine-readable verification report."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--decision-report", required=True, type=Path)
+    parser.add_argument("--bind-dir", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+    try:
+        report = build_report(args.decision_report, args.bind_dir)
+    except ValueError as exc:
+        parser.error(str(exc))
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/demo/verify_runtime_proof_evidence.py
+++ b/scripts/demo/verify_runtime_proof_evidence.py
@@ -53,6 +53,24 @@ def verify_decision_report(report: dict[str, Any]) -> None:
     calls = report.get("controlled_provider_calls")
     if isinstance(calls, bool) or not isinstance(calls, int) or calls < 1:
         failures.append("controlled_provider_calls")
+    kernel_calls = report.get("kernel_decide_calls")
+    successful_kernel_calls = report.get("kernel_decide_successful_calls")
+    if (
+        isinstance(kernel_calls, bool)
+        or not isinstance(kernel_calls, int)
+        or kernel_calls < 1
+    ):
+        failures.append("kernel_decide_calls")
+    if (
+        isinstance(successful_kernel_calls, bool)
+        or not isinstance(successful_kernel_calls, int)
+        or successful_kernel_calls < 1
+        or (
+            isinstance(kernel_calls, int)
+            and successful_kernel_calls > kernel_calls
+        )
+    ):
+        failures.append("kernel_decide_successful_calls")
     components = report.get("real_runtime_components")
     if not isinstance(components, list) or not DECISION_COMPONENTS.issubset(components):
         failures.append("real_runtime_components")

--- a/scripts/demo/verify_runtime_proof_evidence_manifest.py
+++ b/scripts/demo/verify_runtime_proof_evidence_manifest.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Verify a downloaded Runtime Proof Evidence manifest offline."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path, PurePosixPath
+import sys
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.demo.build_runtime_proof_evidence_manifest import (  # noqa: E402
+    MANIFEST_NAME,
+    canonical_bytes,
+)
+
+REQUIRED = {"decision-pipeline/report.json", "external-bind/committed.json", "external-bind/blocked.json", "external-bind/rolled-back.json", "external-bind/manifest.json", "verification-report.json", "ci-context.json", "reviewer-summary.md"}
+
+
+def verify_manifest(root: Path) -> dict[str, Any]:
+    """Fail closed on malformed metadata, unsafe paths, or digest mismatches."""
+    try:
+        manifest = json.loads((root / MANIFEST_NAME).read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"cannot load manifest: {exc}") from exc
+    if not isinstance(manifest, dict) or not isinstance(manifest.get("files"), list):
+        raise ValueError("manifest must be an object containing a file list")
+    supplied_hash = manifest.get("manifest_hash")
+    unhashed = dict(manifest)
+    unhashed.pop("manifest_hash", None)
+    if supplied_hash != hashlib.sha256(canonical_bytes(unhashed)).hexdigest():
+        raise ValueError("aggregate manifest hash mismatch")
+    seen: set[str] = set()
+    for entry in manifest["files"]:
+        if not isinstance(entry, dict) or not isinstance(entry.get("path"), str):
+            raise ValueError("malformed file entry")
+        relative = entry["path"]
+        pure = PurePosixPath(relative)
+        if pure.is_absolute() or ".." in pure.parts or relative in seen:
+            raise ValueError(f"unsafe or duplicate path: {relative}")
+        seen.add(relative)
+        path = root.joinpath(*pure.parts)
+        if not path.is_file():
+            raise ValueError(f"missing bundled file: {relative}")
+        content = path.read_bytes()
+        if entry.get("size_bytes") != len(content) or entry.get("sha256") != hashlib.sha256(content).hexdigest():
+            raise ValueError(f"file integrity mismatch: {relative}")
+        if path.suffix == ".json":
+            try:
+                value = json.loads(content)
+            except (UnicodeError, json.JSONDecodeError) as exc:
+                raise ValueError(f"malformed JSON: {relative}") from exc
+            if not isinstance(value, dict):
+                raise ValueError(f"JSON evidence is not an object: {relative}")
+    if not REQUIRED.issubset(seen):
+        raise ValueError("required proof files absent from manifest: " + ", ".join(sorted(REQUIRED - seen)))
+    actual = {path.relative_to(root).as_posix() for path in root.rglob("*") if path.is_file() and path.name != MANIFEST_NAME}
+    if actual != seen:
+        raise ValueError("manifest does not enumerate the complete bundle")
+    return {"format_version": 1, "verification_type": "runtime_proof_evidence_manifest_verification", "manifest_hash": supplied_hash, "files_verified": len(seen), "overall_verified": True}
+
+
+def main() -> int:
+    """Verify a bundle and emit a JSON report to standard output."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("bundle", type=Path)
+    args = parser.parse_args()
+    try:
+        report = verify_manifest(args.bundle)
+    except ValueError as exc:
+        parser.error(str(exc))
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_decide_pipeline_poc.py
+++ b/scripts/run_decide_pipeline_poc.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import base64
+from functools import wraps
 import hashlib
 import json
 import os
@@ -102,6 +103,8 @@ def _project_report(
     ledger_entry: dict[str, Any],
     replay_digest: str,
     calls: int,
+    kernel_calls: int,
+    kernel_successful_calls: int,
 ) -> dict[str, Any]:
     """Normalize nondeterministic runtime output into reviewer evidence."""
     gate = response.get("gate") if isinstance(response.get("gate"), dict) else {}
@@ -129,6 +132,8 @@ def _project_report(
         ],
         "controlled_components": ["veritas_os.core.llm_client.chat output"],
         "controlled_provider_calls": calls,
+        "kernel_decide_calls": kernel_calls,
+        "kernel_decide_successful_calls": kernel_successful_calls,
         "outbound_provider_network_calls": 0,
         "request_fixture_digest": _digest(fixture),
         "controlled_provider_transcript_digest": _digest(transcript),
@@ -162,11 +167,32 @@ def _project_report(
     }
 
 
+def _observed_kernel_decide(
+    original_kernel_decide: Any,
+    counters: dict[str, int],
+    *,
+    force_failure: bool = False,
+) -> Any:
+    """Wrap kernel.decide without changing its inspectable call signature."""
+
+    @wraps(original_kernel_decide)
+    async def observer(*args: Any, **kwargs: Any) -> Any:
+        counters["calls"] += 1
+        if force_failure:
+            raise RuntimeError("forced kernel failure for fail-closed proof test")
+        result = await original_kernel_decide(*args, **kwargs)
+        counters["successful_calls"] += 1
+        return result
+
+    return observer
+
+
 def run_proof(
     report_path: Path,
     *,
     force_verify_failure: bool = False,
     omit_encryption_key: bool = False,
+    force_kernel_failure: bool = False,
 ) -> int:
     """Execute the real route and independently enforce proof invariants.
 
@@ -174,6 +200,7 @@ def run_proof(
         report_path: Destination for normalized machine-readable evidence.
         force_verify_failure: Test-only fault injection after HTTP completion.
         omit_encryption_key: Test-only proof of mandatory encryption failure.
+        force_kernel_failure: Test-only proof that core fallback cannot pass.
 
     Returns:
         Zero only when every mandatory reviewer proof check passes.
@@ -203,7 +230,7 @@ def run_proof(
         call_count = 0
         original_kernel_decide = decision_kernel.decide
         kernel_available = callable(original_kernel_decide)
-        kernel_calls = 0
+        kernel_counters = {"calls": 0, "successful_calls": 0}
 
         def controlled_chat(*args: Any, **kwargs: Any) -> dict[str, Any]:
             """Supply the fixture exactly at the central provider seam."""
@@ -211,11 +238,11 @@ def run_proof(
             call_count += 1
             return dict(transcript["response"])
 
-        async def observed_kernel_decide(*args: Any, **kwargs: Any) -> Any:
-            """Count, without replacing, calls to the real kernel."""
-            nonlocal kernel_calls
-            kernel_calls += 1
-            return await original_kernel_decide(*args, **kwargs)
+        observed_kernel_decide = _observed_kernel_decide(
+            original_kernel_decide,
+            kernel_counters,
+            force_failure=force_kernel_failure,
+        )
 
         with patch.object(llm_client, "chat", controlled_chat), patch.object(
             decision_kernel, "decide", observed_kernel_decide
@@ -239,7 +266,11 @@ def run_proof(
         else:
             payload = DecideResponse.model_validate(response.json()).model_dump()
         statuses["request_validation"] = bool(payload)
-        statuses["pipeline"] = kernel_available and kernel_calls > 0
+        statuses["pipeline"] = bool(
+            kernel_available
+            and kernel_counters["calls"] > 0
+            and kernel_counters["successful_calls"] > 0
+        )
         statuses["controlled_provider"] = call_count > 0
 
         log_path = trust_log.LOG_JSONL
@@ -282,6 +313,8 @@ def run_proof(
                 ledger_entry,
                 _digest(replay),
                 call_count,
+                kernel_counters["calls"],
+                kernel_counters["successful_calls"],
             )
             serialized = _canonical_bytes(report)
             forbidden = (api_key, encryption_key)
@@ -316,11 +349,13 @@ def main() -> int:
     parser.add_argument("--report", type=Path, default=DEFAULT_REPORT)
     parser.add_argument("--force-verify-failure", action="store_true", help=argparse.SUPPRESS)
     parser.add_argument("--omit-encryption-key", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--force-kernel-failure", action="store_true", help=argparse.SUPPRESS)
     args = parser.parse_args()
     return run_proof(
         args.report,
         force_verify_failure=args.force_verify_failure,
         omit_encryption_key=args.omit_encryption_key,
+        force_kernel_failure=args.force_kernel_failure,
     )
 
 

--- a/veritas_os/requirements-core.txt
+++ b/veritas_os/requirements-core.txt
@@ -10,6 +10,7 @@ jinja2==3.1.6
 jsonschema==4.23.0
 openai==1.53.0
 httpx==0.28.1
+requests==2.34.2
 # Fixed CVE-2026-45409 in IDNA URL handling.
 idna==3.15
 numpy==1.26.4

--- a/veritas_os/requirements.txt
+++ b/veritas_os/requirements.txt
@@ -30,6 +30,7 @@ jsonschema==4.23.0
 # --- Core: LLM Integration ---
 openai==1.53.0
 httpx==0.28.1
+requests==2.34.2
 # Fixed CVE-2026-45409 in IDNA URL handling.
 idna==3.15
 

--- a/veritas_os/tests/test_decide_pipeline_poc.py
+++ b/veritas_os/tests/test_decide_pipeline_poc.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import inspect
 import os
 import subprocess
 import sys
@@ -48,6 +49,8 @@ def test_real_decide_route_generates_strict_evidence(tmp_path: Path) -> None:
     assert report["permission_decide_exercised"]
     assert report["request_validation_exercised"]
     assert report["controlled_provider_calls"] > 0
+    assert report["kernel_decide_calls"] > 0
+    assert report["kernel_decide_successful_calls"] > 0
     assert report["outbound_provider_network_calls"] == 0
     assert report["trustlog_append_verified"]
     assert report["trustlog_chain_verified"]
@@ -84,13 +87,52 @@ def test_proof_fails_without_encryption_material(tmp_path: Path) -> None:
     assert not (tmp_path / "report.json").exists()
 
 
+@pytest.mark.integration
+def test_kernel_exception_and_pipeline_fallback_cannot_pass(tmp_path: Path) -> None:
+    """HTTP fallback must fail proof when the real kernel does not return."""
+    result = _run(tmp_path, "--force-kernel-failure")
+
+    assert result.returncode != 0
+    assert "HTTP_ROUTE               PASS" in result.stdout
+    assert "PIPELINE_KERNEL          FAIL" in result.stdout
+    assert "RESULT                   FAIL" in result.stdout
+    assert not (tmp_path / "report.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_kernel_observer_preserves_signature_and_counts_success() -> None:
+    """The observer must be transparent to signature-based core dispatch."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("decide_poc_runner", RUNNER)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    async def kernel_decide(
+        context: dict[str, object],
+        query: str,
+        alternatives: list[dict[str, object]],
+        min_evidence: int = 1,
+    ) -> dict[str, object]:
+        return {"query": query, "min_evidence": min_evidence}
+
+    counters = {"calls": 0, "successful_calls": 0}
+    observer = module._observed_kernel_decide(kernel_decide, counters)
+
+    assert inspect.signature(observer) == inspect.signature(kernel_decide)
+    result = await observer({}, "query", [], 2)
+    assert result == {"query": "query", "min_evidence": 2}
+    assert counters == {"calls": 1, "successful_calls": 1}
+
+
 def test_runner_controls_only_central_llm_seam_and_keeps_bind_separate() -> None:
     """Static boundary guard prevents broad runtime mocks and bind imports."""
     source = RUNNER.read_text(encoding="utf-8")
 
     assert 'patch.object(llm_client, "chat", controlled_chat)' in source
     assert "decision_kernel, \"decide\", observed_kernel_decide" in source
-    assert "original_kernel_decide(*args, **kwargs)" in source
+    assert "result = await original_kernel_decide(*args, **kwargs)" in source
     assert "patch.object(server, \"get_decision_pipeline\"" not in source
     assert "WebhookBindAdapter" not in source
     assert "ExecutionIntent" not in source

--- a/veritas_os/tests/test_runtime_proof_evidence_ci.py
+++ b/veritas_os/tests/test_runtime_proof_evidence_ci.py
@@ -23,6 +23,16 @@ from scripts.demo.verify_runtime_proof_evidence import (
 )
 from scripts.demo.verify_runtime_proof_evidence_manifest import verify_manifest
 
+REPO_ROOT = Path.cwd()
+
+
+def test_workflow_installs_declared_signing_extra() -> None:
+    """Guard the signing dependency needed by the real Decision PoC imports."""
+    workflow = (
+        REPO_ROOT / ".github/workflows/runtime-proof-evidence.yml"
+    ).read_text(encoding="utf-8")
+    assert 'python -m pip install ".[signing]"' in workflow
+
 
 def decision() -> dict[str, object]:
     """Return a minimal valid synthetic Decision Pipeline report fixture."""

--- a/veritas_os/tests/test_runtime_proof_evidence_ci.py
+++ b/veritas_os/tests/test_runtime_proof_evidence_ci.py
@@ -14,6 +14,7 @@ from scripts.demo.build_runtime_proof_evidence_manifest import (
     build_manifest,
     canonical_bytes,
 )
+from scripts.demo.build_runtime_proof_summary import build_summary
 from scripts.demo.verify_runtime_proof_evidence import (
     DECISION_COMPONENTS,
     build_report,
@@ -53,6 +54,31 @@ def test_requests_pin_is_consistent_across_core_manifests() -> None:
         assert manifest.read_text(encoding="utf-8").count("requests==2.34.2") == 1
 
 
+def test_summary_has_literal_markdown_and_nonempty_provenance() -> None:
+    """Python summary generation must preserve backticks without shell parsing."""
+    summary = build_summary("tested-abc", "source-def")
+
+    assert "Tested checkout SHA: `tested-abc`" in summary
+    assert "Source head SHA: `source-def`" in summary
+    assert "authenticated `/v1/decide`: PASS" in summary
+    assert "`controlled_provider_fixture`" in summary
+
+
+def test_summary_rejects_empty_provenance() -> None:
+    """Reviewer summaries must never contain blank SHA provenance fields."""
+    with pytest.raises(ValueError, match="must be non-empty"):
+        build_summary("", "source-def")
+
+
+def test_workflow_avoids_unquoted_markdown_heredocs() -> None:
+    """Prevent shell command substitution from corrupting Markdown evidence."""
+    workflow = (
+        REPO_ROOT / ".github/workflows/runtime-proof-evidence.yml"
+    ).read_text(encoding="utf-8")
+    assert "<<EOF" not in workflow
+    assert "SOURCE_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}" in workflow
+
+
 def decision() -> dict[str, object]:
     """Return a minimal valid synthetic Decision Pipeline report fixture."""
     return {
@@ -63,6 +89,8 @@ def decision() -> dict[str, object]:
         "permission_decide_exercised": True,
         "request_validation_exercised": True,
         "controlled_provider_calls": 1,
+        "kernel_decide_calls": 1,
+        "kernel_decide_successful_calls": 1,
         "outbound_provider_network_calls": 0,
         "trustlog_append_verified": True,
         "trustlog_chain_verified": True,
@@ -117,6 +145,7 @@ def test_valid_decision_report_passes() -> None:
         ("trustlog_append_verified", False),
         ("trustlog_chain_verified", False),
         ("replay_artifact_verified", False),
+        ("kernel_decide_successful_calls", 0),
     ],
 )
 def test_invalid_decision_invariants_fail(field: str, value: object) -> None:
@@ -185,6 +214,9 @@ def test_valid_manifest_and_ci_provenance_pass(tmp_path: Path) -> None:
     context = json.loads((root / "ci-context.json").read_text())
     assert context["commit_sha"] == "abc123"
     assert "secret" not in json.dumps(context).lower()
+    manifest = json.loads((root / MANIFEST_NAME).read_text())
+    assert manifest["tested_sha"] == "abc123"
+    assert manifest["source_head_sha"] == "abc123"
 
 
 def test_altered_file_fails_manifest_verification(tmp_path: Path) -> None:

--- a/veritas_os/tests/test_runtime_proof_evidence_ci.py
+++ b/veritas_os/tests/test_runtime_proof_evidence_ci.py
@@ -1,0 +1,227 @@
+"""Focused tests for independent Runtime Proof Evidence CI tooling."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.demo.build_runtime_proof_evidence_manifest import (
+    MANIFEST_NAME,
+    build_manifest,
+    canonical_bytes,
+)
+from scripts.demo.verify_runtime_proof_evidence import (
+    DECISION_COMPONENTS,
+    build_report,
+    verify_bind_directory,
+    verify_decision_report,
+    verify_secret_hygiene,
+)
+from scripts.demo.verify_runtime_proof_evidence_manifest import verify_manifest
+
+
+def decision() -> dict[str, object]:
+    """Return a minimal valid synthetic Decision Pipeline report fixture."""
+    return {
+        "proof_scope": "real VERITAS decision/governance runtime with controlled model output",
+        "provider_mode": "controlled_provider_fixture",
+        "authenticated_http_route_exercised": True,
+        "route": "POST /v1/decide",
+        "permission_decide_exercised": True,
+        "request_validation_exercised": True,
+        "controlled_provider_calls": 1,
+        "outbound_provider_network_calls": 0,
+        "trustlog_append_verified": True,
+        "trustlog_chain_verified": True,
+        "replay_artifact_verified": True,
+        "execution_authority_claimed": False,
+        "execution_intent_created": False,
+        "bind_invoked": False,
+        "webhook_bind_adapter_invoked": False,
+        "external_effect_occurred": False,
+        "human_approval_fabricated": False,
+        "authority_evidence_fabricated": False,
+        "real_runtime_components": sorted(DECISION_COMPONENTS),
+    }
+
+
+def write_bind(root: Path) -> None:
+    """Write valid synthetic fixtures matching the existing bind contract."""
+    root.mkdir()
+    outcomes = {
+        "committed": ("COMMITTED", 1, 0, True, False),
+        "blocked": ("BLOCKED", 0, 0, False, False),
+        "rolled-back": ("ROLLED_BACK", 1, 1, False, True),
+    }
+    for name, (outcome, actions, compensation, postcondition, compensated) in outcomes.items():
+        value = {
+            "scenario": name,
+            "decision_stage": "synthetic_fixture",
+            "real_veritas_runtime": ["execute_bind_adjudication", "WebhookBindAdapter"],
+            "path": ["synthetic Decision Candidate", "Bind Boundary adjudication"],
+            "final_outcome": outcome,
+            "action_post_count": actions,
+            "compensation_post_count": compensation,
+            "external_post_occurred": actions > 0,
+            "receipt_hash": "a" * 64,
+            "idempotency_status": "first_execution",
+            "verification_result": {"postcondition_satisfied": postcondition, "compensation_verified": compensated},
+        }
+        (root / f"{name}.json").write_text(json.dumps(value), encoding="utf-8")
+    (root / "manifest.json").write_text(json.dumps({"synthetic_data_only": True}), encoding="utf-8")
+
+
+def test_valid_decision_report_passes() -> None:
+    verify_decision_report(decision())
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("bind_invoked", True),
+        ("execution_intent_created", True),
+        ("outbound_provider_network_calls", 1),
+        ("trustlog_append_verified", False),
+        ("trustlog_chain_verified", False),
+        ("replay_artifact_verified", False),
+    ],
+)
+def test_invalid_decision_invariants_fail(field: str, value: object) -> None:
+    report = decision()
+    report[field] = value
+    with pytest.raises(ValueError, match="invalid decision evidence"):
+        verify_decision_report(report)
+
+
+def test_valid_bind_scenarios_pass(tmp_path: Path) -> None:
+    write_bind(tmp_path / "bind")
+    verify_bind_directory(tmp_path / "bind")
+
+
+@pytest.mark.parametrize(
+    ("scenario", "mutation"),
+    [
+        ("committed", {"action_post_count": 0}),
+        ("blocked", {"action_post_count": 1}),
+        ("rolled-back", {"verification_result": {"postcondition_satisfied": False, "compensation_verified": False}}),
+        ("committed", {"decision_stage": "real_pipeline"}),
+        ("committed", {"path": ["POST /v1/decide"]}),
+    ],
+)
+def test_invalid_bind_invariants_fail(tmp_path: Path, scenario: str, mutation: dict[str, object]) -> None:
+    root = tmp_path / "bind"
+    write_bind(root)
+    path = root / f"{scenario}.json"
+    value = json.loads(path.read_text())
+    value.update(mutation)
+    path.write_text(json.dumps(value))
+    with pytest.raises(ValueError, match="invalid bind evidence"):
+        verify_bind_directory(root)
+
+
+def make_bundle(tmp_path: Path) -> Path:
+    """Create the complete minimal bundle expected by the manifest verifier."""
+    root = tmp_path / "bundle"
+    (root / "decision-pipeline").mkdir(parents=True)
+    (root / "external-bind").mkdir()
+    (root / "decision-pipeline/report.json").write_text(json.dumps(decision()))
+    write_bind_contents = tmp_path / "source-bind"
+    write_bind(write_bind_contents)
+    for path in write_bind_contents.iterdir():
+        (root / "external-bind" / path.name).write_bytes(path.read_bytes())
+    verification = {"overall_verified": True, "proofs_independent": True, "decision_to_bind_connection_claimed": False}
+    (root / "verification-report.json").write_text(json.dumps(verification))
+    (root / "ci-context.json").write_text(json.dumps({"metadata_type": "ci_provenance_only", "generated_by": "github_actions", "commit_sha": "abc123"}))
+    (root / "reviewer-summary.md").write_text("independent proofs")
+    manifest = build_manifest(root, "abc123")
+    (root / MANIFEST_NAME).write_text(json.dumps(manifest))
+    return root
+
+
+def rewrite_manifest_hash(root: Path, manifest: dict[str, object]) -> None:
+    """Recalculate the aggregate hash after a deliberate structural mutation."""
+    unhashed = copy.deepcopy(manifest)
+    unhashed.pop("manifest_hash", None)
+    manifest["manifest_hash"] = hashlib.sha256(canonical_bytes(unhashed)).hexdigest()
+    (root / MANIFEST_NAME).write_text(json.dumps(manifest))
+
+
+def test_valid_manifest_and_ci_provenance_pass(tmp_path: Path) -> None:
+    root = make_bundle(tmp_path)
+    assert verify_manifest(root)["overall_verified"]
+    context = json.loads((root / "ci-context.json").read_text())
+    assert context["commit_sha"] == "abc123"
+    assert "secret" not in json.dumps(context).lower()
+
+
+def test_altered_file_fails_manifest_verification(tmp_path: Path) -> None:
+    root = make_bundle(tmp_path)
+    (root / "reviewer-summary.md").write_text("altered")
+    with pytest.raises(ValueError, match="integrity mismatch"):
+        verify_manifest(root)
+
+
+def test_incorrect_sha_fails_manifest_verification(tmp_path: Path) -> None:
+    root = make_bundle(tmp_path)
+    manifest = json.loads((root / MANIFEST_NAME).read_text())
+    manifest["files"][0]["sha256"] = "0" * 64
+    rewrite_manifest_hash(root, manifest)
+    with pytest.raises(ValueError, match="integrity mismatch"):
+        verify_manifest(root)
+
+
+@pytest.mark.parametrize("unsafe", ["../escape.json", "/absolute.json"])
+def test_path_traversal_fails(tmp_path: Path, unsafe: str) -> None:
+    root = make_bundle(tmp_path)
+    manifest = json.loads((root / MANIFEST_NAME).read_text())
+    manifest["files"][0]["path"] = unsafe
+    rewrite_manifest_hash(root, manifest)
+    with pytest.raises(ValueError, match="unsafe or duplicate"):
+        verify_manifest(root)
+
+
+def test_duplicate_manifest_entry_fails(tmp_path: Path) -> None:
+    root = make_bundle(tmp_path)
+    manifest = json.loads((root / MANIFEST_NAME).read_text())
+    manifest["files"].append(copy.deepcopy(manifest["files"][0]))
+    rewrite_manifest_hash(root, manifest)
+    with pytest.raises(ValueError, match="unsafe or duplicate"):
+        verify_manifest(root)
+
+
+def test_missing_required_file_fails(tmp_path: Path) -> None:
+    root = make_bundle(tmp_path)
+    (root / "external-bind/blocked.json").unlink()
+    with pytest.raises(ValueError, match="missing bundled file"):
+        verify_manifest(root)
+
+
+def test_malformed_json_fails(tmp_path: Path) -> None:
+    root = make_bundle(tmp_path)
+    path = root / "ci-context.json"
+    path.write_text("{")
+    manifest = build_manifest(root, "abc123")
+    (root / MANIFEST_NAME).write_text(json.dumps(manifest))
+    with pytest.raises(ValueError, match="malformed JSON"):
+        verify_manifest(root)
+
+
+def test_combined_report_explicitly_preserves_independence(tmp_path: Path) -> None:
+    decision_path = tmp_path / "decision.json"
+    decision_path.write_text(json.dumps(decision()))
+    bind_dir = tmp_path / "bind"
+    write_bind(bind_dir)
+    report = build_report(decision_path, bind_dir)
+    assert report["proofs_independent"] is True
+    assert report["decision_to_bind_connection_claimed"] is False
+    assert report["decision_proof"]["connected_to_bind_proof"] is False
+
+
+def test_secret_hygiene_rejects_secret_fields(tmp_path: Path) -> None:
+    (tmp_path / "bad.json").write_text('{"api_key": "not-allowed"}')
+    with pytest.raises(ValueError, match="secret hygiene"):
+        verify_secret_hygiene(tmp_path)

--- a/veritas_os/tests/test_runtime_proof_evidence_ci.py
+++ b/veritas_os/tests/test_runtime_proof_evidence_ci.py
@@ -34,6 +34,25 @@ def test_workflow_installs_declared_signing_extra() -> None:
     assert 'python -m pip install ".[signing]"' in workflow
 
 
+def test_workflow_smoke_imports_supported_server_path() -> None:
+    """Guard the clean-install server import regression check."""
+    workflow = (
+        REPO_ROOT / ".github/workflows/runtime-proof-evidence.yml"
+    ).read_text(encoding="utf-8")
+    assert 'python -c "import veritas_os.api.server"' in workflow
+
+
+def test_requests_pin_is_consistent_across_core_manifests() -> None:
+    """Keep the approved direct Requests runtime pin reproducible and aligned."""
+    manifests = (
+        REPO_ROOT / "pyproject.toml",
+        REPO_ROOT / "veritas_os/requirements-core.txt",
+        REPO_ROOT / "veritas_os/requirements.txt",
+    )
+    for manifest in manifests:
+        assert manifest.read_text(encoding="utf-8").count("requests==2.34.2") == 1
+
+
 def decision() -> dict[str, object]:
     """Return a minimal valid synthetic Decision Pipeline report fixture."""
     return {


### PR DESCRIPTION
### Motivation

- Provide a dedicated, reviewer-downloadable CI artifact that runs and independently verifies the two existing proof paths (Decision Pipeline PoC and External Bind Boundary PoC) for the exact commit that produced them.
- Ensure the two proofs remain strictly independent (no Decision→Bind bridge, no ExecutionIntent creation, no promotion of `/v1/decide` to execution authority). 
- Produce a fail-closed SHA-256 manifest, manifest verifier, CI provenance metadata, reviewer summary, and a narrow secret-hygiene check so reviewers can validate evidence offline.
- Warn that this PR changes the CI evidence distribution and documentation claims and therefore requires human maintainer review per repository governance.

### Description

- Added a new GitHub Actions workflow `.github/workflows/runtime-proof-evidence.yml` that checks out the repo, sets up Python, runs both PoC runners, verifies their outputs, assembles a runtime-proof bundle, builds and verifies a SHA-256 manifest, runs a secret-hygiene check, writes a reviewer summary and CI provenance, and uploads the artifact `veritas-runtime-proof-evidence` with minimal permissions (`contents: read`).
- Added verification and manifest tooling under `scripts/demo/`: `verify_runtime_proof_evidence.py` (independent combined verifier), `build_runtime_proof_evidence_manifest.py` (manifest builder using canonical JSON+SHA-256), and `verify_runtime_proof_evidence_manifest.py` (offline manifest verifier that rejects path traversal, duplicates, malformed JSON, missing files, and digest mismatches). 
- Added focused unit tests `veritas_os/tests/test_runtime_proof_evidence_ci.py` covering decision-report invariants, bind-scenario invariants, manifest integrity checks, path-traversal/duplicate/missing-file handling, malformed JSON, explicit proof independence, and secret-hygiene assertions. 
- Added documentation `docs/en/guides/runtime-proof-ci-evidence.md` describing what CI runs, how to download and verify the bundle offline, the manifest hashing procedure, and explicit non-claims that the bundle does not assert (e.g., no production runtime claims, no Decision→Bind lineage).

### Testing

- Ran the added test suite `veritas_os/tests/test_runtime_proof_evidence_ci.py` in an isolated environment and observed `23 passed` for the focused tooling/tests. 
- Performed static checks: `ruff check` passed for the new tooling files and `python -m py_compile` succeeded for the new scripts and tests. 
- Local execution of the full PoC runners and repository-wide `pytest` were blocked by unavailable declared dependencies / network/proxy constraints in the local environment, so end-to-end CI execution and commit-linked artifact generation must be validated on GitHub Actions (the workflow is designed to fail-closed if any mandatory invariant fails). 
- Note: the secret-hygiene check is intentionally limited to obvious proof-secret fields and headers and is not a comprehensive secret scanner; human review of CI run outputs is required before public claims are accepted.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7f266a6e3c83269167a42e713088b8)