### PR TITLE
Clarify handoff semantics and candidate-hash binding; update vectors and tests for non-authoritative signals

### DIFF
--- a/docs/en/architecture/canonical-decision-to-bind-handoff-v1.md
+++ b/docs/en/architecture/canonical-decision-to-bind-handoff-v1.md
@@ -38,6 +38,23 @@ flowchart TD
 ready, even if authority or approval is later attached. Formation refusal is
 not Bind `BLOCKED`.
 
+The status classification is normative. `INCOMPLETE` means a required
+canonical value or evidence is absent or unresolved and no supplied substitute
+is positively invalid. `REVIEW_REQUIRED` means human or policy review is
+explicitly required before readiness can be established. `INVALID` is reserved
+for supplied material that is positively malformed, mismatched, stale,
+expired, substituted, contradictory, or otherwise invalid.
+`STRUCTURALLY_REFUSED` means formation lineage is non-promotable and cannot be
+repaired by attaching later evidence. `READY_FOR_GUARDED_PROMOTION` requires
+all v1 prerequisites and trusted verification conditions.
+
+The mere presence of `ALLOW`, `APPROVE`, an authenticated identity, or similar
+non-authoritative metadata does not make a handoff `INVALID`. Those values MUST
+NOT satisfy authority, approval, action, target, policy, or state requirements.
+Consequently, missing required Authority Evidence is `INCOMPLETE`, while
+missing explicitly required Human Approval is `REVIEW_REQUIRED`. In both cases
+the handoff stops and is never ready.
+
 ## Provenance and field envelope
 
 Every security-relevant value uses a provenance record containing `value`,
@@ -115,6 +132,15 @@ typed, explicit, canonicalized, and bound to its target. Existing action
 contract IDs/versions should be referenced where applicable; prose from
 `chosen`, `next_action`, rationale, or completion text is never authoritative.
 
+The vector-level `forbidden_inference` field is test and documentation metadata,
+not part of the `CanonicalDecisionHandoff` runtime input. A runtime validator
+MUST NOT branch on it. Such a vector demonstrates that a tempting
+non-authoritative source exists but does not satisfy a required trusted field;
+it does not necessarily assert that the runtime artifact records an attempted
+inference. Representing an actual semantic-laundering attempt would require a
+separately specified typed artifact or provenance mechanism in a future
+version.
+
 ## Requirements, evidence, and validation
 
 `authority_requirement` states what authority is required. It does not show
@@ -190,6 +216,39 @@ hashing invalidates eligibility. `expected_state_fingerprint` is a trusted
 formation-time observation, never model output; Bind-time live state is a
 separate observation used to detect drift. Missing/stale required state fails
 closed.
+
+### Candidate-hash verification boundary
+
+The v1 `candidate_hash` is an opaque hash or reference value. This specification
+does not define a canonical production algorithm for hashing the handoff's
+candidate shape, which includes `candidate.canonical_action`. The existing
+`hash_decision_candidate(...)` function applies to the existing runtime
+`DecisionCandidate` schema and MUST NOT be reused unless a future contract
+explicitly establishes schema and hash-profile compatibility. In particular, a
+future validator MUST NOT assume that `SHA256(candidate JSON)` is the canonical
+candidate-hash contract.
+
+READY requires a trusted upstream verifier to assert that the supplied
+`candidate_hash` binds the exact supplied candidate under the verifier's
+declared hash/profile contract. A future trusted validation context will express
+this with a typed `CandidateHashBindingAssertion` containing at least:
+
+* `candidate_value_digest`;
+* `asserted_candidate_hash`;
+* `source_artifact_ref`;
+* `source_hash`;
+* `verification_mechanism`; and
+* the fixed semantic claim `CANDIDATE_HASH_BINDS_CANDIDATE`.
+
+An **assertion-value digest** is distinct from a domain or artifact hash. It is
+a deterministic local digest used only to bind a trusted assertion to the exact
+current JSON value, so an assertion about value A cannot be reused after a
+change to value B. It is not `candidate_hash`, `decision_hash`, Authority
+Evidence hash, or approval receipt hash, and MUST NOT redefine any of them.
+Those domain hashes remain governed by their producer/verifier contracts. A
+future validator may recompute the assertion-value digest to detect candidate
+substitution, but MUST NOT claim that doing so independently recomputes the
+canonical candidate hash.
 
 ## Formation invariant and reason codes
 

