### PR TITLE
docs(spec): define canonical Decision-to-Bind handoff v1

### DIFF
--- a/docs/en/architecture/canonical-decision-to-bind-handoff-v1.md
+++ b/docs/en/architecture/canonical-decision-to-bind-handoff-v1.md
@@ -61,6 +61,39 @@ Canonical provenance classes are:
 `DERIVED_CANONICALLY` requires a versioned, deterministic derivation contract.
 It is not permission to infer meaning from prose.
 
+### Canonical READY coverage
+
+Provenance is field-level for scalar execution/security inputs and object-level
+at the named canonical boundary for compound evidence objects. Object-level
+coverage prevents a compound artifact from being misleadingly represented as
+independently verified fragments while retaining its canonical verification
+boundary. Every `READY_FOR_GUARDED_PROMOTION` handoff requires exactly one
+unique `field_path` record for, at minimum:
+
+* `source_decision.request_id`, `source_decision.canonical_decision_id`,
+  `source_decision.canonical_decision_hash`, and
+  `source_decision.canonical_decision_ts`;
+* `candidate.actor_identity`, `candidate.target_system`,
+  `candidate.target_resource`, `candidate.canonical_action`, and
+  `candidate_hash`;
+* the compound-object boundaries `trustlog_lineage`, `replay_lineage`, and
+  `policy_lineage`;
+* the compound-object boundaries `authority_requirement` and
+  `authority_evidence`;
+* the compound-object boundaries `human_approval_requirement` and
+  `human_approval_evidence`; and
+* the compound-object boundary `expected_state` when state binding is required
+  for the action.
+
+Every record explicitly carries `value`, even when an unavailable value is
+represented as `null` in a non-ready handoff. Every mandatory READY record has
+`verification_status=VERIFIED` and MUST NOT use provenance class `UNAVAILABLE`
+or `UNVERIFIED_STRUCTURED_INPUT`. Those classes and unverified statuses remain
+valid structural representations for non-ready states, but cannot satisfy a
+READY prerequisite. The JSON Schema enforces record structure; specification
+coherence tests enforce READY fixture coverage; a future separately reviewed
+runtime implementation would perform actual handoff validation.
+
 ## No-field-inference rule
 
 Execution-formation fields MUST NOT be inferred from plausible language. The
@@ -192,12 +225,22 @@ approval, verified/live state, fresh policy, or TrustLog/replay linkage. This
 handoff must establish those stronger preconditions before a future real flow
 may use the helper; this specification does not call or modify it.
 
-Proof A (#2097/#2098) ends after real `/v1/decide`, governance, controlled
-provider output, verified TrustLog/replay, and `DecideResponse`. Proof B (#2099)
-starts with a synthetic candidate and independently exercises Bind and the
-webhook adapter. CI verifies them separately. No canonical Decision →
-ExecutionIntent → Bind lineage is proven. #2100 specifies the missing boundary;
-it does not fill it.
+The current proof mapping is:
+
+* #2097, External Bind Boundary PoC: synthetic Decision Candidate → real Bind
+  adjudication → real `WebhookBindAdapter` → `COMMITTED` / `BLOCKED` /
+  `ROLLED_BACK`. It does not call real `/v1/decide`.
+* #2098, Decision Pipeline PoC: real authenticated `/v1/decide` → real
+  decision/governance runtime → controlled provider output → verified TrustLog
+  and replay → `DecideResponse` → STOP. It creates no `ExecutionIntent` and
+  does not invoke Bind.
+* #2099, Runtime Proof Evidence CI: independently executes and verifies the
+  #2098 Decision proof and #2097 Bind proof, then emits a SHA-256 manifest, CI
+  provenance, and downloadable reviewer artifact. Packaging both does not
+  create lineage between them.
+
+No canonical Decision → ExecutionIntent → Bind lineage is proven. #2100
+specifies the missing boundary; it does not fill it.
 
 ## Explicit non-claims
 

--- a/docs/en/architecture/canonical-decision-to-bind-handoff-v1.md
+++ b/docs/en/architecture/canonical-decision-to-bind-handoff-v1.md
@@ -1,0 +1,212 @@
+# Canonical Decision-to-Bind Handoff v1
+
+## Status and scope
+
+`CanonicalDecisionHandoff` is a **FUTURE**, reviewable, provenance-aware
+envelope between decision-side evidence and a possible guarded
+`DecisionCandidate` promotion. It is not an `ExecutionIntent`, `BindReceipt`,
+command, Authority Evidence, or permission to execute. This specification and
+its synthetic fixtures do not implement a validator or production bridge.
+
+The current `/v1/decide` response exposes `request_id`, but does not expose a
+canonical `decision_id`, `decision_hash`, or `decision_ts`. Those values remain
+`UNAVAILABLE`/`UNRESOLVED`; `request_id`, an HTTP response hash, arrival time,
+TrustLog retrieval time, CI time, and current time are not substitutes.
+
+```mermaid
+flowchart TD
+  A[LLM / Agent - EXISTING] -->|untrusted proposal| B[DecisionCandidate - EXISTING]
+  B -->|structured validation| C[Decision governance - EXISTING]
+  C -->|separately verified TrustLog + replay| D[CanonicalDecisionHandoff - FUTURE]
+  D -->|provenance, authority, approval, policy, state checks| E[Guarded promotion - FUTURE]
+  E --> F[ExecutionIntent - EXISTING artifact]
+  F -->|STILL NOT EXECUTION| G[Bind Boundary - EXISTING]
+  G --> H[Adapter / external effect - EXISTING, not invoked here]
+```
+
+## State machine
+
+| State | Meaning and transition |
+|---|---|
+| `INCOMPLETE` | Required information is unavailable or unresolved. A newly reconstructed envelope may become ready after verified evidence is supplied. |
+| `REVIEW_REQUIRED` | Explicit policy requires human resolution; it never defaults to allow. |
+| `INVALID` | Fail-closed refusal caused by mismatch, invalidity, staleness, substitution, ambiguity, or forbidden inference. Revalidate/reconstruct; do not promote. |
+| `STRUCTURALLY_REFUSED` | Existing formation lineage is non-promotable. It is immutable and requires reconstruction from eligible lineage. |
+| `READY_FOR_GUARDED_PROMOTION` | Only enough verified structured inputs exist to attempt a future guarded promotion. It does not authorize execution, call an adapter, make approval/authority perpetual, or bypass Bind. |
+
+`EXECUTED` is deliberately absent. `STRUCTURALLY_REFUSED` MUST NOT mutate to
+ready, even if authority or approval is later attached. Formation refusal is
+not Bind `BLOCKED`.
+
+## Provenance and field envelope
+
+Every security-relevant value uses a provenance record containing `value`,
+`source_artifact_type`, `source_artifact_ref`, optional `source_hash`,
+`verification_status`, `verification_mechanism`, optional `observed_at` or
+`issued_at`, and optional `expires_at`/freshness data. An HTTP response is not
+verified merely because it was received.
+
+Canonical provenance classes are:
+
+* `VERIFIED_RUNTIME_EVIDENCE`
+* `VERIFIED_POLICY_ARTIFACT`
+* `VERIFIED_AUTHORITY_EVIDENCE`
+* `VERIFIED_HUMAN_APPROVAL`
+* `VERIFIED_LIVE_STATE`
+* `EXPLICIT_STRUCTURED_INPUT`
+* `UNVERIFIED_STRUCTURED_INPUT`
+* `DERIVED_CANONICALLY`
+* `UNAVAILABLE`
+
+`DERIVED_CANONICALLY` requires a versioned, deterministic derivation contract.
+It is not permission to infer meaning from prose.
+
+## No-field-inference rule
+
+Execution-formation fields MUST NOT be inferred from plausible language. The
+following mappings are prohibited without a future explicit, typed, validated
+source contract:
+
+* `chosen.title` or `next_action` to `intended_action`;
+* `business_decision=APPROVE`, `gate_decision=ALLOW`, or decision status to
+  execution authority or Authority Evidence;
+* `human_review_required=false` to verified approval-not-required, or `true`
+  to evidence that approval occurred;
+* authenticated API user or request `user_id` to authorized execution actor or
+  Authority Evidence;
+* LLM rationale to `target_resource` or `expected_state_fingerprint`;
+* policy-looking text to canonical policy lineage.
+
+A human-readable action description is reviewer context. A canonical action is
+typed, explicit, canonicalized, and bound to its target. Existing action
+contract IDs/versions should be referenced where applicable; prose from
+`chosen`, `next_action`, rationale, or completion text is never authoritative.
+
+## Requirements, evidence, and validation
+
+`authority_requirement` states what authority is required. It does not show
+that an actor possesses it. `authority_evidence` is a separately issued
+artifact, and `validation_result` records verification. Evidence must bind the
+exact actor, canonical action, target system, resource/scope, authority
+type/role, issuer, validity period, evidence hash/ref, and verification status.
+Actor, action, or target mismatch, expiry, or an unverified source fails closed
+(`INVALID`, or `REVIEW_REQUIRED` only where explicit policy says so; never
+allow by default). Authentication is not authorization; identity is not
+execution authority; an API role is not authority for a target operation.
+
+Likewise, `human_approval_requirement` says whether approval is required;
+`human_approval_evidence` proves an approval receipt; and `validation_result`
+records verification. Even `required=false` needs authoritative policy
+provenance. A required receipt binds approver identity and scope, decision and
+candidate reference, exact structured action including amount/subject, exact
+target, approval timestamp, expiry, and receipt hash/ref. Approval for $100,
+user A, action A, or resource A cannot authorize $10,000, user B, action B, or
+resource B. Receipts are non-transferable and non-replayable outside scope.
+
+## Source-of-truth matrix
+
+Legend: “conditional” means only when that source's canonical contract
+explicitly exposes and verifies the value. External means explicit typed input.
+Live means authority, policy, or state verification. No field may be inferred.
+
+| Future `ExecutionIntent` field | `/v1/decide` | TrustLog | Replay | External | Live | Infer? | Mandatory before attempt |
+|---|---|---|---|---|---|---|---|
+| `decision_id` | No today | conditional | conditional | no | lineage verify | NO | yes |
+| `request_id` | yes | verify same | verify same | no | no | NO | yes |
+| `policy_snapshot_id` | No authoritative value today | conditional | conditional | conditional | policy verify | NO | yes |
+| `actor_identity` | conditional identity only | conditional | conditional | yes | authority binding | NO | yes |
+| `target_system` | no authoritative action target | no | no | yes | scope/state | NO | yes |
+| `target_resource` | no | no | no | yes | scope/state | NO | yes |
+| `intended_action` | no (prose is insufficient) | no | no | yes, typed | authority/policy | NO | yes |
+| `evidence_refs` | conditional | yes | yes | yes | verify each | NO | yes |
+| `decision_hash` | No today | conditional | conditional | no | lineage verify | NO | yes |
+| `decision_ts` | No today | conditional | conditional | no | lineage verify | NO | yes |
+| `ttl_seconds` | no | conditional | conditional | conditional | policy freshness | NO | yes |
+| `expected_state_fingerprint` | no | no | no | state request only | trusted state source | NO | when action requires state binding |
+| `approval_context` | no | conditional | conditional | receipt | approval verify | NO | yes (including authoritative not-required) |
+| `policy_lineage` | no authoritative lineage | conditional | conditional | policy artifact | policy verify | NO | yes |
+
+All mandatory fields must have acceptable provenance, not merely non-empty
+defaults. “Dataclass constructible” != “eligible for guarded promotion” !=
+“bind admissible” != “execution allowed”.
+
+## Lineage, hashes, policy, and state
+
+The decision lineage must provide a canonical decision ID, hash, and timestamp
+structurally or cryptographically linked to one decision. A future decision
+hash contract must define domain separation, canonical serialization, format
+version, included fields, excluded volatile fields, deterministic procedure,
+and exclusion of its own hash. `SHA256(response.json())` is not a contract.
+No canonical production decision hash exists for `/v1/decide` today.
+
+TrustLog and replay are separate evidence. Each requires `verified=true`, its
+verification mechanism, artifact identity/hash, the same `request_id` and
+expected source decision identity. TrustLog chain verification and replay
+verification must independently succeed. Cross-request, cross-decision, or
+unrelated proof substitution yields `HANDOFF_REQUEST_LINEAGE_MISMATCH` or
+`HANDOFF_SOURCE_ARTIFACT_MISMATCH`.
+
+Policy lineage identifies snapshot ID, version, semantic digest, applicable
+policy IDs, compiled governance identity where supported, effective/issued
+time, expiry, and supersession state. Missing, stale, or prose-derived policy
+lineage fails closed. Never fabricate `policy_snapshot_id`.
+
+Target identifiers are explicit, typed, canonicalized, action-bound, and
+included in candidate/handoff hashing. Candidate or target mutation after
+hashing invalidates eligibility. `expected_state_fingerprint` is a trusted
+formation-time observation, never model output; Bind-time live state is a
+separate observation used to detect drift. Missing/stale required state fails
+closed.
+
+## Formation invariant and reason codes
+
+The handoff consumes existing `lineage_promotability` and
+`transition_refusal`. A bind-eligible artifact cannot emerge from a
+non-promotable lineage; repackaging or later evidence cannot resurrect it.
+
+Canonical specification-only reason codes are:
+
+`HANDOFF_MISSING_CANONICAL_DECISION_ID`,
+`HANDOFF_MISSING_CANONICAL_DECISION_HASH`,
+`HANDOFF_MISSING_DECISION_TIMESTAMP`, `HANDOFF_TRUSTLOG_UNVERIFIED`,
+`HANDOFF_REPLAY_UNVERIFIED`, `HANDOFF_REQUEST_LINEAGE_MISMATCH`,
+`HANDOFF_CANDIDATE_HASH_MISMATCH`, `HANDOFF_LINEAGE_NON_PROMOTABLE`,
+`HANDOFF_TARGET_UNSPECIFIED`, `HANDOFF_ACTION_UNSPECIFIED`,
+`HANDOFF_ACTOR_UNSPECIFIED`, `HANDOFF_AUTHORITY_REQUIREMENT_UNRESOLVED`,
+`HANDOFF_AUTHORITY_EVIDENCE_MISSING`, `HANDOFF_AUTHORITY_EVIDENCE_INVALID`,
+`HANDOFF_AUTHORITY_EVIDENCE_EXPIRED`,
+`HANDOFF_APPROVAL_REQUIREMENT_UNRESOLVED`,
+`HANDOFF_APPROVAL_EVIDENCE_MISSING`, `HANDOFF_APPROVAL_EVIDENCE_INVALID`,
+`HANDOFF_APPROVAL_EVIDENCE_EXPIRED`, `HANDOFF_POLICY_LINEAGE_MISSING`,
+`HANDOFF_POLICY_LINEAGE_STALE`, `HANDOFF_EXPECTED_STATE_MISSING`,
+`HANDOFF_EXPECTED_STATE_STALE`, `HANDOFF_AMBIGUOUS_ACTION`, and
+`HANDOFF_SOURCE_ARTIFACT_MISMATCH`.
+
+## Compatibility and current proof architecture
+
+`try_promote_decision_candidate_to_execution_intent(...)` validates the
+candidate schema and accepts separately supplied decision, request, policy,
+hash, timestamp, state, approval, and lineage parameters. Supplying parameters
+does not prove common lineage, hash authenticity, authority, exact-operation
+approval, verified/live state, fresh policy, or TrustLog/replay linkage. This
+handoff must establish those stronger preconditions before a future real flow
+may use the helper; this specification does not call or modify it.
+
+Proof A (#2097/#2098) ends after real `/v1/decide`, governance, controlled
+provider output, verified TrustLog/replay, and `DecideResponse`. Proof B (#2099)
+starts with a synthetic candidate and independently exercises Bind and the
+webhook adapter. CI verifies them separately. No canonical Decision →
+ExecutionIntent → Bind lineage is proven. #2100 specifies the missing boundary;
+it does not fill it.
+
+## Explicit non-claims
+
+This specification does **not** prove live Decision-to-Bind integration,
+production DecisionArtifact creation, canonical decision hash implementation,
+live Authority Evidence integration, live IAM/IdP validation, live Human
+Approval integration, live state snapshotting, execution authority, real
+DecisionCandidate extraction from `/v1/decide`, ExecutionIntent creation from
+`/v1/decide`, Bind invocation from `/v1/decide`, live external effect, customer
+deployment, bank integration, regulatory approval, certification, or production
+readiness. Schema conformance is structural only and never makes an artifact
+executable.

--- a/docs/en/architecture/llm-to-control-plane-contract.md
+++ b/docs/en/architecture/llm-to-control-plane-contract.md
@@ -1,5 +1,9 @@
 # LLM-to-Control-Plane Contract
 
+> The specification-only [Canonical Decision-to-Bind Handoff v1](canonical-decision-to-bind-handoff-v1.md)
+> defines the stronger provenance and lineage preconditions for any future
+> real handoff. It does not implement that connection.
+
 ## 1. Purpose
 
 This document defines the contract boundary between LLM-generated outputs and the non-LLM governance components in VERITAS.

--- a/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-01.json
+++ b/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-01.json
@@ -103,16 +103,333 @@
     },
     "provenance": [
       {
+        "field_path": "source_decision.request_id",
+        "value": "req-fixture-001",
+        "provenance_class": "VERIFIED_RUNTIME_EVIDENCE",
+        "source_artifact_type": "synthetic_decide_fixture",
+        "source_artifact_ref": "decide-fixture-001",
+        "source_hash": "sha256:decide-fixture-001",
+        "verification_status": "VERIFIED",
+        "verification_mechanism": "synthetic-fixture-contract-check",
+        "observed_at": "2029-12-31T23:59:00Z",
+        "issued_at": null,
+        "expires_at": null,
+        "freshness": {
+          "synthetic": true
+        }
+      },
+      {
+        "field_path": "source_decision.canonical_decision_id",
+        "value": "decision-fixture-001",
+        "provenance_class": "VERIFIED_RUNTIME_EVIDENCE",
+        "source_artifact_type": "synthetic_decision_lineage_fixture",
+        "source_artifact_ref": "decision-fixture-001",
+        "source_hash": "sha256:decision-fixture-001",
+        "verification_status": "VERIFIED",
+        "verification_mechanism": "synthetic-fixture-contract-check",
+        "observed_at": "2029-12-31T23:59:00Z",
+        "issued_at": null,
+        "expires_at": null,
+        "freshness": {
+          "synthetic": true
+        }
+      },
+      {
+        "field_path": "source_decision.canonical_decision_hash",
+        "value": "sha256:decision-fixture-001",
+        "provenance_class": "DERIVED_CANONICALLY",
+        "source_artifact_type": "synthetic_decision_lineage_fixture",
+        "source_artifact_ref": "decision-fixture-001",
+        "source_hash": "sha256:decision-fixture-001",
+        "verification_status": "VERIFIED",
+        "verification_mechanism": "synthetic-fixture-contract-check",
+        "observed_at": "2029-12-31T23:59:00Z",
+        "issued_at": null,
+        "expires_at": null,
+        "freshness": {
+          "synthetic": true
+        }
+      },
+      {
+        "field_path": "source_decision.canonical_decision_ts",
+        "value": "2030-01-01T00:00:00Z",
+        "provenance_class": "VERIFIED_RUNTIME_EVIDENCE",
+        "source_artifact_type": "synthetic_decision_lineage_fixture",
+        "source_artifact_ref": "decision-fixture-001",
+        "source_hash": "sha256:decision-fixture-001",
+        "verification_status": "VERIFIED",
+        "verification_mechanism": "synthetic-fixture-contract-check",
+        "observed_at": "2029-12-31T23:59:00Z",
+        "issued_at": null,
+        "expires_at": null,
+        "freshness": {
+          "synthetic": true
+        }
+      },
+      {
+        "field_path": "candidate.actor_identity",
+        "value": "actor:fixture:alice",
+        "provenance_class": "EXPLICIT_STRUCTURED_INPUT",
+        "source_artifact_type": "synthetic_candidate_fixture",
+        "source_artifact_ref": "candidate-fixture-001",
+        "source_hash": "sha256:candidate-fixture-001",
+        "verification_status": "VERIFIED",
+        "verification_mechanism": "synthetic-fixture-contract-check",
+        "observed_at": "2029-12-31T23:59:00Z",
+        "issued_at": null,
+        "expires_at": null,
+        "freshness": {
+          "synthetic": true
+        }
+      },
+      {
+        "field_path": "candidate.target_system",
+        "value": "ledger-fixture",
+        "provenance_class": "EXPLICIT_STRUCTURED_INPUT",
+        "source_artifact_type": "synthetic_candidate_fixture",
+        "source_artifact_ref": "candidate-fixture-001",
+        "source_hash": "sha256:candidate-fixture-001",
+        "verification_status": "VERIFIED",
+        "verification_mechanism": "synthetic-fixture-contract-check",
+        "observed_at": "2029-12-31T23:59:00Z",
+        "issued_at": null,
+        "expires_at": null,
+        "freshness": {
+          "synthetic": true
+        }
+      },
+      {
+        "field_path": "candidate.target_resource",
+        "value": "account:fixture:A",
+        "provenance_class": "EXPLICIT_STRUCTURED_INPUT",
+        "source_artifact_type": "synthetic_candidate_fixture",
+        "source_artifact_ref": "candidate-fixture-001",
+        "source_hash": "sha256:candidate-fixture-001",
+        "verification_status": "VERIFIED",
+        "verification_mechanism": "synthetic-fixture-contract-check",
+        "observed_at": "2029-12-31T23:59:00Z",
+        "issued_at": null,
+        "expires_at": null,
+        "freshness": {
+          "synthetic": true
+        }
+      },
+      {
         "field_path": "candidate.canonical_action",
         "value": {
-          "contract_id": "fixture.transfer"
+          "contract_id": "fixture.transfer",
+          "version": "1",
+          "parameters": {
+            "amount": "100.00",
+            "currency": "USD"
+          }
         },
         "provenance_class": "EXPLICIT_STRUCTURED_INPUT",
         "source_artifact_type": "synthetic_action_fixture",
         "source_artifact_ref": "action-fixture-001",
         "source_hash": "sha256:action-fixture-001",
         "verification_status": "VERIFIED",
-        "verification_mechanism": "fixture-contract-check",
+        "verification_mechanism": "synthetic-fixture-contract-check",
+        "observed_at": "2029-12-31T23:59:00Z",
+        "issued_at": null,
+        "expires_at": null,
+        "freshness": {
+          "synthetic": true
+        }
+      },
+      {
+        "field_path": "candidate_hash",
+        "value": "sha256:candidate-fixture-001",
+        "provenance_class": "DERIVED_CANONICALLY",
+        "source_artifact_type": "synthetic_candidate_fixture",
+        "source_artifact_ref": "candidate-fixture-001",
+        "source_hash": "sha256:candidate-fixture-001",
+        "verification_status": "VERIFIED",
+        "verification_mechanism": "synthetic-fixture-contract-check",
+        "observed_at": "2029-12-31T23:59:00Z",
+        "issued_at": null,
+        "expires_at": null,
+        "freshness": {
+          "synthetic": true
+        }
+      },
+      {
+        "field_path": "trustlog_lineage",
+        "value": {
+          "verified": true,
+          "request_id": "req-fixture-001",
+          "artifact_ref": "trustlog-fixture-001",
+          "chain_hash": "sha256:trustlog-fixture-001"
+        },
+        "provenance_class": "VERIFIED_RUNTIME_EVIDENCE",
+        "source_artifact_type": "synthetic_trustlog_fixture",
+        "source_artifact_ref": "trustlog-fixture-001",
+        "source_hash": "sha256:trustlog-fixture-001",
+        "verification_status": "VERIFIED",
+        "verification_mechanism": "synthetic-fixture-contract-check",
+        "observed_at": "2029-12-31T23:59:00Z",
+        "issued_at": null,
+        "expires_at": null,
+        "freshness": {
+          "synthetic": true
+        }
+      },
+      {
+        "field_path": "replay_lineage",
+        "value": {
+          "verified": true,
+          "request_id": "req-fixture-001",
+          "artifact_ref": "replay-fixture-001",
+          "artifact_hash": "sha256:replay-fixture-001"
+        },
+        "provenance_class": "VERIFIED_RUNTIME_EVIDENCE",
+        "source_artifact_type": "synthetic_replay_fixture",
+        "source_artifact_ref": "replay-fixture-001",
+        "source_hash": "sha256:replay-fixture-001",
+        "verification_status": "VERIFIED",
+        "verification_mechanism": "synthetic-fixture-contract-check",
+        "observed_at": "2029-12-31T23:59:00Z",
+        "issued_at": null,
+        "expires_at": null,
+        "freshness": {
+          "synthetic": true
+        }
+      },
+      {
+        "field_path": "policy_lineage",
+        "value": {
+          "verified": true,
+          "snapshot_id": "policy-fixture-001",
+          "version": "1",
+          "semantic_digest": "sha256:policy-fixture-001",
+          "policy_ids": [
+            "fixture-policy"
+          ],
+          "effective_at": "2029-01-01T00:00:00Z",
+          "expires_at": "2031-01-01T00:00:00Z",
+          "superseded": false
+        },
+        "provenance_class": "VERIFIED_POLICY_ARTIFACT",
+        "source_artifact_type": "synthetic_policy_fixture",
+        "source_artifact_ref": "policy-fixture-001",
+        "source_hash": "sha256:policy-fixture-001",
+        "verification_status": "VERIFIED",
+        "verification_mechanism": "synthetic-fixture-contract-check",
+        "observed_at": "2029-12-31T23:59:00Z",
+        "issued_at": null,
+        "expires_at": null,
+        "freshness": {
+          "synthetic": true
+        }
+      },
+      {
+        "field_path": "authority_requirement",
+        "value": {
+          "resolved": true,
+          "required": true,
+          "authority_type": "fixture-transfer-operator"
+        },
+        "provenance_class": "VERIFIED_POLICY_ARTIFACT",
+        "source_artifact_type": "synthetic_policy_fixture",
+        "source_artifact_ref": "policy-fixture-001",
+        "source_hash": "sha256:policy-fixture-001",
+        "verification_status": "VERIFIED",
+        "verification_mechanism": "synthetic-fixture-contract-check",
+        "observed_at": "2029-12-31T23:59:00Z",
+        "issued_at": null,
+        "expires_at": null,
+        "freshness": {
+          "synthetic": true
+        }
+      },
+      {
+        "field_path": "authority_evidence",
+        "value": {
+          "validation_result": "VALID",
+          "actor_identity": "actor:fixture:alice",
+          "action_contract_id": "fixture.transfer",
+          "target_system": "ledger-fixture",
+          "target_scope": "account:fixture:A",
+          "issuer": "fixture-iam",
+          "issued_at": "2029-12-31T00:00:00Z",
+          "expires_at": "2030-02-01T00:00:00Z",
+          "evidence_ref": "authority-fixture-001",
+          "evidence_hash": "sha256:authority-fixture-001"
+        },
+        "provenance_class": "VERIFIED_AUTHORITY_EVIDENCE",
+        "source_artifact_type": "synthetic_authority_fixture",
+        "source_artifact_ref": "authority-fixture-001",
+        "source_hash": "sha256:authority-fixture-001",
+        "verification_status": "VERIFIED",
+        "verification_mechanism": "synthetic-fixture-contract-check",
+        "observed_at": "2029-12-31T23:59:00Z",
+        "issued_at": null,
+        "expires_at": null,
+        "freshness": {
+          "synthetic": true
+        }
+      },
+      {
+        "field_path": "human_approval_requirement",
+        "value": {
+          "resolved": true,
+          "required": true,
+          "policy_ref": "fixture-policy"
+        },
+        "provenance_class": "VERIFIED_POLICY_ARTIFACT",
+        "source_artifact_type": "synthetic_policy_fixture",
+        "source_artifact_ref": "policy-fixture-001",
+        "source_hash": "sha256:policy-fixture-001",
+        "verification_status": "VERIFIED",
+        "verification_mechanism": "synthetic-fixture-contract-check",
+        "observed_at": "2029-12-31T23:59:00Z",
+        "issued_at": null,
+        "expires_at": null,
+        "freshness": {
+          "synthetic": true
+        }
+      },
+      {
+        "field_path": "human_approval_evidence",
+        "value": {
+          "validation_result": "VALID",
+          "approver_identity": "approver:fixture:bob",
+          "approval_scope": "fixture.transfer:100.00:USD",
+          "candidate_ref": "candidate-fixture-001",
+          "action_contract_id": "fixture.transfer",
+          "target_resource": "account:fixture:A",
+          "approved_at": "2029-12-31T12:00:00Z",
+          "expires_at": "2030-01-02T00:00:00Z",
+          "receipt_ref": "approval-fixture-001",
+          "receipt_hash": "sha256:approval-fixture-001"
+        },
+        "provenance_class": "VERIFIED_HUMAN_APPROVAL",
+        "source_artifact_type": "synthetic_approval_fixture",
+        "source_artifact_ref": "approval-fixture-001",
+        "source_hash": "sha256:approval-fixture-001",
+        "verification_status": "VERIFIED",
+        "verification_mechanism": "synthetic-fixture-contract-check",
+        "observed_at": "2029-12-31T23:59:00Z",
+        "issued_at": null,
+        "expires_at": null,
+        "freshness": {
+          "synthetic": true
+        }
+      },
+      {
+        "field_path": "expected_state",
+        "value": {
+          "fingerprint": "sha256:state-fixture-001",
+          "observed_at": "2029-12-31T23:59:00Z",
+          "source_ref": "state-fixture-001",
+          "verified": true
+        },
+        "provenance_class": "VERIFIED_LIVE_STATE",
+        "source_artifact_type": "synthetic_state_fixture",
+        "source_artifact_ref": "state-fixture-001",
+        "source_hash": "sha256:state-fixture-001",
+        "verification_status": "VERIFIED",
+        "verification_mechanism": "synthetic-fixture-contract-check",
         "observed_at": "2029-12-31T23:59:00Z",
         "issued_at": null,
         "expires_at": null,

--- a/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-01.json
+++ b/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-01.json
@@ -1,0 +1,140 @@
+{
+  "vector_id": "DTBH-V1-01",
+  "description": "complete structured fixture",
+  "input": {
+    "format_version": "canonical-decision-handoff/v1",
+    "handoff_id": "handoff-fixture-01",
+    "handoff_status": "READY_FOR_GUARDED_PROMOTION",
+    "source_decision": {
+      "request_id": "req-fixture-001",
+      "canonical_decision_id": "decision-fixture-001",
+      "canonical_decision_hash": "sha256:decision-fixture-001",
+      "canonical_decision_ts": "2030-01-01T00:00:00Z",
+      "gate_decision": "ALLOW"
+    },
+    "candidate": {
+      "candidate_id": "candidate-fixture-001",
+      "actor_identity": "actor:fixture:alice",
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonical_action": {
+        "contract_id": "fixture.transfer",
+        "version": "1",
+        "parameters": {
+          "amount": "100.00",
+          "currency": "USD"
+        }
+      },
+      "lineage_promotability": "promotable"
+    },
+    "candidate_hash": "sha256:candidate-fixture-001",
+    "decision_lineage": {
+      "verified": true,
+      "decision_id": "decision-fixture-001"
+    },
+    "trustlog_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "trustlog-fixture-001",
+      "chain_hash": "sha256:trustlog-fixture-001"
+    },
+    "replay_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "replay-fixture-001",
+      "artifact_hash": "sha256:replay-fixture-001"
+    },
+    "policy_lineage": {
+      "verified": true,
+      "snapshot_id": "policy-fixture-001",
+      "version": "1",
+      "semantic_digest": "sha256:policy-fixture-001",
+      "policy_ids": [
+        "fixture-policy"
+      ],
+      "effective_at": "2029-01-01T00:00:00Z",
+      "expires_at": "2031-01-01T00:00:00Z",
+      "superseded": false
+    },
+    "authority_requirement": {
+      "resolved": true,
+      "required": true,
+      "authority_type": "fixture-transfer-operator"
+    },
+    "authority_evidence": {
+      "validation_result": "VALID",
+      "actor_identity": "actor:fixture:alice",
+      "action_contract_id": "fixture.transfer",
+      "target_system": "ledger-fixture",
+      "target_scope": "account:fixture:A",
+      "issuer": "fixture-iam",
+      "issued_at": "2029-12-31T00:00:00Z",
+      "expires_at": "2030-02-01T00:00:00Z",
+      "evidence_ref": "authority-fixture-001",
+      "evidence_hash": "sha256:authority-fixture-001"
+    },
+    "human_approval_requirement": {
+      "resolved": true,
+      "required": true,
+      "policy_ref": "fixture-policy"
+    },
+    "human_approval_evidence": {
+      "validation_result": "VALID",
+      "approver_identity": "approver:fixture:bob",
+      "approval_scope": "fixture.transfer:100.00:USD",
+      "candidate_ref": "candidate-fixture-001",
+      "action_contract_id": "fixture.transfer",
+      "target_resource": "account:fixture:A",
+      "approved_at": "2029-12-31T12:00:00Z",
+      "expires_at": "2030-01-02T00:00:00Z",
+      "receipt_ref": "approval-fixture-001",
+      "receipt_hash": "sha256:approval-fixture-001"
+    },
+    "target_context": {
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonicalized": true
+    },
+    "expected_state": {
+      "fingerprint": "sha256:state-fixture-001",
+      "observed_at": "2029-12-31T23:59:00Z",
+      "source_ref": "state-fixture-001",
+      "verified": true
+    },
+    "provenance": [
+      {
+        "field_path": "candidate.canonical_action",
+        "value": {
+          "contract_id": "fixture.transfer"
+        },
+        "provenance_class": "EXPLICIT_STRUCTURED_INPUT",
+        "source_artifact_type": "synthetic_action_fixture",
+        "source_artifact_ref": "action-fixture-001",
+        "source_hash": "sha256:action-fixture-001",
+        "verification_status": "VERIFIED",
+        "verification_mechanism": "fixture-contract-check",
+        "observed_at": "2029-12-31T23:59:00Z",
+        "issued_at": null,
+        "expires_at": null,
+        "freshness": {
+          "synthetic": true
+        }
+      }
+    ],
+    "refusal_reason_codes": [],
+    "created_at": "2030-01-01T00:00:01Z",
+    "expires_at": "2030-01-01T00:05:01Z",
+    "non_claims": [
+      "synthetic fixture only",
+      "no ExecutionIntent",
+      "no Bind invocation",
+      "no external effect"
+    ]
+  },
+  "expected_handoff_status": "READY_FOR_GUARDED_PROMOTION",
+  "expected_reason_codes": [],
+  "execution_intent_created": false,
+  "bind_invoked": false,
+  "external_effect": false,
+  "synthetic_fixture": true
+}

--- a/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-02.json
+++ b/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-02.json
@@ -1,0 +1,144 @@
+{
+  "vector_id": "DTBH-V1-02",
+  "description": "missing canonical decision hash",
+  "input": {
+    "format_version": "canonical-decision-handoff/v1",
+    "handoff_id": "handoff-fixture-02",
+    "handoff_status": "INCOMPLETE",
+    "source_decision": {
+      "request_id": "req-fixture-001",
+      "canonical_decision_id": "decision-fixture-001",
+      "canonical_decision_hash": null,
+      "canonical_decision_ts": "2030-01-01T00:00:00Z",
+      "gate_decision": "ALLOW"
+    },
+    "candidate": {
+      "candidate_id": "candidate-fixture-001",
+      "actor_identity": "actor:fixture:alice",
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonical_action": {
+        "contract_id": "fixture.transfer",
+        "version": "1",
+        "parameters": {
+          "amount": "100.00",
+          "currency": "USD"
+        }
+      },
+      "lineage_promotability": "promotable"
+    },
+    "candidate_hash": "sha256:candidate-fixture-001",
+    "decision_lineage": {
+      "verified": true,
+      "decision_id": "decision-fixture-001"
+    },
+    "trustlog_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "trustlog-fixture-001",
+      "chain_hash": "sha256:trustlog-fixture-001"
+    },
+    "replay_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "replay-fixture-001",
+      "artifact_hash": "sha256:replay-fixture-001"
+    },
+    "policy_lineage": {
+      "verified": true,
+      "snapshot_id": "policy-fixture-001",
+      "version": "1",
+      "semantic_digest": "sha256:policy-fixture-001",
+      "policy_ids": [
+        "fixture-policy"
+      ],
+      "effective_at": "2029-01-01T00:00:00Z",
+      "expires_at": "2031-01-01T00:00:00Z",
+      "superseded": false
+    },
+    "authority_requirement": {
+      "resolved": true,
+      "required": true,
+      "authority_type": "fixture-transfer-operator"
+    },
+    "authority_evidence": {
+      "validation_result": "VALID",
+      "actor_identity": "actor:fixture:alice",
+      "action_contract_id": "fixture.transfer",
+      "target_system": "ledger-fixture",
+      "target_scope": "account:fixture:A",
+      "issuer": "fixture-iam",
+      "issued_at": "2029-12-31T00:00:00Z",
+      "expires_at": "2030-02-01T00:00:00Z",
+      "evidence_ref": "authority-fixture-001",
+      "evidence_hash": "sha256:authority-fixture-001"
+    },
+    "human_approval_requirement": {
+      "resolved": true,
+      "required": true,
+      "policy_ref": "fixture-policy"
+    },
+    "human_approval_evidence": {
+      "validation_result": "VALID",
+      "approver_identity": "approver:fixture:bob",
+      "approval_scope": "fixture.transfer:100.00:USD",
+      "candidate_ref": "candidate-fixture-001",
+      "action_contract_id": "fixture.transfer",
+      "target_resource": "account:fixture:A",
+      "approved_at": "2029-12-31T12:00:00Z",
+      "expires_at": "2030-01-02T00:00:00Z",
+      "receipt_ref": "approval-fixture-001",
+      "receipt_hash": "sha256:approval-fixture-001"
+    },
+    "target_context": {
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonicalized": true
+    },
+    "expected_state": {
+      "fingerprint": "sha256:state-fixture-001",
+      "observed_at": "2029-12-31T23:59:00Z",
+      "source_ref": "state-fixture-001",
+      "verified": true
+    },
+    "provenance": [
+      {
+        "field_path": "candidate.canonical_action",
+        "value": {
+          "contract_id": "fixture.transfer"
+        },
+        "provenance_class": "EXPLICIT_STRUCTURED_INPUT",
+        "source_artifact_type": "synthetic_action_fixture",
+        "source_artifact_ref": "action-fixture-001",
+        "source_hash": "sha256:action-fixture-001",
+        "verification_status": "VERIFIED",
+        "verification_mechanism": "fixture-contract-check",
+        "observed_at": "2029-12-31T23:59:00Z",
+        "issued_at": null,
+        "expires_at": null,
+        "freshness": {
+          "synthetic": true
+        }
+      }
+    ],
+    "refusal_reason_codes": [
+      "HANDOFF_MISSING_CANONICAL_DECISION_HASH"
+    ],
+    "created_at": "2030-01-01T00:00:01Z",
+    "expires_at": "2030-01-01T00:05:01Z",
+    "non_claims": [
+      "synthetic fixture only",
+      "no ExecutionIntent",
+      "no Bind invocation",
+      "no external effect"
+    ]
+  },
+  "expected_handoff_status": "INCOMPLETE",
+  "expected_reason_codes": [
+    "HANDOFF_MISSING_CANONICAL_DECISION_HASH"
+  ],
+  "execution_intent_created": false,
+  "bind_invoked": false,
+  "external_effect": false,
+  "synthetic_fixture": true
+}

