### PR TITLE
docs(spec): define Canonical Decision Artifact v1

### DIFF
--- a/docs/en/architecture/canonical-decision-artifact-v1.md
+++ b/docs/en/architecture/canonical-decision-artifact-v1.md
@@ -112,8 +112,12 @@ The v1 vocabularies mirror normalized `DecideResponse`: `decision_status` is
 `APPROVE`, `DENY`, `HOLD`, `REVIEW_REQUIRED`,
 `POLICY_DEFINITION_REQUIRED`, or `EVIDENCE_REQUIRED`; and
 `actionability_status` is `reviewable_only`,
-`bind_required_before_execution`, `actionable_after_bind`, `blocked`,
-`human_review_required`, or `formation_transition_refused`. Compatibility
+`bind_required_before_execution`, `blocked`, `human_review_required`, or
+`formation_transition_refused`. This is deliberately the strict pre-Bind
+subset of the wider `DecideResponse` vocabulary. Runtime
+`actionable_after_bind` requires a committed Bind outcome plus both Bind receipt
+and execution-intent lineage, so the pre-Bind CDA producer refuses rather than
+represents that state. Compatibility
 aliases (`allow`, `deny`, `modify`, `rejected`, `abstain`) are never artifact
 gate values. Although `unknown` remains a compatibility/default input to the
 current response model, v1 refuses canonical production from that unresolved
@@ -127,6 +131,16 @@ boolean to be true; and `(block, APPROVE)`, `(hold, APPROVE)`, and
 including these conditions, before hash verification. The existing
 `DecideResponse` remains the source of truth; this specification does not
 create a divergent runtime semantics system.
+
+The two bound actionability fields also preserve the pre-Bind execution
+boundary. `reviewable_only`, `bind_required_before_execution`, and
+`human_review_required` require `requires_bind_before_execution=true`;
+`blocked` and `formation_transition_refused` require it to be false. An
+`actionability_status` of `human_review_required` requires the review boolean
+to be true, but the reverse is intentionally not global because a more
+restrictive status may retain that signal. The stable structural-refusal
+runtime additionally requires `formation_transition_refused` to retain
+`human_review_required=true`.
 
 ### Opaque-value bindings
 

--- a/docs/en/architecture/canonical-decision-artifact-v1.md
+++ b/docs/en/architecture/canonical-decision-artifact-v1.md
@@ -53,12 +53,14 @@ artifact. A future boundary may normalize an aware offset input to UTC before
 artifact construction; naive and invalid inputs are refused.
 
 The producer MUST consume a pre-Bind snapshot. It MUST refuse production if
-any populated Bind lineage/result field is present, including `bind_outcome`,
-`bind_receipt_id`, `execution_intent_id`, `bound_execution_intent_id`,
+any post-Bind field has a JSON value other than `null`. The complete v1 set is
+`bind_outcome`, `bind_failure_reason`, `bind_reason_code`, `bind_receipt_id`,
+`execution_intent_id`, `bound_execution_intent_id`,
 `authority_check_result`, `constraint_check_result`, `drift_check_result`,
-`risk_check_result`, or `bind_summary`. It MUST NOT silently strip those values
-to reconstruct a decision post hoc. Later Bind augmentation cannot alter an
-already emitted artifact.
+`risk_check_result`, `bind_summary`, `bind_operator_summary`, and
+`bind_operator_detail`. It MUST NOT silently strip those values to reconstruct
+a decision post hoc. `BLOCKED` and `ROLLED_BACK` results are still post-Bind.
+Later Bind augmentation cannot alter an already emitted artifact.
 
 ## Exact artifact and projection
 
@@ -93,12 +95,38 @@ The `decision` projection includes exactly:
    present, without widening their schemas or repairing structural refusal.
 
 All keys are mandatory; genuine absence is represented by the schema-defined
-`null`, never omission. Missing `governance_identity` produces `null` plus
-`formation_status=INCOMPLETE`; it is structurally representable but not a
-complete canonical formation. No policy snapshot, lineage, signer, or
-authority is fabricated. Governance identity alone does not satisfy the
-handoff's full `policy_lineage`. A non-promotable/refused source remains bound
-as such and is never repaired by artifact construction.
+`null`, never omission. `COMPLETE` means only that the normalized source has a
+governance identity object and `governance_identity_binding` is non-null.
+`INCOMPLETE` means it is unavailable and that binding is null. Neither value
+asserts independent cryptographic verification. The schema rejects both
+contradictory combinations. No policy snapshot, lineage, signer, or authority
+is fabricated. Governance identity alone does not satisfy the handoff's full
+`policy_lineage`. A non-promotable/refused source remains bound as such and is
+never repaired by artifact construction.
+
+### Closed decision semantics
+
+The v1 vocabularies mirror normalized `DecideResponse`: `decision_status` is
+`allow`, `modify`, `rejected`, `block`, or `abstain`; `gate_decision` is
+`proceed`, `hold`, `block`, or `human_review_required`; `business_decision` is
+`APPROVE`, `DENY`, `HOLD`, `REVIEW_REQUIRED`,
+`POLICY_DEFINITION_REQUIRED`, or `EVIDENCE_REQUIRED`; and
+`actionability_status` is `reviewable_only`,
+`bind_required_before_execution`, `actionable_after_bind`, `blocked`,
+`human_review_required`, or `formation_transition_refused`. Compatibility
+aliases (`allow`, `deny`, `modify`, `rejected`, `abstain`) are never artifact
+gate values. Although `unknown` remains a compatibility/default input to the
+current response model, v1 refuses canonical production from that unresolved
+gate state rather than representing it.
+
+Schema semantic conditions mirror the source contract: `proceed` and
+`APPROVE` each require `human_review_required=false`; `REVIEW_REQUIRED` and
+`human_review_required` gate are bidirectionally coupled and require the
+boolean to be true; and `(block, APPROVE)`, `(hold, APPROVE)`, and
+`(proceed, DENY)` are forbidden. A future verifier MUST run schema validation,
+including these conditions, before hash verification. The existing
+`DecideResponse` remains the source of truth; this specification does not
+create a divergent runtime semantics system.
 
 ### Opaque-value bindings
 
@@ -174,7 +202,7 @@ decision is a new event; a future, separate contract may link supersession.
 
 The following normalized response values do not define v1 identity:
 
-* `ok`, `error`, `version`, response latency/meta, temporary paths, UI or
+* `ok`, `error`, `version`, response latency/`meta`, temporary paths, UI or
   reviewer summaries, `persona`, `memory_citations`, `memory_used_count`,
   `plan`, `planner`, `reason`, `critique`, `debate`, `values`, `evidence`,
   `telos_score`, `fuji`, `rsi_note`, `extras`, `gate`, `evo`, disclosure and
@@ -183,7 +211,7 @@ The following normalized response values do not define v1 identity:
 * `alternatives` and mirrored `options`: unselected compatibility surfaces
   whose generated/default alternative IDs are not stable decision identity;
   only the selected value is bound once;
-* `query`, `pipeline_steps`, raw TrustLog copies, and
+* `query`, `pipeline_steps`, `trust_log`, `user_summary`, and
   `deterministic_replay`: request/audit/replay material independently verified
   later, not canonical decision state;
 * participation, pre-Bind detection/preservation details, recovery guidance,
@@ -199,6 +227,12 @@ The following normalized response values do not define v1 identity:
 Changing an excluded response field does not change canonical identity;
 changing an included value does. There is no undocumented source-field
 fallback.
+
+Vectors marked `EMIT` are producer-eligible normalized source fixtures.
+`HASH_REFERENCE_ONLY` vectors intentionally isolate hash sensitivity and make
+no claim that the isolated tuple is reachable through coupled runtime
+semantics. `REFUSE` vectors document producer refusal. The golden and excluded
+field stability vectors are `EMIT`; mutation vectors are hash-reference-only.
 
 ## Verification and independent domains
 

--- a/docs/en/architecture/canonical-decision-artifact-v1.md
+++ b/docs/en/architecture/canonical-decision-artifact-v1.md
@@ -1,0 +1,252 @@
+# Canonical Decision Artifact v1
+
+## Status, purpose, and boundary
+
+This specification defines the **future**, immutable
+`CanonicalDecisionArtifact` representation of one finalized, normalized
+VERITAS decision event. It supplies a stable `decision_id`, `decision_hash`,
+and `decision_ts` for the decision side. The current `/v1/decide` response has
+`request_id`, but does **not** emit any of those three authoritative canonical
+values. This milestone adds only a schema, synthetic vectors, documentation,
+and test-only coherence logic; it adds no producer, verifier, or consumer.
+
+The processing boundary is exactly:
+
+```text
+normalized pre-Bind DecideResponse snapshot
+  -> canonical decision projection
+  -> versioned, domain-separated canonical serialization
+  -> decision_hash -> decision_id -> CanonicalDecisionArtifact -> STOP
+```
+
+The artifact is not a `DecisionCandidate`, `CanonicalDecisionHandoff`,
+`ExecutionIntent`, Authority Evidence, Human Approval, `BindReceipt`, execution
+instruction, or permission. In particular:
+
+* `request_id != decision_id`; a request identifier is not decision identity.
+* response hash != decision hash.
+* HTTP arrival time, TrustLog retrieval time, CI time, and current wall clock
+  != the canonical historical `decision_ts`.
+* `ALLOW != authority`; `APPROVE != Human Approval Receipt`.
+* authenticated identity != execution authority.
+* `chosen != canonical executable action`; `next_action != intended_action`.
+* `READY_FOR_GUARDED_PROMOTION != execution`.
+
+These separations are security boundaries. Human approval is required before a
+future runtime implementation may change governance or Bind behavior.
+
+## Source and finalization contract
+
+The source contract is `DecideResponse` after its ordinary Pydantic validation
+and normalization, identified independently by
+`canonical-decision-projection/v1`. Raw provider output, a raw request, HTTP
+response bytes, normalized `DecideResponse`, and the canonical projection are
+five different values. Only the declared projection of the normalized response
+is hashed; `SHA256(response.json())` is prohibited.
+
+`decision_ts` is captured at the future decision-finalization boundary: the
+instant the normalized pre-Bind decision state becomes final. It MUST be passed
+to the future producer at that boundary and MUST NOT be inferred or backfilled.
+V1 requires exactly `YYYY-MM-DDTHH:MM:SS.ffffffZ`: UTC `Z`, exactly six
+fractional digits, and no offset or naive representation in the emitted
+artifact. A future boundary may normalize an aware offset input to UTC before
+artifact construction; naive and invalid inputs are refused.
+
+The producer MUST consume a pre-Bind snapshot. It MUST refuse production if
+any populated Bind lineage/result field is present, including `bind_outcome`,
+`bind_receipt_id`, `execution_intent_id`, `bound_execution_intent_id`,
+`authority_check_result`, `constraint_check_result`, `drift_check_result`,
+`risk_check_result`, or `bind_summary`. It MUST NOT silently strip those values
+to reconstruct a decision post hoc. Later Bind augmentation cannot alter an
+already emitted artifact.
+
+## Exact artifact and projection
+
+The closed JSON Schema is
+[`schemas/canonical-decision-artifact-v1.schema.json`](../../../schemas/canonical-decision-artifact-v1.schema.json).
+The top-level fields are exactly `format_version`, `hash_profile`,
+`decision_id`, `decision_hash`, `decision_ts`, `request_id`, `source_contract`,
+and `decision`. `source_contract` is exactly `{type: "DecideResponse",
+projection_version: "canonical-decision-projection/v1"}`.
+
+The `decision` projection includes exactly:
+
+1. `formation_status`: exposes incomplete formation rather than inventing
+   missing governance identity;
+2. `chosen_binding`: binds the selected normalized value without granting it
+   action semantics;
+3. `decision_status` and `rejection_reason`: bind the overall disposition;
+4. `gate_decision` and `business_decision`: bind the distinct safety and
+   business conclusions without laundering either into authority;
+5. `next_action`, `actionability_status`, and
+   `requires_bind_before_execution`: bind recorded decision-side guidance and
+   its execution boundary without forming an action;
+6. `human_review_required`: binds the recorded requirement signal, not proof
+   that review occurred or that approval is unnecessary;
+7. `required_evidence`, `missing_evidence`, and `satisfied_evidence`: bind the
+   ordered, normalized recorded evidence state, not evidence authenticity;
+8. `rationale`, `refusal_reason`, `actionability_block_reason`, and
+   `actionability_refusal_type`: bind decision/refusal meaning relevant to an
+   audit; and
+9. `governance_identity_binding`, `lineage_promotability_binding`, and
+   `transition_refusal_binding`: bind the exact normalized objects, when
+   present, without widening their schemas or repairing structural refusal.
+
+All keys are mandatory; genuine absence is represented by the schema-defined
+`null`, never omission. Missing `governance_identity` produces `null` plus
+`formation_status=INCOMPLETE`; it is structurally representable but not a
+complete canonical formation. No policy snapshot, lineage, signer, or
+authority is fabricated. Governance identity alone does not satisfy the
+handoff's full `policy_lineage`. A non-promotable/refused source remains bound
+as such and is never repaired by artifact construction.
+
+### Opaque-value bindings
+
+Because current `chosen`, `governance_identity`, `lineage_promotability`, and
+`transition_refusal` sources are extensible objects, v1 places each behind a
+closed digest boundary. For a binding, canonical-serialize the exact normalized
+JSON-safe value using the rules below, then hash the UTF-8 bytes of this object:
+
+```json
+{"profile":"<binding profile>","value":<normalized value>}
+```
+
+The profiles are, respectively:
+
+* `veritas.canonical-decision.chosen-value/v1`;
+* `veritas.canonical-decision.governance-identity/v1`;
+* `veritas.canonical-decision.lineage-promotability/v1`; and
+* `veritas.canonical-decision.transition-refusal/v1`.
+
+The binding records that profile and the lowercase SHA-256 digest. Chosen
+digest != candidate hash != executable action authorization. Governance and
+formation digests bind exact recorded values; they do not attest their truth.
+
+## Hash profile, serialization, and preimage
+
+`hash_profile` is fixed to `veritas.canonical-decision/v1`; the algorithm is
+SHA-256. The exact preimage is the following object, using values copied from
+the artifact:
+
+```json
+{
+  "profile": "veritas.canonical-decision/v1",
+  "format_version": "canonical-decision-artifact/v1",
+  "request_id": "<artifact.request_id>",
+  "decision_ts": "<artifact.decision_ts>",
+  "source_contract": "<artifact.source_contract object>",
+  "decision": "<artifact.decision object>"
+}
+```
+
+Thus the preimage fields are **exactly** `profile`, `format_version`,
+`request_id`, `decision_ts`, `source_contract.type`,
+`source_contract.projection_version`, and every `decision` field enumerated in
+the preceding section. There is no “all except” rule. `hash_profile` declares
+the same procedure but the preimage domain key is named `profile`.
+`decision_hash`, `decision_id`, and every value derived from either are
+excluded, proving that the construction is non-circular.
+
+Canonical JSON here deliberately matches the repository's current
+`canonical_json_dumps`: UTF-8 JSON, Unicode preserved, lexicographically sorted
+map keys, compact separators `,` and `:`, JSON `null`/`true`/`false`, list order
+preserved, and no insignificant whitespace. Inputs MUST contain only JSON
+types; finite JSON numbers only; NaN and Infinity are refused. Python repr,
+sets, tuples, object identity, filesystem data, UUID generation, current time,
+environment variables, Git SHA, and CI identifiers are forbidden. The test
+reference additionally uses `allow_nan=False`; this tightens input rejection
+without changing bytes for the JSON-safe values accepted by the repository
+helper. No generic helper is changed by this specification.
+
+`decision_hash` is the 64-character lowercase SHA-256 hex digest of those
+bytes. The content-addressed identifier uses the full digest:
+
+```text
+decision_id = "cda:v1:sha256:" + decision_hash
+```
+
+Consequently, the same preimage always has the same hash and ID; any included
+field change produces a new decision event, hash, and ID. `request_id` alone
+cannot determine the ID. Once emitted, an artifact is immutable. A reconsidered
+decision is a new event; a future, separate contract may link supersession.
+
+## Explicit exclusions
+
+The following normalized response values do not define v1 identity:
+
+* `ok`, `error`, `version`, response latency/meta, temporary paths, UI or
+  reviewer summaries, `persona`, `memory_citations`, `memory_used_count`,
+  `plan`, `planner`, `reason`, `critique`, `debate`, `values`, `evidence`,
+  `telos_score`, `fuji`, `rsi_note`, `extras`, `gate`, `evo`, disclosure and
+  notification presentation, diagnostics, and coercion metadata: volatile,
+  debug, compatibility, presentation, or separately governed context;
+* `alternatives` and mirrored `options`: unselected compatibility surfaces
+  whose generated/default alternative IDs are not stable decision identity;
+  only the selected value is bound once;
+* `query`, `pipeline_steps`, raw TrustLog copies, and
+  `deterministic_replay`: request/audit/replay material independently verified
+  later, not canonical decision state;
+* participation, pre-Bind detection/preservation details, recovery guidance,
+  WAT diagnostics, and other additive extension fields: diagnostic or
+  separately versioned contexts not selected for the minimal v1 projection;
+* every Bind field listed in the source-boundary section: post-decision state
+  that must never retroactively redefine the decision; and
+* `decision_hash`, `decision_id`, artifact verification status, TrustLog chain
+  state, replay proof, candidate, Authority Evidence, Human Approval,
+  `ExecutionIntent`, `BindReceipt`, adapter, and external-effect state: derived
+  identity or independent security domains.
+
+Changing an excluded response field does not change canonical identity;
+changing an included value does. There is no undocumented source-field
+fallback.
+
+## Verification and independent domains
+
+A future verifier fails closed: (1) validate schema/version; (2) exclude the
+two identity outputs; (3) construct the exact v1 preimage; (4) canonicalize;
+(5) SHA-256; (6) compare `decision_hash`; (7) derive the expected full
+`decision_id`; (8) compare it; and (9) reject any mismatch. The artifact has no
+`verified: true` shortcut.
+
+Canonical decision hash, chosen-value digest, candidate hash, handoff
+assertion-value digest, TrustLog chain hash, replay artifact hash, Authority
+Evidence hash, Human Approval receipt hash, and Bind intent hash are separate
+domains. No digest substitutes for another. TrustLog and replay remain
+independently verified properties matched later to request/decision identity;
+neither is in this preimage, avoiding circularity.
+
+A verified artifact may later map `artifact.request_id` to
+`source_decision.request_id`, `artifact.decision_id` to
+`source_decision.canonical_decision_id`, `artifact.decision_hash` to
+`source_decision.canonical_decision_hash`, and `artifact.decision_ts` to
+`source_decision.canonical_decision_ts`. Copying strings is insufficient:
+handoff provenance must record artifact reference/hash, verification mechanism,
+and successful independent status. The artifact does not create the handoff or
+candidate. It never derives actor, target system/resource, or canonical action
+from chosen, next action, rationale, business result, or API identity. Authority
+Requirement, Authority Evidence, Human Approval/not-required proof, full policy
+lineage, and expected state remain independent.
+
+## Threat model
+
+V1 fails or prevents: request ID substituted for decision ID; HTTP-response
+hash substitution; current-time timestamp backfill; post-Bind reconstruction;
+chosen/action laundering; ALLOW/APPROVE authority laundering; compatibility or
+volatile-field hash drift; alternate serialization; self-hash recursion;
+cross-domain digest confusion; cross-request substitution; reuse of one ID with
+modified state; governance substitution; and erasure of structural refusal.
+Residual risk remains until a separately reviewed producer and verifier capture
+the correct boundary and validate every binding; this PR must not be treated as
+runtime protection.
+
+## Non-claims and remaining work
+
+This milestone provides no live `/v1/decide` emission, production builder or
+verifier, canonical candidate extraction, Authority Evidence, Human Approval
+verification, live policy verification, TrustLog verification, replay
+verification, `CanonicalDecisionHandoff` creation, guarded promotion,
+`ExecutionIntent`, Bind, external effect, or production/customer/regulatory
+certification. A later PR must define and review the finalization capture,
+pre-Bind producer, artifact persistence/reference, independent verification,
+TrustLog/replay matching, structured candidate/evidence inputs, and handoff
+consumer. It must not change the existing handoff validator implicitly.

--- a/docs/en/architecture/canonical-decision-to-bind-handoff-v1.md
+++ b/docs/en/architecture/canonical-decision-to-bind-handoff-v1.md
@@ -13,6 +13,18 @@ canonical `decision_id`, `decision_hash`, or `decision_ts`. Those values remain
 `UNAVAILABLE`/`UNRESOLVED`; `request_id`, an HTTP response hash, arrival time,
 TrustLog retrieval time, CI time, and current time are not substitutes.
 