--- a/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-21.json
+++ b/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-21.json
@@ -4,7 +4,7 @@
   "input": {
     "format_version": "canonical-decision-handoff/v1",
     "handoff_id": "handoff-fixture-21",
-    "handoff_status": "INVALID",
+    "handoff_status": "INCOMPLETE",
     "source_decision": {
       "request_id": "req-fixture-001",
       "canonical_decision_id": "decision-fixture-001",
@@ -122,7 +122,7 @@
       "no external effect"
     ]
   },
-  "expected_handoff_status": "INVALID",
+  "expected_handoff_status": "INCOMPLETE",
   "expected_reason_codes": [
     "HANDOFF_AUTHORITY_EVIDENCE_MISSING"
   ],

--- a/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-23.json
+++ b/docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-23.json
@@ -4,7 +4,7 @@
   "input": {
     "format_version": "canonical-decision-handoff/v1",
     "handoff_id": "handoff-fixture-23",
-    "handoff_status": "INVALID",
+    "handoff_status": "INCOMPLETE",
     "source_decision": {
       "request_id": "req-fixture-001",
       "canonical_decision_id": "decision-fixture-001",
@@ -123,7 +123,7 @@
       "no external effect"
     ]
   },
-  "expected_handoff_status": "INVALID",
+  "expected_handoff_status": "INCOMPLETE",
   "expected_reason_codes": [
     "HANDOFF_AUTHORITY_EVIDENCE_MISSING"
   ],

--- a/docs/en/security/decision-to-bind-handoff-threat-model.md
+++ b/docs/en/security/decision-to-bind-handoff-threat-model.md
@@ -13,7 +13,7 @@ external effect.
 
 | Threat | Example | Required control |
 |---|---|---|
-| Semantic laundering | `ALLOW` or `APPROVE` becomes authority | Separate requirement, evidence, and validation; prose/status is untrusted. |
+| Semantic laundering | `ALLOW` is accepted as authority, `APPROVE` as Human Approval, or authenticated identity as execution authority | Ignore non-authoritative sources when satisfying security requirements; separately validate requirement, evidence, and binding. Mere source-signal presence is not itself invalid. |
 | Action inference | `next_action` becomes executable | Require typed canonical action from explicit structured input. |
 | Confused deputy | Authenticated caller requests an out-of-scope effect | Verify exact actor/action/target/policy-scope authority. |
 | Identity/authority conflation | API identity is treated as authorization | Bind independent Authority Evidence. |
@@ -41,6 +41,13 @@ allow. `REVIEW_REQUIRED` is a stop, not permission. Structural refusal occurs
 before Bind and cannot be healed by attaching evidence. Bind remains a separate
 adjudication boundary and must revalidate live state and time-sensitive
 evidence.
+
+Semantic laundering occurs when a non-authoritative signal is accepted as
+satisfying a security requirement. The defensive behavior is to ignore or
+reject that source for that purpose. Its mere presence in a source decision
+does not prove that an inference was attempted and does not automatically make
+the whole handoff `INVALID`: the independently required field remains missing
+and receives its normal fail-closed status.
 
 **Security warning:** this document defines controls but implements none. Until
 a separately reviewed future implementation establishes canonical decision

--- a/tests/spec/test_decision_to_bind_handoff_spec.py
+++ b/tests/spec/test_decision_to_bind_handoff_spec.py
@@ -180,11 +180,63 @@ def test_forbidden_inference_and_binding_vectors_fail_closed() -> None:
     for vector_id in ("DTBH-V1-09", "DTBH-V1-10", "DTBH-V1-13"):
         assert by_id[vector_id]["expected_handoff_status"] == "INVALID"
     for vector_id in ("DTBH-V1-21", "DTBH-V1-23"):