--- a/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-03.json
+++ b/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-03.json
@@ -1,0 +1,144 @@
+{
+  "vector_id": "DTBH-V1-03",
+  "description": "request_id mismatch between response and TrustLog",
+  "input": {
+    "format_version": "canonical-decision-handoff/v1",
+    "handoff_id": "handoff-fixture-03",
+    "handoff_status": "INVALID",
+    "source_decision": {
+      "request_id": "req-fixture-001",
+      "canonical_decision_id": "decision-fixture-001",
+      "canonical_decision_hash": "sha256:decision-fixture-001",
+      "canonical_decision_ts": "2030-01-01T00:00:00Z",
+      "gate_decision": "ALLOW"
+    },
+    "candidate": {
+      "candidate_id": "candidate-fixture-001",
+      "actor_identity": "actor:fixture:alice",
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonical_action": {
+        "contract_id": "fixture.transfer",
+        "version": "1",
+        "parameters": {
+          "amount": "100.00",
+          "currency": "USD"
+        }
+      },
+      "lineage_promotability": "promotable"
+    },
+    "candidate_hash": "sha256:candidate-fixture-001",
+    "decision_lineage": {
+      "verified": true,
+      "decision_id": "decision-fixture-001"
+    },
+    "trustlog_lineage": {
+      "verified": true,
+      "request_id": "req-other",
+      "artifact_ref": "trustlog-fixture-001",
+      "chain_hash": "sha256:trustlog-fixture-001"
+    },
+    "replay_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "replay-fixture-001",
+      "artifact_hash": "sha256:replay-fixture-001"
+    },
+    "policy_lineage": {
+      "verified": true,
+      "snapshot_id": "policy-fixture-001",
+      "version": "1",
+      "semantic_digest": "sha256:policy-fixture-001",
+      "policy_ids": [
+        "fixture-policy"
+      ],
+      "effective_at": "2029-01-01T00:00:00Z",
+      "expires_at": "2031-01-01T00:00:00Z",
+      "superseded": false
+    },
+    "authority_requirement": {
+      "resolved": true,
+      "required": true,
+      "authority_type": "fixture-transfer-operator"
+    },
+    "authority_evidence": {
+      "validation_result": "VALID",
+      "actor_identity": "actor:fixture:alice",
+      "action_contract_id": "fixture.transfer",
+      "target_system": "ledger-fixture",
+      "target_scope": "account:fixture:A",
+      "issuer": "fixture-iam",
+      "issued_at": "2029-12-31T00:00:00Z",
+      "expires_at": "2030-02-01T00:00:00Z",
+      "evidence_ref": "authority-fixture-001",
+      "evidence_hash": "sha256:authority-fixture-001"
+    },
+    "human_approval_requirement": {
+      "resolved": true,
+      "required": true,
+      "policy_ref": "fixture-policy"
+    },
+    "human_approval_evidence": {
+      "validation_result": "VALID",
+      "approver_identity": "approver:fixture:bob",
+      "approval_scope": "fixture.transfer:100.00:USD",
+      "candidate_ref": "candidate-fixture-001",
+      "action_contract_id": "fixture.transfer",
+      "target_resource": "account:fixture:A",
+      "approved_at": "2029-12-31T12:00:00Z",
+      "expires_at": "2030-01-02T00:00:00Z",
+      "receipt_ref": "approval-fixture-001",
+      "receipt_hash": "sha256:approval-fixture-001"
+    },
+    "target_context": {
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonicalized": true
+    },
+    "expected_state": {
+      "fingerprint": "sha256:state-fixture-001",
+      "observed_at": "2029-12-31T23:59:00Z",
+      "source_ref": "state-fixture-001",
+      "verified": true
+    },
+    "provenance": [
+      {
+        "field_path": "candidate.canonical_action",
+        "value": {
+          "contract_id": "fixture.transfer"
+        },
+        "provenance_class": "EXPLICIT_STRUCTURED_INPUT",
+        "source_artifact_type": "synthetic_action_fixture",
+        "source_artifact_ref": "action-fixture-001",
+        "source_hash": "sha256:action-fixture-001",
+        "verification_status": "VERIFIED",
+        "verification_mechanism": "fixture-contract-check",
+        "observed_at": "2029-12-31T23:59:00Z",
+        "issued_at": null,
+        "expires_at": null,
+        "freshness": {
+          "synthetic": true
+        }
+      }
+    ],
+    "refusal_reason_codes": [
+      "HANDOFF_REQUEST_LINEAGE_MISMATCH"
+    ],
+    "created_at": "2030-01-01T00:00:01Z",
+    "expires_at": "2030-01-01T00:05:01Z",
+    "non_claims": [
+      "synthetic fixture only",
+      "no ExecutionIntent",
+      "no Bind invocation",
+      "no external effect"
+    ]
+  },
+  "expected_handoff_status": "INVALID",
+  "expected_reason_codes": [
+    "HANDOFF_REQUEST_LINEAGE_MISMATCH"
+  ],
+  "execution_intent_created": false,
+  "bind_invoked": false,
+  "external_effect": false,
+  "synthetic_fixture": true
+}