+The future canonical source for those values is a **verified**
+[`CanonicalDecisionArtifact v1`](canonical-decision-artifact-v1.md). Its
+allowed mapping is `artifact.request_id` to `source_decision.request_id`,
+`artifact.decision_id` to `source_decision.canonical_decision_id`,
+`artifact.decision_hash` to `source_decision.canonical_decision_hash`, and
+`artifact.decision_ts` to `source_decision.canonical_decision_ts`. Merely
+copying these four strings is insufficient for READY: provenance must bind the
+source artifact reference and hash, verification mechanism, and successful
+verification status. This is a future producer/consumer contract only; the v1
+runtime validator continues to accept an already formed handoff plus trusted
+validation context and does not yet depend on artifact production.
+
 ```mermaid
 flowchart TD
   A[LLM / Agent - EXISTING] -->|untrusted proposal| B[DecisionCandidate - EXISTING]

--- a/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-01.json
+++ b/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-01.json
@@ -1,0 +1,162 @@
+{
+  "vector_id": "CDA-V1-01",
+  "description": "Golden complete canonical decision",
+  "synthetic_fixture": true,
+  "source_projection": {
+    "request_id": "req-cda-synthetic-001",
+    "chosen": {
+      "id": "choice-stable-01",
+      "score": 0.875,
+      "title": "Hold for verified review"
+    },
+    "decision_status": "allow",
+    "rejection_reason": null,
+    "gate_decision": "ALLOW",
+    "business_decision": "HOLD",
+    "next_action": "REQUEST_VERIFIED_REVIEW",
+    "actionability_status": "reviewable_only",
+    "requires_bind_before_execution": true,
+    "human_review_required": true,
+    "required_evidence": [
+      "authority_evidence",
+      "human_approval"
+    ],
+    "missing_evidence": [
+      "authority_evidence"
+    ],
+    "satisfied_evidence": [
+      "policy_evaluation"
+    ],
+    "rationale": "Synthetic decision requires separately verified authority.",
+    "refusal_reason": null,
+    "actionability_block_reason": "BIND_REQUIRED",
+    "actionability_refusal_type": null,
+    "governance_identity": {
+      "digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "policy_version": "synthetic-v7",
+      "signature_verified": true
+    },
+    "lineage_promotability": {
+      "promotability_family": "lineage_promotability",
+      "promotability_status": "restricted",
+      "promotability_version": "v1",
+      "reason_code": "AUTHORITY_PENDING",
+      "transformation_stable": true
+    },
+    "transition_refusal": {
+      "bind_receipt_created": false,
+      "execution_intent_created": false,
+      "reason_code": null,
+      "transition_status": "allowed"
+    }
+  },
+  "artifact": {
+    "format_version": "canonical-decision-artifact/v1",
+    "hash_profile": "veritas.canonical-decision/v1",
+    "decision_id": "cda:v1:sha256:aaa8bf9fac5a3b70ddf9bbea388228cf9b5e56f4a2575b8100d51d058e15bb0e",
+    "decision_hash": "aaa8bf9fac5a3b70ddf9bbea388228cf9b5e56f4a2575b8100d51d058e15bb0e",
+    "decision_ts": "2031-02-03T04:05:06.123456Z",
+    "request_id": "req-cda-synthetic-001",
+    "source_contract": {
+      "type": "DecideResponse",
+      "projection_version": "canonical-decision-projection/v1"
+    },
+    "decision": {
+      "formation_status": "COMPLETE",
+      "chosen_binding": {
+        "profile": "veritas.canonical-decision.chosen-value/v1",
+        "sha256": "f419527eddae068f9362c66ab338f54fb41d6f9f04adfb553294c59c5077e6f6"
+      },
+      "decision_status": "allow",
+      "rejection_reason": null,
+      "gate_decision": "ALLOW",
+      "business_decision": "HOLD",
+      "next_action": "REQUEST_VERIFIED_REVIEW",
+      "actionability_status": "reviewable_only",
+      "requires_bind_before_execution": true,
+      "human_review_required": true,
+      "required_evidence": [
+        "authority_evidence",
+        "human_approval"
+      ],
+      "missing_evidence": [
+        "authority_evidence"
+      ],
+      "satisfied_evidence": [
+        "policy_evaluation"
+      ],
+      "rationale": "Synthetic decision requires separately verified authority.",
+      "refusal_reason": null,
+      "actionability_block_reason": "BIND_REQUIRED",
+      "actionability_refusal_type": null,
+      "governance_identity_binding": {
+        "profile": "veritas.canonical-decision.governance-identity/v1",
+        "sha256": "c3aa80f8117ede4fa868319513b8304193b5323e0f960d3069076d2217a4e9ec"
+      },
+      "lineage_promotability_binding": {
+        "profile": "veritas.canonical-decision.lineage-promotability/v1",
+        "sha256": "bfb740a44e9a7332445fa6e4255696df1454e78d5b1cbd913fad11f48504d19b"
+      },
+      "transition_refusal_binding": {
+        "profile": "veritas.canonical-decision.transition-refusal/v1",
+        "sha256": "5747ed3a654db328097d821eebd8a2474e795ff2ae74fccee734d6c1f7f9d97c"
+      }
+    }
+  },
+  "canonical_preimage": {
+    "profile": "veritas.canonical-decision/v1",
+    "format_version": "canonical-decision-artifact/v1",
+    "request_id": "req-cda-synthetic-001",
+    "decision_ts": "2031-02-03T04:05:06.123456Z",
+    "source_contract": {
+      "type": "DecideResponse",
+      "projection_version": "canonical-decision-projection/v1"
+    },
+    "decision": {
+      "formation_status": "COMPLETE",
+      "chosen_binding": {
+        "profile": "veritas.canonical-decision.chosen-value/v1",
+        "sha256": "f419527eddae068f9362c66ab338f54fb41d6f9f04adfb553294c59c5077e6f6"
+      },
+      "decision_status": "allow",
+      "rejection_reason": null,
+      "gate_decision": "ALLOW",
+      "business_decision": "HOLD",
+      "next_action": "REQUEST_VERIFIED_REVIEW",
+      "actionability_status": "reviewable_only",
+      "requires_bind_before_execution": true,
+      "human_review_required": true,
+      "required_evidence": [
+        "authority_evidence",
+        "human_approval"
+      ],
+      "missing_evidence": [
+        "authority_evidence"
+      ],
+      "satisfied_evidence": [
+        "policy_evaluation"
+      ],
+      "rationale": "Synthetic decision requires separately verified authority.",
+      "refusal_reason": null,
+      "actionability_block_reason": "BIND_REQUIRED",
+      "actionability_refusal_type": null,
+      "governance_identity_binding": {
+        "profile": "veritas.canonical-decision.governance-identity/v1",
+        "sha256": "c3aa80f8117ede4fa868319513b8304193b5323e0f960d3069076d2217a4e9ec"
+      },
+      "lineage_promotability_binding": {
+        "profile": "veritas.canonical-decision.lineage-promotability/v1",
+        "sha256": "bfb740a44e9a7332445fa6e4255696df1454e78d5b1cbd913fad11f48504d19b"
+      },
+      "transition_refusal_binding": {
+        "profile": "veritas.canonical-decision.transition-refusal/v1",
+        "sha256": "5747ed3a654db328097d821eebd8a2474e795ff2ae74fccee734d6c1f7f9d97c"
+      }
+    }
+  },
+  "expected_canonical_serialized": "{\"decision\":{\"actionability_block_reason\":\"BIND_REQUIRED\",\"actionability_refusal_type\":null,\"actionability_status\":\"reviewable_only\",\"business_decision\":\"HOLD\",\"chosen_binding\":{\"profile\":\"veritas.canonical-decision.chosen-value/v1\",\"sha256\":\"f419527eddae068f9362c66ab338f54fb41d6f9f04adfb553294c59c5077e6f6\"},\"decision_status\":\"allow\",\"formation_status\":\"COMPLETE\",\"gate_decision\":\"ALLOW\",\"governance_identity_binding\":{\"profile\":\"veritas.canonical-decision.governance-identity/v1\",\"sha256\":\"c3aa80f8117ede4fa868319513b8304193b5323e0f960d3069076d2217a4e9ec\"},\"human_review_required\":true,\"lineage_promotability_binding\":{\"profile\":\"veritas.canonical-decision.lineage-promotability/v1\",\"sha256\":\"bfb740a44e9a7332445fa6e4255696df1454e78d5b1cbd913fad11f48504d19b\"},\"missing_evidence\":[\"authority_evidence\"],\"next_action\":\"REQUEST_VERIFIED_REVIEW\",\"rationale\":\"Synthetic decision requires separately verified authority.\",\"refusal_reason\":null,\"rejection_reason\":null,\"required_evidence\":[\"authority_evidence\",\"human_approval\"],\"requires_bind_before_execution\":true,\"satisfied_evidence\":[\"policy_evaluation\"],\"transition_refusal_binding\":{\"profile\":\"veritas.canonical-decision.transition-refusal/v1\",\"sha256\":\"5747ed3a654db328097d821eebd8a2474e795ff2ae74fccee734d6c1f7f9d97c\"}},\"decision_ts\":\"2031-02-03T04:05:06.123456Z\",\"format_version\":\"canonical-decision-artifact/v1\",\"profile\":\"veritas.canonical-decision/v1\",\"request_id\":\"req-cda-synthetic-001\",\"source_contract\":{\"projection_version\":\"canonical-decision-projection/v1\",\"type\":\"DecideResponse\"}}",
+  "expected_decision_hash": "aaa8bf9fac5a3b70ddf9bbea388228cf9b5e56f4a2575b8100d51d058e15bb0e",
+  "expected_decision_id": "cda:v1:sha256:aaa8bf9fac5a3b70ddf9bbea388228cf9b5e56f4a2575b8100d51d058e15bb0e",
+  "expected_schema_valid": true,
+  "expected_production": "EMIT"
+}

--- a/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-01.json
+++ b/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-01.json
@@ -11,12 +11,12 @@
     },
     "decision_status": "allow",
     "rejection_reason": null,
-    "gate_decision": "ALLOW",
+    "gate_decision": "hold",
     "business_decision": "HOLD",
     "next_action": "REQUEST_VERIFIED_REVIEW",
     "actionability_status": "reviewable_only",
     "requires_bind_before_execution": true,
-    "human_review_required": true,
+    "human_review_required": false,
     "required_evidence": [
       "authority_evidence",
       "human_approval"
@@ -41,20 +41,27 @@
       "promotability_status": "restricted",
       "promotability_version": "v1",
       "reason_code": "AUTHORITY_PENDING",
-      "transformation_stable": true
+      "transformation_stable": true,
+      "invariant_id": "BIND_ELIGIBLE_ARTIFACT_CANNOT_EMERGE_FROM_NON_PROMOTABLE_LINEAGE",
+      "source_participation_state": null,
+      "source_preservation_state": null,
+      "concise_rationale": null
     },
     "transition_refusal": {
       "bind_receipt_created": false,
       "execution_intent_created": false,
       "reason_code": null,
-      "transition_status": "allowed"
+      "transition_status": "allowed",
+      "invariant_id": "BIND_ELIGIBLE_ARTIFACT_CANNOT_EMERGE_FROM_NON_PROMOTABLE_LINEAGE",
+      "source_promotability_status": null,
+      "concise_rationale": null
     }
   },
   "artifact": {
     "format_version": "canonical-decision-artifact/v1",
     "hash_profile": "veritas.canonical-decision/v1",
-    "decision_id": "cda:v1:sha256:aaa8bf9fac5a3b70ddf9bbea388228cf9b5e56f4a2575b8100d51d058e15bb0e",
-    "decision_hash": "aaa8bf9fac5a3b70ddf9bbea388228cf9b5e56f4a2575b8100d51d058e15bb0e",
+    "decision_id": "cda:v1:sha256:1c6e265c50812c2b86eab04ef5523a7f1e56c45db4888ca527840ec94f0456a8",
+    "decision_hash": "1c6e265c50812c2b86eab04ef5523a7f1e56c45db4888ca527840ec94f0456a8",
     "decision_ts": "2031-02-03T04:05:06.123456Z",
     "request_id": "req-cda-synthetic-001",
     "source_contract": {
@@ -69,12 +76,12 @@
       },
       "decision_status": "allow",
       "rejection_reason": null,
-      "gate_decision": "ALLOW",
+      "gate_decision": "hold",
       "business_decision": "HOLD",
       "next_action": "REQUEST_VERIFIED_REVIEW",
       "actionability_status": "reviewable_only",
       "requires_bind_before_execution": true,
-      "human_review_required": true,
+      "human_review_required": false,
       "required_evidence": [
         "authority_evidence",
         "human_approval"
@@ -95,11 +102,11 @@
       },
       "lineage_promotability_binding": {
         "profile": "veritas.canonical-decision.lineage-promotability/v1",
-        "sha256": "bfb740a44e9a7332445fa6e4255696df1454e78d5b1cbd913fad11f48504d19b"
+        "sha256": "35c203c9baed4c3679bbcec66346bb97bd62d33dbd1fc5ff6339fed852500840"
       },
       "transition_refusal_binding": {
         "profile": "veritas.canonical-decision.transition-refusal/v1",
-        "sha256": "5747ed3a654db328097d821eebd8a2474e795ff2ae74fccee734d6c1f7f9d97c"
+        "sha256": "42405ab6973875446269a4f3bdcc1e527e393a9f5e2f60e964f756f234029bc6"
       }
     }
   },
@@ -120,12 +127,12 @@
       },
       "decision_status": "allow",
       "rejection_reason": null,
-      "gate_decision": "ALLOW",
+      "gate_decision": "hold",
       "business_decision": "HOLD",
       "next_action": "REQUEST_VERIFIED_REVIEW",
       "actionability_status": "reviewable_only",
       "requires_bind_before_execution": true,
-      "human_review_required": true,
+      "human_review_required": false,
       "required_evidence": [
         "authority_evidence",
         "human_approval"
@@ -146,17 +153,17 @@
       },
       "lineage_promotability_binding": {
         "profile": "veritas.canonical-decision.lineage-promotability/v1",
-        "sha256": "bfb740a44e9a7332445fa6e4255696df1454e78d5b1cbd913fad11f48504d19b"
+        "sha256": "35c203c9baed4c3679bbcec66346bb97bd62d33dbd1fc5ff6339fed852500840"
       },
       "transition_refusal_binding": {
         "profile": "veritas.canonical-decision.transition-refusal/v1",
-        "sha256": "5747ed3a654db328097d821eebd8a2474e795ff2ae74fccee734d6c1f7f9d97c"
+        "sha256": "42405ab6973875446269a4f3bdcc1e527e393a9f5e2f60e964f756f234029bc6"
       }
     }
   },
-  "expected_canonical_serialized": "{\"decision\":{\"actionability_block_reason\":\"BIND_REQUIRED\",\"actionability_refusal_type\":null,\"actionability_status\":\"reviewable_only\",\"business_decision\":\"HOLD\",\"chosen_binding\":{\"profile\":\"veritas.canonical-decision.chosen-value/v1\",\"sha256\":\"f419527eddae068f9362c66ab338f54fb41d6f9f04adfb553294c59c5077e6f6\"},\"decision_status\":\"allow\",\"formation_status\":\"COMPLETE\",\"gate_decision\":\"ALLOW\",\"governance_identity_binding\":{\"profile\":\"veritas.canonical-decision.governance-identity/v1\",\"sha256\":\"c3aa80f8117ede4fa868319513b8304193b5323e0f960d3069076d2217a4e9ec\"},\"human_review_required\":true,\"lineage_promotability_binding\":{\"profile\":\"veritas.canonical-decision.lineage-promotability/v1\",\"sha256\":\"bfb740a44e9a7332445fa6e4255696df1454e78d5b1cbd913fad11f48504d19b\"},\"missing_evidence\":[\"authority_evidence\"],\"next_action\":\"REQUEST_VERIFIED_REVIEW\",\"rationale\":\"Synthetic decision requires separately verified authority.\",\"refusal_reason\":null,\"rejection_reason\":null,\"required_evidence\":[\"authority_evidence\",\"human_approval\"],\"requires_bind_before_execution\":true,\"satisfied_evidence\":[\"policy_evaluation\"],\"transition_refusal_binding\":{\"profile\":\"veritas.canonical-decision.transition-refusal/v1\",\"sha256\":\"5747ed3a654db328097d821eebd8a2474e795ff2ae74fccee734d6c1f7f9d97c\"}},\"decision_ts\":\"2031-02-03T04:05:06.123456Z\",\"format_version\":\"canonical-decision-artifact/v1\",\"profile\":\"veritas.canonical-decision/v1\",\"request_id\":\"req-cda-synthetic-001\",\"source_contract\":{\"projection_version\":\"canonical-decision-projection/v1\",\"type\":\"DecideResponse\"}}",
-  "expected_decision_hash": "aaa8bf9fac5a3b70ddf9bbea388228cf9b5e56f4a2575b8100d51d058e15bb0e",
-  "expected_decision_id": "cda:v1:sha256:aaa8bf9fac5a3b70ddf9bbea388228cf9b5e56f4a2575b8100d51d058e15bb0e",
+  "expected_canonical_serialized": "{\"decision\":{\"actionability_block_reason\":\"BIND_REQUIRED\",\"actionability_refusal_type\":null,\"actionability_status\":\"reviewable_only\",\"business_decision\":\"HOLD\",\"chosen_binding\":{\"profile\":\"veritas.canonical-decision.chosen-value/v1\",\"sha256\":\"f419527eddae068f9362c66ab338f54fb41d6f9f04adfb553294c59c5077e6f6\"},\"decision_status\":\"allow\",\"formation_status\":\"COMPLETE\",\"gate_decision\":\"hold\",\"governance_identity_binding\":{\"profile\":\"veritas.canonical-decision.governance-identity/v1\",\"sha256\":\"c3aa80f8117ede4fa868319513b8304193b5323e0f960d3069076d2217a4e9ec\"},\"human_review_required\":false,\"lineage_promotability_binding\":{\"profile\":\"veritas.canonical-decision.lineage-promotability/v1\",\"sha256\":\"35c203c9baed4c3679bbcec66346bb97bd62d33dbd1fc5ff6339fed852500840\"},\"missing_evidence\":[\"authority_evidence\"],\"next_action\":\"REQUEST_VERIFIED_REVIEW\",\"rationale\":\"Synthetic decision requires separately verified authority.\",\"refusal_reason\":null,\"rejection_reason\":null,\"required_evidence\":[\"authority_evidence\",\"human_approval\"],\"requires_bind_before_execution\":true,\"satisfied_evidence\":[\"policy_evaluation\"],\"transition_refusal_binding\":{\"profile\":\"veritas.canonical-decision.transition-refusal/v1\",\"sha256\":\"42405ab6973875446269a4f3bdcc1e527e393a9f5e2f60e964f756f234029bc6\"}},\"decision_ts\":\"2031-02-03T04:05:06.123456Z\",\"format_version\":\"canonical-decision-artifact/v1\",\"profile\":\"veritas.canonical-decision/v1\",\"request_id\":\"req-cda-synthetic-001\",\"source_contract\":{\"projection_version\":\"canonical-decision-projection/v1\",\"type\":\"DecideResponse\"}}",
+  "expected_decision_hash": "1c6e265c50812c2b86eab04ef5523a7f1e56c45db4888ca527840ec94f0456a8",
+  "expected_decision_id": "cda:v1:sha256:1c6e265c50812c2b86eab04ef5523a7f1e56c45db4888ca527840ec94f0456a8",
   "expected_schema_valid": true,
   "expected_production": "EMIT"
 }

--- a/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-02.json
+++ b/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-02.json
@@ -1,0 +1,63 @@
+{
+  "vector_id": "CDA-V1-02",
+  "description": "Included mutation: request_id",
+  "synthetic_fixture": true,
+  "mutation": "request_id",
+  "artifact": {
+    "format_version": "canonical-decision-artifact/v1",
+    "hash_profile": "veritas.canonical-decision/v1",
+    "decision_id": "cda:v1:sha256:979368325a6839249b85fcb961aabf65195a901e9c1c565f20cec2a9b13d812b",
+    "decision_hash": "979368325a6839249b85fcb961aabf65195a901e9c1c565f20cec2a9b13d812b",
+    "decision_ts": "2031-02-03T04:05:06.123456Z",
+    "request_id": "req-cda-synthetic-002",
+    "source_contract": {
+      "type": "DecideResponse",
+      "projection_version": "canonical-decision-projection/v1"
+    },
+    "decision": {
+      "formation_status": "COMPLETE",
+      "chosen_binding": {
+        "profile": "veritas.canonical-decision.chosen-value/v1",
+        "sha256": "f419527eddae068f9362c66ab338f54fb41d6f9f04adfb553294c59c5077e6f6"
+      },
+      "decision_status": "allow",
+      "rejection_reason": null,
+      "gate_decision": "ALLOW",
+      "business_decision": "HOLD",
+      "next_action": "REQUEST_VERIFIED_REVIEW",
+      "actionability_status": "reviewable_only",
+      "requires_bind_before_execution": true,
+      "human_review_required": true,
+      "required_evidence": [
+        "authority_evidence",
+        "human_approval"
+      ],
+      "missing_evidence": [
+        "authority_evidence"
+      ],
+      "satisfied_evidence": [
+        "policy_evaluation"
+      ],
+      "rationale": "Synthetic decision requires separately verified authority.",
+      "refusal_reason": null,
+      "actionability_block_reason": "BIND_REQUIRED",
+      "actionability_refusal_type": null,
+      "governance_identity_binding": {
+        "profile": "veritas.canonical-decision.governance-identity/v1",
+        "sha256": "c3aa80f8117ede4fa868319513b8304193b5323e0f960d3069076d2217a4e9ec"
+      },
+      "lineage_promotability_binding": {
+        "profile": "veritas.canonical-decision.lineage-promotability/v1",
+        "sha256": "bfb740a44e9a7332445fa6e4255696df1454e78d5b1cbd913fad11f48504d19b"
+      },
+      "transition_refusal_binding": {
+        "profile": "veritas.canonical-decision.transition-refusal/v1",
+        "sha256": "5747ed3a654db328097d821eebd8a2474e795ff2ae74fccee734d6c1f7f9d97c"
+      }
+    }
+  },
+  "expected_decision_hash": "979368325a6839249b85fcb961aabf65195a901e9c1c565f20cec2a9b13d812b",
+  "expected_decision_id": "cda:v1:sha256:979368325a6839249b85fcb961aabf65195a901e9c1c565f20cec2a9b13d812b",
+  "expected_schema_valid": true,
+  "expected_production": "EMIT"
+}

--- a/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-02.json
+++ b/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-02.json
@@ -6,8 +6,8 @@
   "artifact": {
     "format_version": "canonical-decision-artifact/v1",
     "hash_profile": "veritas.canonical-decision/v1",
-    "decision_id": "cda:v1:sha256:979368325a6839249b85fcb961aabf65195a901e9c1c565f20cec2a9b13d812b",
-    "decision_hash": "979368325a6839249b85fcb961aabf65195a901e9c1c565f20cec2a9b13d812b",
+    "decision_id": "cda:v1:sha256:8c5331dab624c9ed0b4d75f1459e50ece44880d2859528d9ad646a5e0c104ead",
+    "decision_hash": "8c5331dab624c9ed0b4d75f1459e50ece44880d2859528d9ad646a5e0c104ead",
     "decision_ts": "2031-02-03T04:05:06.123456Z",
     "request_id": "req-cda-synthetic-002",
     "source_contract": {
@@ -22,12 +22,12 @@
       },
       "decision_status": "allow",
       "rejection_reason": null,
-      "gate_decision": "ALLOW",
+      "gate_decision": "hold",
       "business_decision": "HOLD",
       "next_action": "REQUEST_VERIFIED_REVIEW",
       "actionability_status": "reviewable_only",
       "requires_bind_before_execution": true,
-      "human_review_required": true,
+      "human_review_required": false,
       "required_evidence": [
         "authority_evidence",
         "human_approval"
@@ -48,16 +48,16 @@
       },
       "lineage_promotability_binding": {
         "profile": "veritas.canonical-decision.lineage-promotability/v1",
-        "sha256": "bfb740a44e9a7332445fa6e4255696df1454e78d5b1cbd913fad11f48504d19b"
+        "sha256": "35c203c9baed4c3679bbcec66346bb97bd62d33dbd1fc5ff6339fed852500840"
       },
       "transition_refusal_binding": {
         "profile": "veritas.canonical-decision.transition-refusal/v1",
-        "sha256": "5747ed3a654db328097d821eebd8a2474e795ff2ae74fccee734d6c1f7f9d97c"
+        "sha256": "42405ab6973875446269a4f3bdcc1e527e393a9f5e2f60e964f756f234029bc6"
       }
     }
   },
-  "expected_decision_hash": "979368325a6839249b85fcb961aabf65195a901e9c1c565f20cec2a9b13d812b",
-  "expected_decision_id": "cda:v1:sha256:979368325a6839249b85fcb961aabf65195a901e9c1c565f20cec2a9b13d812b",
+  "expected_decision_hash": "8c5331dab624c9ed0b4d75f1459e50ece44880d2859528d9ad646a5e0c104ead",
+  "expected_decision_id": "cda:v1:sha256:8c5331dab624c9ed0b4d75f1459e50ece44880d2859528d9ad646a5e0c104ead",
   "expected_schema_valid": true,
-  "expected_production": "EMIT"
+  "expected_production": "HASH_REFERENCE_ONLY"
 }

--- a/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-03.json
+++ b/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-03.json
@@ -1,0 +1,63 @@
+{
+  "vector_id": "CDA-V1-03",
+  "description": "Included mutation: decision_ts",
+  "synthetic_fixture": true,
+  "mutation": "decision_ts",
+  "artifact": {
+    "format_version": "canonical-decision-artifact/v1",
+    "hash_profile": "veritas.canonical-decision/v1",
+    "decision_id": "cda:v1:sha256:42a9ee7d9443f59b173263665dbfd21f338de8d3a1c6db267aa0e5f31bb7171e",
+    "decision_hash": "42a9ee7d9443f59b173263665dbfd21f338de8d3a1c6db267aa0e5f31bb7171e",
+    "decision_ts": "2031-02-03T04:05:07.123456Z",
+    "request_id": "req-cda-synthetic-001",
+    "source_contract": {
+      "type": "DecideResponse",
+      "projection_version": "canonical-decision-projection/v1"
+    },
+    "decision": {
+      "formation_status": "COMPLETE",
+      "chosen_binding": {
+        "profile": "veritas.canonical-decision.chosen-value/v1",
+        "sha256": "f419527eddae068f9362c66ab338f54fb41d6f9f04adfb553294c59c5077e6f6"
+      },
+      "decision_status": "allow",
+      "rejection_reason": null,
+      "gate_decision": "ALLOW",
+      "business_decision": "HOLD",
+      "next_action": "REQUEST_VERIFIED_REVIEW",
+      "actionability_status": "reviewable_only",
+      "requires_bind_before_execution": true,
+      "human_review_required": true,
+      "required_evidence": [
+        "authority_evidence",
+        "human_approval"
+      ],
+      "missing_evidence": [
+        "authority_evidence"
+      ],
+      "satisfied_evidence": [
+        "policy_evaluation"
+      ],
+      "rationale": "Synthetic decision requires separately verified authority.",
+      "refusal_reason": null,
+      "actionability_block_reason": "BIND_REQUIRED",
+      "actionability_refusal_type": null,
+      "governance_identity_binding": {
+        "profile": "veritas.canonical-decision.governance-identity/v1",
+        "sha256": "c3aa80f8117ede4fa868319513b8304193b5323e0f960d3069076d2217a4e9ec"
+      },
+      "lineage_promotability_binding": {
+        "profile": "veritas.canonical-decision.lineage-promotability/v1",
+        "sha256": "bfb740a44e9a7332445fa6e4255696df1454e78d5b1cbd913fad11f48504d19b"
+      },
+      "transition_refusal_binding": {
+        "profile": "veritas.canonical-decision.transition-refusal/v1",
+        "sha256": "5747ed3a654db328097d821eebd8a2474e795ff2ae74fccee734d6c1f7f9d97c"
+      }
+    }
+  },
+  "expected_decision_hash": "42a9ee7d9443f59b173263665dbfd21f338de8d3a1c6db267aa0e5f31bb7171e",
+  "expected_decision_id": "cda:v1:sha256:42a9ee7d9443f59b173263665dbfd21f338de8d3a1c6db267aa0e5f31bb7171e",
+  "expected_schema_valid": true,
+  "expected_production": "EMIT"
+}

--- a/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-03.json
+++ b/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-03.json
@@ -6,8 +6,8 @@
   "artifact": {
     "format_version": "canonical-decision-artifact/v1",
     "hash_profile": "veritas.canonical-decision/v1",
-    "decision_id": "cda:v1:sha256:42a9ee7d9443f59b173263665dbfd21f338de8d3a1c6db267aa0e5f31bb7171e",
-    "decision_hash": "42a9ee7d9443f59b173263665dbfd21f338de8d3a1c6db267aa0e5f31bb7171e",
+    "decision_id": "cda:v1:sha256:eba81d0edde340d4567bbb369969c26d7b5931bef8789772859d55170a33d6b2",
+    "decision_hash": "eba81d0edde340d4567bbb369969c26d7b5931bef8789772859d55170a33d6b2",
     "decision_ts": "2031-02-03T04:05:07.123456Z",
     "request_id": "req-cda-synthetic-001",
     "source_contract": {
@@ -22,12 +22,12 @@
       },
       "decision_status": "allow",
       "rejection_reason": null,
-      "gate_decision": "ALLOW",
+      "gate_decision": "hold",
       "business_decision": "HOLD",
       "next_action": "REQUEST_VERIFIED_REVIEW",
       "actionability_status": "reviewable_only",
       "requires_bind_before_execution": true,
-      "human_review_required": true,
+      "human_review_required": false,
       "required_evidence": [
         "authority_evidence",
         "human_approval"
@@ -48,16 +48,16 @@
       },
       "lineage_promotability_binding": {
         "profile": "veritas.canonical-decision.lineage-promotability/v1",
-        "sha256": "bfb740a44e9a7332445fa6e4255696df1454e78d5b1cbd913fad11f48504d19b"
+        "sha256": "35c203c9baed4c3679bbcec66346bb97bd62d33dbd1fc5ff6339fed852500840"
       },
       "transition_refusal_binding": {
         "profile": "veritas.canonical-decision.transition-refusal/v1",
-        "sha256": "5747ed3a654db328097d821eebd8a2474e795ff2ae74fccee734d6c1f7f9d97c"
+        "sha256": "42405ab6973875446269a4f3bdcc1e527e393a9f5e2f60e964f756f234029bc6"
       }
     }
   },
-  "expected_decision_hash": "42a9ee7d9443f59b173263665dbfd21f338de8d3a1c6db267aa0e5f31bb7171e",
-  "expected_decision_id": "cda:v1:sha256:42a9ee7d9443f59b173263665dbfd21f338de8d3a1c6db267aa0e5f31bb7171e",
+  "expected_decision_hash": "eba81d0edde340d4567bbb369969c26d7b5931bef8789772859d55170a33d6b2",
+  "expected_decision_id": "cda:v1:sha256:eba81d0edde340d4567bbb369969c26d7b5931bef8789772859d55170a33d6b2",
   "expected_schema_valid": true,
-  "expected_production": "EMIT"
+  "expected_production": "HASH_REFERENCE_ONLY"
 }

--- a/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-04.json
+++ b/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-04.json
@@ -6,8 +6,8 @@
   "artifact": {
     "format_version": "canonical-decision-artifact/v1",
     "hash_profile": "veritas.canonical-decision/v1",
-    "decision_id": "cda:v1:sha256:fa50d5e9e61c671ca7d517d4a0a66cda4ad0609609513d2670b75ce5b4adcd18",
-    "decision_hash": "fa50d5e9e61c671ca7d517d4a0a66cda4ad0609609513d2670b75ce5b4adcd18",
+    "decision_id": "cda:v1:sha256:08f880a661c45db0e9b1ee9c20905904c92955cf48928fd1993a070b8f857b6e",
+    "decision_hash": "08f880a661c45db0e9b1ee9c20905904c92955cf48928fd1993a070b8f857b6e",
     "decision_ts": "2031-02-03T04:05:06.123456Z",
     "request_id": "req-cda-synthetic-001",
     "source_contract": {
@@ -22,12 +22,12 @@
       },
       "decision_status": "allow",
       "rejection_reason": null,
-      "gate_decision": "ALLOW",
+      "gate_decision": "hold",
       "business_decision": "HOLD",
       "next_action": "REQUEST_VERIFIED_REVIEW",
       "actionability_status": "reviewable_only",
       "requires_bind_before_execution": true,
-      "human_review_required": true,
+      "human_review_required": false,
       "required_evidence": [
         "authority_evidence",
         "human_approval"
@@ -48,16 +48,16 @@
       },
       "lineage_promotability_binding": {
         "profile": "veritas.canonical-decision.lineage-promotability/v1",
-        "sha256": "bfb740a44e9a7332445fa6e4255696df1454e78d5b1cbd913fad11f48504d19b"
+        "sha256": "35c203c9baed4c3679bbcec66346bb97bd62d33dbd1fc5ff6339fed852500840"
       },
       "transition_refusal_binding": {
         "profile": "veritas.canonical-decision.transition-refusal/v1",
-        "sha256": "5747ed3a654db328097d821eebd8a2474e795ff2ae74fccee734d6c1f7f9d97c"
+        "sha256": "42405ab6973875446269a4f3bdcc1e527e393a9f5e2f60e964f756f234029bc6"
       }
     }
   },
-  "expected_decision_hash": "fa50d5e9e61c671ca7d517d4a0a66cda4ad0609609513d2670b75ce5b4adcd18",
-  "expected_decision_id": "cda:v1:sha256:fa50d5e9e61c671ca7d517d4a0a66cda4ad0609609513d2670b75ce5b4adcd18",
+  "expected_decision_hash": "08f880a661c45db0e9b1ee9c20905904c92955cf48928fd1993a070b8f857b6e",
+  "expected_decision_id": "cda:v1:sha256:08f880a661c45db0e9b1ee9c20905904c92955cf48928fd1993a070b8f857b6e",
   "expected_schema_valid": true,
-  "expected_production": "EMIT"
+  "expected_production": "HASH_REFERENCE_ONLY"
 }

--- a/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-04.json
+++ b/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-04.json
@@ -1,0 +1,63 @@
+{
+  "vector_id": "CDA-V1-04",
+  "description": "Included mutation: chosen binding",
+  "synthetic_fixture": true,
+  "mutation": "chosen binding",
+  "artifact": {
+    "format_version": "canonical-decision-artifact/v1",
+    "hash_profile": "veritas.canonical-decision/v1",
+    "decision_id": "cda:v1:sha256:fa50d5e9e61c671ca7d517d4a0a66cda4ad0609609513d2670b75ce5b4adcd18",
+    "decision_hash": "fa50d5e9e61c671ca7d517d4a0a66cda4ad0609609513d2670b75ce5b4adcd18",
+    "decision_ts": "2031-02-03T04:05:06.123456Z",
+    "request_id": "req-cda-synthetic-001",
+    "source_contract": {
+      "type": "DecideResponse",
+      "projection_version": "canonical-decision-projection/v1"
+    },
+    "decision": {
+      "formation_status": "COMPLETE",
+      "chosen_binding": {
+        "profile": "veritas.canonical-decision.chosen-value/v1",
+        "sha256": "8ced83b9982d885ba9c46582846cf8e5edb274d609d67200cd188614eaa5da05"
+      },
+      "decision_status": "allow",
+      "rejection_reason": null,
+      "gate_decision": "ALLOW",
+      "business_decision": "HOLD",
+      "next_action": "REQUEST_VERIFIED_REVIEW",
+      "actionability_status": "reviewable_only",
+      "requires_bind_before_execution": true,
+      "human_review_required": true,
+      "required_evidence": [
+        "authority_evidence",
+        "human_approval"
+      ],
+      "missing_evidence": [
+        "authority_evidence"
+      ],
+      "satisfied_evidence": [
+        "policy_evaluation"
+      ],
+      "rationale": "Synthetic decision requires separately verified authority.",
+      "refusal_reason": null,
+      "actionability_block_reason": "BIND_REQUIRED",
+      "actionability_refusal_type": null,
+      "governance_identity_binding": {
+        "profile": "veritas.canonical-decision.governance-identity/v1",
+        "sha256": "c3aa80f8117ede4fa868319513b8304193b5323e0f960d3069076d2217a4e9ec"
+      },
+      "lineage_promotability_binding": {
+        "profile": "veritas.canonical-decision.lineage-promotability/v1",
+        "sha256": "bfb740a44e9a7332445fa6e4255696df1454e78d5b1cbd913fad11f48504d19b"
+      },
+      "transition_refusal_binding": {
+        "profile": "veritas.canonical-decision.transition-refusal/v1",
+        "sha256": "5747ed3a654db328097d821eebd8a2474e795ff2ae74fccee734d6c1f7f9d97c"
+      }
+    }
+  },
+  "expected_decision_hash": "fa50d5e9e61c671ca7d517d4a0a66cda4ad0609609513d2670b75ce5b4adcd18",
+  "expected_decision_id": "cda:v1:sha256:fa50d5e9e61c671ca7d517d4a0a66cda4ad0609609513d2670b75ce5b4adcd18",
+  "expected_schema_valid": true,
+  "expected_production": "EMIT"
+}

--- a/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-05.json
+++ b/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-05.json
@@ -6,8 +6,8 @@
   "artifact": {
     "format_version": "canonical-decision-artifact/v1",
     "hash_profile": "veritas.canonical-decision/v1",
-    "decision_id": "cda:v1:sha256:60d9df7b805fd7912cff59d2ff1a942ab07a7fcf75928cec7eb353a501741a8d",
-    "decision_hash": "60d9df7b805fd7912cff59d2ff1a942ab07a7fcf75928cec7eb353a501741a8d",
+    "decision_id": "cda:v1:sha256:4586510d84e7349e76d40be332a2745a48284cae6e9022000af6f483a21b23fb",
+    "decision_hash": "4586510d84e7349e76d40be332a2745a48284cae6e9022000af6f483a21b23fb",
     "decision_ts": "2031-02-03T04:05:06.123456Z",
     "request_id": "req-cda-synthetic-001",
     "source_contract": {
@@ -22,12 +22,12 @@
       },
       "decision_status": "allow",
       "rejection_reason": null,
-      "gate_decision": "DENY",
+      "gate_decision": "block",
       "business_decision": "HOLD",
       "next_action": "REQUEST_VERIFIED_REVIEW",
       "actionability_status": "reviewable_only",
       "requires_bind_before_execution": true,
-      "human_review_required": true,
+      "human_review_required": false,
       "required_evidence": [
         "authority_evidence",
         "human_approval"
@@ -48,16 +48,16 @@
       },
       "lineage_promotability_binding": {
         "profile": "veritas.canonical-decision.lineage-promotability/v1",
-        "sha256": "bfb740a44e9a7332445fa6e4255696df1454e78d5b1cbd913fad11f48504d19b"
+        "sha256": "35c203c9baed4c3679bbcec66346bb97bd62d33dbd1fc5ff6339fed852500840"
       },
       "transition_refusal_binding": {
         "profile": "veritas.canonical-decision.transition-refusal/v1",
-        "sha256": "5747ed3a654db328097d821eebd8a2474e795ff2ae74fccee734d6c1f7f9d97c"
+        "sha256": "42405ab6973875446269a4f3bdcc1e527e393a9f5e2f60e964f756f234029bc6"
       }
     }
   },
-  "expected_decision_hash": "60d9df7b805fd7912cff59d2ff1a942ab07a7fcf75928cec7eb353a501741a8d",
-  "expected_decision_id": "cda:v1:sha256:60d9df7b805fd7912cff59d2ff1a942ab07a7fcf75928cec7eb353a501741a8d",
+  "expected_decision_hash": "4586510d84e7349e76d40be332a2745a48284cae6e9022000af6f483a21b23fb",
+  "expected_decision_id": "cda:v1:sha256:4586510d84e7349e76d40be332a2745a48284cae6e9022000af6f483a21b23fb",
   "expected_schema_valid": true,
-  "expected_production": "EMIT"
+  "expected_production": "HASH_REFERENCE_ONLY"
 }

--- a/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-05.json
+++ b/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-05.json
@@ -1,0 +1,63 @@
+{
+  "vector_id": "CDA-V1-05",
+  "description": "Included mutation: gate_decision",
+  "synthetic_fixture": true,
+  "mutation": "gate_decision",
+  "artifact": {
+    "format_version": "canonical-decision-artifact/v1",
+    "hash_profile": "veritas.canonical-decision/v1",
+    "decision_id": "cda:v1:sha256:60d9df7b805fd7912cff59d2ff1a942ab07a7fcf75928cec7eb353a501741a8d",
+    "decision_hash": "60d9df7b805fd7912cff59d2ff1a942ab07a7fcf75928cec7eb353a501741a8d",
+    "decision_ts": "2031-02-03T04:05:06.123456Z",
+    "request_id": "req-cda-synthetic-001",
+    "source_contract": {
+      "type": "DecideResponse",
+      "projection_version": "canonical-decision-projection/v1"
+    },
+    "decision": {
+      "formation_status": "COMPLETE",
+      "chosen_binding": {
+        "profile": "veritas.canonical-decision.chosen-value/v1",
+        "sha256": "f419527eddae068f9362c66ab338f54fb41d6f9f04adfb553294c59c5077e6f6"
+      },
+      "decision_status": "allow",
+      "rejection_reason": null,
+      "gate_decision": "DENY",
+      "business_decision": "HOLD",
+      "next_action": "REQUEST_VERIFIED_REVIEW",
+      "actionability_status": "reviewable_only",
+      "requires_bind_before_execution": true,
+      "human_review_required": true,
+      "required_evidence": [
+        "authority_evidence",
+        "human_approval"
+      ],
+      "missing_evidence": [
+        "authority_evidence"
+      ],
+      "satisfied_evidence": [
+        "policy_evaluation"
+      ],
+      "rationale": "Synthetic decision requires separately verified authority.",
+      "refusal_reason": null,
+      "actionability_block_reason": "BIND_REQUIRED",
+      "actionability_refusal_type": null,
+      "governance_identity_binding": {
+        "profile": "veritas.canonical-decision.governance-identity/v1",
+        "sha256": "c3aa80f8117ede4fa868319513b8304193b5323e0f960d3069076d2217a4e9ec"
+      },
+      "lineage_promotability_binding": {
+        "profile": "veritas.canonical-decision.lineage-promotability/v1",
+        "sha256": "bfb740a44e9a7332445fa6e4255696df1454e78d5b1cbd913fad11f48504d19b"
+      },
+      "transition_refusal_binding": {
+        "profile": "veritas.canonical-decision.transition-refusal/v1",
+        "sha256": "5747ed3a654db328097d821eebd8a2474e795ff2ae74fccee734d6c1f7f9d97c"
+      }
+    }
+  },
+  "expected_decision_hash": "60d9df7b805fd7912cff59d2ff1a942ab07a7fcf75928cec7eb353a501741a8d",
+  "expected_decision_id": "cda:v1:sha256:60d9df7b805fd7912cff59d2ff1a942ab07a7fcf75928cec7eb353a501741a8d",
+  "expected_schema_valid": true,
+  "expected_production": "EMIT"
+}

--- a/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-06.json
+++ b/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-06.json
@@ -6,8 +6,8 @@
   "artifact": {
     "format_version": "canonical-decision-artifact/v1",
     "hash_profile": "veritas.canonical-decision/v1",
-    "decision_id": "cda:v1:sha256:df010f36f5b003b319e653dc6b960296ce7b46c4a49d2f3d53ef43f8e01a45ac",
-    "decision_hash": "df010f36f5b003b319e653dc6b960296ce7b46c4a49d2f3d53ef43f8e01a45ac",
+    "decision_id": "cda:v1:sha256:92ef818d7491ec6e9f9fa72d470553f3ae093a173e34777115d6ab47e7892661",
+    "decision_hash": "92ef818d7491ec6e9f9fa72d470553f3ae093a173e34777115d6ab47e7892661",
     "decision_ts": "2031-02-03T04:05:06.123456Z",
     "request_id": "req-cda-synthetic-001",
     "source_contract": {
@@ -22,12 +22,12 @@
       },
       "decision_status": "allow",
       "rejection_reason": null,
-      "gate_decision": "ALLOW",
-      "business_decision": "APPROVE",
+      "gate_decision": "hold",
+      "business_decision": "DENY",
       "next_action": "REQUEST_VERIFIED_REVIEW",
       "actionability_status": "reviewable_only",
       "requires_bind_before_execution": true,
-      "human_review_required": true,
+      "human_review_required": false,
       "required_evidence": [
         "authority_evidence",
         "human_approval"
@@ -48,16 +48,16 @@
       },
       "lineage_promotability_binding": {
         "profile": "veritas.canonical-decision.lineage-promotability/v1",
-        "sha256": "bfb740a44e9a7332445fa6e4255696df1454e78d5b1cbd913fad11f48504d19b"
+        "sha256": "35c203c9baed4c3679bbcec66346bb97bd62d33dbd1fc5ff6339fed852500840"
       },
       "transition_refusal_binding": {
         "profile": "veritas.canonical-decision.transition-refusal/v1",
-        "sha256": "5747ed3a654db328097d821eebd8a2474e795ff2ae74fccee734d6c1f7f9d97c"
+        "sha256": "42405ab6973875446269a4f3bdcc1e527e393a9f5e2f60e964f756f234029bc6"
       }
     }
   },
-  "expected_decision_hash": "df010f36f5b003b319e653dc6b960296ce7b46c4a49d2f3d53ef43f8e01a45ac",
-  "expected_decision_id": "cda:v1:sha256:df010f36f5b003b319e653dc6b960296ce7b46c4a49d2f3d53ef43f8e01a45ac",
+  "expected_decision_hash": "92ef818d7491ec6e9f9fa72d470553f3ae093a173e34777115d6ab47e7892661",
+  "expected_decision_id": "cda:v1:sha256:92ef818d7491ec6e9f9fa72d470553f3ae093a173e34777115d6ab47e7892661",
   "expected_schema_valid": true,
-  "expected_production": "EMIT"
+  "expected_production": "HASH_REFERENCE_ONLY"
 }

--- a/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-06.json
+++ b/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-06.json
@@ -1,0 +1,63 @@
+{
+  "vector_id": "CDA-V1-06",
+  "description": "Included mutation: business_decision",
+  "synthetic_fixture": true,
+  "mutation": "business_decision",
+  "artifact": {
+    "format_version": "canonical-decision-artifact/v1",
+    "hash_profile": "veritas.canonical-decision/v1",
+    "decision_id": "cda:v1:sha256:df010f36f5b003b319e653dc6b960296ce7b46c4a49d2f3d53ef43f8e01a45ac",
+    "decision_hash": "df010f36f5b003b319e653dc6b960296ce7b46c4a49d2f3d53ef43f8e01a45ac",
+    "decision_ts": "2031-02-03T04:05:06.123456Z",
+    "request_id": "req-cda-synthetic-001",
+    "source_contract": {
+      "type": "DecideResponse",
+      "projection_version": "canonical-decision-projection/v1"
+    },
+    "decision": {
+      "formation_status": "COMPLETE",
+      "chosen_binding": {
+        "profile": "veritas.canonical-decision.chosen-value/v1",
+        "sha256": "f419527eddae068f9362c66ab338f54fb41d6f9f04adfb553294c59c5077e6f6"
+      },
+      "decision_status": "allow",
+      "rejection_reason": null,
+      "gate_decision": "ALLOW",
+      "business_decision": "APPROVE",
+      "next_action": "REQUEST_VERIFIED_REVIEW",
+      "actionability_status": "reviewable_only",
+      "requires_bind_before_execution": true,
+      "human_review_required": true,
+      "required_evidence": [
+        "authority_evidence",
+        "human_approval"
+      ],
+      "missing_evidence": [
+        "authority_evidence"
+      ],
+      "satisfied_evidence": [
+        "policy_evaluation"
+      ],
+      "rationale": "Synthetic decision requires separately verified authority.",
+      "refusal_reason": null,
+      "actionability_block_reason": "BIND_REQUIRED",
+      "actionability_refusal_type": null,
+      "governance_identity_binding": {
+        "profile": "veritas.canonical-decision.governance-identity/v1",
+        "sha256": "c3aa80f8117ede4fa868319513b8304193b5323e0f960d3069076d2217a4e9ec"
+      },
+      "lineage_promotability_binding": {
+        "profile": "veritas.canonical-decision.lineage-promotability/v1",
+        "sha256": "bfb740a44e9a7332445fa6e4255696df1454e78d5b1cbd913fad11f48504d19b"
+      },
+      "transition_refusal_binding": {
+        "profile": "veritas.canonical-decision.transition-refusal/v1",
+        "sha256": "5747ed3a654db328097d821eebd8a2474e795ff2ae74fccee734d6c1f7f9d97c"
+      }
+    }
+  },
+  "expected_decision_hash": "df010f36f5b003b319e653dc6b960296ce7b46c4a49d2f3d53ef43f8e01a45ac",
+  "expected_decision_id": "cda:v1:sha256:df010f36f5b003b319e653dc6b960296ce7b46c4a49d2f3d53ef43f8e01a45ac",
+  "expected_schema_valid": true,
+  "expected_production": "EMIT"
+}

--- a/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-07.json
+++ b/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-07.json
@@ -6,8 +6,8 @@
   "artifact": {
     "format_version": "canonical-decision-artifact/v1",
     "hash_profile": "veritas.canonical-decision/v1",
-    "decision_id": "cda:v1:sha256:2bfe09f64337ea95d2772cd4a969ac7366571d65f2ff9b9830957deca445dd86",
-    "decision_hash": "2bfe09f64337ea95d2772cd4a969ac7366571d65f2ff9b9830957deca445dd86",
+    "decision_id": "cda:v1:sha256:a90309336f270182dfa02f1a00723b0e3eef3215308a167785b129b2132b7259",
+    "decision_hash": "a90309336f270182dfa02f1a00723b0e3eef3215308a167785b129b2132b7259",
     "decision_ts": "2031-02-03T04:05:06.123456Z",
     "request_id": "req-cda-synthetic-001",
     "source_contract": {
@@ -22,12 +22,12 @@
       },
       "decision_status": "allow",
       "rejection_reason": null,
-      "gate_decision": "ALLOW",
+      "gate_decision": "hold",
       "business_decision": "HOLD",
       "next_action": "REQUEST_VERIFIED_REVIEW",
       "actionability_status": "blocked",
       "requires_bind_before_execution": true,
-      "human_review_required": true,
+      "human_review_required": false,
       "required_evidence": [
         "authority_evidence",
         "human_approval"
@@ -48,16 +48,16 @@
       },
       "lineage_promotability_binding": {
         "profile": "veritas.canonical-decision.lineage-promotability/v1",
-        "sha256": "bfb740a44e9a7332445fa6e4255696df1454e78d5b1cbd913fad11f48504d19b"
+        "sha256": "35c203c9baed4c3679bbcec66346bb97bd62d33dbd1fc5ff6339fed852500840"
       },
       "transition_refusal_binding": {
         "profile": "veritas.canonical-decision.transition-refusal/v1",
-        "sha256": "5747ed3a654db328097d821eebd8a2474e795ff2ae74fccee734d6c1f7f9d97c"
+        "sha256": "42405ab6973875446269a4f3bdcc1e527e393a9f5e2f60e964f756f234029bc6"
       }
     }
   },
-  "expected_decision_hash": "2bfe09f64337ea95d2772cd4a969ac7366571d65f2ff9b9830957deca445dd86",
-  "expected_decision_id": "cda:v1:sha256:2bfe09f64337ea95d2772cd4a969ac7366571d65f2ff9b9830957deca445dd86",
+  "expected_decision_hash": "a90309336f270182dfa02f1a00723b0e3eef3215308a167785b129b2132b7259",
+  "expected_decision_id": "cda:v1:sha256:a90309336f270182dfa02f1a00723b0e3eef3215308a167785b129b2132b7259",
   "expected_schema_valid": true,
-  "expected_production": "EMIT"
+  "expected_production": "HASH_REFERENCE_ONLY"
 }

--- a/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-07.json
+++ b/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-07.json
@@ -6,8 +6,8 @@
   "artifact": {
     "format_version": "canonical-decision-artifact/v1",
     "hash_profile": "veritas.canonical-decision/v1",
-    "decision_id": "cda:v1:sha256:a90309336f270182dfa02f1a00723b0e3eef3215308a167785b129b2132b7259",
-    "decision_hash": "a90309336f270182dfa02f1a00723b0e3eef3215308a167785b129b2132b7259",
+    "decision_id": "cda:v1:sha256:842fc2dd2de291c8edda2a42f07081e8b6a4b2b4f6e952cfb0e0d48036f64db1",
+    "decision_hash": "842fc2dd2de291c8edda2a42f07081e8b6a4b2b4f6e952cfb0e0d48036f64db1",
     "decision_ts": "2031-02-03T04:05:06.123456Z",
     "request_id": "req-cda-synthetic-001",
     "source_contract": {
@@ -25,7 +25,7 @@
       "gate_decision": "hold",
       "business_decision": "HOLD",
       "next_action": "REQUEST_VERIFIED_REVIEW",
-      "actionability_status": "blocked",
+      "actionability_status": "bind_required_before_execution",
       "requires_bind_before_execution": true,
       "human_review_required": false,
       "required_evidence": [
@@ -56,8 +56,8 @@
       }
     }
   },
-  "expected_decision_hash": "a90309336f270182dfa02f1a00723b0e3eef3215308a167785b129b2132b7259",
-  "expected_decision_id": "cda:v1:sha256:a90309336f270182dfa02f1a00723b0e3eef3215308a167785b129b2132b7259",
+  "expected_decision_hash": "842fc2dd2de291c8edda2a42f07081e8b6a4b2b4f6e952cfb0e0d48036f64db1",
+  "expected_decision_id": "cda:v1:sha256:842fc2dd2de291c8edda2a42f07081e8b6a4b2b4f6e952cfb0e0d48036f64db1",
   "expected_schema_valid": true,
   "expected_production": "HASH_REFERENCE_ONLY"
 }

--- a/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-07.json
+++ b/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-07.json
@@ -1,0 +1,63 @@
+{
+  "vector_id": "CDA-V1-07",
+  "description": "Included mutation: actionability_status",
+  "synthetic_fixture": true,
+  "mutation": "actionability_status",
+  "artifact": {
+    "format_version": "canonical-decision-artifact/v1",
+    "hash_profile": "veritas.canonical-decision/v1",
+    "decision_id": "cda:v1:sha256:2bfe09f64337ea95d2772cd4a969ac7366571d65f2ff9b9830957deca445dd86",
+    "decision_hash": "2bfe09f64337ea95d2772cd4a969ac7366571d65f2ff9b9830957deca445dd86",
+    "decision_ts": "2031-02-03T04:05:06.123456Z",
+    "request_id": "req-cda-synthetic-001",
+    "source_contract": {
+      "type": "DecideResponse",
+      "projection_version": "canonical-decision-projection/v1"
+    },
+    "decision": {
+      "formation_status": "COMPLETE",
+      "chosen_binding": {
+        "profile": "veritas.canonical-decision.chosen-value/v1",
+        "sha256": "f419527eddae068f9362c66ab338f54fb41d6f9f04adfb553294c59c5077e6f6"
+      },
+      "decision_status": "allow",
+      "rejection_reason": null,
+      "gate_decision": "ALLOW",
+      "business_decision": "HOLD",
+      "next_action": "REQUEST_VERIFIED_REVIEW",
+      "actionability_status": "blocked",
+      "requires_bind_before_execution": true,
+      "human_review_required": true,
+      "required_evidence": [
+        "authority_evidence",
+        "human_approval"
+      ],
+      "missing_evidence": [
+        "authority_evidence"
+      ],
+      "satisfied_evidence": [
+        "policy_evaluation"
+      ],
+      "rationale": "Synthetic decision requires separately verified authority.",
+      "refusal_reason": null,
+      "actionability_block_reason": "BIND_REQUIRED",
+      "actionability_refusal_type": null,
+      "governance_identity_binding": {
+        "profile": "veritas.canonical-decision.governance-identity/v1",
+        "sha256": "c3aa80f8117ede4fa868319513b8304193b5323e0f960d3069076d2217a4e9ec"
+      },
+      "lineage_promotability_binding": {
+        "profile": "veritas.canonical-decision.lineage-promotability/v1",
+        "sha256": "bfb740a44e9a7332445fa6e4255696df1454e78d5b1cbd913fad11f48504d19b"
+      },
+      "transition_refusal_binding": {
+        "profile": "veritas.canonical-decision.transition-refusal/v1",
+        "sha256": "5747ed3a654db328097d821eebd8a2474e795ff2ae74fccee734d6c1f7f9d97c"
+      }
+    }
+  },
+  "expected_decision_hash": "2bfe09f64337ea95d2772cd4a969ac7366571d65f2ff9b9830957deca445dd86",
+  "expected_decision_id": "cda:v1:sha256:2bfe09f64337ea95d2772cd4a969ac7366571d65f2ff9b9830957deca445dd86",
+  "expected_schema_valid": true,
+  "expected_production": "EMIT"
+}

--- a/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-08.json
+++ b/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-08.json
@@ -6,8 +6,8 @@
   "artifact": {
     "format_version": "canonical-decision-artifact/v1",
     "hash_profile": "veritas.canonical-decision/v1",
-    "decision_id": "cda:v1:sha256:b262aa34b49e97a579794086936a09ef5b2a11a430397def48fa6b09fb503235",
-    "decision_hash": "b262aa34b49e97a579794086936a09ef5b2a11a430397def48fa6b09fb503235",
+    "decision_id": "cda:v1:sha256:dc508f9a7dc26fb13f24f369328d6df8212f65f95ba0b06418f7b943ad08ae49",
+    "decision_hash": "dc508f9a7dc26fb13f24f369328d6df8212f65f95ba0b06418f7b943ad08ae49",
     "decision_ts": "2031-02-03T04:05:06.123456Z",
     "request_id": "req-cda-synthetic-001",
     "source_contract": {
@@ -22,12 +22,12 @@
       },
       "decision_status": "allow",
       "rejection_reason": null,
-      "gate_decision": "ALLOW",
+      "gate_decision": "hold",
       "business_decision": "HOLD",
       "next_action": "REQUEST_VERIFIED_REVIEW",
       "actionability_status": "reviewable_only",
       "requires_bind_before_execution": true,
-      "human_review_required": false,
+      "human_review_required": true,
       "required_evidence": [
         "authority_evidence",
         "human_approval"
@@ -48,16 +48,16 @@
       },
       "lineage_promotability_binding": {
         "profile": "veritas.canonical-decision.lineage-promotability/v1",
-        "sha256": "bfb740a44e9a7332445fa6e4255696df1454e78d5b1cbd913fad11f48504d19b"
+        "sha256": "35c203c9baed4c3679bbcec66346bb97bd62d33dbd1fc5ff6339fed852500840"
       },
       "transition_refusal_binding": {
         "profile": "veritas.canonical-decision.transition-refusal/v1",
-        "sha256": "5747ed3a654db328097d821eebd8a2474e795ff2ae74fccee734d6c1f7f9d97c"
+        "sha256": "42405ab6973875446269a4f3bdcc1e527e393a9f5e2f60e964f756f234029bc6"
       }
     }
   },
-  "expected_decision_hash": "b262aa34b49e97a579794086936a09ef5b2a11a430397def48fa6b09fb503235",
-  "expected_decision_id": "cda:v1:sha256:b262aa34b49e97a579794086936a09ef5b2a11a430397def48fa6b09fb503235",
+  "expected_decision_hash": "dc508f9a7dc26fb13f24f369328d6df8212f65f95ba0b06418f7b943ad08ae49",
+  "expected_decision_id": "cda:v1:sha256:dc508f9a7dc26fb13f24f369328d6df8212f65f95ba0b06418f7b943ad08ae49",
   "expected_schema_valid": true,
-  "expected_production": "EMIT"
+  "expected_production": "HASH_REFERENCE_ONLY"
 }

--- a/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-08.json
+++ b/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-08.json
@@ -1,0 +1,63 @@
+{
+  "vector_id": "CDA-V1-08",
+  "description": "Included mutation: human_review_required",
+  "synthetic_fixture": true,
+  "mutation": "human_review_required",
+  "artifact": {
+    "format_version": "canonical-decision-artifact/v1",
+    "hash_profile": "veritas.canonical-decision/v1",
+    "decision_id": "cda:v1:sha256:b262aa34b49e97a579794086936a09ef5b2a11a430397def48fa6b09fb503235",
+    "decision_hash": "b262aa34b49e97a579794086936a09ef5b2a11a430397def48fa6b09fb503235",
+    "decision_ts": "2031-02-03T04:05:06.123456Z",
+    "request_id": "req-cda-synthetic-001",
+    "source_contract": {
+      "type": "DecideResponse",
+      "projection_version": "canonical-decision-projection/v1"
+    },
+    "decision": {
+      "formation_status": "COMPLETE",
+      "chosen_binding": {
+        "profile": "veritas.canonical-decision.chosen-value/v1",
+        "sha256": "f419527eddae068f9362c66ab338f54fb41d6f9f04adfb553294c59c5077e6f6"
+      },
+      "decision_status": "allow",
+      "rejection_reason": null,
+      "gate_decision": "ALLOW",
+      "business_decision": "HOLD",
+      "next_action": "REQUEST_VERIFIED_REVIEW",
+      "actionability_status": "reviewable_only",
+      "requires_bind_before_execution": true,
+      "human_review_required": false,
+      "required_evidence": [
+        "authority_evidence",
+        "human_approval"
+      ],
+      "missing_evidence": [
+        "authority_evidence"
+      ],
+      "satisfied_evidence": [
+        "policy_evaluation"
+      ],
+      "rationale": "Synthetic decision requires separately verified authority.",
+      "refusal_reason": null,
+      "actionability_block_reason": "BIND_REQUIRED",
+      "actionability_refusal_type": null,
+      "governance_identity_binding": {
+        "profile": "veritas.canonical-decision.governance-identity/v1",
+        "sha256": "c3aa80f8117ede4fa868319513b8304193b5323e0f960d3069076d2217a4e9ec"
+      },
+      "lineage_promotability_binding": {
+        "profile": "veritas.canonical-decision.lineage-promotability/v1",
+        "sha256": "bfb740a44e9a7332445fa6e4255696df1454e78d5b1cbd913fad11f48504d19b"
+      },
+      "transition_refusal_binding": {
+        "profile": "veritas.canonical-decision.transition-refusal/v1",
+        "sha256": "5747ed3a654db328097d821eebd8a2474e795ff2ae74fccee734d6c1f7f9d97c"
+      }
+    }
+  },
+  "expected_decision_hash": "b262aa34b49e97a579794086936a09ef5b2a11a430397def48fa6b09fb503235",
+  "expected_decision_id": "cda:v1:sha256:b262aa34b49e97a579794086936a09ef5b2a11a430397def48fa6b09fb503235",
+  "expected_schema_valid": true,
+  "expected_production": "EMIT"
+}

--- a/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-09.json
+++ b/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-09.json
@@ -6,8 +6,8 @@
   "artifact": {
     "format_version": "canonical-decision-artifact/v1",
     "hash_profile": "veritas.canonical-decision/v1",
-    "decision_id": "cda:v1:sha256:4beb4990ba84574a7ba72ea6024bf63ba4b7f264aac11a8854fae6fe664ef899",
-    "decision_hash": "4beb4990ba84574a7ba72ea6024bf63ba4b7f264aac11a8854fae6fe664ef899",
+    "decision_id": "cda:v1:sha256:d96481d43576d970001546556d84c69ac102973b5fd4305888baa1ace63b2d1c",
+    "decision_hash": "d96481d43576d970001546556d84c69ac102973b5fd4305888baa1ace63b2d1c",
     "decision_ts": "2031-02-03T04:05:06.123456Z",
     "request_id": "req-cda-synthetic-001",
     "source_contract": {
@@ -22,12 +22,12 @@
       },
       "decision_status": "allow",
       "rejection_reason": null,
-      "gate_decision": "ALLOW",
+      "gate_decision": "hold",
       "business_decision": "HOLD",
       "next_action": "REQUEST_VERIFIED_REVIEW",
       "actionability_status": "reviewable_only",
       "requires_bind_before_execution": true,
-      "human_review_required": true,
+      "human_review_required": false,
       "required_evidence": [
         "authority_evidence",
         "human_approval"
@@ -49,16 +49,16 @@
       },
       "lineage_promotability_binding": {
         "profile": "veritas.canonical-decision.lineage-promotability/v1",
-        "sha256": "bfb740a44e9a7332445fa6e4255696df1454e78d5b1cbd913fad11f48504d19b"
+        "sha256": "35c203c9baed4c3679bbcec66346bb97bd62d33dbd1fc5ff6339fed852500840"
       },
       "transition_refusal_binding": {
         "profile": "veritas.canonical-decision.transition-refusal/v1",
-        "sha256": "5747ed3a654db328097d821eebd8a2474e795ff2ae74fccee734d6c1f7f9d97c"
+        "sha256": "42405ab6973875446269a4f3bdcc1e527e393a9f5e2f60e964f756f234029bc6"
       }
     }
   },
-  "expected_decision_hash": "4beb4990ba84574a7ba72ea6024bf63ba4b7f264aac11a8854fae6fe664ef899",
-  "expected_decision_id": "cda:v1:sha256:4beb4990ba84574a7ba72ea6024bf63ba4b7f264aac11a8854fae6fe664ef899",
+  "expected_decision_hash": "d96481d43576d970001546556d84c69ac102973b5fd4305888baa1ace63b2d1c",
+  "expected_decision_id": "cda:v1:sha256:d96481d43576d970001546556d84c69ac102973b5fd4305888baa1ace63b2d1c",
   "expected_schema_valid": true,
-  "expected_production": "EMIT"
+  "expected_production": "HASH_REFERENCE_ONLY"
 }

--- a/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-09.json
+++ b/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-09.json
@@ -1,0 +1,64 @@
+{
+  "vector_id": "CDA-V1-09",
+  "description": "Included mutation: evidence state",
+  "synthetic_fixture": true,
+  "mutation": "evidence state",
+  "artifact": {
+    "format_version": "canonical-decision-artifact/v1",
+    "hash_profile": "veritas.canonical-decision/v1",
+    "decision_id": "cda:v1:sha256:4beb4990ba84574a7ba72ea6024bf63ba4b7f264aac11a8854fae6fe664ef899",
+    "decision_hash": "4beb4990ba84574a7ba72ea6024bf63ba4b7f264aac11a8854fae6fe664ef899",
+    "decision_ts": "2031-02-03T04:05:06.123456Z",
+    "request_id": "req-cda-synthetic-001",
+    "source_contract": {
+      "type": "DecideResponse",
+      "projection_version": "canonical-decision-projection/v1"
+    },
+    "decision": {
+      "formation_status": "COMPLETE",
+      "chosen_binding": {
+        "profile": "veritas.canonical-decision.chosen-value/v1",
+        "sha256": "f419527eddae068f9362c66ab338f54fb41d6f9f04adfb553294c59c5077e6f6"
+      },
+      "decision_status": "allow",
+      "rejection_reason": null,
+      "gate_decision": "ALLOW",
+      "business_decision": "HOLD",
+      "next_action": "REQUEST_VERIFIED_REVIEW",
+      "actionability_status": "reviewable_only",
+      "requires_bind_before_execution": true,
+      "human_review_required": true,
+      "required_evidence": [
+        "authority_evidence",
+        "human_approval"
+      ],
+      "missing_evidence": [
+        "authority_evidence",
+        "human_approval"
+      ],
+      "satisfied_evidence": [
+        "policy_evaluation"
+      ],
+      "rationale": "Synthetic decision requires separately verified authority.",
+      "refusal_reason": null,
+      "actionability_block_reason": "BIND_REQUIRED",
+      "actionability_refusal_type": null,
+      "governance_identity_binding": {
+        "profile": "veritas.canonical-decision.governance-identity/v1",
+        "sha256": "c3aa80f8117ede4fa868319513b8304193b5323e0f960d3069076d2217a4e9ec"
+      },
+      "lineage_promotability_binding": {
+        "profile": "veritas.canonical-decision.lineage-promotability/v1",
+        "sha256": "bfb740a44e9a7332445fa6e4255696df1454e78d5b1cbd913fad11f48504d19b"
+      },
+      "transition_refusal_binding": {
+        "profile": "veritas.canonical-decision.transition-refusal/v1",
+        "sha256": "5747ed3a654db328097d821eebd8a2474e795ff2ae74fccee734d6c1f7f9d97c"
+      }
+    }
+  },
+  "expected_decision_hash": "4beb4990ba84574a7ba72ea6024bf63ba4b7f264aac11a8854fae6fe664ef899",
+  "expected_decision_id": "cda:v1:sha256:4beb4990ba84574a7ba72ea6024bf63ba4b7f264aac11a8854fae6fe664ef899",
+  "expected_schema_valid": true,
+  "expected_production": "EMIT"
+}

--- a/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-10.json
+++ b/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-10.json
@@ -6,8 +6,8 @@
   "artifact": {
     "format_version": "canonical-decision-artifact/v1",
     "hash_profile": "veritas.canonical-decision/v1",
-    "decision_id": "cda:v1:sha256:37007a2fc5f12b20194209fe93518c77e7c5bc786b62d6ceea3f79911dc9cbf2",
-    "decision_hash": "37007a2fc5f12b20194209fe93518c77e7c5bc786b62d6ceea3f79911dc9cbf2",
+    "decision_id": "cda:v1:sha256:4cb616ecfa7384dce7dd860dd2783cca270b5f6e952584f20ec4198cc7e38851",
+    "decision_hash": "4cb616ecfa7384dce7dd860dd2783cca270b5f6e952584f20ec4198cc7e38851",
     "decision_ts": "2031-02-03T04:05:06.123456Z",
     "request_id": "req-cda-synthetic-001",
     "source_contract": {
@@ -22,12 +22,12 @@
       },
       "decision_status": "allow",
       "rejection_reason": null,
-      "gate_decision": "ALLOW",
+      "gate_decision": "hold",
       "business_decision": "HOLD",
       "next_action": "REQUEST_VERIFIED_REVIEW",
       "actionability_status": "reviewable_only",
       "requires_bind_before_execution": true,
-      "human_review_required": true,
+      "human_review_required": false,
       "required_evidence": [
         "authority_evidence",
         "human_approval"
@@ -48,16 +48,16 @@
       },
       "lineage_promotability_binding": {
         "profile": "veritas.canonical-decision.lineage-promotability/v1",
-        "sha256": "bfb740a44e9a7332445fa6e4255696df1454e78d5b1cbd913fad11f48504d19b"
+        "sha256": "35c203c9baed4c3679bbcec66346bb97bd62d33dbd1fc5ff6339fed852500840"
       },
       "transition_refusal_binding": {
         "profile": "veritas.canonical-decision.transition-refusal/v1",
-        "sha256": "5747ed3a654db328097d821eebd8a2474e795ff2ae74fccee734d6c1f7f9d97c"
+        "sha256": "42405ab6973875446269a4f3bdcc1e527e393a9f5e2f60e964f756f234029bc6"
       }
     }
   },
-  "expected_decision_hash": "37007a2fc5f12b20194209fe93518c77e7c5bc786b62d6ceea3f79911dc9cbf2",
-  "expected_decision_id": "cda:v1:sha256:37007a2fc5f12b20194209fe93518c77e7c5bc786b62d6ceea3f79911dc9cbf2",
+  "expected_decision_hash": "4cb616ecfa7384dce7dd860dd2783cca270b5f6e952584f20ec4198cc7e38851",
+  "expected_decision_id": "cda:v1:sha256:4cb616ecfa7384dce7dd860dd2783cca270b5f6e952584f20ec4198cc7e38851",
   "expected_schema_valid": true,
-  "expected_production": "EMIT"
+  "expected_production": "HASH_REFERENCE_ONLY"
 }

--- a/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-10.json
+++ b/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-10.json
@@ -1,0 +1,63 @@
+{
+  "vector_id": "CDA-V1-10",
+  "description": "Included mutation: governance identity binding",
+  "synthetic_fixture": true,
+  "mutation": "governance identity binding",
+  "artifact": {
+    "format_version": "canonical-decision-artifact/v1",
+    "hash_profile": "veritas.canonical-decision/v1",
+    "decision_id": "cda:v1:sha256:37007a2fc5f12b20194209fe93518c77e7c5bc786b62d6ceea3f79911dc9cbf2",
+    "decision_hash": "37007a2fc5f12b20194209fe93518c77e7c5bc786b62d6ceea3f79911dc9cbf2",
+    "decision_ts": "2031-02-03T04:05:06.123456Z",
+    "request_id": "req-cda-synthetic-001",
+    "source_contract": {
+      "type": "DecideResponse",
+      "projection_version": "canonical-decision-projection/v1"
+    },
+    "decision": {
+      "formation_status": "COMPLETE",
+      "chosen_binding": {
+        "profile": "veritas.canonical-decision.chosen-value/v1",
+        "sha256": "f419527eddae068f9362c66ab338f54fb41d6f9f04adfb553294c59c5077e6f6"
+      },
+      "decision_status": "allow",
+      "rejection_reason": null,
+      "gate_decision": "ALLOW",
+      "business_decision": "HOLD",
+      "next_action": "REQUEST_VERIFIED_REVIEW",
+      "actionability_status": "reviewable_only",
+      "requires_bind_before_execution": true,
+      "human_review_required": true,
+      "required_evidence": [
+        "authority_evidence",
+        "human_approval"
+      ],
+      "missing_evidence": [
+        "authority_evidence"
+      ],
+      "satisfied_evidence": [
+        "policy_evaluation"
+      ],
+      "rationale": "Synthetic decision requires separately verified authority.",
+      "refusal_reason": null,
+      "actionability_block_reason": "BIND_REQUIRED",
+      "actionability_refusal_type": null,
+      "governance_identity_binding": {
+        "profile": "veritas.canonical-decision.governance-identity/v1",
+        "sha256": "08a91c556d57a77061015d40f7ab0308dd9731bba8d3a1f50067354eb7e5964b"
+      },
+      "lineage_promotability_binding": {
+        "profile": "veritas.canonical-decision.lineage-promotability/v1",
+        "sha256": "bfb740a44e9a7332445fa6e4255696df1454e78d5b1cbd913fad11f48504d19b"
+      },
+      "transition_refusal_binding": {
+        "profile": "veritas.canonical-decision.transition-refusal/v1",
+        "sha256": "5747ed3a654db328097d821eebd8a2474e795ff2ae74fccee734d6c1f7f9d97c"
+      }
+    }
+  },
+  "expected_decision_hash": "37007a2fc5f12b20194209fe93518c77e7c5bc786b62d6ceea3f79911dc9cbf2",
+  "expected_decision_id": "cda:v1:sha256:37007a2fc5f12b20194209fe93518c77e7c5bc786b62d6ceea3f79911dc9cbf2",
+  "expected_schema_valid": true,
+  "expected_production": "EMIT"
+}

--- a/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-11.json
+++ b/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-11.json
@@ -1,0 +1,63 @@
+{
+  "vector_id": "CDA-V1-11",
+  "description": "Included mutation: formation refusal/promotability state",
+  "synthetic_fixture": true,
+  "mutation": "formation refusal/promotability state",
+  "artifact": {
+    "format_version": "canonical-decision-artifact/v1",
+    "hash_profile": "veritas.canonical-decision/v1",
+    "decision_id": "cda:v1:sha256:3b00f02a49243cca9d0a6c02fd23419187c8d4e0689bf07127ab50e35f6759a8",
+    "decision_hash": "3b00f02a49243cca9d0a6c02fd23419187c8d4e0689bf07127ab50e35f6759a8",
+    "decision_ts": "2031-02-03T04:05:06.123456Z",
+    "request_id": "req-cda-synthetic-001",
+    "source_contract": {
+      "type": "DecideResponse",
+      "projection_version": "canonical-decision-projection/v1"
+    },
+    "decision": {
+      "formation_status": "COMPLETE",
+      "chosen_binding": {
+        "profile": "veritas.canonical-decision.chosen-value/v1",
+        "sha256": "f419527eddae068f9362c66ab338f54fb41d6f9f04adfb553294c59c5077e6f6"
+      },
+      "decision_status": "allow",
+      "rejection_reason": null,
+      "gate_decision": "ALLOW",
+      "business_decision": "HOLD",
+      "next_action": "REQUEST_VERIFIED_REVIEW",
+      "actionability_status": "reviewable_only",
+      "requires_bind_before_execution": true,
+      "human_review_required": true,
+      "required_evidence": [
+        "authority_evidence",
+        "human_approval"
+      ],
+      "missing_evidence": [
+        "authority_evidence"
+      ],
+      "satisfied_evidence": [
+        "policy_evaluation"
+      ],
+      "rationale": "Synthetic decision requires separately verified authority.",
+      "refusal_reason": null,
+      "actionability_block_reason": "BIND_REQUIRED",
+      "actionability_refusal_type": null,
+      "governance_identity_binding": {
+        "profile": "veritas.canonical-decision.governance-identity/v1",
+        "sha256": "c3aa80f8117ede4fa868319513b8304193b5323e0f960d3069076d2217a4e9ec"
+      },
+      "lineage_promotability_binding": {
+        "profile": "veritas.canonical-decision.lineage-promotability/v1",
+        "sha256": "7c7cbd111bc5e794051147b25129d33b0acb4ede89977dfbba4088d4a98b2893"
+      },
+      "transition_refusal_binding": {
+        "profile": "veritas.canonical-decision.transition-refusal/v1",
+        "sha256": "5747ed3a654db328097d821eebd8a2474e795ff2ae74fccee734d6c1f7f9d97c"
+      }
+    }
+  },
+  "expected_decision_hash": "3b00f02a49243cca9d0a6c02fd23419187c8d4e0689bf07127ab50e35f6759a8",
+  "expected_decision_id": "cda:v1:sha256:3b00f02a49243cca9d0a6c02fd23419187c8d4e0689bf07127ab50e35f6759a8",
+  "expected_schema_valid": true,
+  "expected_production": "EMIT"
+}

--- a/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-11.json
+++ b/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-11.json
@@ -6,8 +6,8 @@
   "artifact": {
     "format_version": "canonical-decision-artifact/v1",
     "hash_profile": "veritas.canonical-decision/v1",
-    "decision_id": "cda:v1:sha256:3b00f02a49243cca9d0a6c02fd23419187c8d4e0689bf07127ab50e35f6759a8",
-    "decision_hash": "3b00f02a49243cca9d0a6c02fd23419187c8d4e0689bf07127ab50e35f6759a8",
+    "decision_id": "cda:v1:sha256:88ab1877f435a4dc16b32ad32c2f1d6f054017649ffb7dce89b1cf169a714d03",
+    "decision_hash": "88ab1877f435a4dc16b32ad32c2f1d6f054017649ffb7dce89b1cf169a714d03",
     "decision_ts": "2031-02-03T04:05:06.123456Z",
     "request_id": "req-cda-synthetic-001",
     "source_contract": {
@@ -22,12 +22,12 @@
       },
       "decision_status": "allow",
       "rejection_reason": null,
-      "gate_decision": "ALLOW",
+      "gate_decision": "hold",
       "business_decision": "HOLD",
       "next_action": "REQUEST_VERIFIED_REVIEW",
       "actionability_status": "reviewable_only",
       "requires_bind_before_execution": true,
-      "human_review_required": true,
+      "human_review_required": false,
       "required_evidence": [
         "authority_evidence",
         "human_approval"
@@ -52,12 +52,12 @@
       },
       "transition_refusal_binding": {
         "profile": "veritas.canonical-decision.transition-refusal/v1",
-        "sha256": "5747ed3a654db328097d821eebd8a2474e795ff2ae74fccee734d6c1f7f9d97c"
+        "sha256": "42405ab6973875446269a4f3bdcc1e527e393a9f5e2f60e964f756f234029bc6"
       }
     }
   },
-  "expected_decision_hash": "3b00f02a49243cca9d0a6c02fd23419187c8d4e0689bf07127ab50e35f6759a8",
-  "expected_decision_id": "cda:v1:sha256:3b00f02a49243cca9d0a6c02fd23419187c8d4e0689bf07127ab50e35f6759a8",
+  "expected_decision_hash": "88ab1877f435a4dc16b32ad32c2f1d6f054017649ffb7dce89b1cf169a714d03",
+  "expected_decision_id": "cda:v1:sha256:88ab1877f435a4dc16b32ad32c2f1d6f054017649ffb7dce89b1cf169a714d03",
   "expected_schema_valid": true,
-  "expected_production": "EMIT"
+  "expected_production": "HASH_REFERENCE_ONLY"
 }

--- a/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-12.json
+++ b/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-12.json
@@ -1,0 +1,154 @@
+{
+  "vector_id": "CDA-V1-12",
+  "description": "Excluded source fields are identity-stable",
+  "synthetic_fixture": true,
+  "source_projection": {
+    "request_id": "req-cda-synthetic-001",
+    "chosen": {
+      "id": "choice-stable-01",
+      "score": 0.875,
+      "title": "Hold for verified review"
+    },
+    "decision_status": "allow",
+    "rejection_reason": null,
+    "gate_decision": "ALLOW",
+    "business_decision": "HOLD",
+    "next_action": "REQUEST_VERIFIED_REVIEW",
+    "actionability_status": "reviewable_only",
+    "requires_bind_before_execution": true,
+    "human_review_required": true,
+    "required_evidence": [
+      "authority_evidence",
+      "human_approval"
+    ],
+    "missing_evidence": [
+      "authority_evidence"
+    ],
+    "satisfied_evidence": [
+      "policy_evaluation"
+    ],
+    "rationale": "Synthetic decision requires separately verified authority.",
+    "refusal_reason": null,
+    "actionability_block_reason": "BIND_REQUIRED",
+    "actionability_refusal_type": null,
+    "governance_identity": {
+      "digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "policy_version": "synthetic-v7",
+      "signature_verified": true
+    },
+    "lineage_promotability": {
+      "promotability_family": "lineage_promotability",
+      "promotability_status": "restricted",
+      "promotability_version": "v1",
+      "reason_code": "AUTHORITY_PENDING",
+      "transformation_stable": true
+    },
+    "transition_refusal": {
+      "bind_receipt_created": false,
+      "execution_intent_created": false,
+      "reason_code": null,
+      "transition_status": "allowed"
+    },
+    "meta": {
+      "latency_ms": 999
+    },
+    "persona": {
+      "name": "volatile"
+    },
+    "coercion_events": [
+      "synthetic"
+    ],
+    "ui_summary": "presentation only",
+    "options": [
+      {
+        "id": "random-compatibility-id"
+      }
+    ],
+    "trustlog": {
+      "copy": "not identity"
+    },
+    "deterministic_replay": {
+      "copy": "not identity"
+    }
+  },
+  "excluded_source_mutations": {
+    "meta": {
+      "latency_ms": 999
+    },
+    "persona": {
+      "name": "volatile"
+    },
+    "coercion_events": [
+      "synthetic"
+    ],
+    "ui_summary": "presentation only",
+    "options": [
+      {
+        "id": "random-compatibility-id"
+      }
+    ],
+    "trustlog": {
+      "copy": "not identity"
+    },
+    "deterministic_replay": {
+      "copy": "not identity"
+    }
+  },
+  "artifact": {
+    "format_version": "canonical-decision-artifact/v1",
+    "hash_profile": "veritas.canonical-decision/v1",
+    "decision_id": "cda:v1:sha256:aaa8bf9fac5a3b70ddf9bbea388228cf9b5e56f4a2575b8100d51d058e15bb0e",
+    "decision_hash": "aaa8bf9fac5a3b70ddf9bbea388228cf9b5e56f4a2575b8100d51d058e15bb0e",
+    "decision_ts": "2031-02-03T04:05:06.123456Z",
+    "request_id": "req-cda-synthetic-001",
+    "source_contract": {
+      "type": "DecideResponse",
+      "projection_version": "canonical-decision-projection/v1"
+    },
+    "decision": {
+      "formation_status": "COMPLETE",
+      "chosen_binding": {
+        "profile": "veritas.canonical-decision.chosen-value/v1",
+        "sha256": "f419527eddae068f9362c66ab338f54fb41d6f9f04adfb553294c59c5077e6f6"
+      },
+      "decision_status": "allow",
+      "rejection_reason": null,
+      "gate_decision": "ALLOW",
+      "business_decision": "HOLD",
+      "next_action": "REQUEST_VERIFIED_REVIEW",
+      "actionability_status": "reviewable_only",
+      "requires_bind_before_execution": true,
+      "human_review_required": true,
+      "required_evidence": [
+        "authority_evidence",
+        "human_approval"
+      ],
+      "missing_evidence": [
+        "authority_evidence"
+      ],
+      "satisfied_evidence": [
+        "policy_evaluation"
+      ],
+      "rationale": "Synthetic decision requires separately verified authority.",
+      "refusal_reason": null,
+      "actionability_block_reason": "BIND_REQUIRED",
+      "actionability_refusal_type": null,
+      "governance_identity_binding": {
+        "profile": "veritas.canonical-decision.governance-identity/v1",
+        "sha256": "c3aa80f8117ede4fa868319513b8304193b5323e0f960d3069076d2217a4e9ec"
+      },
+      "lineage_promotability_binding": {
+        "profile": "veritas.canonical-decision.lineage-promotability/v1",
+        "sha256": "bfb740a44e9a7332445fa6e4255696df1454e78d5b1cbd913fad11f48504d19b"
+      },
+      "transition_refusal_binding": {
+        "profile": "veritas.canonical-decision.transition-refusal/v1",
+        "sha256": "5747ed3a654db328097d821eebd8a2474e795ff2ae74fccee734d6c1f7f9d97c"
+      }
+    }
+  },
+  "expected_decision_hash": "aaa8bf9fac5a3b70ddf9bbea388228cf9b5e56f4a2575b8100d51d058e15bb0e",
+  "expected_decision_id": "cda:v1:sha256:aaa8bf9fac5a3b70ddf9bbea388228cf9b5e56f4a2575b8100d51d058e15bb0e",
+  "expected_schema_valid": true,
+  "expected_production": "EMIT"
+}

--- a/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-12.json
+++ b/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-12.json
@@ -11,12 +11,12 @@
     },
     "decision_status": "allow",
     "rejection_reason": null,
-    "gate_decision": "ALLOW",
+    "gate_decision": "hold",
     "business_decision": "HOLD",
     "next_action": "REQUEST_VERIFIED_REVIEW",
     "actionability_status": "reviewable_only",
     "requires_bind_before_execution": true,
-    "human_review_required": true,
+    "human_review_required": false,
     "required_evidence": [
       "authority_evidence",
       "human_approval"
@@ -41,13 +41,20 @@
       "promotability_status": "restricted",
       "promotability_version": "v1",
       "reason_code": "AUTHORITY_PENDING",
-      "transformation_stable": true
+      "transformation_stable": true,
+      "invariant_id": "BIND_ELIGIBLE_ARTIFACT_CANNOT_EMERGE_FROM_NON_PROMOTABLE_LINEAGE",
+      "source_participation_state": null,
+      "source_preservation_state": null,
+      "concise_rationale": null
     },
     "transition_refusal": {
       "bind_receipt_created": false,
       "execution_intent_created": false,
       "reason_code": null,
-      "transition_status": "allowed"
+      "transition_status": "allowed",
+      "invariant_id": "BIND_ELIGIBLE_ARTIFACT_CANNOT_EMERGE_FROM_NON_PROMOTABLE_LINEAGE",
+      "source_promotability_status": null,
+      "concise_rationale": null
     },
     "meta": {
       "latency_ms": 999
@@ -55,21 +62,25 @@
     "persona": {
       "name": "volatile"
     },
-    "coercion_events": [
-      "synthetic"
-    ],
-    "ui_summary": "presentation only",
-    "options": [
+    "alternatives": [
       {
-        "id": "random-compatibility-id"
+        "id": "alt-stable",
+        "title": "Unselected"
       }
     ],
-    "trustlog": {
-      "copy": "not identity"
+    "options": [
+      {
+        "id": "alt-stable",
+        "title": "Unselected"
+      }
+    ],
+    "trust_log": {
+      "request_id": "req-cda-synthetic-001"
     },
     "deterministic_replay": {
       "copy": "not identity"
-    }
+    },
+    "user_summary": "Presentation only"
   },
   "excluded_source_mutations": {
     "meta": {
@@ -78,27 +89,31 @@
     "persona": {
       "name": "volatile"
     },
-    "coercion_events": [
-      "synthetic"
-    ],
-    "ui_summary": "presentation only",
-    "options": [
+    "alternatives": [
       {
-        "id": "random-compatibility-id"
+        "id": "alt-stable",
+        "title": "Unselected"
       }
     ],
-    "trustlog": {
-      "copy": "not identity"
+    "options": [
+      {
+        "id": "alt-stable",
+        "title": "Unselected"
+      }
+    ],
+    "trust_log": {
+      "request_id": "req-cda-synthetic-001"
     },
     "deterministic_replay": {
       "copy": "not identity"
-    }
+    },
+    "user_summary": "Presentation only"
   },
   "artifact": {
     "format_version": "canonical-decision-artifact/v1",
     "hash_profile": "veritas.canonical-decision/v1",
-    "decision_id": "cda:v1:sha256:aaa8bf9fac5a3b70ddf9bbea388228cf9b5e56f4a2575b8100d51d058e15bb0e",
-    "decision_hash": "aaa8bf9fac5a3b70ddf9bbea388228cf9b5e56f4a2575b8100d51d058e15bb0e",
+    "decision_id": "cda:v1:sha256:1c6e265c50812c2b86eab04ef5523a7f1e56c45db4888ca527840ec94f0456a8",
+    "decision_hash": "1c6e265c50812c2b86eab04ef5523a7f1e56c45db4888ca527840ec94f0456a8",
     "decision_ts": "2031-02-03T04:05:06.123456Z",
     "request_id": "req-cda-synthetic-001",
     "source_contract": {
@@ -113,12 +128,12 @@
       },
       "decision_status": "allow",
       "rejection_reason": null,
-      "gate_decision": "ALLOW",
+      "gate_decision": "hold",
       "business_decision": "HOLD",
       "next_action": "REQUEST_VERIFIED_REVIEW",
       "actionability_status": "reviewable_only",
       "requires_bind_before_execution": true,
-      "human_review_required": true,
+      "human_review_required": false,
       "required_evidence": [
         "authority_evidence",
         "human_approval"
@@ -139,16 +154,16 @@
       },
       "lineage_promotability_binding": {
         "profile": "veritas.canonical-decision.lineage-promotability/v1",
-        "sha256": "bfb740a44e9a7332445fa6e4255696df1454e78d5b1cbd913fad11f48504d19b"
+        "sha256": "35c203c9baed4c3679bbcec66346bb97bd62d33dbd1fc5ff6339fed852500840"
       },
       "transition_refusal_binding": {
         "profile": "veritas.canonical-decision.transition-refusal/v1",
-        "sha256": "5747ed3a654db328097d821eebd8a2474e795ff2ae74fccee734d6c1f7f9d97c"
+        "sha256": "42405ab6973875446269a4f3bdcc1e527e393a9f5e2f60e964f756f234029bc6"
       }
     }
   },
-  "expected_decision_hash": "aaa8bf9fac5a3b70ddf9bbea388228cf9b5e56f4a2575b8100d51d058e15bb0e",
-  "expected_decision_id": "cda:v1:sha256:aaa8bf9fac5a3b70ddf9bbea388228cf9b5e56f4a2575b8100d51d058e15bb0e",
+  "expected_decision_hash": "1c6e265c50812c2b86eab04ef5523a7f1e56c45db4888ca527840ec94f0456a8",
+  "expected_decision_id": "cda:v1:sha256:1c6e265c50812c2b86eab04ef5523a7f1e56c45db4888ca527840ec94f0456a8",
   "expected_schema_valid": true,
   "expected_production": "EMIT"
 }

--- a/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-13.json
+++ b/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-13.json
@@ -11,12 +11,12 @@
     },
     "decision_status": "allow",
     "rejection_reason": null,
-    "gate_decision": "ALLOW",
+    "gate_decision": "hold",
     "business_decision": "HOLD",
     "next_action": "REQUEST_VERIFIED_REVIEW",
     "actionability_status": "reviewable_only",
     "requires_bind_before_execution": true,
-    "human_review_required": true,
+    "human_review_required": false,
     "required_evidence": [
       "authority_evidence",
       "human_approval"
@@ -41,13 +41,20 @@
       "promotability_status": "restricted",
       "promotability_version": "v1",
       "reason_code": "AUTHORITY_PENDING",
-      "transformation_stable": true
+      "transformation_stable": true,
+      "invariant_id": "BIND_ELIGIBLE_ARTIFACT_CANNOT_EMERGE_FROM_NON_PROMOTABLE_LINEAGE",
+      "source_participation_state": null,
+      "source_preservation_state": null,
+      "concise_rationale": null
     },
     "transition_refusal": {
       "bind_receipt_created": false,
       "execution_intent_created": false,
       "reason_code": null,
-      "transition_status": "allowed"
+      "transition_status": "allowed",
+      "invariant_id": "BIND_ELIGIBLE_ARTIFACT_CANNOT_EMERGE_FROM_NON_PROMOTABLE_LINEAGE",
+      "source_promotability_status": null,
+      "concise_rationale": null
     },
     "bind_receipt_id": "bind-synthetic-1",
     "execution_intent_id": "intent-synthetic-1",
@@ -55,5 +62,22 @@
   },
   "expected_schema_valid": null,
   "expected_production": "REFUSE",
-  "expected_reason": "POST_BIND_SOURCE_REFUSED"
+  "expected_reason": "POST_BIND_SOURCE_REFUSED",
+  "post_bind_source_fields": [
+    "bind_outcome",
+    "bind_failure_reason",
+    "bind_reason_code",
+    "bind_receipt_id",
+    "execution_intent_id",
+    "bound_execution_intent_id",
+    "authority_check_result",
+    "constraint_check_result",
+    "drift_check_result",
+    "risk_check_result",
+    "bind_summary",
+    "bind_operator_summary",
+    "bind_operator_detail"
+  ],
+  "populated_definition": "JSON value is not null",
+  "blocked_and_rolled_back_are_post_bind": true
 }

--- a/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-13.json
+++ b/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-13.json
@@ -1,0 +1,59 @@
+{
+  "vector_id": "CDA-V1-13",
+  "description": "Populated Bind lineage requires producer refusal",
+  "synthetic_fixture": true,
+  "source_projection": {
+    "request_id": "req-cda-synthetic-001",
+    "chosen": {
+      "id": "choice-stable-01",
+      "score": 0.875,
+      "title": "Hold for verified review"
+    },
+    "decision_status": "allow",
+    "rejection_reason": null,
+    "gate_decision": "ALLOW",
+    "business_decision": "HOLD",
+    "next_action": "REQUEST_VERIFIED_REVIEW",
+    "actionability_status": "reviewable_only",
+    "requires_bind_before_execution": true,
+    "human_review_required": true,
+    "required_evidence": [
+      "authority_evidence",
+      "human_approval"
+    ],
+    "missing_evidence": [
+      "authority_evidence"
+    ],
+    "satisfied_evidence": [
+      "policy_evaluation"
+    ],
+    "rationale": "Synthetic decision requires separately verified authority.",
+    "refusal_reason": null,
+    "actionability_block_reason": "BIND_REQUIRED",
+    "actionability_refusal_type": null,
+    "governance_identity": {
+      "digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "policy_version": "synthetic-v7",
+      "signature_verified": true
+    },
+    "lineage_promotability": {
+      "promotability_family": "lineage_promotability",
+      "promotability_status": "restricted",
+      "promotability_version": "v1",
+      "reason_code": "AUTHORITY_PENDING",
+      "transformation_stable": true
+    },
+    "transition_refusal": {
+      "bind_receipt_created": false,
+      "execution_intent_created": false,
+      "reason_code": null,
+      "transition_status": "allowed"
+    },
+    "bind_receipt_id": "bind-synthetic-1",
+    "execution_intent_id": "intent-synthetic-1",
+    "bind_outcome": "COMMITTED"
+  },
+  "expected_schema_valid": null,
+  "expected_production": "REFUSE",
+  "expected_reason": "POST_BIND_SOURCE_REFUSED"
+}

--- a/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-14.json
+++ b/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-14.json
@@ -1,0 +1,61 @@
+{
+  "vector_id": "CDA-V1-14",
+  "description": "Refused timestamp: NAIVE_TIMESTAMP",
+  "synthetic_fixture": true,
+  "artifact": {
+    "format_version": "canonical-decision-artifact/v1",
+    "hash_profile": "veritas.canonical-decision/v1",
+    "decision_id": "cda:v1:sha256:79eb8f279ce807835af80af004cb95842ada50fde2357f1e32a8b2d4a291e20d",
+    "decision_hash": "79eb8f279ce807835af80af004cb95842ada50fde2357f1e32a8b2d4a291e20d",
+    "decision_ts": "2031-02-03T04:05:06",
+    "request_id": "req-cda-synthetic-001",
+    "source_contract": {
+      "type": "DecideResponse",
+      "projection_version": "canonical-decision-projection/v1"
+    },
+    "decision": {
+      "formation_status": "COMPLETE",
+      "chosen_binding": {
+        "profile": "veritas.canonical-decision.chosen-value/v1",
+        "sha256": "f419527eddae068f9362c66ab338f54fb41d6f9f04adfb553294c59c5077e6f6"
+      },
+      "decision_status": "allow",
+      "rejection_reason": null,
+      "gate_decision": "ALLOW",
+      "business_decision": "HOLD",
+      "next_action": "REQUEST_VERIFIED_REVIEW",
+      "actionability_status": "reviewable_only",
+      "requires_bind_before_execution": true,
+      "human_review_required": true,
+      "required_evidence": [
+        "authority_evidence",
+        "human_approval"
+      ],
+      "missing_evidence": [
+        "authority_evidence"
+      ],
+      "satisfied_evidence": [
+        "policy_evaluation"
+      ],
+      "rationale": "Synthetic decision requires separately verified authority.",
+      "refusal_reason": null,
+      "actionability_block_reason": "BIND_REQUIRED",
+      "actionability_refusal_type": null,
+      "governance_identity_binding": {
+        "profile": "veritas.canonical-decision.governance-identity/v1",
+        "sha256": "c3aa80f8117ede4fa868319513b8304193b5323e0f960d3069076d2217a4e9ec"
+      },
+      "lineage_promotability_binding": {
+        "profile": "veritas.canonical-decision.lineage-promotability/v1",
+        "sha256": "bfb740a44e9a7332445fa6e4255696df1454e78d5b1cbd913fad11f48504d19b"
+      },
+      "transition_refusal_binding": {
+        "profile": "veritas.canonical-decision.transition-refusal/v1",
+        "sha256": "5747ed3a654db328097d821eebd8a2474e795ff2ae74fccee734d6c1f7f9d97c"
+      }
+    }
+  },
+  "expected_schema_valid": false,
+  "expected_production": "REFUSE",
+  "expected_reason": "NAIVE_TIMESTAMP"
+}

--- a/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-14.json
+++ b/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-14.json
@@ -5,8 +5,8 @@
   "artifact": {
     "format_version": "canonical-decision-artifact/v1",
     "hash_profile": "veritas.canonical-decision/v1",
-    "decision_id": "cda:v1:sha256:79eb8f279ce807835af80af004cb95842ada50fde2357f1e32a8b2d4a291e20d",
-    "decision_hash": "79eb8f279ce807835af80af004cb95842ada50fde2357f1e32a8b2d4a291e20d",
+    "decision_id": "cda:v1:sha256:cb46e0feb22041aa59174a003ccbe84a1c40ae7e830f84cbfbb86d1ca22086ea",
+    "decision_hash": "cb46e0feb22041aa59174a003ccbe84a1c40ae7e830f84cbfbb86d1ca22086ea",
     "decision_ts": "2031-02-03T04:05:06",
     "request_id": "req-cda-synthetic-001",
     "source_contract": {
@@ -21,12 +21,12 @@
       },
       "decision_status": "allow",
       "rejection_reason": null,
-      "gate_decision": "ALLOW",
+      "gate_decision": "hold",
       "business_decision": "HOLD",
       "next_action": "REQUEST_VERIFIED_REVIEW",
       "actionability_status": "reviewable_only",
       "requires_bind_before_execution": true,
-      "human_review_required": true,
+      "human_review_required": false,
       "required_evidence": [
         "authority_evidence",
         "human_approval"
@@ -47,11 +47,11 @@
       },
       "lineage_promotability_binding": {
         "profile": "veritas.canonical-decision.lineage-promotability/v1",
-        "sha256": "bfb740a44e9a7332445fa6e4255696df1454e78d5b1cbd913fad11f48504d19b"
+        "sha256": "35c203c9baed4c3679bbcec66346bb97bd62d33dbd1fc5ff6339fed852500840"
       },
       "transition_refusal_binding": {
         "profile": "veritas.canonical-decision.transition-refusal/v1",
-        "sha256": "5747ed3a654db328097d821eebd8a2474e795ff2ae74fccee734d6c1f7f9d97c"
+        "sha256": "42405ab6973875446269a4f3bdcc1e527e393a9f5e2f60e964f756f234029bc6"
       }
     }
   },

--- a/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-15.json
+++ b/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-15.json
@@ -1,0 +1,61 @@
+{
+  "vector_id": "CDA-V1-15",
+  "description": "Refused timestamp: INVALID_TIMESTAMP",
+  "synthetic_fixture": true,
+  "artifact": {
+    "format_version": "canonical-decision-artifact/v1",
+    "hash_profile": "veritas.canonical-decision/v1",
+    "decision_id": "cda:v1:sha256:f1e5aef776137edea33557f518c56d057810bc13cd3b52d265ee41e09411ed90",
+    "decision_hash": "f1e5aef776137edea33557f518c56d057810bc13cd3b52d265ee41e09411ed90",
+    "decision_ts": "not-a-timestamp",
+    "request_id": "req-cda-synthetic-001",
+    "source_contract": {
+      "type": "DecideResponse",
+      "projection_version": "canonical-decision-projection/v1"
+    },
+    "decision": {
+      "formation_status": "COMPLETE",
+      "chosen_binding": {
+        "profile": "veritas.canonical-decision.chosen-value/v1",
+        "sha256": "f419527eddae068f9362c66ab338f54fb41d6f9f04adfb553294c59c5077e6f6"
+      },
+      "decision_status": "allow",
+      "rejection_reason": null,
+      "gate_decision": "ALLOW",
+      "business_decision": "HOLD",
+      "next_action": "REQUEST_VERIFIED_REVIEW",
+      "actionability_status": "reviewable_only",
+      "requires_bind_before_execution": true,
+      "human_review_required": true,
+      "required_evidence": [
+        "authority_evidence",
+        "human_approval"
+      ],
+      "missing_evidence": [
+        "authority_evidence"
+      ],
+      "satisfied_evidence": [
+        "policy_evaluation"
+      ],
+      "rationale": "Synthetic decision requires separately verified authority.",
+      "refusal_reason": null,
+      "actionability_block_reason": "BIND_REQUIRED",
+      "actionability_refusal_type": null,
+      "governance_identity_binding": {
+        "profile": "veritas.canonical-decision.governance-identity/v1",
+        "sha256": "c3aa80f8117ede4fa868319513b8304193b5323e0f960d3069076d2217a4e9ec"
+      },
+      "lineage_promotability_binding": {
+        "profile": "veritas.canonical-decision.lineage-promotability/v1",
+        "sha256": "bfb740a44e9a7332445fa6e4255696df1454e78d5b1cbd913fad11f48504d19b"
+      },
+      "transition_refusal_binding": {
+        "profile": "veritas.canonical-decision.transition-refusal/v1",
+        "sha256": "5747ed3a654db328097d821eebd8a2474e795ff2ae74fccee734d6c1f7f9d97c"
+      }
+    }
+  },
+  "expected_schema_valid": false,
+  "expected_production": "REFUSE",
+  "expected_reason": "INVALID_TIMESTAMP"
+}

--- a/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-15.json
+++ b/docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-15.json
@@ -5,8 +5,8 @@
   "artifact": {
     "format_version": "canonical-decision-artifact/v1",
     "hash_profile": "veritas.canonical-decision/v1",
-    "decision_id": "cda:v1:sha256:f1e5aef776137edea33557f518c56d057810bc13cd3b52d265ee41e09411ed90",
-    "decision_hash": "f1e5aef776137edea33557f518c56d057810bc13cd3b52d265ee41e09411ed90",
+    "decision_id": "cda:v1:sha256:40c729a427a4e1f0487c1dc60d606fd3ea30613936bf4ae2e89a1eef2876afb9",
+    "decision_hash": "40c729a427a4e1f0487c1dc60d606fd3ea30613936bf4ae2e89a1eef2876afb9",
     "decision_ts": "not-a-timestamp",
     "request_id": "req-cda-synthetic-001",
     "source_contract": {
@@ -21,12 +21,12 @@
       },
       "decision_status": "allow",
       "rejection_reason": null,
-      "gate_decision": "ALLOW",
+      "gate_decision": "hold",
       "business_decision": "HOLD",
       "next_action": "REQUEST_VERIFIED_REVIEW",
       "actionability_status": "reviewable_only",
       "requires_bind_before_execution": true,
-      "human_review_required": true,
+      "human_review_required": false,
       "required_evidence": [
         "authority_evidence",
         "human_approval"
@@ -47,11 +47,11 @@
       },
       "lineage_promotability_binding": {
         "profile": "veritas.canonical-decision.lineage-promotability/v1",
-        "sha256": "bfb740a44e9a7332445fa6e4255696df1454e78d5b1cbd913fad11f48504d19b"
+        "sha256": "35c203c9baed4c3679bbcec66346bb97bd62d33dbd1fc5ff6339fed852500840"
       },
       "transition_refusal_binding": {
         "profile": "veritas.canonical-decision.transition-refusal/v1",
-        "sha256": "5747ed3a654db328097d821eebd8a2474e795ff2ae74fccee734d6c1f7f9d97c"
+        "sha256": "42405ab6973875446269a4f3bdcc1e527e393a9f5e2f60e964f756f234029bc6"
       }
     }
   },

--- a/schemas/canonical-decision-artifact-v1.schema.json
+++ b/schemas/canonical-decision-artifact-v1.schema.json
@@ -68,7 +68,7 @@
         "gate_decision": {"enum": ["proceed", "hold", "block", "human_review_required"]},
         "business_decision": {"enum": ["APPROVE", "DENY", "HOLD", "REVIEW_REQUIRED", "POLICY_DEFINITION_REQUIRED", "EVIDENCE_REQUIRED"]},
         "next_action": {"type": "string"},
-        "actionability_status": {"enum": ["reviewable_only", "bind_required_before_execution", "actionable_after_bind", "blocked", "human_review_required", "formation_transition_refused"]},
+        "actionability_status": {"enum": ["reviewable_only", "bind_required_before_execution", "blocked", "human_review_required", "formation_transition_refused"]},
         "requires_bind_before_execution": {"type": "boolean"},
         "human_review_required": {"type": "boolean"},
         "required_evidence": {"$ref": "#/$defs/stringList"},
@@ -91,7 +91,11 @@
         {"if": {"properties": {"gate_decision": {"const": "human_review_required"}}}, "then": {"properties": {"business_decision": {"const": "REVIEW_REQUIRED"}, "human_review_required": {"const": true}}}},
         {"not": {"properties": {"gate_decision": {"const": "block"}, "business_decision": {"const": "APPROVE"}}, "required": ["gate_decision", "business_decision"]}},
         {"not": {"properties": {"gate_decision": {"const": "hold"}, "business_decision": {"const": "APPROVE"}}, "required": ["gate_decision", "business_decision"]}},
-        {"not": {"properties": {"gate_decision": {"const": "proceed"}, "business_decision": {"const": "DENY"}}, "required": ["gate_decision", "business_decision"]}}
+        {"not": {"properties": {"gate_decision": {"const": "proceed"}, "business_decision": {"const": "DENY"}}, "required": ["gate_decision", "business_decision"]}},
+        {"if": {"properties": {"actionability_status": {"enum": ["reviewable_only", "bind_required_before_execution", "human_review_required"]}}}, "then": {"properties": {"requires_bind_before_execution": {"const": true}}}},
+        {"if": {"properties": {"actionability_status": {"enum": ["blocked", "formation_transition_refused"]}}}, "then": {"properties": {"requires_bind_before_execution": {"const": false}}}},
+        {"if": {"properties": {"actionability_status": {"const": "human_review_required"}}}, "then": {"properties": {"human_review_required": {"const": true}}}},
+        {"if": {"properties": {"actionability_status": {"const": "formation_transition_refused"}}}, "then": {"properties": {"human_review_required": {"const": true}}}}
       ]
     }
   }

--- a/schemas/canonical-decision-artifact-v1.schema.json
+++ b/schemas/canonical-decision-artifact-v1.schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://veritas-os.example/schemas/canonical-decision-artifact-v1.schema.json",
+  "title": "CanonicalDecisionArtifact v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["format_version", "hash_profile", "decision_id", "decision_hash", "decision_ts", "request_id", "source_contract", "decision"],
+  "properties": {
+    "format_version": {"const": "canonical-decision-artifact/v1"},
+    "hash_profile": {"const": "veritas.canonical-decision/v1"},
+    "decision_id": {"type": "string", "pattern": "^cda:v1:sha256:[0-9a-f]{64}$"},
+    "decision_hash": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "decision_ts": {"type": "string", "pattern": "^[0-9]{4}-(0[1-9]|1[0-2])-([0-2][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]\\.[0-9]{6}Z$", "format": "date-time"},
+    "request_id": {"type": "string", "minLength": 1},
+    "source_contract": {
+      "type": "object", "additionalProperties": false,
+      "required": ["type", "projection_version"],
+      "properties": {
+        "type": {"const": "DecideResponse"},
+        "projection_version": {"const": "canonical-decision-projection/v1"}
+      }
+    },
+    "decision": {"$ref": "#/$defs/decision"}
+  },
+  "$defs": {
+    "digestBinding": {
+      "type": "object", "additionalProperties": false,
+      "required": ["profile", "sha256"],
+      "properties": {
+        "profile": {"type": "string", "minLength": 1},
+        "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+      }
+    },
+    "nullableString": {"type": ["string", "null"]},
+    "stringList": {"type": "array", "items": {"type": "string"}},
+    "decision": {
+      "type": "object", "additionalProperties": false,
+      "required": ["formation_status", "chosen_binding", "decision_status", "rejection_reason", "gate_decision", "business_decision", "next_action", "actionability_status", "requires_bind_before_execution", "human_review_required", "required_evidence", "missing_evidence", "satisfied_evidence", "rationale", "refusal_reason", "actionability_block_reason", "actionability_refusal_type", "governance_identity_binding", "lineage_promotability_binding", "transition_refusal_binding"],
+      "properties": {
+        "formation_status": {"enum": ["COMPLETE", "INCOMPLETE"]},
+        "chosen_binding": {"$ref": "#/$defs/digestBinding"},
+        "decision_status": {"type": "string"},
+        "rejection_reason": {"$ref": "#/$defs/nullableString"},
+        "gate_decision": {"type": "string"},
+        "business_decision": {"type": "string"},
+        "next_action": {"type": "string"},
+        "actionability_status": {"type": "string"},
+        "requires_bind_before_execution": {"type": "boolean"},
+        "human_review_required": {"type": "boolean"},
+        "required_evidence": {"$ref": "#/$defs/stringList"},
+        "missing_evidence": {"$ref": "#/$defs/stringList"},
+        "satisfied_evidence": {"$ref": "#/$defs/stringList"},
+        "rationale": {"$ref": "#/$defs/nullableString"},
+        "refusal_reason": {"$ref": "#/$defs/nullableString"},
+        "actionability_block_reason": {"$ref": "#/$defs/nullableString"},
+        "actionability_refusal_type": {"$ref": "#/$defs/nullableString"},
+        "governance_identity_binding": {"anyOf": [{"$ref": "#/$defs/digestBinding"}, {"type": "null"}]},
+        "lineage_promotability_binding": {"anyOf": [{"$ref": "#/$defs/digestBinding"}, {"type": "null"}]},
+        "transition_refusal_binding": {"anyOf": [{"$ref": "#/$defs/digestBinding"}, {"type": "null"}]}
+      }
+    }
+  }
+}

--- a/schemas/canonical-decision-artifact-v1.schema.json
+++ b/schemas/canonical-decision-artifact-v1.schema.json
@@ -23,11 +23,35 @@
     "decision": {"$ref": "#/$defs/decision"}
   },
   "$defs": {
-    "digestBinding": {
+    "chosenBinding": {
       "type": "object", "additionalProperties": false,
       "required": ["profile", "sha256"],
       "properties": {
-        "profile": {"type": "string", "minLength": 1},
+        "profile": {"const": "veritas.canonical-decision.chosen-value/v1"},
+        "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+      }
+    },
+    "governanceIdentityBinding": {
+      "type": "object", "additionalProperties": false,
+      "required": ["profile", "sha256"],
+      "properties": {
+        "profile": {"const": "veritas.canonical-decision.governance-identity/v1"},
+        "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+      }
+    },
+    "lineagePromotabilityBinding": {
+      "type": "object", "additionalProperties": false,
+      "required": ["profile", "sha256"],
+      "properties": {
+        "profile": {"const": "veritas.canonical-decision.lineage-promotability/v1"},
+        "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+      }
+    },
+    "transitionRefusalBinding": {
+      "type": "object", "additionalProperties": false,
+      "required": ["profile", "sha256"],
+      "properties": {
+        "profile": {"const": "veritas.canonical-decision.transition-refusal/v1"},
         "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
       }
     },
@@ -38,13 +62,13 @@
       "required": ["formation_status", "chosen_binding", "decision_status", "rejection_reason", "gate_decision", "business_decision", "next_action", "actionability_status", "requires_bind_before_execution", "human_review_required", "required_evidence", "missing_evidence", "satisfied_evidence", "rationale", "refusal_reason", "actionability_block_reason", "actionability_refusal_type", "governance_identity_binding", "lineage_promotability_binding", "transition_refusal_binding"],
       "properties": {
         "formation_status": {"enum": ["COMPLETE", "INCOMPLETE"]},
-        "chosen_binding": {"$ref": "#/$defs/digestBinding"},
-        "decision_status": {"type": "string"},
+        "chosen_binding": {"$ref": "#/$defs/chosenBinding"},
+        "decision_status": {"enum": ["allow", "modify", "rejected", "block", "abstain"]},
         "rejection_reason": {"$ref": "#/$defs/nullableString"},
-        "gate_decision": {"type": "string"},
-        "business_decision": {"type": "string"},
+        "gate_decision": {"enum": ["proceed", "hold", "block", "human_review_required"]},
+        "business_decision": {"enum": ["APPROVE", "DENY", "HOLD", "REVIEW_REQUIRED", "POLICY_DEFINITION_REQUIRED", "EVIDENCE_REQUIRED"]},
         "next_action": {"type": "string"},
-        "actionability_status": {"type": "string"},
+        "actionability_status": {"enum": ["reviewable_only", "bind_required_before_execution", "actionable_after_bind", "blocked", "human_review_required", "formation_transition_refused"]},
         "requires_bind_before_execution": {"type": "boolean"},
         "human_review_required": {"type": "boolean"},
         "required_evidence": {"$ref": "#/$defs/stringList"},
@@ -54,10 +78,21 @@
         "refusal_reason": {"$ref": "#/$defs/nullableString"},
         "actionability_block_reason": {"$ref": "#/$defs/nullableString"},
         "actionability_refusal_type": {"$ref": "#/$defs/nullableString"},
-        "governance_identity_binding": {"anyOf": [{"$ref": "#/$defs/digestBinding"}, {"type": "null"}]},
-        "lineage_promotability_binding": {"anyOf": [{"$ref": "#/$defs/digestBinding"}, {"type": "null"}]},
-        "transition_refusal_binding": {"anyOf": [{"$ref": "#/$defs/digestBinding"}, {"type": "null"}]}
-      }
+        "governance_identity_binding": {"anyOf": [{"$ref": "#/$defs/governanceIdentityBinding"}, {"type": "null"}]},
+        "lineage_promotability_binding": {"anyOf": [{"$ref": "#/$defs/lineagePromotabilityBinding"}, {"type": "null"}]},
+        "transition_refusal_binding": {"anyOf": [{"$ref": "#/$defs/transitionRefusalBinding"}, {"type": "null"}]}
+      },
+      "allOf": [
+        {"if": {"properties": {"formation_status": {"const": "COMPLETE"}}}, "then": {"properties": {"governance_identity_binding": {"$ref": "#/$defs/governanceIdentityBinding"}}}},
+        {"if": {"properties": {"formation_status": {"const": "INCOMPLETE"}}}, "then": {"properties": {"governance_identity_binding": {"type": "null"}}}},
+        {"not": {"properties": {"gate_decision": {"const": "proceed"}, "human_review_required": {"const": true}}, "required": ["gate_decision", "human_review_required"]}},
+        {"not": {"properties": {"business_decision": {"const": "APPROVE"}, "human_review_required": {"const": true}}, "required": ["business_decision", "human_review_required"]}},
+        {"if": {"properties": {"business_decision": {"const": "REVIEW_REQUIRED"}}}, "then": {"properties": {"gate_decision": {"const": "human_review_required"}, "human_review_required": {"const": true}}}},
+        {"if": {"properties": {"gate_decision": {"const": "human_review_required"}}}, "then": {"properties": {"business_decision": {"const": "REVIEW_REQUIRED"}, "human_review_required": {"const": true}}}},
+        {"not": {"properties": {"gate_decision": {"const": "block"}, "business_decision": {"const": "APPROVE"}}, "required": ["gate_decision", "business_decision"]}},
+        {"not": {"properties": {"gate_decision": {"const": "hold"}, "business_decision": {"const": "APPROVE"}}, "required": ["gate_decision", "business_decision"]}},
+        {"not": {"properties": {"gate_decision": {"const": "proceed"}, "business_decision": {"const": "DENY"}}, "required": ["gate_decision", "business_decision"]}}
+      ]
     }
   }
 }

--- a/tests/spec/test_canonical_decision_artifact_spec.py
+++ b/tests/spec/test_canonical_decision_artifact_spec.py
@@ -17,7 +17,6 @@ from veritas_os.core.decision_semantics import (
     FORBIDDEN_GATE_BUSINESS_COMBINATIONS,
 )
 
-
 SCHEMA_PATH = Path("schemas/canonical-decision-artifact-v1.schema.json")
 SPEC_PATH = Path("docs/en/architecture/canonical-decision-artifact-v1.md")
 HANDOFF_SPEC_PATH = Path(
@@ -486,11 +485,66 @@ def test_closed_vocabularies_match_normalized_source_contract() -> None:
     assert set(decision["actionability_status"]["enum"]) == {
         "reviewable_only",
         "bind_required_before_execution",
-        "actionable_after_bind",
         "blocked",
         "human_review_required",
         "formation_transition_refused",
     }
+
+
+@pytest.mark.parametrize(
+    ("status", "requires_bind", "review_required"),
+    (
+        ("reviewable_only", False, False),
+        ("bind_required_before_execution", False, False),
+        ("human_review_required", False, True),
+        ("blocked", True, False),
+        ("formation_transition_refused", True, True),
+        ("human_review_required", True, False),
+    ),
+)
+def test_actionability_boundary_contradictions_are_schema_invalid(
+    status: str,
+    requires_bind: bool,
+    review_required: bool,
+) -> None:
+    """Reject contradictory pre-Bind actionability boundary combinations."""
+    artifact = deepcopy(_vectors()[0]["artifact"])
+    artifact["decision"].update(
+        actionability_status=status,
+        requires_bind_before_execution=requires_bind,
+        human_review_required=review_required,
+    )
+
+    with pytest.raises(ValidationError):
+        Draft202012Validator(_load_json(SCHEMA_PATH)).validate(artifact)
+
+
+def test_actionable_after_bind_is_post_bind_only_and_schema_invalid() -> None:
+    """Tie the excluded status to runtime's committed bound-lineage rule."""
+    artifact = deepcopy(_vectors()[0]["artifact"])
+    artifact["decision"]["actionability_status"] = "actionable_after_bind"
+    pipeline_contract = Path("veritas_os/core/pipeline/pipeline_response.py").read_text(
+        encoding="utf-8"
+    )
+
+    with pytest.raises(ValidationError):
+        Draft202012Validator(_load_json(SCHEMA_PATH)).validate(artifact)
+    for bound_lineage_requirement in (
+        'normalized_outcome == "COMMITTED"',
+        "normalized_bind_receipt_id is not None",
+        "normalized_execution_intent_id is not None",
+        'status = "actionable_after_bind"',
+    ):
+        assert bound_lineage_requirement in pipeline_contract
+
+
+def test_golden_actionability_boundary_remains_valid() -> None:
+    """Preserve V01's coherent pre-Bind reviewable-only boundary."""
+    golden = _vectors()[0]["artifact"]
+
+    assert golden["decision"]["actionability_status"] == "reviewable_only"
+    assert golden["decision"]["requires_bind_before_execution"] is True
+    Draft202012Validator(_load_json(SCHEMA_PATH)).validate(golden)
 
 
 def test_schema_mirrors_gate_business_human_review_invariants() -> None:

--- a/tests/spec/test_canonical_decision_artifact_spec.py
+++ b/tests/spec/test_canonical_decision_artifact_spec.py
@@ -1,0 +1,294 @@
+"""Coherence tests for the specification-only canonical decision artifact."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator, FormatChecker, ValidationError
+
+
+SCHEMA_PATH = Path("schemas/canonical-decision-artifact-v1.schema.json")
+SPEC_PATH = Path(
+    "docs/en/architecture/canonical-decision-artifact-v1.md"
+)
+HANDOFF_SPEC_PATH = Path(
+    "docs/en/architecture/canonical-decision-to-bind-handoff-v1.md"
+)
+VECTOR_DIR = Path(
+    "docs/en/architecture/test-vectors/canonical-decision-artifact-v1"
+)
+FORMAT_VERSION = "canonical-decision-artifact/v1"
+HASH_PROFILE = "veritas.canonical-decision/v1"
+TOP_LEVEL_FIELDS = {
+    "format_version",
+    "hash_profile",
+    "decision_id",
+    "decision_hash",
+    "decision_ts",
+    "request_id",
+    "source_contract",
+    "decision",
+}
+DECISION_FIELDS = {
+    "formation_status",
+    "chosen_binding",
+    "decision_status",
+    "rejection_reason",
+    "gate_decision",
+    "business_decision",
+    "next_action",
+    "actionability_status",
+    "requires_bind_before_execution",
+    "human_review_required",
+    "required_evidence",
+    "missing_evidence",
+    "satisfied_evidence",
+    "rationale",
+    "refusal_reason",
+    "actionability_block_reason",
+    "actionability_refusal_type",
+    "governance_identity_binding",
+    "lineage_promotability_binding",
+    "transition_refusal_binding",
+}
+
+
+def _load_json(path: Path) -> dict[str, object]:
+    """Load a repository-owned synthetic JSON vector."""
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _vectors() -> list[dict[str, object]]:
+    """Return canonical decision vectors in deterministic filename order."""
+    return [
+        _load_json(path)
+        for path in sorted(VECTOR_DIR.glob("vector-*.json"))
+    ]
+
+
+def _reference_serialize_for_spec_fixture(value: object) -> str:
+    """Serialize JSON for test-only verification of the normative profile."""
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
+
+
+def _reference_hash_for_spec_fixture(artifact: dict[str, object]) -> str:
+    """Recompute a v1 decision hash only for specification fixtures."""
+    preimage = {
+        "profile": artifact["hash_profile"],
+        "format_version": artifact["format_version"],
+        "request_id": artifact["request_id"],
+        "decision_ts": artifact["decision_ts"],
+        "source_contract": artifact["source_contract"],
+        "decision": artifact["decision"],
+    }
+    serialized = _reference_serialize_for_spec_fixture(preimage)
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
+def _normalize_aware_timestamp_for_spec_fixture(value: str) -> str:
+    """Demonstrate the documented test-only aware-offset normalization."""
+    parsed = datetime.fromisoformat(value)
+    if parsed.tzinfo is None:
+        raise ValueError("decision timestamp must be timezone-aware")
+    utc_value = parsed.astimezone(timezone.utc)
+    return utc_value.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def test_schema_and_all_expected_valid_vectors() -> None:
+    """Check the schema and validate every expected valid artifact."""
+    schema = _load_json(SCHEMA_PATH)
+    Draft202012Validator.check_schema(schema)
+    validator = Draft202012Validator(
+        schema,
+        format_checker=FormatChecker(),
+    )
+    vectors = _vectors()
+
+    assert len(vectors) == 15
+    assert len({vector["vector_id"] for vector in vectors}) == 15
+    assert all(vector["synthetic_fixture"] is True for vector in vectors)
+    for vector in vectors:
+        if vector["expected_schema_valid"] is True:
+            validator.validate(vector["artifact"])
+        elif vector["expected_schema_valid"] is False:
+            with pytest.raises(ValidationError):
+                validator.validate(vector["artifact"])
+
+
+def test_schema_is_closed_versioned_and_has_exact_artifact_shape() -> None:
+    """Pin the closed top-level and canonical projection field sets."""
+    schema = _load_json(SCHEMA_PATH)
+
+    assert schema["additionalProperties"] is False
+    assert set(schema["required"]) == TOP_LEVEL_FIELDS
+    assert set(schema["properties"]) == TOP_LEVEL_FIELDS
+    assert schema["properties"]["format_version"]["const"] == FORMAT_VERSION
+    assert schema["properties"]["hash_profile"]["const"] == HASH_PROFILE
+    decision = schema["$defs"]["decision"]
+    assert decision["additionalProperties"] is False
+    assert set(decision["required"]) == DECISION_FIELDS
+    assert set(decision["properties"]) == DECISION_FIELDS
+
+
+def test_hash_and_id_shapes_and_golden_bytes_are_stable() -> None:
+    """Pin golden serialization, full digest, and content-addressed ID."""
+    golden = _vectors()[0]
+    artifact = golden["artifact"]
+    serialized = _reference_serialize_for_spec_fixture(
+        golden["canonical_preimage"]
+    )
+    digest = _reference_hash_for_spec_fixture(artifact)
+
+    assert serialized == golden["expected_canonical_serialized"]
+    assert digest == golden["expected_decision_hash"]
+    assert artifact["decision_hash"] == digest
+    assert golden["expected_decision_id"] == f"cda:v1:sha256:{digest}"
+    assert artifact["decision_id"] == golden["expected_decision_id"]
+    assert len(digest) == 64
+    assert artifact["request_id"] not in artifact["decision_id"]
+
+
+def test_every_included_mutation_changes_hash_and_id() -> None:
+    """Prove the focused included-field sensitivity vectors."""
+    vectors = _vectors()
+    golden_hash = vectors[0]["expected_decision_hash"]
+    golden_id = vectors[0]["expected_decision_id"]
+    mutation_vectors = vectors[1:11]
+
+    assert {vector["mutation"] for vector in mutation_vectors} == {
+        "request_id",
+        "decision_ts",
+        "chosen binding",
+        "gate_decision",
+        "business_decision",
+        "actionability_status",
+        "human_review_required",
+        "evidence state",
+        "governance identity binding",
+        "formation refusal/promotability state",
+    }
+    for vector in mutation_vectors:
+        artifact = vector["artifact"]
+        assert _reference_hash_for_spec_fixture(artifact) == artifact[
+            "decision_hash"
+        ]
+        assert vector["expected_decision_hash"] != golden_hash
+        assert vector["expected_decision_id"] != golden_id
+
+
+def test_excluded_fields_and_bind_retroactivity_contract() -> None:
+    """Pin exclusion stability and fail-closed post-Bind production."""
+    vectors = {vector["vector_id"]: vector for vector in _vectors()}
+    golden = vectors["CDA-V1-01"]
+    excluded = vectors["CDA-V1-12"]
+    post_bind = vectors["CDA-V1-13"]
+
+    assert excluded["excluded_source_mutations"]
+    assert excluded["expected_decision_hash"] == golden[
+        "expected_decision_hash"
+    ]
+    assert excluded["expected_decision_id"] == golden["expected_decision_id"]
+    assert post_bind["expected_production"] == "REFUSE"
+    assert post_bind["expected_reason"] == "POST_BIND_SOURCE_REFUSED"
+    assert "artifact" not in post_bind
+
+
+def test_timestamp_contract_and_deterministic_normalization() -> None:
+    """Require exact UTC microseconds and reject naive/invalid timestamps."""
+    by_id = {vector["vector_id"]: vector for vector in _vectors()}
+
+    assert _normalize_aware_timestamp_for_spec_fixture(
+        "2031-02-03T05:05:06.123456+01:00"
+    ) == "2031-02-03T04:05:06.123456Z"
+    with pytest.raises(ValueError, match="timezone-aware"):
+        _normalize_aware_timestamp_for_spec_fixture(
+            "2031-02-03T04:05:06.123456"
+        )
+    assert by_id["CDA-V1-14"]["expected_reason"] == "NAIVE_TIMESTAMP"
+    assert by_id["CDA-V1-15"]["expected_reason"] == "INVALID_TIMESTAMP"
+
+
+def test_hash_preimage_has_no_self_reference_or_response_shortcut() -> None:
+    """Prove exact preimage keys and the non-circular construction."""
+    golden = _vectors()[0]
+    preimage = golden["canonical_preimage"]
+
+    assert set(preimage) == {
+        "profile",
+        "format_version",
+        "request_id",
+        "decision_ts",
+        "source_contract",
+        "decision",
+    }
+    assert "decision_hash" not in preimage
+    assert "decision_id" not in preimage
+    specification = SPEC_PATH.read_text(encoding="utf-8")
+    assert "`SHA256(response.json())` is prohibited" in specification
+    assert "MUST NOT be inferred or backfilled" in specification
+
+
+def test_schema_cannot_carry_execution_bind_or_self_declared_validity() -> None:
+    """Keep execution, Bind, and trust declarations outside the artifact."""
+    schema_text = SCHEMA_PATH.read_text(encoding="utf-8")
+    forbidden = {
+        '"execution_intent"',
+        '"bind_receipt"',
+        '"execution_authorized"',
+        '"adapter"',
+        '"external_effect"',
+        '"verified"',
+    }
+
+    assert not forbidden.intersection(schema_text.splitlines())
+    assert all(term not in schema_text for term in forbidden)
+
+
+def test_non_authority_non_execution_and_incomplete_governance_are_explicit() -> None:
+    """Pin semantic non-claims and absent-governance formation behavior."""
+    specification = SPEC_PATH.read_text(encoding="utf-8")
+
+    for invariant in (
+        "`ALLOW != authority`",
+        "`APPROVE != Human Approval Receipt`",
+        "`chosen != canonical executable action`",
+        "`next_action != intended_action`",
+        "`READY_FOR_GUARDED_PROMOTION != execution`",
+        "`formation_status=INCOMPLETE`",
+    ):
+        assert invariant in specification
+
+
+def test_mismatched_id_is_not_accepted_and_request_id_is_insufficient() -> None:
+    """Prove ID verification requires the full recomputed decision digest."""
+    artifact = deepcopy(_vectors()[0]["artifact"])
+    expected_id = f"cda:v1:sha256:{_reference_hash_for_spec_fixture(artifact)}"
+    artifact["decision_id"] = "cda:v1:sha256:" + ("0" * 64)
+
+    assert artifact["decision_id"] != expected_id
+    assert artifact["request_id"] != expected_id
+
+
+def test_handoff_mapping_names_all_four_verified_artifact_values() -> None:
+    """Keep future artifact-to-handoff mapping explicit and non-operative."""
+    handoff = HANDOFF_SPEC_PATH.read_text(encoding="utf-8")
+
+    for mapping in (
+        "`artifact.request_id` to `source_decision.request_id`",
+        "`artifact.decision_id` to `source_decision.canonical_decision_id`",
+        "`artifact.decision_hash` to `source_decision.canonical_decision_hash`",
+        "`artifact.decision_ts` to `source_decision.canonical_decision_ts`",
+    ):
+        assert mapping in handoff
+    assert "Merely\ncopying these four strings is insufficient for READY" in handoff

--- a/tests/spec/test_canonical_decision_artifact_spec.py
+++ b/tests/spec/test_canonical_decision_artifact_spec.py
@@ -11,17 +11,19 @@ from pathlib import Path
 import pytest
 from jsonschema import Draft202012Validator, FormatChecker, ValidationError
 
+from veritas_os.api.schemas import DecideResponse
+from veritas_os.core.decision_semantics import (
+    CANONICAL_GATE_DECISION_VALUES,
+    FORBIDDEN_GATE_BUSINESS_COMBINATIONS,
+)
+
 
 SCHEMA_PATH = Path("schemas/canonical-decision-artifact-v1.schema.json")
-SPEC_PATH = Path(
-    "docs/en/architecture/canonical-decision-artifact-v1.md"
-)
+SPEC_PATH = Path("docs/en/architecture/canonical-decision-artifact-v1.md")
 HANDOFF_SPEC_PATH = Path(
     "docs/en/architecture/canonical-decision-to-bind-handoff-v1.md"
 )
-VECTOR_DIR = Path(
-    "docs/en/architecture/test-vectors/canonical-decision-artifact-v1"
-)
+VECTOR_DIR = Path("docs/en/architecture/test-vectors/canonical-decision-artifact-v1")
 FORMAT_VERSION = "canonical-decision-artifact/v1"
 HASH_PROFILE = "veritas.canonical-decision/v1"
 TOP_LEVEL_FIELDS = {
@@ -56,6 +58,39 @@ DECISION_FIELDS = {
     "lineage_promotability_binding",
     "transition_refusal_binding",
 }
+BIND_SOURCE_FIELDS = {
+    "bind_outcome",
+    "bind_failure_reason",
+    "bind_reason_code",
+    "bind_receipt_id",
+    "execution_intent_id",
+    "bound_execution_intent_id",
+    "authority_check_result",
+    "constraint_check_result",
+    "drift_check_result",
+    "risk_check_result",
+    "bind_summary",
+    "bind_operator_summary",
+    "bind_operator_detail",
+}
+BINDING_SOURCES = {
+    "chosen_binding": (
+        "veritas.canonical-decision.chosen-value/v1",
+        "chosen",
+    ),
+    "governance_identity_binding": (
+        "veritas.canonical-decision.governance-identity/v1",
+        "governance_identity",
+    ),
+    "lineage_promotability_binding": (
+        "veritas.canonical-decision.lineage-promotability/v1",
+        "lineage_promotability",
+    ),
+    "transition_refusal_binding": (
+        "veritas.canonical-decision.transition-refusal/v1",
+        "transition_refusal",
+    ),
+}
 
 
 def _load_json(path: Path) -> dict[str, object]:
@@ -65,10 +100,7 @@ def _load_json(path: Path) -> dict[str, object]:
 
 def _vectors() -> list[dict[str, object]]:
     """Return canonical decision vectors in deterministic filename order."""
-    return [
-        _load_json(path)
-        for path in sorted(VECTOR_DIR.glob("vector-*.json"))
-    ]
+    return [_load_json(path) for path in sorted(VECTOR_DIR.glob("vector-*.json"))]
 
 
 def _reference_serialize_for_spec_fixture(value: object) -> str:
@@ -94,6 +126,67 @@ def _reference_hash_for_spec_fixture(artifact: dict[str, object]) -> str:
     }
     serialized = _reference_serialize_for_spec_fixture(preimage)
     return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
+def _reference_binding_digest_for_spec_fixture(
+    profile: str,
+    value: object,
+) -> str:
+    """Bind one normalized opaque source value in its documented domain."""
+    serialized = _reference_serialize_for_spec_fixture(
+        {"profile": profile, "value": value}
+    )
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
+def _project_normalized_source_for_spec_fixture(
+    normalized: dict[str, object],
+) -> dict[str, object]:
+    """Build the declared v1 projection for source-coherence tests only."""
+    projected = {
+        field: normalized[field]
+        for field in (
+            "decision_status",
+            "rejection_reason",
+            "gate_decision",
+            "business_decision",
+            "next_action",
+            "actionability_status",
+            "requires_bind_before_execution",
+            "human_review_required",
+            "required_evidence",
+            "missing_evidence",
+            "satisfied_evidence",
+            "rationale",
+            "refusal_reason",
+            "actionability_block_reason",
+            "actionability_refusal_type",
+        )
+    }
+    projected["formation_status"] = (
+        "COMPLETE" if normalized["governance_identity"] is not None else "INCOMPLETE"
+    )
+    for binding_field, (profile, source_field) in BINDING_SOURCES.items():
+        value = normalized[source_field]
+        projected[binding_field] = (
+            {
+                "profile": profile,
+                "sha256": _reference_binding_digest_for_spec_fixture(
+                    profile,
+                    value,
+                ),
+            }
+            if value is not None or source_field == "chosen"
+            else None
+        )
+    return projected
+
+
+def _post_bind_source_is_refused_for_spec_fixture(
+    source: dict[str, object],
+) -> bool:
+    """Apply the documented test-only non-null post-Bind refusal rule."""
+    return any(source.get(field) is not None for field in BIND_SOURCE_FIELDS)
 
 
 def _normalize_aware_timestamp_for_spec_fixture(value: str) -> str:
@@ -145,9 +238,7 @@ def test_hash_and_id_shapes_and_golden_bytes_are_stable() -> None:
     """Pin golden serialization, full digest, and content-addressed ID."""
     golden = _vectors()[0]
     artifact = golden["artifact"]
-    serialized = _reference_serialize_for_spec_fixture(
-        golden["canonical_preimage"]
-    )
+    serialized = _reference_serialize_for_spec_fixture(golden["canonical_preimage"])
     digest = _reference_hash_for_spec_fixture(artifact)
 
     assert serialized == golden["expected_canonical_serialized"]
@@ -157,6 +248,69 @@ def test_hash_and_id_shapes_and_golden_bytes_are_stable() -> None:
     assert artifact["decision_id"] == golden["expected_decision_id"]
     assert len(digest) == 64
     assert artifact["request_id"] not in artifact["decision_id"]
+
+
+def test_golden_source_round_trips_without_hidden_canonicalization() -> None:
+    """Prove V01 is an actually normalized, producer-eligible source."""
+    golden = _vectors()[0]
+    source = golden["source_projection"]
+    normalized = DecideResponse.model_validate(source).model_dump(mode="json")
+
+    assert golden["expected_production"] == "EMIT"
+    assert source["gate_decision"] == normalized["gate_decision"] == "hold"
+    assert source["business_decision"] == normalized["business_decision"] == ("HOLD")
+    assert source["human_review_required"] is False
+    assert normalized["human_review_required"] is False
+    assert (
+        _project_normalized_source_for_spec_fixture(normalized)
+        == golden["artifact"]["decision"]
+    )
+
+
+def test_emit_vectors_are_normalized_and_hash_only_vectors_are_explicit() -> None:
+    """Separate producer eligibility from isolated hash sensitivity."""
+    vectors = _vectors()
+
+    assert {
+        vector["vector_id"]
+        for vector in vectors
+        if vector["expected_production"] == "EMIT"
+    } == {"CDA-V1-01", "CDA-V1-12"}
+    assert all(
+        vector["expected_production"] == "HASH_REFERENCE_ONLY"
+        for vector in vectors[1:11]
+    )
+    for vector in vectors:
+        if vector["expected_production"] != "EMIT":
+            continue
+        normalized = DecideResponse.model_validate(
+            vector["source_projection"]
+        ).model_dump(mode="json")
+        assert (
+            vector["source_projection"]["gate_decision"] == normalized["gate_decision"]
+        )
+        assert (
+            _project_normalized_source_for_spec_fixture(normalized)
+            == (vector["artifact"]["decision"])
+        )
+
+
+def test_golden_opaque_bindings_match_normalized_source_values() -> None:
+    """Recompute each V01 field-specific digest from normalized source."""
+    golden = _vectors()[0]
+    normalized = DecideResponse.model_validate(golden["source_projection"]).model_dump(
+        mode="json"
+    )
+
+    for binding_field, (profile, source_field) in BINDING_SOURCES.items():
+        binding = golden["artifact"]["decision"][binding_field]
+        assert binding["profile"] == profile
+        assert binding["sha256"] == (
+            _reference_binding_digest_for_spec_fixture(
+                profile,
+                normalized[source_field],
+            )
+        )
 
 
 def test_every_included_mutation_changes_hash_and_id() -> None:
@@ -180,9 +334,7 @@ def test_every_included_mutation_changes_hash_and_id() -> None:
     }
     for vector in mutation_vectors:
         artifact = vector["artifact"]
-        assert _reference_hash_for_spec_fixture(artifact) == artifact[
-            "decision_hash"
-        ]
+        assert _reference_hash_for_spec_fixture(artifact) == artifact["decision_hash"]
         assert vector["expected_decision_hash"] != golden_hash
         assert vector["expected_decision_id"] != golden_id
 
@@ -195,26 +347,77 @@ def test_excluded_fields_and_bind_retroactivity_contract() -> None:
     post_bind = vectors["CDA-V1-13"]
 
     assert excluded["excluded_source_mutations"]
-    assert excluded["expected_decision_hash"] == golden[
-        "expected_decision_hash"
-    ]
+    assert excluded["expected_decision_hash"] == golden["expected_decision_hash"]
     assert excluded["expected_decision_id"] == golden["expected_decision_id"]
     assert post_bind["expected_production"] == "REFUSE"
     assert post_bind["expected_reason"] == "POST_BIND_SOURCE_REFUSED"
     assert "artifact" not in post_bind
+    normalized = DecideResponse.model_validate(
+        excluded["source_projection"]
+    ).model_dump(mode="json")
+    assert normalized["trust_log"] is not None
+    assert normalized["user_summary"] == "Presentation only"
+    assert {
+        "meta",
+        "persona",
+        "alternatives",
+        "options",
+        "trust_log",
+        "deterministic_replay",
+        "user_summary",
+    } <= set(excluded["excluded_source_mutations"])
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("bind_outcome", "BLOCKED"),
+        ("bind_failure_reason", "synthetic"),
+        ("bind_reason_code", "SYNTHETIC"),
+        ("bind_receipt_id", "bind-synthetic"),
+        ("execution_intent_id", "intent-synthetic"),
+        ("bound_execution_intent_id", "intent-synthetic"),
+        ("authority_check_result", {"status": "synthetic"}),
+        ("constraint_check_result", {"status": "synthetic"}),
+        ("drift_check_result", {"status": "synthetic"}),
+        ("risk_check_result", {"status": "synthetic"}),
+        ("bind_summary", {"bind_outcome": "ROLLED_BACK"}),
+        ("bind_operator_summary", {"bind_outcome": "BLOCKED"}),
+        ("bind_operator_detail", {"bind_outcome": "ROLLED_BACK"}),
+    ),
+)
+def test_every_current_post_bind_source_field_is_refused(
+    field: str,
+    value: object,
+) -> None:
+    """Refuse every current non-null Bind result or operator surface."""
+    source = deepcopy(_vectors()[0]["source_projection"])
+    source[field] = value
+    normalized = DecideResponse.model_validate(source).model_dump(mode="json")
+
+    assert set(_vectors()[12]["post_bind_source_fields"]) == BIND_SOURCE_FIELDS
+    assert normalized[field] is not None
+    assert _post_bind_source_is_refused_for_spec_fixture(normalized)
+
+
+def test_null_post_bind_fields_are_not_populated() -> None:
+    """Define populated as non-null, while retaining fail-closed values."""
+    source = {field: None for field in BIND_SOURCE_FIELDS}
+
+    assert BIND_SOURCE_FIELDS <= set(DecideResponse.model_fields)
+    assert not _post_bind_source_is_refused_for_spec_fixture(source)
 
 
 def test_timestamp_contract_and_deterministic_normalization() -> None:
     """Require exact UTC microseconds and reject naive/invalid timestamps."""
     by_id = {vector["vector_id"]: vector for vector in _vectors()}
 
-    assert _normalize_aware_timestamp_for_spec_fixture(
-        "2031-02-03T05:05:06.123456+01:00"
-    ) == "2031-02-03T04:05:06.123456Z"
+    assert (
+        _normalize_aware_timestamp_for_spec_fixture("2031-02-03T05:05:06.123456+01:00")
+        == "2031-02-03T04:05:06.123456Z"
+    )
     with pytest.raises(ValueError, match="timezone-aware"):
-        _normalize_aware_timestamp_for_spec_fixture(
-            "2031-02-03T04:05:06.123456"
-        )
+        _normalize_aware_timestamp_for_spec_fixture("2031-02-03T04:05:06.123456")
     assert by_id["CDA-V1-14"]["expected_reason"] == "NAIVE_TIMESTAMP"
     assert by_id["CDA-V1-15"]["expected_reason"] == "INVALID_TIMESTAMP"
 
@@ -255,6 +458,126 @@ def test_schema_cannot_carry_execution_bind_or_self_declared_validity() -> None:
     assert all(term not in schema_text for term in forbidden)
 
 
+def test_closed_vocabularies_match_normalized_source_contract() -> None:
+    """Pin canonical vocabularies and exclude every legacy gate alias."""
+    schema = _load_json(SCHEMA_PATH)
+    decision = schema["$defs"]["decision"]["properties"]
+
+    assert set(decision["decision_status"]["enum"]) == {
+        "allow",
+        "modify",
+        "rejected",
+        "block",
+        "abstain",
+    }
+    assert set(decision["gate_decision"]["enum"]) == set(CANONICAL_GATE_DECISION_VALUES)
+    assert not {"allow", "deny", "modify", "rejected", "abstain"} & set(
+        decision["gate_decision"]["enum"]
+    )
+    assert "unknown" not in decision["gate_decision"]["enum"]
+    assert set(decision["business_decision"]["enum"]) == {
+        "APPROVE",
+        "DENY",
+        "HOLD",
+        "REVIEW_REQUIRED",
+        "POLICY_DEFINITION_REQUIRED",
+        "EVIDENCE_REQUIRED",
+    }
+    assert set(decision["actionability_status"]["enum"]) == {
+        "reviewable_only",
+        "bind_required_before_execution",
+        "actionable_after_bind",
+        "blocked",
+        "human_review_required",
+        "formation_transition_refused",
+    }
+
+
+def test_schema_mirrors_gate_business_human_review_invariants() -> None:
+    """Reject the same coupled semantic combinations as DecideResponse."""
+    schema = _load_json(SCHEMA_PATH)
+    validator = Draft202012Validator(schema)
+    artifact = deepcopy(_vectors()[0]["artifact"])
+    invalid_tuples = [
+        ("proceed", "HOLD", True),
+        ("hold", "APPROVE", False),
+        ("block", "APPROVE", False),
+        ("proceed", "DENY", False),
+        ("hold", "REVIEW_REQUIRED", True),
+        ("human_review_required", "HOLD", True),
+        ("human_review_required", "REVIEW_REQUIRED", False),
+    ]
+
+    assert FORBIDDEN_GATE_BUSINESS_COMBINATIONS == frozenset(
+        {
+            ("block", "APPROVE"),
+            ("hold", "APPROVE"),
+            ("proceed", "DENY"),
+        }
+    )
+    for gate, business, review_required in invalid_tuples:
+        candidate = deepcopy(artifact)
+        candidate["decision"].update(
+            gate_decision=gate,
+            business_decision=business,
+            human_review_required=review_required,
+        )
+        with pytest.raises(ValidationError):
+            validator.validate(candidate)
+        with pytest.raises(ValueError):
+            DecideResponse.model_validate(
+                {
+                    "gate_decision": gate,
+                    "business_decision": business,
+                    "human_review_required": review_required,
+                }
+            )
+
+
+@pytest.mark.parametrize(
+    ("binding_field", "wrong_profile"),
+    (
+        ("chosen_binding", "unknown-profile/v1"),
+        (
+            "governance_identity_binding",
+            "veritas.canonical-decision.chosen-value/v1",
+        ),
+        (
+            "transition_refusal_binding",
+            "veritas.canonical-decision.governance-identity/v1",
+        ),
+    ),
+)
+def test_wrong_or_swapped_binding_profiles_are_schema_invalid(
+    binding_field: str,
+    wrong_profile: str,
+) -> None:
+    """Prevent opaque binding digest domain substitution."""
+    artifact = deepcopy(_vectors()[0]["artifact"])
+    artifact["decision"][binding_field]["profile"] = wrong_profile
+
+    with pytest.raises(ValidationError):
+        Draft202012Validator(_load_json(SCHEMA_PATH)).validate(artifact)
+
+
+@pytest.mark.parametrize(
+    ("formation_status", "binding"),
+    (("COMPLETE", None), ("INCOMPLETE", "golden")),
+)
+def test_formation_status_and_governance_binding_cannot_contradict(
+    formation_status: str,
+    binding: str | None,
+) -> None:
+    """Pin formation completeness to governance binding presence only."""
+    artifact = deepcopy(_vectors()[0]["artifact"])
+    artifact["decision"]["formation_status"] = formation_status
+    if binding is None:
+        artifact["decision"]["governance_identity_binding"] = None
+
+    with pytest.raises(ValidationError):
+        Draft202012Validator(_load_json(SCHEMA_PATH)).validate(artifact)
+
+
 def test_non_authority_non_execution_and_incomplete_governance_are_explicit() -> None:
     """Pin semantic non-claims and absent-governance formation behavior."""
     specification = SPEC_PATH.read_text(encoding="utf-8")
@@ -265,7 +588,7 @@ def test_non_authority_non_execution_and_incomplete_governance_are_explicit() ->
         "`chosen != canonical executable action`",
         "`next_action != intended_action`",
         "`READY_FOR_GUARDED_PROMOTION != execution`",
-        "`formation_status=INCOMPLETE`",
+        "`INCOMPLETE` means it is unavailable",
     ):
         assert invariant in specification
 

--- a/tests/spec/test_decision_to_bind_handoff_spec.py
+++ b/tests/spec/test_decision_to_bind_handoff_spec.py
@@ -315,6 +315,24 @@ def test_target_context_mismatch_has_a_distinct_canonical_reason_code() -> None:
     assert target_context_reason in specification
 
 
+def test_future_canonical_decision_artifact_mapping_is_non_operational() -> None:
+    """Pin the future verified artifact source without changing readiness."""
+    specification = Path(
+        "docs/en/architecture/canonical-decision-to-bind-handoff-v1.md"
+    ).read_text(encoding="utf-8")
+
+    assert "CanonicalDecisionArtifact v1" in specification
+    for field_name in (
+        "canonical_decision_id",
+        "canonical_decision_hash",
+        "canonical_decision_ts",
+    ):
+        assert field_name in specification
+    assert "runtime validator continues to accept an already formed handoff" in (
+        specification
+    )
+
+
 def test_action_substitution_invalidates_authority_and_approval_bindings() -> None:
     """Pin V25's independently visible action-to-evidence mismatches."""
     by_id = {vector["vector_id"]: vector for vector in _vectors()}


### PR DESCRIPTION
### Motivation
- Provide a precise, versioned, closed-schema specification that gives the decision side a canonical, immutable identity triple (`decision_id`, `decision_hash`, `decision_ts`) without changing runtime producers or `/v1/decide` semantics.
- Make explicit the security and provenance boundaries that separate canonical decision identity from TrustLog, replay, Bind, ExecutionIntent, Authority Evidence, and presentation/volatile fields.
- Prevent risky shortcuts and ambiguities (for example `request_id` ≠ `decision_id`, HTTP-response hash ≠ `decision_hash`, and current wall-clock backfill for `decision_ts`) by establishing a deterministic preimage and serialization contract.

### Description
- Add `docs/en/architecture/canonical-decision-artifact-v1.md`, defining the artifact purpose, exact canonical preimage, deterministic serialization rules, decision timestamp contract, field-specific opaque-value digest bindings, explicit exclusions, threat model, and non-claims.
- Add the closed Draft 2020-12 JSON Schema `schemas/canonical-decision-artifact-v1.schema.json`, fixing `format_version` to `canonical-decision-artifact/v1`, `hash_profile` to `veritas.canonical-decision/v1`, and the eight top-level fields (`format_version`, `hash_profile`, `decision_id`, `decision_hash`, `decision_ts`, `request_id`, `source_contract`, `decision`) with `additionalProperties: false` at normative levels.
- Restrict CDA v1 to canonical **pre-Bind** decision semantics. `actionable_after_bind` is deliberately excluded because current runtime only derives it from committed Bind lineage.
- Close critical decision vocabularies and enforce gate/business/human-review and actionability/`requires_bind_before_execution` coherence in the schema.
- Add 15 synthetic, non-production test vectors under `docs/en/architecture/test-vectors/canonical-decision-artifact-v1/`, including:
  - a producer-eligible golden normalized `DecideResponse` fixture,
  - included-field hash sensitivity vectors,
  - excluded-field identity-stability coverage,
  - complete current post-Bind source refusal coverage, and
  - naive/invalid timestamp refusal cases.
- Add spec-coherence tests in `tests/spec/test_canonical_decision_artifact_spec.py` and minimally update handoff docs/tests so a **verified** `CanonicalDecisionArtifact v1` is the future source of canonical decision lineage fields, without changing current #2103 validator behavior.

### Golden contract
- Normalized golden source uses `gate_decision=hold`, `business_decision=HOLD`, and `human_review_required=false`.
- Golden decision hash:
  - `1c6e265c50812c2b86eab04ef5523a7f1e56c45db4888ca527840ec94f0456a8`
- Golden decision ID:
  - `cda:v1:sha256:1c6e265c50812c2b86eab04ef5523a7f1e56c45db4888ca527840ec94f0456a8`
- The golden fixture round-trips through the existing `DecideResponse` model without hidden gate canonicalization.
- Opaque bindings for `chosen`, `governance_identity`, `lineage_promotability`, and `transition_refusal` are independently recomputed in test-only reference logic using their exact field-specific domain profiles.

### Security / boundary guarantees
- `request_id` is not `decision_id`.
- HTTP response hash is not `decision_hash`.
- `decision_ts` cannot be reconstructed from current time, CI time, HTTP arrival time, or TrustLog retrieval time.
- `ALLOW` does not establish authority and `APPROVE` does not establish Human Approval.
- `chosen` / `next_action` do not become executable action semantics.
- TrustLog, replay, candidate, Authority Evidence, Human Approval, ExecutionIntent, BindReceipt, adapter state, and external-effect state remain independent domains.
- The producer contract refuses any normalized source with populated post-Bind fields, including blocked or rolled-back Bind results.
- `CanonicalDecisionArtifact v1` represents only pre-Bind actionability states; contradictory `actionability_status` / `requires_bind_before_execution` combinations are schema-invalid.

### Testing
- Spec coherence tests for Canonical Decision Artifact v1 and the Decision-to-Bind handoff pass on the current head.
- Deterministic test-only reference hashing/serialization pins the golden canonical bytes, decision hash, and content-addressed decision ID.
- Tests verify normalized-source round-trip, canonical vocabularies, gate/business/human-review invariants, field-specific digest profiles, source-to-binding digest integrity, formation-status/governance-binding coherence, complete post-Bind refusal coverage, real `trust_log` / `user_summary` exclusions, and pre-Bind actionability coherence.
- `ruff`, `py_compile`, and diff checks pass for the changed spec/test files.
- Full GitHub CI on current head `764479ae043d00355b6c585a8c7dca4e911175b6` is green, including CI, Security Gates, CodeQL, Runtime Proof Evidence, Runtime Pickle Guard, and Reviewer Evidence Packet Validation.

### Non-claims
This PR is specification-first and intentionally introduces **NO** production artifact builder, **NO** runtime API changes, **NO** changes to #2103 validator behavior, and **NO** creation of ExecutionIntent, Bind, Authority Evidence, Human Approval, or external execution effects. Treat the artifact as an auditable canonical decision projection until a separately reviewed producer and verifier are implemented.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8031f7bbf48326b216faf18d6fe85b)