-        assert by_id[vector_id]["expected_handoff_status"] == "INVALID"
-        assert "HANDOFF_AUTHORITY_EVIDENCE_MISSING" in by_id[vector_id][
-            "expected_reason_codes"
+        assert by_id[vector_id]["expected_handoff_status"] == "INCOMPLETE"
+        assert by_id[vector_id]["expected_reason_codes"] == [
+            "HANDOFF_AUTHORITY_EVIDENCE_MISSING"
         ]
         assert by_id[vector_id]["forbidden_inference"]
+
+
+def test_missing_authority_vectors_have_equivalent_runtime_inputs() -> None:
+    """Prove untrusted declarations cannot distinguish vectors 08 and 21."""
+    by_id = {vector["vector_id"]: vector for vector in _vectors()}
+    ignored_fields = {
+        "handoff_id",
+        "handoff_status",
+        "refusal_reason_codes",
+    }
+
+    def substantive_input(vector_id: str) -> dict[str, object]:
+        handoff = by_id[vector_id]["input"]
+        return {
+            key: value
+            for key, value in handoff.items()
+            if key not in ignored_fields
+        }
+
+    vector_08 = by_id["DTBH-V1-08"]
+    vector_21 = by_id["DTBH-V1-21"]
+    assert substantive_input("DTBH-V1-08") == substantive_input("DTBH-V1-21")
+    assert vector_08["expected_handoff_status"] == "INCOMPLETE"
+    assert vector_21["expected_handoff_status"] == "INCOMPLETE"
+    assert vector_08["expected_reason_codes"] == vector_21[
+        "expected_reason_codes"
+    ] == ["HANDOFF_AUTHORITY_EVIDENCE_MISSING"]
+
+
+def test_non_authoritative_signals_do_not_satisfy_required_evidence() -> None:
+    """Pin missing-evidence outcomes independently of tempting source signals."""
+    by_id = {vector["vector_id"]: vector for vector in _vectors()}
+    identity_vector = by_id["DTBH-V1-23"]
+    approval_vector = by_id["DTBH-V1-22"]
+
+    assert identity_vector["input"]["source_decision"][
+        "authenticated_api_user"
+    ]
+    assert identity_vector["input"]["authority_evidence"] is None
+    assert identity_vector["expected_handoff_status"] == "INCOMPLETE"
+    assert identity_vector["expected_reason_codes"] == [
+        "HANDOFF_AUTHORITY_EVIDENCE_MISSING"
+    ]
+
+    assert approval_vector["input"]["source_decision"][
+        "business_decision"
+    ] == "APPROVE"
+    assert approval_vector["input"]["human_approval_evidence"] is None
+    assert approval_vector["expected_handoff_status"] == "REVIEW_REQUIRED"
+    assert approval_vector["expected_reason_codes"] == [
+        "HANDOFF_APPROVAL_EVIDENCE_MISSING"
+    ]
 
 
 def test_schema_statuses_and_reason_codes_cover_vectors() -> None:


### PR DESCRIPTION
### Motivation

- Make the `CanonicalDecisionHandoff` semantics explicit around status meanings, forbidden inference, and how non-authoritative signals are treated so runtimes fail-closed on missing evidence. 
- Define the candidate-hash verification boundary and assert that existing hash helpers or naive `SHA256(candidate JSON)` must not be assumed as the canonical contract.

### Description

- Expanded documentation in `docs/en/architecture/canonical-decision-to-bind-handoff-v1.md` to clarify `INCOMPLETE`, `REVIEW_REQUIRED`, `INVALID`, `STRUCTURALLY_REFUSED`, `READY_FOR_GUARDED_PROMOTION`, the role of `forbidden_inference` metadata, and the `candidate_hash`/assertion-value digest semantics. 
- Strengthened the threat model in `docs/en/security/decision-to-bind-handoff-threat-model.md` to describe semantic laundering and to prescribe ignoring non-authoritative sources for satisfying security requirements. 
- Updated test vector fixtures `vector-21.json` and `vector-23.json` to expect `handoff_status` = `INCOMPLETE` (instead of `INVALID`) and to keep `HANDOFF_AUTHORITY_EVIDENCE_MISSING` as the reason. 
- Modified `tests/spec/test_decision_to_bind_handoff_spec.py` to align expectations with the clarified semantics, and added two new tests: `test_missing_authority_vectors_have_equivalent_runtime_inputs` and `test_non_authoritative_signals_do_not_satisfy_required_evidence` to ensure non-authoritative declarations do not change runtime outcomes.

### Testing

- Ran the decision-to-bind handoff spec tests via `pytest tests/spec/test_decision_to_bind_handoff_spec.py` and the updated test suite passed. 
- New unit tests `test_missing_authority_vectors_have_equivalent_runtime_inputs` and `test_non_authoritative_signals_do_not_satisfy_required_evidence` executed and succeeded. 
- Test vector expectations were validated against the schema as part of the spec tests and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7f5432c54c832699ad444d62c12083)