--- a/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-04.json
+++ b/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-04.json
@@ -1,0 +1,144 @@
+{
+  "vector_id": "DTBH-V1-04",
+  "description": "replay request mismatch",
+  "input": {
+    "format_version": "canonical-decision-handoff/v1",
+    "handoff_id": "handoff-fixture-04",
+    "handoff_status": "INVALID",
+    "source_decision": {
+      "request_id": "req-fixture-001",
+      "canonical_decision_id": "decision-fixture-001",
+      "canonical_decision_hash": "sha256:decision-fixture-001",
+      "canonical_decision_ts": "2030-01-01T00:00:00Z",
+      "gate_decision": "ALLOW"
+    },
+    "candidate": {
+      "candidate_id": "candidate-fixture-001",
+      "actor_identity": "actor:fixture:alice",
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonical_action": {
+        "contract_id": "fixture.transfer",
+        "version": "1",
+        "parameters": {
+          "amount": "100.00",
+          "currency": "USD"
+        }
+      },
+      "lineage_promotability": "promotable"
+    },
+    "candidate_hash": "sha256:candidate-fixture-001",
+    "decision_lineage": {
+      "verified": true,
+      "decision_id": "decision-fixture-001"
+    },
+    "trustlog_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "trustlog-fixture-001",
+      "chain_hash": "sha256:trustlog-fixture-001"
+    },
+    "replay_lineage": {
+      "verified": true,
+      "request_id": "req-other",
+      "artifact_ref": "replay-fixture-001",
+      "artifact_hash": "sha256:replay-fixture-001"
+    },
+    "policy_lineage": {
+      "verified": true,
+      "snapshot_id": "policy-fixture-001",
+      "version": "1",
+      "semantic_digest": "sha256:policy-fixture-001",
+      "policy_ids": [
+        "fixture-policy"
+      ],
+      "effective_at": "2029-01-01T00:00:00Z",
+      "expires_at": "2031-01-01T00:00:00Z",
+      "superseded": false
+    },
+    "authority_requirement": {
+      "resolved": true,
+      "required": true,
+      "authority_type": "fixture-transfer-operator"
+    },
+    "authority_evidence": {
+      "validation_result": "VALID",
+      "actor_identity": "actor:fixture:alice",
+      "action_contract_id": "fixture.transfer",
+      "target_system": "ledger-fixture",
+      "target_scope": "account:fixture:A",
+      "issuer": "fixture-iam",
+      "issued_at": "2029-12-31T00:00:00Z",
+      "expires_at": "2030-02-01T00:00:00Z",
+      "evidence_ref": "authority-fixture-001",
+      "evidence_hash": "sha256:authority-fixture-001"
+    },
+    "human_approval_requirement": {
+      "resolved": true,
+      "required": true,
+      "policy_ref": "fixture-policy"
+    },
+    "human_approval_evidence": {
+      "validation_result": "VALID",
+      "approver_identity": "approver:fixture:bob",
+      "approval_scope": "fixture.transfer:100.00:USD",
+      "candidate_ref": "candidate-fixture-001",
+      "action_contract_id": "fixture.transfer",
+      "target_resource": "account:fixture:A",
+      "approved_at": "2029-12-31T12:00:00Z",
+      "expires_at": "2030-01-02T00:00:00Z",
+      "receipt_ref": "approval-fixture-001",
+      "receipt_hash": "sha256:approval-fixture-001"
+    },
+    "target_context": {
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonicalized": true
+    },
+    "expected_state": {
+      "fingerprint": "sha256:state-fixture-001",
+      "observed_at": "2029-12-31T23:59:00Z",
+      "source_ref": "state-fixture-001",
+      "verified": true
+    },
+    "provenance": [
+      {
+        "field_path": "candidate.canonical_action",
+        "value": {
+          "contract_id": "fixture.transfer"
+        },
+        "provenance_class": "EXPLICIT_STRUCTURED_INPUT",
+        "source_artifact_type": "synthetic_action_fixture",
+        "source_artifact_ref": "action-fixture-001",
+        "source_hash": "sha256:action-fixture-001",
+        "verification_status": "VERIFIED",
+        "verification_mechanism": "fixture-contract-check",
+        "observed_at": "2029-12-31T23:59:00Z",
+        "issued_at": null,
+        "expires_at": null,
+        "freshness": {
+          "synthetic": true
+        }
+      }
+    ],
+    "refusal_reason_codes": [
+      "HANDOFF_REQUEST_LINEAGE_MISMATCH"
+    ],
+    "created_at": "2030-01-01T00:00:01Z",
+    "expires_at": "2030-01-01T00:05:01Z",
+    "non_claims": [
+      "synthetic fixture only",
+      "no ExecutionIntent",
+      "no Bind invocation",
+      "no external effect"
+    ]
+  },
+  "expected_handoff_status": "INVALID",
+  "expected_reason_codes": [
+    "HANDOFF_REQUEST_LINEAGE_MISMATCH"
+  ],
+  "execution_intent_created": false,
+  "bind_invoked": false,
+  "external_effect": false,
+  "synthetic_fixture": true
+}

--- a/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-05.json
+++ b/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-05.json
@@ -1,0 +1,144 @@
+{
+  "vector_id": "DTBH-V1-05",
+  "description": "candidate mutated after candidate hash",
+  "input": {
+    "format_version": "canonical-decision-handoff/v1",
+    "handoff_id": "handoff-fixture-05",
+    "handoff_status": "INVALID",
+    "source_decision": {
+      "request_id": "req-fixture-001",
+      "canonical_decision_id": "decision-fixture-001",
+      "canonical_decision_hash": "sha256:decision-fixture-001",
+      "canonical_decision_ts": "2030-01-01T00:00:00Z",
+      "gate_decision": "ALLOW"
+    },
+    "candidate": {
+      "candidate_id": "candidate-fixture-001",
+      "actor_identity": "actor:fixture:alice",
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:B",
+      "canonical_action": {
+        "contract_id": "fixture.transfer",
+        "version": "1",
+        "parameters": {
+          "amount": "100.00",
+          "currency": "USD"
+        }
+      },
+      "lineage_promotability": "promotable"
+    },
+    "candidate_hash": "sha256:candidate-fixture-001",
+    "decision_lineage": {
+      "verified": true,
+      "decision_id": "decision-fixture-001"
+    },
+    "trustlog_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "trustlog-fixture-001",
+      "chain_hash": "sha256:trustlog-fixture-001"
+    },
+    "replay_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "replay-fixture-001",
+      "artifact_hash": "sha256:replay-fixture-001"
+    },
+    "policy_lineage": {
+      "verified": true,
+      "snapshot_id": "policy-fixture-001",
+      "version": "1",
+      "semantic_digest": "sha256:policy-fixture-001",
+      "policy_ids": [
+        "fixture-policy"
+      ],
+      "effective_at": "2029-01-01T00:00:00Z",
+      "expires_at": "2031-01-01T00:00:00Z",
+      "superseded": false
+    },
+    "authority_requirement": {
+      "resolved": true,
+      "required": true,
+      "authority_type": "fixture-transfer-operator"
+    },
+    "authority_evidence": {
+      "validation_result": "VALID",
+      "actor_identity": "actor:fixture:alice",
+      "action_contract_id": "fixture.transfer",
+      "target_system": "ledger-fixture",
+      "target_scope": "account:fixture:A",
+      "issuer": "fixture-iam",
+      "issued_at": "2029-12-31T00:00:00Z",
+      "expires_at": "2030-02-01T00:00:00Z",
+      "evidence_ref": "authority-fixture-001",
+      "evidence_hash": "sha256:authority-fixture-001"
+    },
+    "human_approval_requirement": {
+      "resolved": true,
+      "required": true,
+      "policy_ref": "fixture-policy"
+    },
+    "human_approval_evidence": {
+      "validation_result": "VALID",
+      "approver_identity": "approver:fixture:bob",
+      "approval_scope": "fixture.transfer:100.00:USD",
+      "candidate_ref": "candidate-fixture-001",
+      "action_contract_id": "fixture.transfer",
+      "target_resource": "account:fixture:A",
+      "approved_at": "2029-12-31T12:00:00Z",
+      "expires_at": "2030-01-02T00:00:00Z",
+      "receipt_ref": "approval-fixture-001",
+      "receipt_hash": "sha256:approval-fixture-001"
+    },
+    "target_context": {
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonicalized": true
+    },
+    "expected_state": {
+      "fingerprint": "sha256:state-fixture-001",
+      "observed_at": "2029-12-31T23:59:00Z",
+      "source_ref": "state-fixture-001",
+      "verified": true
+    },
+    "provenance": [
+      {
+        "field_path": "candidate.canonical_action",
+        "value": {
+          "contract_id": "fixture.transfer"
+        },
+        "provenance_class": "EXPLICIT_STRUCTURED_INPUT",
+        "source_artifact_type": "synthetic_action_fixture",
+        "source_artifact_ref": "action-fixture-001",
+        "source_hash": "sha256:action-fixture-001",
+        "verification_status": "VERIFIED",
+        "verification_mechanism": "fixture-contract-check",
+        "observed_at": "2029-12-31T23:59:00Z",
+        "issued_at": null,
+        "expires_at": null,
+        "freshness": {
+          "synthetic": true
+        }
+      }
+    ],
+    "refusal_reason_codes": [
+      "HANDOFF_CANDIDATE_HASH_MISMATCH"
+    ],
+    "created_at": "2030-01-01T00:00:01Z",
+    "expires_at": "2030-01-01T00:05:01Z",
+    "non_claims": [
+      "synthetic fixture only",
+      "no ExecutionIntent",
+      "no Bind invocation",
+      "no external effect"
+    ]
+  },
+  "expected_handoff_status": "INVALID",
+  "expected_reason_codes": [
+    "HANDOFF_CANDIDATE_HASH_MISMATCH"
+  ],
+  "execution_intent_created": false,
+  "bind_invoked": false,
+  "external_effect": false,
+  "synthetic_fixture": true
+}

--- a/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-06.json
+++ b/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-06.json
@@ -1,0 +1,144 @@
+{
+  "vector_id": "DTBH-V1-06",
+  "description": "target resource missing",
+  "input": {
+    "format_version": "canonical-decision-handoff/v1",
+    "handoff_id": "handoff-fixture-06",
+    "handoff_status": "INVALID",
+    "source_decision": {
+      "request_id": "req-fixture-001",
+      "canonical_decision_id": "decision-fixture-001",
+      "canonical_decision_hash": "sha256:decision-fixture-001",
+      "canonical_decision_ts": "2030-01-01T00:00:00Z",
+      "gate_decision": "ALLOW"
+    },
+    "candidate": {
+      "candidate_id": "candidate-fixture-001",
+      "actor_identity": "actor:fixture:alice",
+      "target_system": "ledger-fixture",
+      "target_resource": "",
+      "canonical_action": {
+        "contract_id": "fixture.transfer",
+        "version": "1",
+        "parameters": {
+          "amount": "100.00",
+          "currency": "USD"
+        }
+      },
+      "lineage_promotability": "promotable"
+    },
+    "candidate_hash": "sha256:candidate-fixture-001",
+    "decision_lineage": {
+      "verified": true,
+      "decision_id": "decision-fixture-001"
+    },
+    "trustlog_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "trustlog-fixture-001",
+      "chain_hash": "sha256:trustlog-fixture-001"
+    },
+    "replay_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "replay-fixture-001",
+      "artifact_hash": "sha256:replay-fixture-001"
+    },
+    "policy_lineage": {
+      "verified": true,
+      "snapshot_id": "policy-fixture-001",
+      "version": "1",
+      "semantic_digest": "sha256:policy-fixture-001",
+      "policy_ids": [
+        "fixture-policy"
+      ],
+      "effective_at": "2029-01-01T00:00:00Z",
+      "expires_at": "2031-01-01T00:00:00Z",
+      "superseded": false
+    },
+    "authority_requirement": {
+      "resolved": true,
+      "required": true,
+      "authority_type": "fixture-transfer-operator"
+    },
+    "authority_evidence": {
+      "validation_result": "VALID",
+      "actor_identity": "actor:fixture:alice",
+      "action_contract_id": "fixture.transfer",
+      "target_system": "ledger-fixture",
+      "target_scope": "account:fixture:A",
+      "issuer": "fixture-iam",
+      "issued_at": "2029-12-31T00:00:00Z",
+      "expires_at": "2030-02-01T00:00:00Z",
+      "evidence_ref": "authority-fixture-001",
+      "evidence_hash": "sha256:authority-fixture-001"
+    },
+    "human_approval_requirement": {
+      "resolved": true,
+      "required": true,
+      "policy_ref": "fixture-policy"
+    },
+    "human_approval_evidence": {
+      "validation_result": "VALID",
+      "approver_identity": "approver:fixture:bob",
+      "approval_scope": "fixture.transfer:100.00:USD",
+      "candidate_ref": "candidate-fixture-001",
+      "action_contract_id": "fixture.transfer",
+      "target_resource": "account:fixture:A",
+      "approved_at": "2029-12-31T12:00:00Z",
+      "expires_at": "2030-01-02T00:00:00Z",
+      "receipt_ref": "approval-fixture-001",
+      "receipt_hash": "sha256:approval-fixture-001"
+    },
+    "target_context": {
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonicalized": true
+    },
+    "expected_state": {
+      "fingerprint": "sha256:state-fixture-001",
+      "observed_at": "2029-12-31T23:59:00Z",
+      "source_ref": "state-fixture-001",
+      "verified": true
+    },
+    "provenance": [
+      {
+        "field_path": "candidate.canonical_action",
+        "value": {
+          "contract_id": "fixture.transfer"
+        },
+        "provenance_class": "EXPLICIT_STRUCTURED_INPUT",
+        "source_artifact_type": "synthetic_action_fixture",
+        "source_artifact_ref": "action-fixture-001",
+        "source_hash": "sha256:action-fixture-001",
+        "verification_status": "VERIFIED",
+        "verification_mechanism": "fixture-contract-check",
+        "observed_at": "2029-12-31T23:59:00Z",
+        "issued_at": null,
+        "expires_at": null,
+        "freshness": {
+          "synthetic": true
+        }
+      }
+    ],
+    "refusal_reason_codes": [
+      "HANDOFF_TARGET_UNSPECIFIED"
+    ],
+    "created_at": "2030-01-01T00:00:01Z",
+    "expires_at": "2030-01-01T00:05:01Z",
+    "non_claims": [
+      "synthetic fixture only",
+      "no ExecutionIntent",
+      "no Bind invocation",
+      "no external effect"
+    ]
+  },
+  "expected_handoff_status": "INVALID",
+  "expected_reason_codes": [
+    "HANDOFF_TARGET_UNSPECIFIED"
+  ],
+  "execution_intent_created": false,
+  "bind_invoked": false,
+  "external_effect": false,
+  "synthetic_fixture": true
+}

--- a/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-07.json
+++ b/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-07.json
@@ -1,0 +1,140 @@
+{
+  "vector_id": "DTBH-V1-07",
+  "description": "action supplied only as natural-language rationale",
+  "input": {
+    "format_version": "canonical-decision-handoff/v1",
+    "handoff_id": "handoff-fixture-07",
+    "handoff_status": "INVALID",
+    "source_decision": {
+      "request_id": "req-fixture-001",
+      "canonical_decision_id": "decision-fixture-001",
+      "canonical_decision_hash": "sha256:decision-fixture-001",
+      "canonical_decision_ts": "2030-01-01T00:00:00Z",
+      "gate_decision": "ALLOW"
+    },
+    "candidate": {
+      "candidate_id": "candidate-fixture-001",
+      "actor_identity": "actor:fixture:alice",
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "lineage_promotability": "promotable",
+      "rationale": "Transfer the funds now"
+    },
+    "candidate_hash": "sha256:candidate-fixture-001",
+    "decision_lineage": {
+      "verified": true,
+      "decision_id": "decision-fixture-001"
+    },
+    "trustlog_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "trustlog-fixture-001",
+      "chain_hash": "sha256:trustlog-fixture-001"
+    },
+    "replay_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "replay-fixture-001",
+      "artifact_hash": "sha256:replay-fixture-001"
+    },
+    "policy_lineage": {
+      "verified": true,
+      "snapshot_id": "policy-fixture-001",
+      "version": "1",
+      "semantic_digest": "sha256:policy-fixture-001",
+      "policy_ids": [
+        "fixture-policy"
+      ],
+      "effective_at": "2029-01-01T00:00:00Z",
+      "expires_at": "2031-01-01T00:00:00Z",
+      "superseded": false
+    },
+    "authority_requirement": {
+      "resolved": true,
+      "required": true,
+      "authority_type": "fixture-transfer-operator"
+    },
+    "authority_evidence": {
+      "validation_result": "VALID",
+      "actor_identity": "actor:fixture:alice",
+      "action_contract_id": "fixture.transfer",
+      "target_system": "ledger-fixture",
+      "target_scope": "account:fixture:A",
+      "issuer": "fixture-iam",
+      "issued_at": "2029-12-31T00:00:00Z",
+      "expires_at": "2030-02-01T00:00:00Z",
+      "evidence_ref": "authority-fixture-001",
+      "evidence_hash": "sha256:authority-fixture-001"
+    },
+    "human_approval_requirement": {
+      "resolved": true,
+      "required": true,
+      "policy_ref": "fixture-policy"
+    },
+    "human_approval_evidence": {
+      "validation_result": "VALID",
+      "approver_identity": "approver:fixture:bob",
+      "approval_scope": "fixture.transfer:100.00:USD",
+      "candidate_ref": "candidate-fixture-001",
+      "action_contract_id": "fixture.transfer",
+      "target_resource": "account:fixture:A",
+      "approved_at": "2029-12-31T12:00:00Z",
+      "expires_at": "2030-01-02T00:00:00Z",
+      "receipt_ref": "approval-fixture-001",
+      "receipt_hash": "sha256:approval-fixture-001"
+    },
+    "target_context": {
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonicalized": true
+    },
+    "expected_state": {
+      "fingerprint": "sha256:state-fixture-001",
+      "observed_at": "2029-12-31T23:59:00Z",
+      "source_ref": "state-fixture-001",
+      "verified": true
+    },
+    "provenance": [
+      {
+        "field_path": "candidate.canonical_action",
+        "value": {
+          "contract_id": "fixture.transfer"
+        },
+        "provenance_class": "EXPLICIT_STRUCTURED_INPUT",
+        "source_artifact_type": "synthetic_action_fixture",
+        "source_artifact_ref": "action-fixture-001",
+        "source_hash": "sha256:action-fixture-001",
+        "verification_status": "VERIFIED",
+        "verification_mechanism": "fixture-contract-check",
+        "observed_at": "2029-12-31T23:59:00Z",
+        "issued_at": null,
+        "expires_at": null,
+        "freshness": {
+          "synthetic": true
+        }
+      }
+    ],
+    "refusal_reason_codes": [
+      "HANDOFF_ACTION_UNSPECIFIED",
+      "HANDOFF_AMBIGUOUS_ACTION"
+    ],
+    "created_at": "2030-01-01T00:00:01Z",
+    "expires_at": "2030-01-01T00:05:01Z",
+    "non_claims": [
+      "synthetic fixture only",
+      "no ExecutionIntent",
+      "no Bind invocation",
+      "no external effect"
+    ]
+  },
+  "expected_handoff_status": "INVALID",
+  "expected_reason_codes": [
+    "HANDOFF_ACTION_UNSPECIFIED",
+    "HANDOFF_AMBIGUOUS_ACTION"
+  ],
+  "execution_intent_created": false,
+  "bind_invoked": false,
+  "external_effect": false,
+  "synthetic_fixture": true,
+  "forbidden_inference": "natural-language rationale must not become intended_action"
+}

--- a/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-08.json
+++ b/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-08.json
@@ -1,0 +1,133 @@
+{
+  "vector_id": "DTBH-V1-08",
+  "description": "required authority but evidence missing",
+  "input": {
+    "format_version": "canonical-decision-handoff/v1",
+    "handoff_id": "handoff-fixture-08",
+    "handoff_status": "INCOMPLETE",
+    "source_decision": {
+      "request_id": "req-fixture-001",
+      "canonical_decision_id": "decision-fixture-001",
+      "canonical_decision_hash": "sha256:decision-fixture-001",
+      "canonical_decision_ts": "2030-01-01T00:00:00Z",
+      "gate_decision": "ALLOW"
+    },
+    "candidate": {
+      "candidate_id": "candidate-fixture-001",
+      "actor_identity": "actor:fixture:alice",
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonical_action": {
+        "contract_id": "fixture.transfer",
+        "version": "1",
+        "parameters": {
+          "amount": "100.00",
+          "currency": "USD"
+        }
+      },
+      "lineage_promotability": "promotable"
+    },
+    "candidate_hash": "sha256:candidate-fixture-001",
+    "decision_lineage": {
+      "verified": true,
+      "decision_id": "decision-fixture-001"
+    },
+    "trustlog_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "trustlog-fixture-001",
+      "chain_hash": "sha256:trustlog-fixture-001"
+    },
+    "replay_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "replay-fixture-001",
+      "artifact_hash": "sha256:replay-fixture-001"
+    },
+    "policy_lineage": {
+      "verified": true,
+      "snapshot_id": "policy-fixture-001",
+      "version": "1",
+      "semantic_digest": "sha256:policy-fixture-001",
+      "policy_ids": [
+        "fixture-policy"
+      ],
+      "effective_at": "2029-01-01T00:00:00Z",
+      "expires_at": "2031-01-01T00:00:00Z",
+      "superseded": false
+    },
+    "authority_requirement": {
+      "resolved": true,
+      "required": true,
+      "authority_type": "fixture-transfer-operator"
+    },
+    "authority_evidence": null,
+    "human_approval_requirement": {
+      "resolved": true,
+      "required": true,
+      "policy_ref": "fixture-policy"
+    },
+    "human_approval_evidence": {
+      "validation_result": "VALID",
+      "approver_identity": "approver:fixture:bob",
+      "approval_scope": "fixture.transfer:100.00:USD",
+      "candidate_ref": "candidate-fixture-001",
+      "action_contract_id": "fixture.transfer",
+      "target_resource": "account:fixture:A",
+      "approved_at": "2029-12-31T12:00:00Z",
+      "expires_at": "2030-01-02T00:00:00Z",
+      "receipt_ref": "approval-fixture-001",
+      "receipt_hash": "sha256:approval-fixture-001"
+    },
+    "target_context": {
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonicalized": true
+    },
+    "expected_state": {
+      "fingerprint": "sha256:state-fixture-001",
+      "observed_at": "2029-12-31T23:59:00Z",
+      "source_ref": "state-fixture-001",
+      "verified": true
+    },
+    "provenance": [
+      {
+        "field_path": "candidate.canonical_action",
+        "value": {
+          "contract_id": "fixture.transfer"
+        },
+        "provenance_class": "EXPLICIT_STRUCTURED_INPUT",
+        "source_artifact_type": "synthetic_action_fixture",
+        "source_artifact_ref": "action-fixture-001",
+        "source_hash": "sha256:action-fixture-001",
+        "verification_status": "VERIFIED",
+        "verification_mechanism": "fixture-contract-check",
+        "observed_at": "2029-12-31T23:59:00Z",
+        "issued_at": null,
+        "expires_at": null,
+        "freshness": {
+          "synthetic": true
+        }
+      }
+    ],
+    "refusal_reason_codes": [
+      "HANDOFF_AUTHORITY_EVIDENCE_MISSING"
+    ],
+    "created_at": "2030-01-01T00:00:01Z",
+    "expires_at": "2030-01-01T00:05:01Z",
+    "non_claims": [
+      "synthetic fixture only",
+      "no ExecutionIntent",
+      "no Bind invocation",
+      "no external effect"
+    ]
+  },
+  "expected_handoff_status": "INCOMPLETE",
+  "expected_reason_codes": [
+    "HANDOFF_AUTHORITY_EVIDENCE_MISSING"
+  ],
+  "execution_intent_created": false,
+  "bind_invoked": false,
+  "external_effect": false,
+  "synthetic_fixture": true
+}

--- a/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-09.json
+++ b/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-09.json
@@ -1,0 +1,144 @@
+{
+  "vector_id": "DTBH-V1-09",
+  "description": "Authority Evidence actor mismatch",
+  "input": {
+    "format_version": "canonical-decision-handoff/v1",
+    "handoff_id": "handoff-fixture-09",
+    "handoff_status": "INVALID",
+    "source_decision": {
+      "request_id": "req-fixture-001",
+      "canonical_decision_id": "decision-fixture-001",
+      "canonical_decision_hash": "sha256:decision-fixture-001",
+      "canonical_decision_ts": "2030-01-01T00:00:00Z",
+      "gate_decision": "ALLOW"
+    },
+    "candidate": {
+      "candidate_id": "candidate-fixture-001",
+      "actor_identity": "actor:fixture:alice",
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonical_action": {
+        "contract_id": "fixture.transfer",
+        "version": "1",
+        "parameters": {
+          "amount": "100.00",
+          "currency": "USD"
+        }
+      },
+      "lineage_promotability": "promotable"
+    },
+    "candidate_hash": "sha256:candidate-fixture-001",
+    "decision_lineage": {
+      "verified": true,
+      "decision_id": "decision-fixture-001"
+    },
+    "trustlog_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "trustlog-fixture-001",
+      "chain_hash": "sha256:trustlog-fixture-001"
+    },
+    "replay_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "replay-fixture-001",
+      "artifact_hash": "sha256:replay-fixture-001"
+    },
+    "policy_lineage": {
+      "verified": true,
+      "snapshot_id": "policy-fixture-001",
+      "version": "1",
+      "semantic_digest": "sha256:policy-fixture-001",
+      "policy_ids": [
+        "fixture-policy"
+      ],
+      "effective_at": "2029-01-01T00:00:00Z",
+      "expires_at": "2031-01-01T00:00:00Z",
+      "superseded": false
+    },
+    "authority_requirement": {
+      "resolved": true,
+      "required": true,
+      "authority_type": "fixture-transfer-operator"
+    },
+    "authority_evidence": {
+      "validation_result": "VALID",
+      "actor_identity": "actor:fixture:mallory",
+      "action_contract_id": "fixture.transfer",
+      "target_system": "ledger-fixture",
+      "target_scope": "account:fixture:A",
+      "issuer": "fixture-iam",
+      "issued_at": "2029-12-31T00:00:00Z",
+      "expires_at": "2030-02-01T00:00:00Z",
+      "evidence_ref": "authority-fixture-001",
+      "evidence_hash": "sha256:authority-fixture-001"
+    },
+    "human_approval_requirement": {
+      "resolved": true,
+      "required": true,
+      "policy_ref": "fixture-policy"
+    },
+    "human_approval_evidence": {
+      "validation_result": "VALID",
+      "approver_identity": "approver:fixture:bob",
+      "approval_scope": "fixture.transfer:100.00:USD",
+      "candidate_ref": "candidate-fixture-001",
+      "action_contract_id": "fixture.transfer",
+      "target_resource": "account:fixture:A",
+      "approved_at": "2029-12-31T12:00:00Z",
+      "expires_at": "2030-01-02T00:00:00Z",
+      "receipt_ref": "approval-fixture-001",
+      "receipt_hash": "sha256:approval-fixture-001"
+    },
+    "target_context": {
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonicalized": true
+    },
+    "expected_state": {
+      "fingerprint": "sha256:state-fixture-001",
+      "observed_at": "2029-12-31T23:59:00Z",
+      "source_ref": "state-fixture-001",
+      "verified": true
+    },
+    "provenance": [
+      {
+        "field_path": "candidate.canonical_action",
+        "value": {
+          "contract_id": "fixture.transfer"
+        },
+        "provenance_class": "EXPLICIT_STRUCTURED_INPUT",
+        "source_artifact_type": "synthetic_action_fixture",
+        "source_artifact_ref": "action-fixture-001",
+        "source_hash": "sha256:action-fixture-001",
+        "verification_status": "VERIFIED",
+        "verification_mechanism": "fixture-contract-check",
+        "observed_at": "2029-12-31T23:59:00Z",
+        "issued_at": null,
+        "expires_at": null,
+        "freshness": {
+          "synthetic": true
+        }
+      }
+    ],
+    "refusal_reason_codes": [
+      "HANDOFF_AUTHORITY_EVIDENCE_INVALID"
+    ],
+    "created_at": "2030-01-01T00:00:01Z",
+    "expires_at": "2030-01-01T00:05:01Z",
+    "non_claims": [
+      "synthetic fixture only",
+      "no ExecutionIntent",
+      "no Bind invocation",
+      "no external effect"
+    ]
+  },
+  "expected_handoff_status": "INVALID",
+  "expected_reason_codes": [
+    "HANDOFF_AUTHORITY_EVIDENCE_INVALID"
+  ],
+  "execution_intent_created": false,
+  "bind_invoked": false,
+  "external_effect": false,
+  "synthetic_fixture": true
+}

--- a/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-10.json
+++ b/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-10.json
@@ -1,0 +1,144 @@
+{
+  "vector_id": "DTBH-V1-10",
+  "description": "Authority Evidence target mismatch",
+  "input": {
+    "format_version": "canonical-decision-handoff/v1",
+    "handoff_id": "handoff-fixture-10",
+    "handoff_status": "INVALID",
+    "source_decision": {
+      "request_id": "req-fixture-001",
+      "canonical_decision_id": "decision-fixture-001",
+      "canonical_decision_hash": "sha256:decision-fixture-001",
+      "canonical_decision_ts": "2030-01-01T00:00:00Z",
+      "gate_decision": "ALLOW"
+    },
+    "candidate": {
+      "candidate_id": "candidate-fixture-001",
+      "actor_identity": "actor:fixture:alice",
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonical_action": {
+        "contract_id": "fixture.transfer",
+        "version": "1",
+        "parameters": {
+          "amount": "100.00",
+          "currency": "USD"
+        }
+      },
+      "lineage_promotability": "promotable"
+    },
+    "candidate_hash": "sha256:candidate-fixture-001",
+    "decision_lineage": {
+      "verified": true,
+      "decision_id": "decision-fixture-001"
+    },
+    "trustlog_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "trustlog-fixture-001",
+      "chain_hash": "sha256:trustlog-fixture-001"
+    },
+    "replay_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "replay-fixture-001",
+      "artifact_hash": "sha256:replay-fixture-001"
+    },
+    "policy_lineage": {
+      "verified": true,
+      "snapshot_id": "policy-fixture-001",
+      "version": "1",
+      "semantic_digest": "sha256:policy-fixture-001",
+      "policy_ids": [
+        "fixture-policy"
+      ],
+      "effective_at": "2029-01-01T00:00:00Z",
+      "expires_at": "2031-01-01T00:00:00Z",
+      "superseded": false
+    },
+    "authority_requirement": {
+      "resolved": true,
+      "required": true,
+      "authority_type": "fixture-transfer-operator"
+    },
+    "authority_evidence": {
+      "validation_result": "VALID",
+      "actor_identity": "actor:fixture:alice",
+      "action_contract_id": "fixture.transfer",
+      "target_system": "ledger-fixture",
+      "target_scope": "account:fixture:B",
+      "issuer": "fixture-iam",
+      "issued_at": "2029-12-31T00:00:00Z",
+      "expires_at": "2030-02-01T00:00:00Z",
+      "evidence_ref": "authority-fixture-001",
+      "evidence_hash": "sha256:authority-fixture-001"
+    },
+    "human_approval_requirement": {
+      "resolved": true,
+      "required": true,
+      "policy_ref": "fixture-policy"
+    },
+    "human_approval_evidence": {
+      "validation_result": "VALID",
+      "approver_identity": "approver:fixture:bob",
+      "approval_scope": "fixture.transfer:100.00:USD",
+      "candidate_ref": "candidate-fixture-001",
+      "action_contract_id": "fixture.transfer",
+      "target_resource": "account:fixture:A",
+      "approved_at": "2029-12-31T12:00:00Z",
+      "expires_at": "2030-01-02T00:00:00Z",
+      "receipt_ref": "approval-fixture-001",
+      "receipt_hash": "sha256:approval-fixture-001"
+    },
+    "target_context": {
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonicalized": true
+    },
+    "expected_state": {
+      "fingerprint": "sha256:state-fixture-001",
+      "observed_at": "2029-12-31T23:59:00Z",
+      "source_ref": "state-fixture-001",
+      "verified": true
+    },
+    "provenance": [
+      {
+        "field_path": "candidate.canonical_action",
+        "value": {
+          "contract_id": "fixture.transfer"
+        },
+        "provenance_class": "EXPLICIT_STRUCTURED_INPUT",
+        "source_artifact_type": "synthetic_action_fixture",
+        "source_artifact_ref": "action-fixture-001",
+        "source_hash": "sha256:action-fixture-001",
+        "verification_status": "VERIFIED",
+        "verification_mechanism": "fixture-contract-check",
+        "observed_at": "2029-12-31T23:59:00Z",
+        "issued_at": null,
+        "expires_at": null,
+        "freshness": {
+          "synthetic": true
+        }
+      }
+    ],
+    "refusal_reason_codes": [
+      "HANDOFF_AUTHORITY_EVIDENCE_INVALID"
+    ],
+    "created_at": "2030-01-01T00:00:01Z",
+    "expires_at": "2030-01-01T00:05:01Z",
+    "non_claims": [
+      "synthetic fixture only",
+      "no ExecutionIntent",
+      "no Bind invocation",
+      "no external effect"
+    ]
+  },
+  "expected_handoff_status": "INVALID",
+  "expected_reason_codes": [
+    "HANDOFF_AUTHORITY_EVIDENCE_INVALID"
+  ],
+  "execution_intent_created": false,
+  "bind_invoked": false,
+  "external_effect": false,
+  "synthetic_fixture": true
+}

--- a/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-11.json
+++ b/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-11.json
@@ -1,0 +1,144 @@
+{
+  "vector_id": "DTBH-V1-11",
+  "description": "Authority Evidence expired",
+  "input": {
+    "format_version": "canonical-decision-handoff/v1",
+    "handoff_id": "handoff-fixture-11",
+    "handoff_status": "INVALID",
+    "source_decision": {
+      "request_id": "req-fixture-001",
+      "canonical_decision_id": "decision-fixture-001",
+      "canonical_decision_hash": "sha256:decision-fixture-001",
+      "canonical_decision_ts": "2030-01-01T00:00:00Z",
+      "gate_decision": "ALLOW"
+    },
+    "candidate": {
+      "candidate_id": "candidate-fixture-001",
+      "actor_identity": "actor:fixture:alice",
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonical_action": {
+        "contract_id": "fixture.transfer",
+        "version": "1",
+        "parameters": {
+          "amount": "100.00",
+          "currency": "USD"
+        }
+      },
+      "lineage_promotability": "promotable"
+    },
+    "candidate_hash": "sha256:candidate-fixture-001",
+    "decision_lineage": {
+      "verified": true,
+      "decision_id": "decision-fixture-001"
+    },
+    "trustlog_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "trustlog-fixture-001",
+      "chain_hash": "sha256:trustlog-fixture-001"
+    },
+    "replay_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "replay-fixture-001",
+      "artifact_hash": "sha256:replay-fixture-001"
+    },
+    "policy_lineage": {
+      "verified": true,
+      "snapshot_id": "policy-fixture-001",
+      "version": "1",
+      "semantic_digest": "sha256:policy-fixture-001",
+      "policy_ids": [
+        "fixture-policy"
+      ],
+      "effective_at": "2029-01-01T00:00:00Z",
+      "expires_at": "2031-01-01T00:00:00Z",
+      "superseded": false
+    },
+    "authority_requirement": {
+      "resolved": true,
+      "required": true,
+      "authority_type": "fixture-transfer-operator"
+    },
+    "authority_evidence": {
+      "validation_result": "VALID",
+      "actor_identity": "actor:fixture:alice",
+      "action_contract_id": "fixture.transfer",
+      "target_system": "ledger-fixture",
+      "target_scope": "account:fixture:A",
+      "issuer": "fixture-iam",
+      "issued_at": "2029-12-31T00:00:00Z",
+      "expires_at": "2029-01-01T00:00:00Z",
+      "evidence_ref": "authority-fixture-001",
+      "evidence_hash": "sha256:authority-fixture-001"
+    },
+    "human_approval_requirement": {
+      "resolved": true,
+      "required": true,
+      "policy_ref": "fixture-policy"
+    },
+    "human_approval_evidence": {
+      "validation_result": "VALID",
+      "approver_identity": "approver:fixture:bob",
+      "approval_scope": "fixture.transfer:100.00:USD",
+      "candidate_ref": "candidate-fixture-001",
+      "action_contract_id": "fixture.transfer",
+      "target_resource": "account:fixture:A",
+      "approved_at": "2029-12-31T12:00:00Z",
+      "expires_at": "2030-01-02T00:00:00Z",
+      "receipt_ref": "approval-fixture-001",
+      "receipt_hash": "sha256:approval-fixture-001"
+    },
+    "target_context": {
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonicalized": true
+    },
+    "expected_state": {
+      "fingerprint": "sha256:state-fixture-001",
+      "observed_at": "2029-12-31T23:59:00Z",
+      "source_ref": "state-fixture-001",
+      "verified": true
+    },
+    "provenance": [
+      {
+        "field_path": "candidate.canonical_action",
+        "value": {
+          "contract_id": "fixture.transfer"
+        },
+        "provenance_class": "EXPLICIT_STRUCTURED_INPUT",
+        "source_artifact_type": "synthetic_action_fixture",
+        "source_artifact_ref": "action-fixture-001",
+        "source_hash": "sha256:action-fixture-001",
+        "verification_status": "VERIFIED",
+        "verification_mechanism": "fixture-contract-check",
+        "observed_at": "2029-12-31T23:59:00Z",
+        "issued_at": null,
+        "expires_at": null,
+        "freshness": {
+          "synthetic": true
+        }
+      }
+    ],
+    "refusal_reason_codes": [
+      "HANDOFF_AUTHORITY_EVIDENCE_EXPIRED"
+    ],
+    "created_at": "2030-01-01T00:00:01Z",
+    "expires_at": "2030-01-01T00:05:01Z",
+    "non_claims": [
+      "synthetic fixture only",
+      "no ExecutionIntent",
+      "no Bind invocation",
+      "no external effect"
+    ]
+  },
+  "expected_handoff_status": "INVALID",
+  "expected_reason_codes": [
+    "HANDOFF_AUTHORITY_EVIDENCE_EXPIRED"
+  ],
+  "execution_intent_created": false,
+  "bind_invoked": false,
+  "external_effect": false,
+  "synthetic_fixture": true
+}

--- a/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-12.json
+++ b/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-12.json
@@ -1,0 +1,133 @@
+{
+  "vector_id": "DTBH-V1-12",
+  "description": "Human Approval required but receipt missing",
+  "input": {
+    "format_version": "canonical-decision-handoff/v1",
+    "handoff_id": "handoff-fixture-12",
+    "handoff_status": "REVIEW_REQUIRED",
+    "source_decision": {
+      "request_id": "req-fixture-001",
+      "canonical_decision_id": "decision-fixture-001",
+      "canonical_decision_hash": "sha256:decision-fixture-001",
+      "canonical_decision_ts": "2030-01-01T00:00:00Z",
+      "gate_decision": "ALLOW"
+    },
+    "candidate": {
+      "candidate_id": "candidate-fixture-001",
+      "actor_identity": "actor:fixture:alice",
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonical_action": {
+        "contract_id": "fixture.transfer",
+        "version": "1",
+        "parameters": {
+          "amount": "100.00",
+          "currency": "USD"
+        }
+      },
+      "lineage_promotability": "promotable"
+    },
+    "candidate_hash": "sha256:candidate-fixture-001",
+    "decision_lineage": {
+      "verified": true,
+      "decision_id": "decision-fixture-001"
+    },
+    "trustlog_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "trustlog-fixture-001",
+      "chain_hash": "sha256:trustlog-fixture-001"
+    },
+    "replay_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "replay-fixture-001",
+      "artifact_hash": "sha256:replay-fixture-001"
+    },
+    "policy_lineage": {
+      "verified": true,
+      "snapshot_id": "policy-fixture-001",
+      "version": "1",
+      "semantic_digest": "sha256:policy-fixture-001",
+      "policy_ids": [
+        "fixture-policy"
+      ],
+      "effective_at": "2029-01-01T00:00:00Z",
+      "expires_at": "2031-01-01T00:00:00Z",
+      "superseded": false
+    },
+    "authority_requirement": {
+      "resolved": true,
+      "required": true,
+      "authority_type": "fixture-transfer-operator"
+    },
+    "authority_evidence": {
+      "validation_result": "VALID",
+      "actor_identity": "actor:fixture:alice",
+      "action_contract_id": "fixture.transfer",
+      "target_system": "ledger-fixture",
+      "target_scope": "account:fixture:A",
+      "issuer": "fixture-iam",
+      "issued_at": "2029-12-31T00:00:00Z",
+      "expires_at": "2030-02-01T00:00:00Z",
+      "evidence_ref": "authority-fixture-001",
+      "evidence_hash": "sha256:authority-fixture-001"
+    },
+    "human_approval_requirement": {
+      "resolved": true,
+      "required": true,
+      "policy_ref": "fixture-policy"
+    },
+    "human_approval_evidence": null,
+    "target_context": {
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonicalized": true
+    },
+    "expected_state": {
+      "fingerprint": "sha256:state-fixture-001",
+      "observed_at": "2029-12-31T23:59:00Z",
+      "source_ref": "state-fixture-001",
+      "verified": true
+    },
+    "provenance": [
+      {
+        "field_path": "candidate.canonical_action",
+        "value": {
+          "contract_id": "fixture.transfer"
+        },
+        "provenance_class": "EXPLICIT_STRUCTURED_INPUT",
+        "source_artifact_type": "synthetic_action_fixture",
+        "source_artifact_ref": "action-fixture-001",
+        "source_hash": "sha256:action-fixture-001",
+        "verification_status": "VERIFIED",
+        "verification_mechanism": "fixture-contract-check",
+        "observed_at": "2029-12-31T23:59:00Z",
+        "issued_at": null,
+        "expires_at": null,
+        "freshness": {
+          "synthetic": true
+        }
+      }
+    ],
+    "refusal_reason_codes": [
+      "HANDOFF_APPROVAL_EVIDENCE_MISSING"
+    ],
+    "created_at": "2030-01-01T00:00:01Z",
+    "expires_at": "2030-01-01T00:05:01Z",
+    "non_claims": [
+      "synthetic fixture only",
+      "no ExecutionIntent",
+      "no Bind invocation",
+      "no external effect"
+    ]
+  },
+  "expected_handoff_status": "REVIEW_REQUIRED",
+  "expected_reason_codes": [
+    "HANDOFF_APPROVAL_EVIDENCE_MISSING"
+  ],
+  "execution_intent_created": false,
+  "bind_invoked": false,
+  "external_effect": false,
+  "synthetic_fixture": true
+}

--- a/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-13.json
+++ b/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-13.json
@@ -1,0 +1,144 @@
+{
+  "vector_id": "DTBH-V1-13",
+  "description": "approval receipt belongs to different action",
+  "input": {
+    "format_version": "canonical-decision-handoff/v1",
+    "handoff_id": "handoff-fixture-13",
+    "handoff_status": "INVALID",
+    "source_decision": {
+      "request_id": "req-fixture-001",
+      "canonical_decision_id": "decision-fixture-001",
+      "canonical_decision_hash": "sha256:decision-fixture-001",
+      "canonical_decision_ts": "2030-01-01T00:00:00Z",
+      "gate_decision": "ALLOW"
+    },
+    "candidate": {
+      "candidate_id": "candidate-fixture-001",
+      "actor_identity": "actor:fixture:alice",
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonical_action": {
+        "contract_id": "fixture.transfer",
+        "version": "1",
+        "parameters": {
+          "amount": "100.00",
+          "currency": "USD"
+        }
+      },
+      "lineage_promotability": "promotable"
+    },
+    "candidate_hash": "sha256:candidate-fixture-001",
+    "decision_lineage": {
+      "verified": true,
+      "decision_id": "decision-fixture-001"
+    },
+    "trustlog_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "trustlog-fixture-001",
+      "chain_hash": "sha256:trustlog-fixture-001"
+    },
+    "replay_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "replay-fixture-001",
+      "artifact_hash": "sha256:replay-fixture-001"
+    },
+    "policy_lineage": {
+      "verified": true,
+      "snapshot_id": "policy-fixture-001",
+      "version": "1",
+      "semantic_digest": "sha256:policy-fixture-001",
+      "policy_ids": [
+        "fixture-policy"
+      ],
+      "effective_at": "2029-01-01T00:00:00Z",
+      "expires_at": "2031-01-01T00:00:00Z",
+      "superseded": false
+    },
+    "authority_requirement": {
+      "resolved": true,
+      "required": true,
+      "authority_type": "fixture-transfer-operator"
+    },
+    "authority_evidence": {
+      "validation_result": "VALID",
+      "actor_identity": "actor:fixture:alice",
+      "action_contract_id": "fixture.transfer",
+      "target_system": "ledger-fixture",
+      "target_scope": "account:fixture:A",
+      "issuer": "fixture-iam",
+      "issued_at": "2029-12-31T00:00:00Z",
+      "expires_at": "2030-02-01T00:00:00Z",
+      "evidence_ref": "authority-fixture-001",
+      "evidence_hash": "sha256:authority-fixture-001"
+    },
+    "human_approval_requirement": {
+      "resolved": true,
+      "required": true,
+      "policy_ref": "fixture-policy"
+    },
+    "human_approval_evidence": {
+      "validation_result": "VALID",
+      "approver_identity": "approver:fixture:bob",
+      "approval_scope": "fixture.transfer:100.00:USD",
+      "candidate_ref": "candidate-fixture-001",
+      "action_contract_id": "fixture.delete",
+      "target_resource": "account:fixture:A",
+      "approved_at": "2029-12-31T12:00:00Z",
+      "expires_at": "2030-01-02T00:00:00Z",
+      "receipt_ref": "approval-fixture-001",
+      "receipt_hash": "sha256:approval-fixture-001"
+    },
+    "target_context": {
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonicalized": true
+    },
+    "expected_state": {
+      "fingerprint": "sha256:state-fixture-001",
+      "observed_at": "2029-12-31T23:59:00Z",
+      "source_ref": "state-fixture-001",
+      "verified": true
+    },
+    "provenance": [
+      {
+        "field_path": "candidate.canonical_action",
+        "value": {
+          "contract_id": "fixture.transfer"
+        },
+        "provenance_class": "EXPLICIT_STRUCTURED_INPUT",
+        "source_artifact_type": "synthetic_action_fixture",
+        "source_artifact_ref": "action-fixture-001",
+        "source_hash": "sha256:action-fixture-001",
+        "verification_status": "VERIFIED",
+        "verification_mechanism": "fixture-contract-check",
+        "observed_at": "2029-12-31T23:59:00Z",
+        "issued_at": null,
+        "expires_at": null,
+        "freshness": {
+          "synthetic": true
+        }
+      }
+    ],
+    "refusal_reason_codes": [
+      "HANDOFF_APPROVAL_EVIDENCE_INVALID"
+    ],
+    "created_at": "2030-01-01T00:00:01Z",
+    "expires_at": "2030-01-01T00:05:01Z",
+    "non_claims": [
+      "synthetic fixture only",
+      "no ExecutionIntent",
+      "no Bind invocation",
+      "no external effect"
+    ]
+  },
+  "expected_handoff_status": "INVALID",
+  "expected_reason_codes": [
+    "HANDOFF_APPROVAL_EVIDENCE_INVALID"
+  ],
+  "execution_intent_created": false,
+  "bind_invoked": false,
+  "external_effect": false,
+  "synthetic_fixture": true
+}

--- a/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-14.json
+++ b/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-14.json
@@ -1,0 +1,144 @@
+{
+  "vector_id": "DTBH-V1-14",
+  "description": "approval receipt expired",
+  "input": {
+    "format_version": "canonical-decision-handoff/v1",
+    "handoff_id": "handoff-fixture-14",
+    "handoff_status": "INVALID",
+    "source_decision": {
+      "request_id": "req-fixture-001",
+      "canonical_decision_id": "decision-fixture-001",
+      "canonical_decision_hash": "sha256:decision-fixture-001",
+      "canonical_decision_ts": "2030-01-01T00:00:00Z",
+      "gate_decision": "ALLOW"
+    },
+    "candidate": {
+      "candidate_id": "candidate-fixture-001",
+      "actor_identity": "actor:fixture:alice",
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonical_action": {
+        "contract_id": "fixture.transfer",
+        "version": "1",
+        "parameters": {
+          "amount": "100.00",
+          "currency": "USD"
+        }
+      },
+      "lineage_promotability": "promotable"
+    },
+    "candidate_hash": "sha256:candidate-fixture-001",
+    "decision_lineage": {
+      "verified": true,
+      "decision_id": "decision-fixture-001"
+    },
+    "trustlog_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "trustlog-fixture-001",
+      "chain_hash": "sha256:trustlog-fixture-001"
+    },
+    "replay_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "replay-fixture-001",
+      "artifact_hash": "sha256:replay-fixture-001"
+    },
+    "policy_lineage": {
+      "verified": true,
+      "snapshot_id": "policy-fixture-001",
+      "version": "1",
+      "semantic_digest": "sha256:policy-fixture-001",
+      "policy_ids": [
+        "fixture-policy"
+      ],
+      "effective_at": "2029-01-01T00:00:00Z",
+      "expires_at": "2031-01-01T00:00:00Z",
+      "superseded": false
+    },
+    "authority_requirement": {
+      "resolved": true,
+      "required": true,
+      "authority_type": "fixture-transfer-operator"
+    },
+    "authority_evidence": {
+      "validation_result": "VALID",
+      "actor_identity": "actor:fixture:alice",
+      "action_contract_id": "fixture.transfer",
+      "target_system": "ledger-fixture",
+      "target_scope": "account:fixture:A",
+      "issuer": "fixture-iam",
+      "issued_at": "2029-12-31T00:00:00Z",
+      "expires_at": "2030-02-01T00:00:00Z",
+      "evidence_ref": "authority-fixture-001",
+      "evidence_hash": "sha256:authority-fixture-001"
+    },
+    "human_approval_requirement": {
+      "resolved": true,
+      "required": true,
+      "policy_ref": "fixture-policy"
+    },
+    "human_approval_evidence": {
+      "validation_result": "VALID",
+      "approver_identity": "approver:fixture:bob",
+      "approval_scope": "fixture.transfer:100.00:USD",
+      "candidate_ref": "candidate-fixture-001",
+      "action_contract_id": "fixture.transfer",
+      "target_resource": "account:fixture:A",
+      "approved_at": "2029-12-31T12:00:00Z",
+      "expires_at": "2029-01-01T00:00:00Z",
+      "receipt_ref": "approval-fixture-001",
+      "receipt_hash": "sha256:approval-fixture-001"
+    },
+    "target_context": {
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonicalized": true
+    },
+    "expected_state": {
+      "fingerprint": "sha256:state-fixture-001",
+      "observed_at": "2029-12-31T23:59:00Z",
+      "source_ref": "state-fixture-001",
+      "verified": true
+    },
+    "provenance": [
+      {
+        "field_path": "candidate.canonical_action",
+        "value": {
+          "contract_id": "fixture.transfer"
+        },
+        "provenance_class": "EXPLICIT_STRUCTURED_INPUT",
+        "source_artifact_type": "synthetic_action_fixture",
+        "source_artifact_ref": "action-fixture-001",
+        "source_hash": "sha256:action-fixture-001",
+        "verification_status": "VERIFIED",
+        "verification_mechanism": "fixture-contract-check",
+        "observed_at": "2029-12-31T23:59:00Z",
+        "issued_at": null,
+        "expires_at": null,
+        "freshness": {
+          "synthetic": true
+        }
+      }
+    ],
+    "refusal_reason_codes": [
+      "HANDOFF_APPROVAL_EVIDENCE_EXPIRED"
+    ],
+    "created_at": "2030-01-01T00:00:01Z",
+    "expires_at": "2030-01-01T00:05:01Z",
+    "non_claims": [
+      "synthetic fixture only",
+      "no ExecutionIntent",
+      "no Bind invocation",
+      "no external effect"
+    ]
+  },
+  "expected_handoff_status": "INVALID",
+  "expected_reason_codes": [
+    "HANDOFF_APPROVAL_EVIDENCE_EXPIRED"
+  ],
+  "execution_intent_created": false,
+  "bind_invoked": false,
+  "external_effect": false,
+  "synthetic_fixture": true
+}

--- a/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-15.json
+++ b/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-15.json
@@ -1,0 +1,146 @@
+{
+  "vector_id": "DTBH-V1-15",
+  "description": "human_review_required false without authoritative proof",
+  "input": {
+    "format_version": "canonical-decision-handoff/v1",
+    "handoff_id": "handoff-fixture-15",
+    "handoff_status": "INCOMPLETE",
+    "source_decision": {
+      "request_id": "req-fixture-001",
+      "canonical_decision_id": "decision-fixture-001",
+      "canonical_decision_hash": "sha256:decision-fixture-001",
+      "canonical_decision_ts": "2030-01-01T00:00:00Z",
+      "gate_decision": "ALLOW",
+      "human_review_required": false
+    },
+    "candidate": {
+      "candidate_id": "candidate-fixture-001",
+      "actor_identity": "actor:fixture:alice",
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonical_action": {
+        "contract_id": "fixture.transfer",
+        "version": "1",
+        "parameters": {
+          "amount": "100.00",
+          "currency": "USD"
+        }
+      },
+      "lineage_promotability": "promotable"
+    },
+    "candidate_hash": "sha256:candidate-fixture-001",
+    "decision_lineage": {
+      "verified": true,
+      "decision_id": "decision-fixture-001"
+    },
+    "trustlog_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "trustlog-fixture-001",
+      "chain_hash": "sha256:trustlog-fixture-001"
+    },
+    "replay_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "replay-fixture-001",
+      "artifact_hash": "sha256:replay-fixture-001"
+    },
+    "policy_lineage": {
+      "verified": true,
+      "snapshot_id": "policy-fixture-001",
+      "version": "1",
+      "semantic_digest": "sha256:policy-fixture-001",
+      "policy_ids": [
+        "fixture-policy"
+      ],
+      "effective_at": "2029-01-01T00:00:00Z",
+      "expires_at": "2031-01-01T00:00:00Z",
+      "superseded": false
+    },
+    "authority_requirement": {
+      "resolved": true,
+      "required": true,
+      "authority_type": "fixture-transfer-operator"
+    },
+    "authority_evidence": {
+      "validation_result": "VALID",
+      "actor_identity": "actor:fixture:alice",
+      "action_contract_id": "fixture.transfer",
+      "target_system": "ledger-fixture",
+      "target_scope": "account:fixture:A",
+      "issuer": "fixture-iam",
+      "issued_at": "2029-12-31T00:00:00Z",
+      "expires_at": "2030-02-01T00:00:00Z",
+      "evidence_ref": "authority-fixture-001",
+      "evidence_hash": "sha256:authority-fixture-001"
+    },
+    "human_approval_requirement": {
+      "resolved": false,
+      "required": true,
+      "policy_ref": "fixture-policy"
+    },
+    "human_approval_evidence": {
+      "validation_result": "VALID",
+      "approver_identity": "approver:fixture:bob",
+      "approval_scope": "fixture.transfer:100.00:USD",
+      "candidate_ref": "candidate-fixture-001",
+      "action_contract_id": "fixture.transfer",
+      "target_resource": "account:fixture:A",
+      "approved_at": "2029-12-31T12:00:00Z",
+      "expires_at": "2030-01-02T00:00:00Z",
+      "receipt_ref": "approval-fixture-001",
+      "receipt_hash": "sha256:approval-fixture-001"
+    },
+    "target_context": {
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonicalized": true
+    },
+    "expected_state": {
+      "fingerprint": "sha256:state-fixture-001",
+      "observed_at": "2029-12-31T23:59:00Z",
+      "source_ref": "state-fixture-001",
+      "verified": true
+    },
+    "provenance": [
+      {
+        "field_path": "candidate.canonical_action",
+        "value": {
+          "contract_id": "fixture.transfer"
+        },
+        "provenance_class": "EXPLICIT_STRUCTURED_INPUT",
+        "source_artifact_type": "synthetic_action_fixture",
+        "source_artifact_ref": "action-fixture-001",
+        "source_hash": "sha256:action-fixture-001",
+        "verification_status": "VERIFIED",
+        "verification_mechanism": "fixture-contract-check",
+        "observed_at": "2029-12-31T23:59:00Z",
+        "issued_at": null,
+        "expires_at": null,
+        "freshness": {
+          "synthetic": true
+        }
+      }
+    ],
+    "refusal_reason_codes": [
+      "HANDOFF_APPROVAL_REQUIREMENT_UNRESOLVED"
+    ],
+    "created_at": "2030-01-01T00:00:01Z",
+    "expires_at": "2030-01-01T00:05:01Z",
+    "non_claims": [
+      "synthetic fixture only",
+      "no ExecutionIntent",
+      "no Bind invocation",
+      "no external effect"
+    ]
+  },
+  "expected_handoff_status": "INCOMPLETE",
+  "expected_reason_codes": [
+    "HANDOFF_APPROVAL_REQUIREMENT_UNRESOLVED"
+  ],
+  "execution_intent_created": false,
+  "bind_invoked": false,
+  "external_effect": false,
+  "synthetic_fixture": true,
+  "forbidden_inference": "human_review_required=false must not prove approval is unnecessary"
+}

--- a/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-16.json
+++ b/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-16.json
@@ -1,0 +1,133 @@
+{
+  "vector_id": "DTBH-V1-16",
+  "description": "policy lineage missing",
+  "input": {
+    "format_version": "canonical-decision-handoff/v1",
+    "handoff_id": "handoff-fixture-16",
+    "handoff_status": "INCOMPLETE",
+    "source_decision": {
+      "request_id": "req-fixture-001",
+      "canonical_decision_id": "decision-fixture-001",
+      "canonical_decision_hash": "sha256:decision-fixture-001",
+      "canonical_decision_ts": "2030-01-01T00:00:00Z",
+      "gate_decision": "ALLOW"
+    },
+    "candidate": {
+      "candidate_id": "candidate-fixture-001",
+      "actor_identity": "actor:fixture:alice",
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonical_action": {
+        "contract_id": "fixture.transfer",
+        "version": "1",
+        "parameters": {
+          "amount": "100.00",
+          "currency": "USD"
+        }
+      },
+      "lineage_promotability": "promotable"
+    },
+    "candidate_hash": "sha256:candidate-fixture-001",
+    "decision_lineage": {
+      "verified": true,
+      "decision_id": "decision-fixture-001"
+    },
+    "trustlog_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "trustlog-fixture-001",
+      "chain_hash": "sha256:trustlog-fixture-001"
+    },
+    "replay_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "replay-fixture-001",
+      "artifact_hash": "sha256:replay-fixture-001"
+    },
+    "policy_lineage": null,
+    "authority_requirement": {
+      "resolved": true,
+      "required": true,
+      "authority_type": "fixture-transfer-operator"
+    },
+    "authority_evidence": {
+      "validation_result": "VALID",
+      "actor_identity": "actor:fixture:alice",
+      "action_contract_id": "fixture.transfer",
+      "target_system": "ledger-fixture",
+      "target_scope": "account:fixture:A",
+      "issuer": "fixture-iam",
+      "issued_at": "2029-12-31T00:00:00Z",
+      "expires_at": "2030-02-01T00:00:00Z",
+      "evidence_ref": "authority-fixture-001",
+      "evidence_hash": "sha256:authority-fixture-001"
+    },
+    "human_approval_requirement": {
+      "resolved": true,
+      "required": true,
+      "policy_ref": "fixture-policy"
+    },
+    "human_approval_evidence": {
+      "validation_result": "VALID",
+      "approver_identity": "approver:fixture:bob",
+      "approval_scope": "fixture.transfer:100.00:USD",
+      "candidate_ref": "candidate-fixture-001",
+      "action_contract_id": "fixture.transfer",
+      "target_resource": "account:fixture:A",
+      "approved_at": "2029-12-31T12:00:00Z",
+      "expires_at": "2030-01-02T00:00:00Z",
+      "receipt_ref": "approval-fixture-001",
+      "receipt_hash": "sha256:approval-fixture-001"
+    },
+    "target_context": {
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonicalized": true
+    },
+    "expected_state": {
+      "fingerprint": "sha256:state-fixture-001",
+      "observed_at": "2029-12-31T23:59:00Z",
+      "source_ref": "state-fixture-001",
+      "verified": true
+    },
+    "provenance": [
+      {
+        "field_path": "candidate.canonical_action",
+        "value": {
+          "contract_id": "fixture.transfer"
+        },
+        "provenance_class": "EXPLICIT_STRUCTURED_INPUT",
+        "source_artifact_type": "synthetic_action_fixture",
+        "source_artifact_ref": "action-fixture-001",
+        "source_hash": "sha256:action-fixture-001",
+        "verification_status": "VERIFIED",
+        "verification_mechanism": "fixture-contract-check",
+        "observed_at": "2029-12-31T23:59:00Z",
+        "issued_at": null,
+        "expires_at": null,
+        "freshness": {
+          "synthetic": true
+        }
+      }
+    ],
+    "refusal_reason_codes": [
+      "HANDOFF_POLICY_LINEAGE_MISSING"
+    ],
+    "created_at": "2030-01-01T00:00:01Z",
+    "expires_at": "2030-01-01T00:05:01Z",
+    "non_claims": [
+      "synthetic fixture only",
+      "no ExecutionIntent",
+      "no Bind invocation",
+      "no external effect"
+    ]
+  },
+  "expected_handoff_status": "INCOMPLETE",
+  "expected_reason_codes": [
+    "HANDOFF_POLICY_LINEAGE_MISSING"
+  ],
+  "execution_intent_created": false,
+  "bind_invoked": false,
+  "external_effect": false,
+  "synthetic_fixture": true
+}

--- a/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-17.json
+++ b/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-17.json
@@ -1,0 +1,144 @@
+{
+  "vector_id": "DTBH-V1-17",
+  "description": "policy snapshot stale or superseded",
+  "input": {
+    "format_version": "canonical-decision-handoff/v1",
+    "handoff_id": "handoff-fixture-17",
+    "handoff_status": "REVIEW_REQUIRED",
+    "source_decision": {
+      "request_id": "req-fixture-001",
+      "canonical_decision_id": "decision-fixture-001",
+      "canonical_decision_hash": "sha256:decision-fixture-001",
+      "canonical_decision_ts": "2030-01-01T00:00:00Z",
+      "gate_decision": "ALLOW"
+    },
+    "candidate": {
+      "candidate_id": "candidate-fixture-001",
+      "actor_identity": "actor:fixture:alice",
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonical_action": {
+        "contract_id": "fixture.transfer",
+        "version": "1",
+        "parameters": {
+          "amount": "100.00",
+          "currency": "USD"
+        }
+      },
+      "lineage_promotability": "promotable"
+    },
+    "candidate_hash": "sha256:candidate-fixture-001",
+    "decision_lineage": {
+      "verified": true,
+      "decision_id": "decision-fixture-001"
+    },
+    "trustlog_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "trustlog-fixture-001",
+      "chain_hash": "sha256:trustlog-fixture-001"
+    },
+    "replay_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "replay-fixture-001",
+      "artifact_hash": "sha256:replay-fixture-001"
+    },
+    "policy_lineage": {
+      "verified": true,
+      "snapshot_id": "policy-fixture-001",
+      "version": "1",
+      "semantic_digest": "sha256:policy-fixture-001",
+      "policy_ids": [
+        "fixture-policy"
+      ],
+      "effective_at": "2029-01-01T00:00:00Z",
+      "expires_at": "2031-01-01T00:00:00Z",
+      "superseded": true
+    },
+    "authority_requirement": {
+      "resolved": true,
+      "required": true,
+      "authority_type": "fixture-transfer-operator"
+    },
+    "authority_evidence": {
+      "validation_result": "VALID",
+      "actor_identity": "actor:fixture:alice",
+      "action_contract_id": "fixture.transfer",
+      "target_system": "ledger-fixture",
+      "target_scope": "account:fixture:A",
+      "issuer": "fixture-iam",
+      "issued_at": "2029-12-31T00:00:00Z",
+      "expires_at": "2030-02-01T00:00:00Z",
+      "evidence_ref": "authority-fixture-001",
+      "evidence_hash": "sha256:authority-fixture-001"
+    },
+    "human_approval_requirement": {
+      "resolved": true,
+      "required": true,
+      "policy_ref": "fixture-policy"
+    },
+    "human_approval_evidence": {
+      "validation_result": "VALID",
+      "approver_identity": "approver:fixture:bob",
+      "approval_scope": "fixture.transfer:100.00:USD",
+      "candidate_ref": "candidate-fixture-001",
+      "action_contract_id": "fixture.transfer",
+      "target_resource": "account:fixture:A",
+      "approved_at": "2029-12-31T12:00:00Z",
+      "expires_at": "2030-01-02T00:00:00Z",
+      "receipt_ref": "approval-fixture-001",
+      "receipt_hash": "sha256:approval-fixture-001"
+    },
+    "target_context": {
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonicalized": true
+    },
+    "expected_state": {
+      "fingerprint": "sha256:state-fixture-001",
+      "observed_at": "2029-12-31T23:59:00Z",
+      "source_ref": "state-fixture-001",
+      "verified": true
+    },
+    "provenance": [
+      {
+        "field_path": "candidate.canonical_action",
+        "value": {
+          "contract_id": "fixture.transfer"
+        },
+        "provenance_class": "EXPLICIT_STRUCTURED_INPUT",
+        "source_artifact_type": "synthetic_action_fixture",
+        "source_artifact_ref": "action-fixture-001",
+        "source_hash": "sha256:action-fixture-001",
+        "verification_status": "VERIFIED",
+        "verification_mechanism": "fixture-contract-check",
+        "observed_at": "2029-12-31T23:59:00Z",
+        "issued_at": null,
+        "expires_at": null,
+        "freshness": {
+          "synthetic": true
+        }
+      }
+    ],
+    "refusal_reason_codes": [
+      "HANDOFF_POLICY_LINEAGE_STALE"
+    ],
+    "created_at": "2030-01-01T00:00:01Z",
+    "expires_at": "2030-01-01T00:05:01Z",
+    "non_claims": [
+      "synthetic fixture only",
+      "no ExecutionIntent",
+      "no Bind invocation",
+      "no external effect"
+    ]
+  },
+  "expected_handoff_status": "REVIEW_REQUIRED",
+  "expected_reason_codes": [
+    "HANDOFF_POLICY_LINEAGE_STALE"
+  ],
+  "execution_intent_created": false,
+  "bind_invoked": false,
+  "external_effect": false,
+  "synthetic_fixture": true
+}

--- a/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-18.json
+++ b/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-18.json
@@ -1,0 +1,139 @@
+{
+  "vector_id": "DTBH-V1-18",
+  "description": "expected state missing for state-bound action",
+  "input": {
+    "format_version": "canonical-decision-handoff/v1",
+    "handoff_id": "handoff-fixture-18",
+    "handoff_status": "INCOMPLETE",
+    "source_decision": {
+      "request_id": "req-fixture-001",
+      "canonical_decision_id": "decision-fixture-001",
+      "canonical_decision_hash": "sha256:decision-fixture-001",
+      "canonical_decision_ts": "2030-01-01T00:00:00Z",
+      "gate_decision": "ALLOW"
+    },
+    "candidate": {
+      "candidate_id": "candidate-fixture-001",
+      "actor_identity": "actor:fixture:alice",
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonical_action": {
+        "contract_id": "fixture.transfer",
+        "version": "1",
+        "parameters": {
+          "amount": "100.00",
+          "currency": "USD"
+        }
+      },
+      "lineage_promotability": "promotable"
+    },
+    "candidate_hash": "sha256:candidate-fixture-001",
+    "decision_lineage": {
+      "verified": true,
+      "decision_id": "decision-fixture-001"
+    },
+    "trustlog_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "trustlog-fixture-001",
+      "chain_hash": "sha256:trustlog-fixture-001"
+    },
+    "replay_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "replay-fixture-001",
+      "artifact_hash": "sha256:replay-fixture-001"
+    },
+    "policy_lineage": {
+      "verified": true,
+      "snapshot_id": "policy-fixture-001",
+      "version": "1",
+      "semantic_digest": "sha256:policy-fixture-001",
+      "policy_ids": [
+        "fixture-policy"
+      ],
+      "effective_at": "2029-01-01T00:00:00Z",
+      "expires_at": "2031-01-01T00:00:00Z",
+      "superseded": false
+    },
+    "authority_requirement": {
+      "resolved": true,
+      "required": true,
+      "authority_type": "fixture-transfer-operator"
+    },
+    "authority_evidence": {
+      "validation_result": "VALID",
+      "actor_identity": "actor:fixture:alice",
+      "action_contract_id": "fixture.transfer",
+      "target_system": "ledger-fixture",
+      "target_scope": "account:fixture:A",
+      "issuer": "fixture-iam",
+      "issued_at": "2029-12-31T00:00:00Z",
+      "expires_at": "2030-02-01T00:00:00Z",
+      "evidence_ref": "authority-fixture-001",
+      "evidence_hash": "sha256:authority-fixture-001"
+    },
+    "human_approval_requirement": {
+      "resolved": true,
+      "required": true,
+      "policy_ref": "fixture-policy"
+    },
+    "human_approval_evidence": {
+      "validation_result": "VALID",
+      "approver_identity": "approver:fixture:bob",
+      "approval_scope": "fixture.transfer:100.00:USD",
+      "candidate_ref": "candidate-fixture-001",
+      "action_contract_id": "fixture.transfer",
+      "target_resource": "account:fixture:A",
+      "approved_at": "2029-12-31T12:00:00Z",
+      "expires_at": "2030-01-02T00:00:00Z",
+      "receipt_ref": "approval-fixture-001",
+      "receipt_hash": "sha256:approval-fixture-001"
+    },
+    "target_context": {
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonicalized": true
+    },
+    "expected_state": null,
+    "provenance": [
+      {
+        "field_path": "candidate.canonical_action",
+        "value": {
+          "contract_id": "fixture.transfer"
+        },
+        "provenance_class": "EXPLICIT_STRUCTURED_INPUT",
+        "source_artifact_type": "synthetic_action_fixture",
+        "source_artifact_ref": "action-fixture-001",
+        "source_hash": "sha256:action-fixture-001",
+        "verification_status": "VERIFIED",
+        "verification_mechanism": "fixture-contract-check",
+        "observed_at": "2029-12-31T23:59:00Z",
+        "issued_at": null,
+        "expires_at": null,
+        "freshness": {
+          "synthetic": true
+        }
+      }
+    ],
+    "refusal_reason_codes": [
+      "HANDOFF_EXPECTED_STATE_MISSING"
+    ],
+    "created_at": "2030-01-01T00:00:01Z",
+    "expires_at": "2030-01-01T00:05:01Z",
+    "non_claims": [
+      "synthetic fixture only",
+      "no ExecutionIntent",
+      "no Bind invocation",
+      "no external effect"
+    ]
+  },
+  "expected_handoff_status": "INCOMPLETE",
+  "expected_reason_codes": [
+    "HANDOFF_EXPECTED_STATE_MISSING"
+  ],
+  "execution_intent_created": false,
+  "bind_invoked": false,
+  "external_effect": false,
+  "synthetic_fixture": true
+}

--- a/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-19.json
+++ b/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-19.json
@@ -1,0 +1,144 @@
+{
+  "vector_id": "DTBH-V1-19",
+  "description": "non-promotable formation lineage",
+  "input": {
+    "format_version": "canonical-decision-handoff/v1",
+    "handoff_id": "handoff-fixture-19",
+    "handoff_status": "STRUCTURALLY_REFUSED",
+    "source_decision": {
+      "request_id": "req-fixture-001",
+      "canonical_decision_id": "decision-fixture-001",
+      "canonical_decision_hash": "sha256:decision-fixture-001",
+      "canonical_decision_ts": "2030-01-01T00:00:00Z",
+      "gate_decision": "ALLOW"
+    },
+    "candidate": {
+      "candidate_id": "candidate-fixture-001",
+      "actor_identity": "actor:fixture:alice",
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonical_action": {
+        "contract_id": "fixture.transfer",
+        "version": "1",
+        "parameters": {
+          "amount": "100.00",
+          "currency": "USD"
+        }
+      },
+      "lineage_promotability": "non_promotable"
+    },
+    "candidate_hash": "sha256:candidate-fixture-001",
+    "decision_lineage": {
+      "verified": true,
+      "decision_id": "decision-fixture-001"
+    },
+    "trustlog_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "trustlog-fixture-001",
+      "chain_hash": "sha256:trustlog-fixture-001"
+    },
+    "replay_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "replay-fixture-001",
+      "artifact_hash": "sha256:replay-fixture-001"
+    },
+    "policy_lineage": {
+      "verified": true,
+      "snapshot_id": "policy-fixture-001",
+      "version": "1",
+      "semantic_digest": "sha256:policy-fixture-001",
+      "policy_ids": [
+        "fixture-policy"
+      ],
+      "effective_at": "2029-01-01T00:00:00Z",
+      "expires_at": "2031-01-01T00:00:00Z",
+      "superseded": false
+    },
+    "authority_requirement": {
+      "resolved": true,
+      "required": true,
+      "authority_type": "fixture-transfer-operator"
+    },
+    "authority_evidence": {
+      "validation_result": "VALID",
+      "actor_identity": "actor:fixture:alice",
+      "action_contract_id": "fixture.transfer",
+      "target_system": "ledger-fixture",
+      "target_scope": "account:fixture:A",
+      "issuer": "fixture-iam",
+      "issued_at": "2029-12-31T00:00:00Z",
+      "expires_at": "2030-02-01T00:00:00Z",
+      "evidence_ref": "authority-fixture-001",
+      "evidence_hash": "sha256:authority-fixture-001"
+    },
+    "human_approval_requirement": {
+      "resolved": true,
+      "required": true,
+      "policy_ref": "fixture-policy"
+    },
+    "human_approval_evidence": {
+      "validation_result": "VALID",
+      "approver_identity": "approver:fixture:bob",
+      "approval_scope": "fixture.transfer:100.00:USD",
+      "candidate_ref": "candidate-fixture-001",
+      "action_contract_id": "fixture.transfer",
+      "target_resource": "account:fixture:A",
+      "approved_at": "2029-12-31T12:00:00Z",
+      "expires_at": "2030-01-02T00:00:00Z",
+      "receipt_ref": "approval-fixture-001",
+      "receipt_hash": "sha256:approval-fixture-001"
+    },
+    "target_context": {
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonicalized": true
+    },
+    "expected_state": {
+      "fingerprint": "sha256:state-fixture-001",
+      "observed_at": "2029-12-31T23:59:00Z",
+      "source_ref": "state-fixture-001",
+      "verified": true
+    },
+    "provenance": [
+      {
+        "field_path": "candidate.canonical_action",
+        "value": {
+          "contract_id": "fixture.transfer"
+        },
+        "provenance_class": "EXPLICIT_STRUCTURED_INPUT",
+        "source_artifact_type": "synthetic_action_fixture",
+        "source_artifact_ref": "action-fixture-001",
+        "source_hash": "sha256:action-fixture-001",
+        "verification_status": "VERIFIED",
+        "verification_mechanism": "fixture-contract-check",
+        "observed_at": "2029-12-31T23:59:00Z",
+        "issued_at": null,
+        "expires_at": null,
+        "freshness": {
+          "synthetic": true
+        }
+      }
+    ],
+    "refusal_reason_codes": [
+      "HANDOFF_LINEAGE_NON_PROMOTABLE"
+    ],
+    "created_at": "2030-01-01T00:00:01Z",
+    "expires_at": "2030-01-01T00:05:01Z",
+    "non_claims": [
+      "synthetic fixture only",
+      "no ExecutionIntent",
+      "no Bind invocation",
+      "no external effect"
+    ]
+  },
+  "expected_handoff_status": "STRUCTURALLY_REFUSED",
+  "expected_reason_codes": [
+    "HANDOFF_LINEAGE_NON_PROMOTABLE"
+  ],
+  "execution_intent_created": false,
+  "bind_invoked": false,
+  "external_effect": false,
+  "synthetic_fixture": true
+}

--- a/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-20.json
+++ b/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-20.json
@@ -1,0 +1,144 @@
+{
+  "vector_id": "DTBH-V1-20",
+  "description": "non-promotable lineage with new authority evidence",
+  "input": {
+    "format_version": "canonical-decision-handoff/v1",
+    "handoff_id": "handoff-fixture-20",
+    "handoff_status": "STRUCTURALLY_REFUSED",
+    "source_decision": {
+      "request_id": "req-fixture-001",
+      "canonical_decision_id": "decision-fixture-001",
+      "canonical_decision_hash": "sha256:decision-fixture-001",
+      "canonical_decision_ts": "2030-01-01T00:00:00Z",
+      "gate_decision": "ALLOW"
+    },
+    "candidate": {
+      "candidate_id": "candidate-fixture-001",
+      "actor_identity": "actor:fixture:alice",
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonical_action": {
+        "contract_id": "fixture.transfer",
+        "version": "1",
+        "parameters": {
+          "amount": "100.00",
+          "currency": "USD"
+        }
+      },
+      "lineage_promotability": "non_promotable"
+    },
+    "candidate_hash": "sha256:candidate-fixture-001",
+    "decision_lineage": {
+      "verified": true,
+      "decision_id": "decision-fixture-001"
+    },
+    "trustlog_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "trustlog-fixture-001",
+      "chain_hash": "sha256:trustlog-fixture-001"
+    },
+    "replay_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "replay-fixture-001",
+      "artifact_hash": "sha256:replay-fixture-001"
+    },
+    "policy_lineage": {
+      "verified": true,
+      "snapshot_id": "policy-fixture-001",
+      "version": "1",
+      "semantic_digest": "sha256:policy-fixture-001",
+      "policy_ids": [
+        "fixture-policy"
+      ],
+      "effective_at": "2029-01-01T00:00:00Z",
+      "expires_at": "2031-01-01T00:00:00Z",
+      "superseded": false
+    },
+    "authority_requirement": {
+      "resolved": true,
+      "required": true,
+      "authority_type": "fixture-transfer-operator"
+    },
+    "authority_evidence": {
+      "validation_result": "VALID",
+      "actor_identity": "actor:fixture:alice",
+      "action_contract_id": "fixture.transfer",
+      "target_system": "ledger-fixture",
+      "target_scope": "account:fixture:A",
+      "issuer": "fixture-iam",
+      "issued_at": "2029-12-31T00:00:00Z",
+      "expires_at": "2030-02-01T00:00:00Z",
+      "evidence_ref": "authority-fixture-001",
+      "evidence_hash": "sha256:authority-fixture-001"
+    },
+    "human_approval_requirement": {
+      "resolved": true,
+      "required": true,
+      "policy_ref": "fixture-policy"
+    },
+    "human_approval_evidence": {
+      "validation_result": "VALID",
+      "approver_identity": "approver:fixture:bob",
+      "approval_scope": "fixture.transfer:100.00:USD",
+      "candidate_ref": "candidate-fixture-001",
+      "action_contract_id": "fixture.transfer",
+      "target_resource": "account:fixture:A",
+      "approved_at": "2029-12-31T12:00:00Z",
+      "expires_at": "2030-01-02T00:00:00Z",
+      "receipt_ref": "approval-fixture-001",
+      "receipt_hash": "sha256:approval-fixture-001"
+    },
+    "target_context": {
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonicalized": true
+    },
+    "expected_state": {
+      "fingerprint": "sha256:state-fixture-001",
+      "observed_at": "2029-12-31T23:59:00Z",
+      "source_ref": "state-fixture-001",
+      "verified": true
+    },
+    "provenance": [
+      {
+        "field_path": "candidate.canonical_action",
+        "value": {
+          "contract_id": "fixture.transfer"
+        },
+        "provenance_class": "EXPLICIT_STRUCTURED_INPUT",
+        "source_artifact_type": "synthetic_action_fixture",
+        "source_artifact_ref": "action-fixture-001",
+        "source_hash": "sha256:action-fixture-001",
+        "verification_status": "VERIFIED",
+        "verification_mechanism": "fixture-contract-check",
+        "observed_at": "2029-12-31T23:59:00Z",
+        "issued_at": null,
+        "expires_at": null,
+        "freshness": {
+          "synthetic": true
+        }
+      }
+    ],
+    "refusal_reason_codes": [
+      "HANDOFF_LINEAGE_NON_PROMOTABLE"
+    ],
+    "created_at": "2030-01-01T00:00:01Z",
+    "expires_at": "2030-01-01T00:05:01Z",
+    "non_claims": [
+      "synthetic fixture only",
+      "no ExecutionIntent",
+      "no Bind invocation",
+      "no external effect"
+    ]
+  },
+  "expected_handoff_status": "STRUCTURALLY_REFUSED",
+  "expected_reason_codes": [
+    "HANDOFF_LINEAGE_NON_PROMOTABLE"
+  ],
+  "execution_intent_created": false,
+  "bind_invoked": false,
+  "external_effect": false,
+  "synthetic_fixture": true
+}

--- a/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-21.json
+++ b/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-21.json
@@ -1,0 +1,134 @@
+{
+  "vector_id": "DTBH-V1-21",
+  "description": "ALLOW result but authority missing",
+  "input": {
+    "format_version": "canonical-decision-handoff/v1",
+    "handoff_id": "handoff-fixture-21",
+    "handoff_status": "INVALID",
+    "source_decision": {
+      "request_id": "req-fixture-001",
+      "canonical_decision_id": "decision-fixture-001",
+      "canonical_decision_hash": "sha256:decision-fixture-001",
+      "canonical_decision_ts": "2030-01-01T00:00:00Z",
+      "gate_decision": "ALLOW"
+    },
+    "candidate": {
+      "candidate_id": "candidate-fixture-001",
+      "actor_identity": "actor:fixture:alice",
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonical_action": {
+        "contract_id": "fixture.transfer",
+        "version": "1",
+        "parameters": {
+          "amount": "100.00",
+          "currency": "USD"
+        }
+      },
+      "lineage_promotability": "promotable"
+    },
+    "candidate_hash": "sha256:candidate-fixture-001",
+    "decision_lineage": {
+      "verified": true,
+      "decision_id": "decision-fixture-001"
+    },
+    "trustlog_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "trustlog-fixture-001",
+      "chain_hash": "sha256:trustlog-fixture-001"
+    },
+    "replay_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "replay-fixture-001",
+      "artifact_hash": "sha256:replay-fixture-001"
+    },
+    "policy_lineage": {
+      "verified": true,
+      "snapshot_id": "policy-fixture-001",
+      "version": "1",
+      "semantic_digest": "sha256:policy-fixture-001",
+      "policy_ids": [
+        "fixture-policy"
+      ],
+      "effective_at": "2029-01-01T00:00:00Z",
+      "expires_at": "2031-01-01T00:00:00Z",
+      "superseded": false
+    },
+    "authority_requirement": {
+      "resolved": true,
+      "required": true,
+      "authority_type": "fixture-transfer-operator"
+    },
+    "authority_evidence": null,
+    "human_approval_requirement": {
+      "resolved": true,
+      "required": true,
+      "policy_ref": "fixture-policy"
+    },
+    "human_approval_evidence": {
+      "validation_result": "VALID",
+      "approver_identity": "approver:fixture:bob",
+      "approval_scope": "fixture.transfer:100.00:USD",
+      "candidate_ref": "candidate-fixture-001",
+      "action_contract_id": "fixture.transfer",
+      "target_resource": "account:fixture:A",
+      "approved_at": "2029-12-31T12:00:00Z",
+      "expires_at": "2030-01-02T00:00:00Z",
+      "receipt_ref": "approval-fixture-001",
+      "receipt_hash": "sha256:approval-fixture-001"
+    },
+    "target_context": {
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonicalized": true
+    },
+    "expected_state": {
+      "fingerprint": "sha256:state-fixture-001",
+      "observed_at": "2029-12-31T23:59:00Z",
+      "source_ref": "state-fixture-001",
+      "verified": true
+    },
+    "provenance": [
+      {
+        "field_path": "candidate.canonical_action",
+        "value": {
+          "contract_id": "fixture.transfer"
+        },
+        "provenance_class": "EXPLICIT_STRUCTURED_INPUT",
+        "source_artifact_type": "synthetic_action_fixture",
+        "source_artifact_ref": "action-fixture-001",
+        "source_hash": "sha256:action-fixture-001",
+        "verification_status": "VERIFIED",
+        "verification_mechanism": "fixture-contract-check",
+        "observed_at": "2029-12-31T23:59:00Z",
+        "issued_at": null,
+        "expires_at": null,
+        "freshness": {
+          "synthetic": true
+        }
+      }
+    ],
+    "refusal_reason_codes": [
+      "HANDOFF_AUTHORITY_EVIDENCE_MISSING"
+    ],
+    "created_at": "2030-01-01T00:00:01Z",
+    "expires_at": "2030-01-01T00:05:01Z",
+    "non_claims": [
+      "synthetic fixture only",
+      "no ExecutionIntent",
+      "no Bind invocation",
+      "no external effect"
+    ]
+  },
+  "expected_handoff_status": "INVALID",
+  "expected_reason_codes": [
+    "HANDOFF_AUTHORITY_EVIDENCE_MISSING"
+  ],
+  "execution_intent_created": false,
+  "bind_invoked": false,
+  "external_effect": false,
+  "synthetic_fixture": true,
+  "forbidden_inference": "gate_decision ALLOW must not become authority"
+}

--- a/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-22.json
+++ b/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-22.json
@@ -1,0 +1,135 @@
+{
+  "vector_id": "DTBH-V1-22",
+  "description": "APPROVE business decision but required approval absent",
+  "input": {
+    "format_version": "canonical-decision-handoff/v1",
+    "handoff_id": "handoff-fixture-22",
+    "handoff_status": "REVIEW_REQUIRED",
+    "source_decision": {
+      "request_id": "req-fixture-001",
+      "canonical_decision_id": "decision-fixture-001",
+      "canonical_decision_hash": "sha256:decision-fixture-001",
+      "canonical_decision_ts": "2030-01-01T00:00:00Z",
+      "gate_decision": "ALLOW",
+      "business_decision": "APPROVE"
+    },
+    "candidate": {
+      "candidate_id": "candidate-fixture-001",
+      "actor_identity": "actor:fixture:alice",
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonical_action": {
+        "contract_id": "fixture.transfer",
+        "version": "1",
+        "parameters": {
+          "amount": "100.00",
+          "currency": "USD"
+        }
+      },
+      "lineage_promotability": "promotable"
+    },
+    "candidate_hash": "sha256:candidate-fixture-001",
+    "decision_lineage": {
+      "verified": true,
+      "decision_id": "decision-fixture-001"
+    },
+    "trustlog_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "trustlog-fixture-001",
+      "chain_hash": "sha256:trustlog-fixture-001"
+    },
+    "replay_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "replay-fixture-001",
+      "artifact_hash": "sha256:replay-fixture-001"
+    },
+    "policy_lineage": {
+      "verified": true,
+      "snapshot_id": "policy-fixture-001",
+      "version": "1",
+      "semantic_digest": "sha256:policy-fixture-001",
+      "policy_ids": [
+        "fixture-policy"
+      ],
+      "effective_at": "2029-01-01T00:00:00Z",
+      "expires_at": "2031-01-01T00:00:00Z",
+      "superseded": false
+    },
+    "authority_requirement": {
+      "resolved": true,
+      "required": true,
+      "authority_type": "fixture-transfer-operator"
+    },
+    "authority_evidence": {
+      "validation_result": "VALID",
+      "actor_identity": "actor:fixture:alice",
+      "action_contract_id": "fixture.transfer",
+      "target_system": "ledger-fixture",
+      "target_scope": "account:fixture:A",
+      "issuer": "fixture-iam",
+      "issued_at": "2029-12-31T00:00:00Z",
+      "expires_at": "2030-02-01T00:00:00Z",
+      "evidence_ref": "authority-fixture-001",
+      "evidence_hash": "sha256:authority-fixture-001"
+    },
+    "human_approval_requirement": {
+      "resolved": true,
+      "required": true,
+      "policy_ref": "fixture-policy"
+    },
+    "human_approval_evidence": null,
+    "target_context": {
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonicalized": true
+    },
+    "expected_state": {
+      "fingerprint": "sha256:state-fixture-001",
+      "observed_at": "2029-12-31T23:59:00Z",
+      "source_ref": "state-fixture-001",
+      "verified": true
+    },
+    "provenance": [
+      {
+        "field_path": "candidate.canonical_action",
+        "value": {
+          "contract_id": "fixture.transfer"
+        },
+        "provenance_class": "EXPLICIT_STRUCTURED_INPUT",
+        "source_artifact_type": "synthetic_action_fixture",
+        "source_artifact_ref": "action-fixture-001",
+        "source_hash": "sha256:action-fixture-001",
+        "verification_status": "VERIFIED",
+        "verification_mechanism": "fixture-contract-check",
+        "observed_at": "2029-12-31T23:59:00Z",
+        "issued_at": null,
+        "expires_at": null,
+        "freshness": {
+          "synthetic": true
+        }
+      }
+    ],
+    "refusal_reason_codes": [
+      "HANDOFF_APPROVAL_EVIDENCE_MISSING"
+    ],
+    "created_at": "2030-01-01T00:00:01Z",
+    "expires_at": "2030-01-01T00:05:01Z",
+    "non_claims": [
+      "synthetic fixture only",
+      "no ExecutionIntent",
+      "no Bind invocation",
+      "no external effect"
+    ]
+  },
+  "expected_handoff_status": "REVIEW_REQUIRED",
+  "expected_reason_codes": [
+    "HANDOFF_APPROVAL_EVIDENCE_MISSING"
+  ],
+  "execution_intent_created": false,
+  "bind_invoked": false,
+  "external_effect": false,
+  "synthetic_fixture": true,
+  "forbidden_inference": "business_decision APPROVE must not become Human Approval"
+}

--- a/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-23.json
+++ b/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-23.json
@@ -1,0 +1,135 @@
+{
+  "vector_id": "DTBH-V1-23",
+  "description": "API user identity present but execution authority missing",
+  "input": {
+    "format_version": "canonical-decision-handoff/v1",
+    "handoff_id": "handoff-fixture-23",
+    "handoff_status": "INVALID",
+    "source_decision": {
+      "request_id": "req-fixture-001",
+      "canonical_decision_id": "decision-fixture-001",
+      "canonical_decision_hash": "sha256:decision-fixture-001",
+      "canonical_decision_ts": "2030-01-01T00:00:00Z",
+      "gate_decision": "ALLOW",
+      "authenticated_api_user": "actor:fixture:alice"
+    },
+    "candidate": {
+      "candidate_id": "candidate-fixture-001",
+      "actor_identity": "actor:fixture:alice",
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonical_action": {
+        "contract_id": "fixture.transfer",
+        "version": "1",
+        "parameters": {
+          "amount": "100.00",
+          "currency": "USD"
+        }
+      },
+      "lineage_promotability": "promotable"
+    },
+    "candidate_hash": "sha256:candidate-fixture-001",
+    "decision_lineage": {
+      "verified": true,
+      "decision_id": "decision-fixture-001"
+    },
+    "trustlog_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "trustlog-fixture-001",
+      "chain_hash": "sha256:trustlog-fixture-001"
+    },
+    "replay_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "replay-fixture-001",
+      "artifact_hash": "sha256:replay-fixture-001"
+    },
+    "policy_lineage": {
+      "verified": true,
+      "snapshot_id": "policy-fixture-001",
+      "version": "1",
+      "semantic_digest": "sha256:policy-fixture-001",
+      "policy_ids": [
+        "fixture-policy"
+      ],
+      "effective_at": "2029-01-01T00:00:00Z",
+      "expires_at": "2031-01-01T00:00:00Z",
+      "superseded": false
+    },
+    "authority_requirement": {
+      "resolved": true,
+      "required": true,
+      "authority_type": "fixture-transfer-operator"
+    },
+    "authority_evidence": null,
+    "human_approval_requirement": {
+      "resolved": true,
+      "required": true,
+      "policy_ref": "fixture-policy"
+    },
+    "human_approval_evidence": {
+      "validation_result": "VALID",
+      "approver_identity": "approver:fixture:bob",
+      "approval_scope": "fixture.transfer:100.00:USD",
+      "candidate_ref": "candidate-fixture-001",
+      "action_contract_id": "fixture.transfer",
+      "target_resource": "account:fixture:A",
+      "approved_at": "2029-12-31T12:00:00Z",
+      "expires_at": "2030-01-02T00:00:00Z",
+      "receipt_ref": "approval-fixture-001",
+      "receipt_hash": "sha256:approval-fixture-001"
+    },
+    "target_context": {
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonicalized": true
+    },
+    "expected_state": {
+      "fingerprint": "sha256:state-fixture-001",
+      "observed_at": "2029-12-31T23:59:00Z",
+      "source_ref": "state-fixture-001",
+      "verified": true
+    },
+    "provenance": [
+      {
+        "field_path": "candidate.canonical_action",
+        "value": {
+          "contract_id": "fixture.transfer"
+        },
+        "provenance_class": "EXPLICIT_STRUCTURED_INPUT",
+        "source_artifact_type": "synthetic_action_fixture",
+        "source_artifact_ref": "action-fixture-001",
+        "source_hash": "sha256:action-fixture-001",
+        "verification_status": "VERIFIED",
+        "verification_mechanism": "fixture-contract-check",
+        "observed_at": "2029-12-31T23:59:00Z",
+        "issued_at": null,
+        "expires_at": null,
+        "freshness": {
+          "synthetic": true
+        }
+      }
+    ],
+    "refusal_reason_codes": [
+      "HANDOFF_AUTHORITY_EVIDENCE_MISSING"
+    ],
+    "created_at": "2030-01-01T00:00:01Z",
+    "expires_at": "2030-01-01T00:05:01Z",
+    "non_claims": [
+      "synthetic fixture only",
+      "no ExecutionIntent",
+      "no Bind invocation",
+      "no external effect"
+    ]
+  },
+  "expected_handoff_status": "INVALID",
+  "expected_reason_codes": [
+    "HANDOFF_AUTHORITY_EVIDENCE_MISSING"
+  ],
+  "execution_intent_created": false,
+  "bind_invoked": false,
+  "external_effect": false,
+  "synthetic_fixture": true,
+  "forbidden_inference": "authenticated API identity must not become execution authority"
+}

--- a/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-24.json
+++ b/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-24.json
@@ -1,0 +1,146 @@
+{
+  "vector_id": "DTBH-V1-24",
+  "description": "target substitution after validation",
+  "input": {
+    "format_version": "canonical-decision-handoff/v1",
+    "handoff_id": "handoff-fixture-24",
+    "handoff_status": "INVALID",
+    "source_decision": {
+      "request_id": "req-fixture-001",
+      "canonical_decision_id": "decision-fixture-001",
+      "canonical_decision_hash": "sha256:decision-fixture-001",
+      "canonical_decision_ts": "2030-01-01T00:00:00Z",
+      "gate_decision": "ALLOW"
+    },
+    "candidate": {
+      "candidate_id": "candidate-fixture-001",
+      "actor_identity": "actor:fixture:alice",
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonical_action": {
+        "contract_id": "fixture.transfer",
+        "version": "1",
+        "parameters": {
+          "amount": "100.00",
+          "currency": "USD"
+        }
+      },
+      "lineage_promotability": "promotable"
+    },
+    "candidate_hash": "sha256:candidate-fixture-001",
+    "decision_lineage": {
+      "verified": true,
+      "decision_id": "decision-fixture-001"
+    },
+    "trustlog_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "trustlog-fixture-001",
+      "chain_hash": "sha256:trustlog-fixture-001"
+    },
+    "replay_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "replay-fixture-001",
+      "artifact_hash": "sha256:replay-fixture-001"
+    },
+    "policy_lineage": {
+      "verified": true,
+      "snapshot_id": "policy-fixture-001",
+      "version": "1",
+      "semantic_digest": "sha256:policy-fixture-001",
+      "policy_ids": [
+        "fixture-policy"
+      ],
+      "effective_at": "2029-01-01T00:00:00Z",
+      "expires_at": "2031-01-01T00:00:00Z",
+      "superseded": false
+    },
+    "authority_requirement": {
+      "resolved": true,
+      "required": true,
+      "authority_type": "fixture-transfer-operator"
+    },
+    "authority_evidence": {
+      "validation_result": "VALID",
+      "actor_identity": "actor:fixture:alice",
+      "action_contract_id": "fixture.transfer",
+      "target_system": "ledger-fixture",
+      "target_scope": "account:fixture:A",
+      "issuer": "fixture-iam",
+      "issued_at": "2029-12-31T00:00:00Z",
+      "expires_at": "2030-02-01T00:00:00Z",
+      "evidence_ref": "authority-fixture-001",
+      "evidence_hash": "sha256:authority-fixture-001"
+    },
+    "human_approval_requirement": {
+      "resolved": true,
+      "required": true,
+      "policy_ref": "fixture-policy"
+    },
+    "human_approval_evidence": {
+      "validation_result": "VALID",
+      "approver_identity": "approver:fixture:bob",
+      "approval_scope": "fixture.transfer:100.00:USD",
+      "candidate_ref": "candidate-fixture-001",
+      "action_contract_id": "fixture.transfer",
+      "target_resource": "account:fixture:A",
+      "approved_at": "2029-12-31T12:00:00Z",
+      "expires_at": "2030-01-02T00:00:00Z",
+      "receipt_ref": "approval-fixture-001",
+      "receipt_hash": "sha256:approval-fixture-001"
+    },
+    "target_context": {
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:B",
+      "canonicalized": true
+    },
+    "expected_state": {
+      "fingerprint": "sha256:state-fixture-001",
+      "observed_at": "2029-12-31T23:59:00Z",
+      "source_ref": "state-fixture-001",
+      "verified": true
+    },
+    "provenance": [
+      {
+        "field_path": "candidate.canonical_action",
+        "value": {
+          "contract_id": "fixture.transfer"
+        },
+        "provenance_class": "EXPLICIT_STRUCTURED_INPUT",
+        "source_artifact_type": "synthetic_action_fixture",
+        "source_artifact_ref": "action-fixture-001",
+        "source_hash": "sha256:action-fixture-001",
+        "verification_status": "VERIFIED",
+        "verification_mechanism": "fixture-contract-check",
+        "observed_at": "2029-12-31T23:59:00Z",
+        "issued_at": null,
+        "expires_at": null,
+        "freshness": {
+          "synthetic": true
+        }
+      }
+    ],
+    "refusal_reason_codes": [
+      "HANDOFF_CANDIDATE_HASH_MISMATCH",
+      "HANDOFF_AUTHORITY_EVIDENCE_INVALID"
+    ],
+    "created_at": "2030-01-01T00:00:01Z",
+    "expires_at": "2030-01-01T00:05:01Z",
+    "non_claims": [
+      "synthetic fixture only",
+      "no ExecutionIntent",
+      "no Bind invocation",
+      "no external effect"
+    ]
+  },
+  "expected_handoff_status": "INVALID",
+  "expected_reason_codes": [
+    "HANDOFF_CANDIDATE_HASH_MISMATCH",
+    "HANDOFF_AUTHORITY_EVIDENCE_INVALID"
+  ],
+  "execution_intent_created": false,
+  "bind_invoked": false,
+  "external_effect": false,
+  "synthetic_fixture": true
+}

--- a/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-25.json
+++ b/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-25.json
@@ -1,0 +1,144 @@
+{
+  "vector_id": "DTBH-V1-25",
+  "description": "action substitution after approval",
+  "input": {
+    "format_version": "canonical-decision-handoff/v1",
+    "handoff_id": "handoff-fixture-25",
+    "handoff_status": "INVALID",
+    "source_decision": {
+      "request_id": "req-fixture-001",
+      "canonical_decision_id": "decision-fixture-001",
+      "canonical_decision_hash": "sha256:decision-fixture-001",
+      "canonical_decision_ts": "2030-01-01T00:00:00Z",
+      "gate_decision": "ALLOW"
+    },
+    "candidate": {
+      "candidate_id": "candidate-fixture-001",
+      "actor_identity": "actor:fixture:alice",
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonical_action": {
+        "contract_id": "fixture.delete",
+        "version": "1",
+        "parameters": {
+          "amount": "100.00",
+          "currency": "USD"
+        }
+      },
+      "lineage_promotability": "promotable"
+    },
+    "candidate_hash": "sha256:candidate-fixture-001",
+    "decision_lineage": {
+      "verified": true,
+      "decision_id": "decision-fixture-001"
+    },
+    "trustlog_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "trustlog-fixture-001",
+      "chain_hash": "sha256:trustlog-fixture-001"
+    },
+    "replay_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "replay-fixture-001",
+      "artifact_hash": "sha256:replay-fixture-001"
+    },
+    "policy_lineage": {
+      "verified": true,
+      "snapshot_id": "policy-fixture-001",
+      "version": "1",
+      "semantic_digest": "sha256:policy-fixture-001",
+      "policy_ids": [
+        "fixture-policy"
+      ],
+      "effective_at": "2029-01-01T00:00:00Z",
+      "expires_at": "2031-01-01T00:00:00Z",
+      "superseded": false
+    },
+    "authority_requirement": {
+      "resolved": true,
+      "required": true,
+      "authority_type": "fixture-transfer-operator"
+    },
+    "authority_evidence": {
+      "validation_result": "VALID",
+      "actor_identity": "actor:fixture:alice",
+      "action_contract_id": "fixture.transfer",
+      "target_system": "ledger-fixture",
+      "target_scope": "account:fixture:A",
+      "issuer": "fixture-iam",
+      "issued_at": "2029-12-31T00:00:00Z",
+      "expires_at": "2030-02-01T00:00:00Z",
+      "evidence_ref": "authority-fixture-001",
+      "evidence_hash": "sha256:authority-fixture-001"
+    },
+    "human_approval_requirement": {
+      "resolved": true,
+      "required": true,
+      "policy_ref": "fixture-policy"
+    },
+    "human_approval_evidence": {
+      "validation_result": "VALID",
+      "approver_identity": "approver:fixture:bob",
+      "approval_scope": "fixture.transfer:100.00:USD",
+      "candidate_ref": "candidate-fixture-001",
+      "action_contract_id": "fixture.transfer",
+      "target_resource": "account:fixture:A",
+      "approved_at": "2029-12-31T12:00:00Z",
+      "expires_at": "2030-01-02T00:00:00Z",
+      "receipt_ref": "approval-fixture-001",
+      "receipt_hash": "sha256:approval-fixture-001"
+    },
+    "target_context": {
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonicalized": true
+    },
+    "expected_state": {
+      "fingerprint": "sha256:state-fixture-001",
+      "observed_at": "2029-12-31T23:59:00Z",
+      "source_ref": "state-fixture-001",
+      "verified": true
+    },
+    "provenance": [
+      {
+        "field_path": "candidate.canonical_action",
+        "value": {
+          "contract_id": "fixture.transfer"
+        },
+        "provenance_class": "EXPLICIT_STRUCTURED_INPUT",
+        "source_artifact_type": "synthetic_action_fixture",
+        "source_artifact_ref": "action-fixture-001",
+        "source_hash": "sha256:action-fixture-001",
+        "verification_status": "VERIFIED",
+        "verification_mechanism": "fixture-contract-check",
+        "observed_at": "2029-12-31T23:59:00Z",
+        "issued_at": null,
+        "expires_at": null,
+        "freshness": {
+          "synthetic": true
+        }
+      }
+    ],
+    "refusal_reason_codes": [
+      "HANDOFF_APPROVAL_EVIDENCE_INVALID"
+    ],
+    "created_at": "2030-01-01T00:00:01Z",
+    "expires_at": "2030-01-01T00:05:01Z",
+    "non_claims": [
+      "synthetic fixture only",
+      "no ExecutionIntent",
+      "no Bind invocation",
+      "no external effect"
+    ]
+  },
+  "expected_handoff_status": "INVALID",
+  "expected_reason_codes": [
+    "HANDOFF_APPROVAL_EVIDENCE_INVALID"
+  ],
+  "execution_intent_created": false,
+  "bind_invoked": false,
+  "external_effect": false,
+  "synthetic_fixture": true
+}

--- a/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-26.json
+++ b/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-26.json
@@ -1,0 +1,145 @@
+{
+  "vector_id": "DTBH-V1-26",
+  "description": "unrelated Decision proof and Bind proof presented together",
+  "input": {
+    "format_version": "canonical-decision-handoff/v1",
+    "handoff_id": "handoff-fixture-26",
+    "handoff_status": "INVALID",
+    "source_decision": {
+      "request_id": "req-fixture-001",
+      "canonical_decision_id": "decision-fixture-001",
+      "canonical_decision_hash": "sha256:decision-fixture-001",
+      "canonical_decision_ts": "2030-01-01T00:00:00Z",
+      "gate_decision": "ALLOW"
+    },
+    "candidate": {
+      "candidate_id": "candidate-fixture-001",
+      "actor_identity": "actor:fixture:alice",
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonical_action": {
+        "contract_id": "fixture.transfer",
+        "version": "1",
+        "parameters": {
+          "amount": "100.00",
+          "currency": "USD"
+        }
+      },
+      "lineage_promotability": "promotable"
+    },
+    "candidate_hash": "sha256:candidate-fixture-001",
+    "decision_lineage": {
+      "verified": true,
+      "decision_id": "decision-fixture-001",
+      "bind_proof_ref": "unrelated-bind-proof-fixture"
+    },
+    "trustlog_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "trustlog-fixture-001",
+      "chain_hash": "sha256:trustlog-fixture-001"
+    },
+    "replay_lineage": {
+      "verified": true,
+      "request_id": "req-fixture-001",
+      "artifact_ref": "replay-fixture-001",
+      "artifact_hash": "sha256:replay-fixture-001"
+    },
+    "policy_lineage": {
+      "verified": true,
+      "snapshot_id": "policy-fixture-001",
+      "version": "1",
+      "semantic_digest": "sha256:policy-fixture-001",
+      "policy_ids": [
+        "fixture-policy"
+      ],
+      "effective_at": "2029-01-01T00:00:00Z",
+      "expires_at": "2031-01-01T00:00:00Z",
+      "superseded": false
+    },
+    "authority_requirement": {
+      "resolved": true,
+      "required": true,
+      "authority_type": "fixture-transfer-operator"
+    },
+    "authority_evidence": {
+      "validation_result": "VALID",
+      "actor_identity": "actor:fixture:alice",
+      "action_contract_id": "fixture.transfer",
+      "target_system": "ledger-fixture",
+      "target_scope": "account:fixture:A",
+      "issuer": "fixture-iam",
+      "issued_at": "2029-12-31T00:00:00Z",
+      "expires_at": "2030-02-01T00:00:00Z",
+      "evidence_ref": "authority-fixture-001",
+      "evidence_hash": "sha256:authority-fixture-001"
+    },
+    "human_approval_requirement": {
+      "resolved": true,
+      "required": true,
+      "policy_ref": "fixture-policy"
+    },
+    "human_approval_evidence": {
+      "validation_result": "VALID",
+      "approver_identity": "approver:fixture:bob",
+      "approval_scope": "fixture.transfer:100.00:USD",
+      "candidate_ref": "candidate-fixture-001",
+      "action_contract_id": "fixture.transfer",
+      "target_resource": "account:fixture:A",
+      "approved_at": "2029-12-31T12:00:00Z",
+      "expires_at": "2030-01-02T00:00:00Z",
+      "receipt_ref": "approval-fixture-001",
+      "receipt_hash": "sha256:approval-fixture-001"
+    },
+    "target_context": {
+      "target_system": "ledger-fixture",
+      "target_resource": "account:fixture:A",
+      "canonicalized": true
+    },
+    "expected_state": {
+      "fingerprint": "sha256:state-fixture-001",
+      "observed_at": "2029-12-31T23:59:00Z",
+      "source_ref": "state-fixture-001",
+      "verified": true
+    },
+    "provenance": [
+      {
+        "field_path": "candidate.canonical_action",
+        "value": {
+          "contract_id": "fixture.transfer"
+        },
+        "provenance_class": "EXPLICIT_STRUCTURED_INPUT",
+        "source_artifact_type": "synthetic_action_fixture",
+        "source_artifact_ref": "action-fixture-001",
+        "source_hash": "sha256:action-fixture-001",
+        "verification_status": "VERIFIED",
+        "verification_mechanism": "fixture-contract-check",
+        "observed_at": "2029-12-31T23:59:00Z",
+        "issued_at": null,
+        "expires_at": null,
+        "freshness": {
+          "synthetic": true
+        }
+      }
+    ],
+    "refusal_reason_codes": [
+      "HANDOFF_SOURCE_ARTIFACT_MISMATCH"
+    ],
+    "created_at": "2030-01-01T00:00:01Z",
+    "expires_at": "2030-01-01T00:05:01Z",
+    "non_claims": [
+      "synthetic fixture only",
+      "no ExecutionIntent",
+      "no Bind invocation",
+      "no external effect"
+    ]
+  },
+  "expected_handoff_status": "INVALID",
+  "expected_reason_codes": [
+    "HANDOFF_SOURCE_ARTIFACT_MISMATCH"
+  ],
+  "execution_intent_created": false,
+  "bind_invoked": false,
+  "external_effect": false,
+  "synthetic_fixture": true
+}

--- a/docs/en/security/decision-to-bind-handoff-threat-model.md
+++ b/docs/en/security/decision-to-bind-handoff-threat-model.md
@@ -32,7 +32,7 @@ external effect.
 | Approval replay | Receipt authorizes another amount/user/target | Enforce exact scope, nonce/reference, time, and one-operation semantics. |
 | Authority replay | Credential is reused beyond scope/window | Bind evidence to operation and verify current validity. |
 | Reviewer/runtime mismatch | Offline reviewer fixture is called live evidence | Label synthetic provenance and verify runtime artifact identities. |
-| Decision-proof/Bind-proof false linkage | #2097/#2098 proof is paired with unrelated #2099 proof | Refuse connected-lineage claims absent shared canonical lineage. |
+| Decision-proof/Bind-proof false linkage | The independently verified #2098 Decision proof and #2097 Bind proof are presented as sharing canonical Decision → ExecutionIntent → Bind lineage merely because #2099 packages and verifies both. | Refuse connected-lineage claims absent shared canonical lineage evidence. |
 
 ## Security posture and residual risk
 
@@ -45,4 +45,6 @@ evidence.
 **Security warning:** this document defines controls but implements none. Until
 a separately reviewed future implementation establishes canonical decision
 lineage and live evidence validation, any claimed Decision-to-Bind connection
-is untrusted. #2097, #2098, and #2099 do not prove that connection.
+is untrusted. #2097 proves the separate external Bind boundary, #2098 proves the
+Decision pipeline through `DecideResponse` and STOP, and #2099 independently
+verifies and packages both proofs. None creates the lineage connection.

--- a/docs/en/security/decision-to-bind-handoff-threat-model.md
+++ b/docs/en/security/decision-to-bind-handoff-threat-model.md
@@ -1,0 +1,48 @@
+# Decision-to-Bind handoff threat model
+
+## Boundary and assets
+
+This threat model applies to the future `CanonicalDecisionHandoff` specified in
+the [architecture contract](../architecture/canonical-decision-to-bind-handoff-v1.md).
+It protects action/target integrity, actor authority, approvals, decision and
+policy lineage, state freshness, and the separation between formation and Bind.
+The artifact and test vectors are specification-only and create no authority or
+external effect.
+
+## Threats and required fail-closed controls
+
+| Threat | Example | Required control |
+|---|---|---|
+| Semantic laundering | `ALLOW` or `APPROVE` becomes authority | Separate requirement, evidence, and validation; prose/status is untrusted. |
+| Action inference | `next_action` becomes executable | Require typed canonical action from explicit structured input. |
+| Confused deputy | Authenticated caller requests an out-of-scope effect | Verify exact actor/action/target/policy-scope authority. |
+| Identity/authority conflation | API identity is treated as authorization | Bind independent Authority Evidence. |
+| Stale Authority Evidence | Expired role is reused | Verify issuer, validity window, freshness, and hash/ref. |
+| Stale Human Approval | Expired receipt is reused | Bind operation and enforce validity/expiry. |
+| Target substitution | Candidate for A is changed to B | Hash canonical target and reject mutation/mismatch. |
+| Action substitution | Approval for A is reused for B | Bind receipt to exact canonical action and parameters. |
+| TOCTOU/state drift | Formation state differs at Bind | Keep formation fingerprint distinct from Bind live observation. |
+| Policy drift | Policy B supersedes decision policy A | Verify semantic digest, effective time, expiry, and supersession. |
+| Cross-request lineage substitution | Request A TrustLog is attached to B | Require identical request and source identities plus chain verification. |
+| Candidate mutation after hashing | Target/action changes post-validation | Deterministically hash the full canonical candidate and compare. |
+| Replay artifact substitution | Unrelated replay is attached | Independently verify replay identity, request, decision, and hash. |
+| Hash-domain ambiguity | Different payloads share an informal hash label | Version canonical serialization and domain-separated included fields. |
+| Fail-open missing values | Empty/`None` defaults appear valid | Treat missing mandatory values as incomplete/invalid, never allow. |
+| Structural refusal laundering | Refused lineage is repackaged | Preserve transformation-stable refusal; require reconstruction. |
+| Approval replay | Receipt authorizes another amount/user/target | Enforce exact scope, nonce/reference, time, and one-operation semantics. |
+| Authority replay | Credential is reused beyond scope/window | Bind evidence to operation and verify current validity. |
+| Reviewer/runtime mismatch | Offline reviewer fixture is called live evidence | Label synthetic provenance and verify runtime artifact identities. |
+| Decision-proof/Bind-proof false linkage | #2097/#2098 proof is paired with unrelated #2099 proof | Refuse connected-lineage claims absent shared canonical lineage. |
+
+## Security posture and residual risk
+
+Missing, ambiguous, stale, mismatched, or unverified values never default to
+allow. `REVIEW_REQUIRED` is a stop, not permission. Structural refusal occurs
+before Bind and cannot be healed by attaching evidence. Bind remains a separate
+adjudication boundary and must revalidate live state and time-sensitive
+evidence.
+
+**Security warning:** this document defines controls but implements none. Until
+a separately reviewed future implementation establishes canonical decision
+lineage and live evidence validation, any claimed Decision-to-Bind connection
+is untrusted. #2097, #2098, and #2099 do not prove that connection.

--- a/schemas/decision-to-bind-handoff-v1.schema.json
+++ b/schemas/decision-to-bind-handoff-v1.schema.json
@@ -172,6 +172,7 @@
       "additionalProperties": false,
       "required": [
         "field_path",
+        "value",
         "provenance_class",
         "source_artifact_type",
         "source_artifact_ref",

--- a/schemas/decision-to-bind-handoff-v1.schema.json
+++ b/schemas/decision-to-bind-handoff-v1.schema.json
@@ -1,0 +1,254 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://veritas-os.example/schemas/decision-to-bind-handoff-v1.schema.json",
+  "title": "CanonicalDecisionHandoff v1 (structural contract only)",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "format_version",
+    "handoff_id",
+    "handoff_status",
+    "source_decision",
+    "candidate",
+    "candidate_hash",
+    "decision_lineage",
+    "trustlog_lineage",
+    "replay_lineage",
+    "policy_lineage",
+    "authority_requirement",
+    "authority_evidence",
+    "human_approval_requirement",
+    "human_approval_evidence",
+    "target_context",
+    "expected_state",
+    "provenance",
+    "refusal_reason_codes",
+    "created_at",
+    "expires_at",
+    "non_claims"
+  ],
+  "properties": {
+    "format_version": {
+      "const": "canonical-decision-handoff/v1"
+    },
+    "handoff_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "handoff_status": {
+      "enum": [
+        "INCOMPLETE",
+        "REVIEW_REQUIRED",
+        "INVALID",
+        "STRUCTURALLY_REFUSED",
+        "READY_FOR_GUARDED_PROMOTION"
+      ]
+    },
+    "source_decision": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "candidate": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "candidate_hash": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "decision_lineage": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "trustlog_lineage": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "replay_lineage": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "policy_lineage": {
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "authority_requirement": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "authority_evidence": {
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "human_approval_requirement": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "human_approval_evidence": {
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "target_context": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "expected_state": {
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "provenance": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/provenanceRecord"
+      },
+      "minItems": 1
+    },
+    "refusal_reason_codes": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "HANDOFF_MISSING_CANONICAL_DECISION_ID",
+          "HANDOFF_MISSING_CANONICAL_DECISION_HASH",
+          "HANDOFF_MISSING_DECISION_TIMESTAMP",
+          "HANDOFF_TRUSTLOG_UNVERIFIED",
+          "HANDOFF_REPLAY_UNVERIFIED",
+          "HANDOFF_REQUEST_LINEAGE_MISMATCH",
+          "HANDOFF_CANDIDATE_HASH_MISMATCH",
+          "HANDOFF_LINEAGE_NON_PROMOTABLE",
+          "HANDOFF_TARGET_UNSPECIFIED",
+          "HANDOFF_ACTION_UNSPECIFIED",
+          "HANDOFF_ACTOR_UNSPECIFIED",
+          "HANDOFF_AUTHORITY_REQUIREMENT_UNRESOLVED",
+          "HANDOFF_AUTHORITY_EVIDENCE_MISSING",
+          "HANDOFF_AUTHORITY_EVIDENCE_INVALID",
+          "HANDOFF_AUTHORITY_EVIDENCE_EXPIRED",
+          "HANDOFF_APPROVAL_REQUIREMENT_UNRESOLVED",
+          "HANDOFF_APPROVAL_EVIDENCE_MISSING",
+          "HANDOFF_APPROVAL_EVIDENCE_INVALID",
+          "HANDOFF_APPROVAL_EVIDENCE_EXPIRED",
+          "HANDOFF_POLICY_LINEAGE_MISSING",
+          "HANDOFF_POLICY_LINEAGE_STALE",
+          "HANDOFF_EXPECTED_STATE_MISSING",
+          "HANDOFF_EXPECTED_STATE_STALE",
+          "HANDOFF_AMBIGUOUS_ACTION",
+          "HANDOFF_SOURCE_ARTIFACT_MISMATCH"
+        ]
+      }
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "expires_at": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "date-time"
+    },
+    "non_claims": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  },
+  "$defs": {
+    "provenanceRecord": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "field_path",
+        "provenance_class",
+        "source_artifact_type",
+        "source_artifact_ref",
+        "verification_status",
+        "verification_mechanism"
+      ],
+      "properties": {
+        "field_path": {
+          "type": "string"
+        },
+        "value": {},
+        "provenance_class": {
+          "enum": [
+            "VERIFIED_RUNTIME_EVIDENCE",
+            "VERIFIED_POLICY_ARTIFACT",
+            "VERIFIED_AUTHORITY_EVIDENCE",
+            "VERIFIED_HUMAN_APPROVAL",
+            "VERIFIED_LIVE_STATE",
+            "EXPLICIT_STRUCTURED_INPUT",
+            "UNVERIFIED_STRUCTURED_INPUT",
+            "DERIVED_CANONICALLY",
+            "UNAVAILABLE"
+          ]
+        },
+        "source_artifact_type": {
+          "type": "string"
+        },
+        "source_artifact_ref": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "source_hash": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "verification_status": {
+          "enum": [
+            "VERIFIED",
+            "UNVERIFIED",
+            "UNAVAILABLE"
+          ]
+        },
+        "verification_mechanism": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "observed_at": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "issued_at": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "expires_at": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "freshness": {
+          "type": [
+            "object",
+            "null"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tests/spec/test_decision_to_bind_handoff_spec.py
+++ b/tests/spec/test_decision_to_bind_handoff_spec.py
@@ -1,0 +1,107 @@
+"""Coherence tests for the specification-only Decision-to-Bind contract."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+
+SCHEMA_PATH = Path("schemas/decision-to-bind-handoff-v1.schema.json")
+VECTOR_DIR = Path(
+    "docs/en/architecture/test-vectors/decision-to-bind-handoff-v1"
+)
+ALLOWED_STATUSES = {
+    "INCOMPLETE",
+    "REVIEW_REQUIRED",
+    "INVALID",
+    "STRUCTURALLY_REFUSED",
+    "READY_FOR_GUARDED_PROMOTION",
+}
+
+
+def _load_json(path: Path) -> dict[str, object]:
+    """Load one repository-owned JSON specification artifact."""
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _vectors() -> list[dict[str, object]]:
+    """Return deterministic vectors in their filename order."""
+    return [_load_json(path) for path in sorted(VECTOR_DIR.glob("vector-*.json"))]
+
+
+def test_schema_and_all_26_vector_inputs_are_valid() -> None:
+    """Validate the schema itself and every synthetic handoff input."""
+    schema = _load_json(SCHEMA_PATH)
+    Draft202012Validator.check_schema(schema)
+    validator = Draft202012Validator(schema)
+    vectors = _vectors()
+
+    assert len(vectors) == 26
+    for vector in vectors:
+        validator.validate(vector["input"])
+
+
+def test_vector_metadata_is_unique_safe_and_specification_only() -> None:
+    """Ensure fixture metadata cannot imply execution or an external effect."""
+    vectors = _vectors()
+    vector_ids = [vector["vector_id"] for vector in vectors]
+
+    assert len(vector_ids) == len(set(vector_ids))
+    for vector in vectors:
+        expected_status = vector["expected_handoff_status"]
+        assert expected_status in ALLOWED_STATUSES
+        assert vector["input"]["handoff_status"] == expected_status
+        assert vector["input"]["refusal_reason_codes"] == vector[
+            "expected_reason_codes"
+        ]
+        assert vector["execution_intent_created"] is False
+        assert vector["bind_invoked"] is False
+        assert vector["external_effect"] is False
+        assert vector["synthetic_fixture"] is True
+        if expected_status != "READY_FOR_GUARDED_PROMOTION":
+            assert vector["expected_reason_codes"]
+
+
+def test_positive_and_structural_refusal_semantics_are_explicit() -> None:
+    """Protect READY meaning and the non-promotable lineage invariant."""
+    by_id = {vector["vector_id"]: vector for vector in _vectors()}
+
+    assert (
+        by_id["DTBH-V1-01"]["expected_handoff_status"]
+        == "READY_FOR_GUARDED_PROMOTION"
+    )
+    assert by_id["DTBH-V1-01"]["expected_reason_codes"] == []
+    for vector_id in ("DTBH-V1-19", "DTBH-V1-20"):
+        assert by_id[vector_id]["expected_handoff_status"] == "STRUCTURALLY_REFUSED"
+        assert "HANDOFF_LINEAGE_NON_PROMOTABLE" in by_id[vector_id][
+            "expected_reason_codes"
+        ]
+
+
+def test_forbidden_inference_and_binding_vectors_fail_closed() -> None:
+    """Pin representative semantic-laundering and substitution refusals."""
+    by_id = {vector["vector_id"]: vector for vector in _vectors()}
+
+    for vector_id in ("DTBH-V1-09", "DTBH-V1-10", "DTBH-V1-13"):
+        assert by_id[vector_id]["expected_handoff_status"] == "INVALID"
+    for vector_id in ("DTBH-V1-21", "DTBH-V1-23"):
+        assert by_id[vector_id]["expected_handoff_status"] == "INVALID"
+        assert "HANDOFF_AUTHORITY_EVIDENCE_MISSING" in by_id[vector_id][
+            "expected_reason_codes"
+        ]
+        assert by_id[vector_id]["forbidden_inference"]
+
+
+def test_schema_statuses_and_reason_codes_cover_vectors() -> None:
+    """Keep documented vector expectations inside the machine contract."""
+    schema = _load_json(SCHEMA_PATH)
+    schema_statuses = set(schema["properties"]["handoff_status"]["enum"])
+    schema_reasons = set(
+        schema["properties"]["refusal_reason_codes"]["items"]["enum"]
+    )
+
+    assert schema_statuses == ALLOWED_STATUSES
+    for vector in _vectors():
+        assert set(vector["expected_reason_codes"]) <= schema_reasons

--- a/tests/spec/test_decision_to_bind_handoff_spec.py
+++ b/tests/spec/test_decision_to_bind_handoff_spec.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import json
+from copy import deepcopy
 from pathlib import Path
 
+import pytest
 from jsonschema import Draft202012Validator
 
 
@@ -19,6 +21,29 @@ ALLOWED_STATUSES = {
     "STRUCTURALLY_REFUSED",
     "READY_FOR_GUARDED_PROMOTION",
 }
+READY_PROVENANCE_PATHS = {
+    "source_decision.request_id",
+    "source_decision.canonical_decision_id",
+    "source_decision.canonical_decision_hash",
+    "source_decision.canonical_decision_ts",
+    "candidate.actor_identity",
+    "candidate.target_system",
+    "candidate.target_resource",
+    "candidate.canonical_action",
+    "candidate_hash",
+    "trustlog_lineage",
+    "replay_lineage",
+    "policy_lineage",
+    "authority_requirement",
+    "authority_evidence",
+    "human_approval_requirement",
+    "human_approval_evidence",
+    "expected_state",
+}
+DISALLOWED_READY_PROVENANCE_CLASSES = {
+    "UNAVAILABLE",
+    "UNVERIFIED_STRUCTURED_INPUT",
+}
 
 
 def _load_json(path: Path) -> dict[str, object]:
@@ -29,6 +54,25 @@ def _load_json(path: Path) -> dict[str, object]:
 def _vectors() -> list[dict[str, object]]:
     """Return deterministic vectors in their filename order."""
     return [_load_json(path) for path in sorted(VECTOR_DIR.glob("vector-*.json"))]
+
+
+def _assert_ready_provenance(handoff: dict[str, object]) -> None:
+    """Assert the documented READY fixture provenance contract.
+
+    This test-only coherence assertion is deliberately not a production handoff
+    validator. Runtime validation remains future, separately reviewed work.
+    """
+    provenance = handoff["provenance"]
+    by_path = {record["field_path"]: record for record in provenance}
+
+    assert READY_PROVENANCE_PATHS <= set(by_path)
+    for field_path in READY_PROVENANCE_PATHS:
+        record = by_path[field_path]
+        assert record["verification_status"] == "VERIFIED"
+        assert (
+            record["provenance_class"]
+            not in DISALLOWED_READY_PROVENANCE_CLASSES
+        )
 
 
 def test_schema_and_all_26_vector_inputs_are_valid() -> None:
@@ -64,6 +108,54 @@ def test_vector_metadata_is_unique_safe_and_specification_only() -> None:
             assert vector["expected_reason_codes"]
 
 
+def test_every_provenance_record_has_value_and_unique_field_path() -> None:
+    """Require explicit values and unambiguous coverage in every fixture."""
+    for vector in _vectors():
+        provenance = vector["input"]["provenance"]
+        field_paths = [record["field_path"] for record in provenance]
+
+        assert len(field_paths) == len(set(field_paths))
+        assert all("value" in record for record in provenance)
+
+
+def test_ready_fixture_has_complete_verified_provenance() -> None:
+    """Pin complete, verified provenance for the sole synthetic READY case."""
+    by_id = {vector["vector_id"]: vector for vector in _vectors()}
+    ready_handoff = by_id["DTBH-V1-01"]["input"]
+
+    assert len(ready_handoff["provenance"]) == len(READY_PROVENANCE_PATHS)
+    _assert_ready_provenance(ready_handoff)
+
+
+def test_removing_any_ready_path_fails_the_coherence_assertion() -> None:
+    """Prove that no mandatory READY provenance path is optional."""
+    by_id = {vector["vector_id"]: vector for vector in _vectors()}
+    ready_handoff = by_id["DTBH-V1-01"]["input"]
+
+    for removed_path in READY_PROVENANCE_PATHS:
+        incomplete = deepcopy(ready_handoff)
+        incomplete["provenance"] = [
+            record
+            for record in incomplete["provenance"]
+            if record["field_path"] != removed_path
+        ]
+        with pytest.raises(AssertionError):
+            _assert_ready_provenance(incomplete)
+
+
+def test_only_ready_vector_satisfies_ready_provenance_contract() -> None:
+    """Prevent non-READY fixtures from accidentally representing readiness."""
+    for vector in _vectors():
+        paths = {
+            record["field_path"]
+            for record in vector["input"]["provenance"]
+        }
+        if vector["expected_handoff_status"] == "READY_FOR_GUARDED_PROMOTION":
+            assert READY_PROVENANCE_PATHS <= paths
+        else:
+            assert not READY_PROVENANCE_PATHS <= paths
+
+
 def test_positive_and_structural_refusal_semantics_are_explicit() -> None:
     """Protect READY meaning and the non-promotable lineage invariant."""
     by_id = {vector["vector_id"]: vector for vector in _vectors()}
@@ -78,6 +170,7 @@ def test_positive_and_structural_refusal_semantics_are_explicit() -> None:
         assert "HANDOFF_LINEAGE_NON_PROMOTABLE" in by_id[vector_id][
             "expected_reason_codes"
         ]
+    assert by_id["DTBH-V1-20"]["input"]["authority_evidence"] is not None
 
 
 def test_forbidden_inference_and_binding_vectors_fail_closed() -> None:


### PR DESCRIPTION
### Motivation

- Define a canonical, reviewable, provenance-first specification for a future safe handoff between decision-side evidence and pre-Bind formation without implementing any runtime bridge. 
- Establish explicit fail-closed invariants, a provenance vocabulary, a source-of-truth matrix, and forbidden inference rules so that no execution-sensitive field can be fabricated from natural language or unaudited artifacts. 
- Provide machine-readable artifacts and deterministic test vectors to make the contract auditable and testable in CI before any future implementation work.

### Description

- Add a specification document `docs/en/architecture/canonical-decision-to-bind-handoff-v1.md` that defines the `CanonicalDecisionHandoff` concept, the v1 state machine (`INCOMPLETE`, `REVIEW_REQUIRED`, `INVALID`, `STRUCTURALLY_REFUSED`, `READY_FOR_GUARDED_PROMOTION`), the provenance vocabulary, forbidden-inference rules, source-of-truth matrix, mandatory bindings for authority/approval/state, and explicit non-claims. 
- Add a focused threat model `docs/en/security/decision-to-bind-handoff-threat-model.md` enumerating semantic laundering, action inference, confused deputy, authority/approval replay/staleness, target substitution, TOCTOU, policy drift, lineage substitution, and related risks. 
- Add a machine-readable JSON Schema `schemas/decision-to-bind-handoff-v1.schema.json` for the structural contract (Draft 2020-12) that describes required properties, provenance record shape, allowed handoff statuses, and canonical refusal reason codes. 
- Add 26 deterministic synthetic test vectors under `docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/` covering the positive READY vector and the refusal/missing/stale/mismatch cases described in the spec (each vector declares `execution_intent_created:false`, `bind_invoked:false`, `external_effect:false`). 
- Add coherence tests `tests/spec/test_decision_to_bind_handoff_spec.py` that validate schema parseability, vector parsing, vector uniqueness, allowed statuses, and expected reason-code coverage. 
- Add a single discoverability link to the new spec in `docs/en/architecture/llm-to-control-plane-contract.md` without altering runtime semantics. 
- Preserve all runtime boundaries and production behavior: no `/v1/decide` changes, no `ExecutionIntent` creation, no Bind invocation, no TrustLog writes, and no live authority or approval validation are introduced by this PR.

### Testing

- Ran `ruff` on the new spec test module (`ruff check tests/spec/test_decision_to_bind_handoff_spec.py`) and it passed locally. 
- Verified `python -m py_compile tests/spec/test_decision_to_bind_handoff_spec.py` succeeded to ensure syntactic validity. 
- Ran `git diff --check` (workspace hygiene) and the repository checks passed for the new files. 
- Attempted focused `pytest` runs that include the new spec tests and relevant existing pre-bind tests, but the environment could not install required runtime packages (network/PyPI access blocked), causing dependency-related collection errors (e.g., `jsonschema`, `pydantic` not importable); the spec tests are written to be validated under CI where dependencies (including `jsonschema`) are available. 

All produced artifacts are specification-only and include explicit non-claims; no production runtime files were modified. Please run CI (which has network and dependency access) to execute the JSON Schema validation and the full pytest suite; the new spec tests are intended to run in CI and validate schema+vectors rather than implement runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7f44ff6570832693bd511d285da89e)