### PR TITLE
feat(governance): add Canonical Decision Artifact v1 runtime builder and verifier

### DIFF
--- a/docs/en/architecture/canonical-decision-artifact-v1.md
+++ b/docs/en/architecture/canonical-decision-artifact-v1.md
@@ -2,13 +2,15 @@
 
 ## Status, purpose, and boundary
 
-This specification defines the **future**, immutable
+This specification defines the immutable
 `CanonicalDecisionArtifact` representation of one finalized, normalized
 VERITAS decision event. It supplies a stable `decision_id`, `decision_hash`,
 and `decision_ts` for the decision side. The current `/v1/decide` response has
 `request_id`, but does **not** emit any of those three authoritative canonical
-values. This milestone adds only a schema, synthetic vectors, documentation,
-and test-only coherence logic; it adds no producer, verifier, or consumer.
+values. A production standalone builder and integrity verifier now implement
+the v1 contract as a pure, independently testable runtime primitive. They are
+not yet wired to `/v1/decide`, pipeline finalization, persistence, TrustLog,
+replay, `CanonicalDecisionHandoff`, `ExecutionIntent`, or Bind.
 
 The processing boundary is exactly:
 
@@ -250,8 +252,8 @@ field stability vectors are `EMIT`; mutation vectors are hash-reference-only.
 
 ## Verification and independent domains
 
-A future verifier fails closed: (1) validate schema/version; (2) exclude the
-two identity outputs; (3) construct the exact v1 preimage; (4) canonicalize;
+The standalone verifier fails closed: (1) validate schema/version; (2) exclude
+the two identity outputs; (3) construct the exact v1 preimage; (4) canonicalize;
 (5) SHA-256; (6) compare `decision_hash`; (7) derive the expected full
 `decision_id`; (8) compare it; and (9) reject any mismatch. The artifact has no
 `verified: true` shortcut.
@@ -283,15 +285,16 @@ chosen/action laundering; ALLOW/APPROVE authority laundering; compatibility or
 volatile-field hash drift; alternate serialization; self-hash recursion;
 cross-domain digest confusion; cross-request substitution; reuse of one ID with
 modified state; governance substitution; and erasure of structural refusal.
-Residual risk remains until a separately reviewed producer and verifier capture
-the correct boundary and validate every binding; this PR must not be treated as
-runtime protection.
+The verifier proves internal structure and content integrity only. A party able
+to replace an entire artifact and recompute its hash and ID can produce an
+internally self-consistent artifact; trusted origin and provenance remain a
+separate future layer.
 
 ## Non-claims and remaining work
 
-This milestone provides no live `/v1/decide` emission, production builder or
-verifier, canonical candidate extraction, Authority Evidence, Human Approval
-verification, live policy verification, TrustLog verification, replay
+This milestone provides no live `/v1/decide` emission, canonical candidate
+extraction, Authority Evidence, Human Approval verification, live policy
+verification, TrustLog verification, replay
 verification, `CanonicalDecisionHandoff` creation, guarded promotion,
 `ExecutionIntent`, Bind, external effect, or production/customer/regulatory
 certification. A later PR must define and review the finalization capture,

--- a/veritas_os/governance/canonical_decision_artifact.py
+++ b/veritas_os/governance/canonical_decision_artifact.py
@@ -16,7 +16,11 @@ from typing import Any, Literal, Mapping
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
-from veritas_os.api.schemas import DecideResponse
+from veritas_os.api.schemas import (
+    DecideResponse,
+    LineagePromotabilitySummary,
+    TransitionRefusal,
+)
 from veritas_os.core.decision_semantics import validate_gate_business_combination
 from veritas_os.security.hash import sha256_hex
 
@@ -419,6 +423,22 @@ def _validated_source_projection(source: DecideResponse) -> dict[str, Any]:
             CanonicalDecisionArtifactBuildReason.SOURCE_REQUEST_ID_MISSING
         )
     try:
+        _validate_canonical_json_value(source.chosen)
+        if source.governance_identity is not None:
+            _validate_canonical_json_value(source.governance_identity)
+        _validate_typed_source_model(
+            source.lineage_promotability,
+            LineagePromotabilitySummary,
+        )
+        _validate_typed_source_model(
+            source.transition_refusal,
+            TransitionRefusal,
+        )
+    except (TypeError, ValueError) as exc:
+        raise CanonicalDecisionArtifactBuildError(
+            CanonicalDecisionArtifactBuildReason.NON_CANONICAL_JSON_VALUE
+        ) from exc
+    try:
         # JSON-mode dumping can coerce non-finite floats under Pydantic's
         # serialization policy.  Inspect the Python projection first so no
         # hash-relevant non-finite or unsupported value can be laundered.
@@ -484,6 +504,36 @@ def _validate_canonical_json_value(value: Any) -> None:
             _validate_canonical_json_value(item)
         return
     raise TypeError(f"unsupported canonical JSON value type: {value_type.__qualname__}")
+
+
+def _validate_typed_source_model(
+    value: BaseModel | None,
+    expected_type: type[BaseModel],
+) -> None:
+    """Validate raw contents of one explicitly allowed typed source model.
+
+    Only the declared top-level Pydantic source model may cross this boundary.
+    Its known fields and Pydantic extras are inspected before ``model_dump`` so
+    nested Python objects cannot be normalized into a CDA binding.
+
+    Args:
+        value: Current raw source-model value, or ``None``.
+        expected_type: Exact Pydantic model type allowed for this source field.
+
+    Raises:
+        TypeError: If the top-level type is unexpected or any contained value
+            is not an exact canonical JSON family.
+        ValueError: If a contained floating-point value is non-finite.
+    """
+    if value is None:
+        return
+    if type(value) is not expected_type:
+        raise TypeError(f"unexpected typed source model: {type(value).__qualname__}")
+    for field_name in expected_type.model_fields:
+        _validate_canonical_json_value(getattr(value, field_name))
+    extras = value.__pydantic_extra__
+    if extras is not None:
+        _validate_canonical_json_value(extras)
 
 
 def _normalize_builder_timestamp(value: datetime | str) -> str:

--- a/veritas_os/governance/canonical_decision_artifact.py
+++ b/veritas_os/governance/canonical_decision_artifact.py
@@ -9,6 +9,7 @@ human approval, handoff readiness, or execution authority.
 from __future__ import annotations
 
 import json
+import math
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Literal, Mapping
@@ -264,6 +265,7 @@ class CanonicalDecisionArtifactVerificationResult(_FrozenModel):
 
 def strict_canonical_json_bytes(value: Any) -> bytes:
     """Return CDA-v1 canonical UTF-8 JSON, refusing non-JSON/non-finite data."""
+    _validate_canonical_json_value(value)
     return json.dumps(
         value,
         ensure_ascii=False,
@@ -303,14 +305,6 @@ def build_canonical_decision_artifact(
     """
     normalized = _validated_source_projection(source)
     request_id = normalized["request_id"]
-    if not isinstance(request_id, str) or not request_id:
-        raise CanonicalDecisionArtifactBuildError(
-            CanonicalDecisionArtifactBuildReason.SOURCE_REQUEST_ID_MISSING
-        )
-    if any(normalized[field] is not None for field in POST_BIND_SOURCE_FIELDS):
-        raise CanonicalDecisionArtifactBuildError(
-            CanonicalDecisionArtifactBuildReason.POST_BIND_SOURCE_REFUSED
-        )
     if normalized["gate_decision"] not in {
         "proceed",
         "hold",
@@ -380,11 +374,12 @@ def verify_canonical_decision_artifact(
     if artifact is None:
         return _verification_failure("ARTIFACT_MISSING")
     try:
-        parsed = (
-            artifact
+        raw = (
+            artifact.model_dump(mode="json")
             if isinstance(artifact, CanonicalDecisionArtifact)
-            else CanonicalDecisionArtifact.model_validate(artifact)
+            else artifact
         )
+        parsed = CanonicalDecisionArtifact.model_validate(raw)
         serialized = strict_canonical_json_bytes(canonical_decision_preimage(parsed))
         computed_hash = sha256_hex(serialized)
     except (TypeError, ValueError, ValidationError):
@@ -419,13 +414,25 @@ def _validated_source_projection(source: DecideResponse) -> dict[str, Any]:
         raise CanonicalDecisionArtifactBuildError(
             CanonicalDecisionArtifactBuildReason.SOURCE_NOT_DECIDE_RESPONSE
         )
+    if type(source.request_id) is not str or not source.request_id:
+        raise CanonicalDecisionArtifactBuildError(
+            CanonicalDecisionArtifactBuildReason.SOURCE_REQUEST_ID_MISSING
+        )
     try:
         # JSON-mode dumping can coerce non-finite floats under Pydantic's
         # serialization policy.  Inspect the Python projection first so no
         # hash-relevant non-finite or unsupported value can be laundered.
-        strict_canonical_json_bytes(
-            source.model_dump(mode="python", include=_SOURCE_FIELDS)
+        python_projection = source.model_dump(mode="python", include=_SOURCE_FIELDS)
+    except (TypeError, ValueError) as exc:
+        raise CanonicalDecisionArtifactBuildError(
+            CanonicalDecisionArtifactBuildReason.NON_CANONICAL_JSON_VALUE
+        ) from exc
+    if any(python_projection[field] is not None for field in POST_BIND_SOURCE_FIELDS):
+        raise CanonicalDecisionArtifactBuildError(
+            CanonicalDecisionArtifactBuildReason.POST_BIND_SOURCE_REFUSED
         )
+    try:
+        strict_canonical_json_bytes(python_projection)
     except (TypeError, ValueError) as exc:
         raise CanonicalDecisionArtifactBuildError(
             CanonicalDecisionArtifactBuildReason.NON_CANONICAL_JSON_VALUE
@@ -443,6 +450,40 @@ def _validated_source_projection(source: DecideResponse) -> dict[str, Any]:
             CanonicalDecisionArtifactBuildReason.SOURCE_NOT_NORMALIZED
         )
     return extracted
+
+
+def _validate_canonical_json_value(value: Any) -> None:
+    """Recursively require exact CDA-v1 canonical JSON value families.
+
+    Python containers and objects that ``json.dumps`` or Pydantic might coerce
+    are deliberately rejected rather than converted into canonical identity.
+
+    Args:
+        value: Candidate value to validate without normalization.
+
+    Raises:
+        TypeError: If a value, container, or mapping key is not an exact JSON
+            family supported by CDA v1.
+        ValueError: If a floating-point value is non-finite.
+    """
+    value_type = type(value)
+    if value is None or value_type is bool or value_type is int or value_type is str:
+        return
+    if value_type is float:
+        if not math.isfinite(value):
+            raise ValueError("canonical JSON numbers must be finite")
+        return
+    if value_type is list:
+        for item in value:
+            _validate_canonical_json_value(item)
+        return
+    if value_type is dict:
+        for key, item in value.items():
+            if type(key) is not str:
+                raise TypeError("canonical JSON object keys must be strings")
+            _validate_canonical_json_value(item)
+        return
+    raise TypeError(f"unsupported canonical JSON value type: {value_type.__qualname__}")
 
 
 def _normalize_builder_timestamp(value: datetime | str) -> str:

--- a/veritas_os/governance/canonical_decision_artifact.py
+++ b/veritas_os/governance/canonical_decision_artifact.py
@@ -1,0 +1,551 @@
+"""Deterministic Canonical Decision Artifact v1 construction and verification.
+
+The verifier establishes only internal structure, canonical hash integrity, and
+content-addressed identifier coherence.  It does not establish source
+authenticity, provenance, TrustLog or replay membership, governance signatures,
+human approval, handoff readiness, or execution authority.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Literal, Mapping
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+from veritas_os.api.schemas import DecideResponse
+from veritas_os.core.decision_semantics import validate_gate_business_combination
+from veritas_os.security.hash import sha256_hex
+
+CDA_FORMAT_VERSION = "canonical-decision-artifact/v1"
+CDA_HASH_PROFILE = "veritas.canonical-decision/v1"
+CDA_PROJECTION_VERSION = "canonical-decision-projection/v1"
+CDA_SOURCE_TYPE = "DecideResponse"
+CDA_DECISION_ID_PREFIX = "cda:v1:sha256:"
+CDA_CHOSEN_BINDING_PROFILE = "veritas.canonical-decision.chosen-value/v1"
+CDA_GOVERNANCE_IDENTITY_BINDING_PROFILE = (
+    "veritas.canonical-decision.governance-identity/v1"
+)
+CDA_LINEAGE_PROMOTABILITY_BINDING_PROFILE = (
+    "veritas.canonical-decision.lineage-promotability/v1"
+)
+CDA_TRANSITION_REFUSAL_BINDING_PROFILE = (
+    "veritas.canonical-decision.transition-refusal/v1"
+)
+
+_DIGEST_PATTERN = r"^[0-9a-f]{64}$"
+_DECISION_ID_PATTERN = r"^cda:v1:sha256:[0-9a-f]{64}$"
+_CANONICAL_TIMESTAMP_PATTERN = (
+    r"^[0-9]{4}-(0[1-9]|1[0-2])-([0-2][0-9]|3[01])T"
+    r"([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]\.[0-9]{6}Z$"
+)
+
+_SOURCE_FIELDS = frozenset(
+    {
+        "request_id",
+        "chosen",
+        "decision_status",
+        "rejection_reason",
+        "gate_decision",
+        "business_decision",
+        "next_action",
+        "actionability_status",
+        "requires_bind_before_execution",
+        "human_review_required",
+        "required_evidence",
+        "missing_evidence",
+        "satisfied_evidence",
+        "rationale",
+        "refusal_reason",
+        "actionability_block_reason",
+        "actionability_refusal_type",
+        "governance_identity",
+        "lineage_promotability",
+        "transition_refusal",
+        "bind_outcome",
+        "bind_failure_reason",
+        "bind_reason_code",
+        "bind_receipt_id",
+        "execution_intent_id",
+        "bound_execution_intent_id",
+        "authority_check_result",
+        "constraint_check_result",
+        "drift_check_result",
+        "risk_check_result",
+        "bind_summary",
+        "bind_operator_summary",
+        "bind_operator_detail",
+    }
+)
+POST_BIND_SOURCE_FIELDS = (
+    "bind_outcome",
+    "bind_failure_reason",
+    "bind_reason_code",
+    "bind_receipt_id",
+    "execution_intent_id",
+    "bound_execution_intent_id",
+    "authority_check_result",
+    "constraint_check_result",
+    "drift_check_result",
+    "risk_check_result",
+    "bind_summary",
+    "bind_operator_summary",
+    "bind_operator_detail",
+)
+PRE_BIND_ACTIONABILITY_STATES = frozenset(
+    {
+        "reviewable_only",
+        "bind_required_before_execution",
+        "blocked",
+        "human_review_required",
+        "formation_transition_refused",
+    }
+)
+
+
+class CanonicalDecisionArtifactBuildReason(str, Enum):
+    """Stable machine-readable reasons for refusing artifact construction."""
+
+    SOURCE_NOT_DECIDE_RESPONSE = "SOURCE_NOT_DECIDE_RESPONSE"
+    SOURCE_NOT_NORMALIZED = "SOURCE_NOT_NORMALIZED"
+    SOURCE_REQUEST_ID_MISSING = "SOURCE_REQUEST_ID_MISSING"
+    POST_BIND_SOURCE_REFUSED = "POST_BIND_SOURCE_REFUSED"
+    UNRESOLVED_GATE_DECISION = "UNRESOLVED_GATE_DECISION"
+    POST_BIND_ACTIONABILITY_REFUSED = "POST_BIND_ACTIONABILITY_REFUSED"
+    ACTIONABILITY_BOUNDARY_INVALID = "ACTIONABILITY_BOUNDARY_INVALID"
+    NAIVE_TIMESTAMP = "NAIVE_TIMESTAMP"
+    INVALID_TIMESTAMP = "INVALID_TIMESTAMP"
+    NON_CANONICAL_JSON_VALUE = "NON_CANONICAL_JSON_VALUE"
+
+
+class CanonicalDecisionArtifactBuildError(ValueError):
+    """Fail-closed builder error carrying a stable reason code."""
+
+    def __init__(self, reason_code: CanonicalDecisionArtifactBuildReason) -> None:
+        self.reason_code = reason_code
+        super().__init__(reason_code.value)
+
+
+class _FrozenModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class CanonicalDecisionSourceContract(_FrozenModel):
+    """Frozen identity of the normalized source projection contract."""
+
+    type: Literal["DecideResponse"] = CDA_SOURCE_TYPE
+    projection_version: Literal["canonical-decision-projection/v1"] = (
+        CDA_PROJECTION_VERSION
+    )
+
+
+class CanonicalDecisionChosenBinding(_FrozenModel):
+    """Opaque binding to the exact normalized chosen value."""
+
+    profile: Literal["veritas.canonical-decision.chosen-value/v1"]
+    sha256: str = Field(pattern=_DIGEST_PATTERN)
+
+
+class CanonicalDecisionGovernanceIdentityBinding(_FrozenModel):
+    """Opaque binding to a structurally present governance identity."""
+
+    profile: Literal["veritas.canonical-decision.governance-identity/v1"]
+    sha256: str = Field(pattern=_DIGEST_PATTERN)
+
+
+class CanonicalDecisionLineagePromotabilityBinding(_FrozenModel):
+    """Opaque binding to the normalized lineage promotability record."""
+
+    profile: Literal["veritas.canonical-decision.lineage-promotability/v1"]
+    sha256: str = Field(pattern=_DIGEST_PATTERN)
+
+
+class CanonicalDecisionTransitionRefusalBinding(_FrozenModel):
+    """Opaque binding to the normalized transition refusal record."""
+
+    profile: Literal["veritas.canonical-decision.transition-refusal/v1"]
+    sha256: str = Field(pattern=_DIGEST_PATTERN)
+
+
+class CanonicalDecisionProjection(_FrozenModel):
+    """Exact closed v1 decision projection."""
+
+    formation_status: Literal["COMPLETE", "INCOMPLETE"]
+    chosen_binding: CanonicalDecisionChosenBinding
+    decision_status: Literal["allow", "modify", "rejected", "block", "abstain"]
+    rejection_reason: str | None
+    gate_decision: Literal["proceed", "hold", "block", "human_review_required"]
+    business_decision: Literal[
+        "APPROVE",
+        "DENY",
+        "HOLD",
+        "REVIEW_REQUIRED",
+        "POLICY_DEFINITION_REQUIRED",
+        "EVIDENCE_REQUIRED",
+    ]
+    next_action: str
+    actionability_status: Literal[
+        "reviewable_only",
+        "bind_required_before_execution",
+        "blocked",
+        "human_review_required",
+        "formation_transition_refused",
+    ]
+    requires_bind_before_execution: bool
+    human_review_required: bool
+    required_evidence: tuple[str, ...]
+    missing_evidence: tuple[str, ...]
+    satisfied_evidence: tuple[str, ...]
+    rationale: str | None
+    refusal_reason: str | None
+    actionability_block_reason: str | None
+    actionability_refusal_type: str | None
+    governance_identity_binding: CanonicalDecisionGovernanceIdentityBinding | None
+    lineage_promotability_binding: CanonicalDecisionLineagePromotabilityBinding | None
+    transition_refusal_binding: CanonicalDecisionTransitionRefusalBinding | None
+
+    @model_validator(mode="after")
+    def _validate_semantics(self) -> "CanonicalDecisionProjection":
+        complete = self.formation_status == "COMPLETE"
+        if complete != (self.governance_identity_binding is not None):
+            raise ValueError("formation status contradicts governance identity binding")
+        _validate_actionability_boundary(
+            self.actionability_status,
+            self.requires_bind_before_execution,
+            self.human_review_required,
+        )
+        validate_gate_business_combination(
+            gate_decision=self.gate_decision,
+            business_decision=self.business_decision,
+            human_review_required=self.human_review_required,
+        )
+        return self
+
+
+class CanonicalDecisionArtifact(_FrozenModel):
+    """Immutable, content-addressed Canonical Decision Artifact v1."""
+
+    format_version: Literal["canonical-decision-artifact/v1"]
+    hash_profile: Literal["veritas.canonical-decision/v1"]
+    decision_id: str = Field(pattern=_DECISION_ID_PATTERN)
+    decision_hash: str = Field(pattern=_DIGEST_PATTERN)
+    decision_ts: str = Field(pattern=_CANONICAL_TIMESTAMP_PATTERN)
+    request_id: str = Field(min_length=1)
+    source_contract: CanonicalDecisionSourceContract
+    decision: CanonicalDecisionProjection
+
+    @model_validator(mode="after")
+    def _validate_timestamp(self) -> "CanonicalDecisionArtifact":
+        if _normalize_timestamp(self.decision_ts) != self.decision_ts:
+            raise ValueError("decision_ts is not canonical UTC")
+        return self
+
+
+class CanonicalDecisionArtifactVerificationReason(str, Enum):
+    """Stable verifier result reasons in deterministic reporting order."""
+
+    ARTIFACT_MISSING = "ARTIFACT_MISSING"
+    ARTIFACT_SCHEMA_INVALID = "ARTIFACT_SCHEMA_INVALID"
+    ARTIFACT_HASH_MISMATCH = "ARTIFACT_HASH_MISMATCH"
+    ARTIFACT_DECISION_ID_MISMATCH = "ARTIFACT_DECISION_ID_MISMATCH"
+
+
+class CanonicalDecisionArtifactVerificationResult(_FrozenModel):
+    """Fail-closed result of independent internal artifact verification."""
+
+    is_valid: bool
+    reason_codes: tuple[str, ...]
+    artifact: CanonicalDecisionArtifact | None
+    computed_decision_hash: str | None
+    expected_decision_id: str | None
+
+
+def strict_canonical_json_bytes(value: Any) -> bytes:
+    """Return CDA-v1 canonical UTF-8 JSON, refusing non-JSON/non-finite data."""
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def canonical_decision_preimage(
+    artifact: CanonicalDecisionArtifact,
+) -> dict[str, Any]:
+    """Construct the exact non-circular CDA-v1 decision hash preimage."""
+    return {
+        "profile": artifact.hash_profile,
+        "format_version": artifact.format_version,
+        "request_id": artifact.request_id,
+        "decision_ts": artifact.decision_ts,
+        "source_contract": artifact.source_contract.model_dump(mode="json"),
+        "decision": artifact.decision.model_dump(mode="json"),
+    }
+
+
+def build_canonical_decision_artifact(
+    source: DecideResponse,
+    *,
+    decision_ts: datetime | str,
+) -> CanonicalDecisionArtifact:
+    """Build an immutable CDA v1 from an already-normalized pre-Bind response.
+
+    Args:
+        source: Authoritative normalized ``DecideResponse`` instance.
+        decision_ts: Required timezone-aware finalization timestamp.
+
+    Raises:
+        CanonicalDecisionArtifactBuildError: If any v1 boundary is violated.
+    """
+    normalized = _validated_source_projection(source)
+    request_id = normalized["request_id"]
+    if not isinstance(request_id, str) or not request_id:
+        raise CanonicalDecisionArtifactBuildError(
+            CanonicalDecisionArtifactBuildReason.SOURCE_REQUEST_ID_MISSING
+        )
+    if any(normalized[field] is not None for field in POST_BIND_SOURCE_FIELDS):
+        raise CanonicalDecisionArtifactBuildError(
+            CanonicalDecisionArtifactBuildReason.POST_BIND_SOURCE_REFUSED
+        )
+    if normalized["gate_decision"] not in {
+        "proceed",
+        "hold",
+        "block",
+        "human_review_required",
+    }:
+        raise CanonicalDecisionArtifactBuildError(
+            CanonicalDecisionArtifactBuildReason.UNRESOLVED_GATE_DECISION
+        )
+    actionability = normalized["actionability_status"]
+    if actionability == "actionable_after_bind":
+        raise CanonicalDecisionArtifactBuildError(
+            CanonicalDecisionArtifactBuildReason.POST_BIND_ACTIONABILITY_REFUSED
+        )
+    try:
+        _validate_actionability_boundary(
+            actionability,
+            normalized["requires_bind_before_execution"],
+            normalized["human_review_required"],
+        )
+        validate_gate_business_combination(
+            gate_decision=normalized["gate_decision"],
+            business_decision=normalized["business_decision"],
+            human_review_required=normalized["human_review_required"],
+        )
+    except ValueError as exc:
+        raise CanonicalDecisionArtifactBuildError(
+            CanonicalDecisionArtifactBuildReason.ACTIONABILITY_BOUNDARY_INVALID
+        ) from exc
+    normalized_ts = _normalize_builder_timestamp(decision_ts)
+    try:
+        decision = _build_projection(normalized)
+        provisional = {
+            "format_version": CDA_FORMAT_VERSION,
+            "hash_profile": CDA_HASH_PROFILE,
+            "decision_ts": normalized_ts,
+            "request_id": request_id,
+            "source_contract": CanonicalDecisionSourceContract(),
+            "decision": decision,
+        }
+        preimage = {
+            "profile": CDA_HASH_PROFILE,
+            "format_version": CDA_FORMAT_VERSION,
+            "request_id": request_id,
+            "decision_ts": normalized_ts,
+            "source_contract": provisional["source_contract"].model_dump(mode="json"),
+            "decision": decision.model_dump(mode="json"),
+        }
+        decision_hash = sha256_hex(strict_canonical_json_bytes(preimage))
+        return CanonicalDecisionArtifact(
+            **provisional,
+            decision_hash=decision_hash,
+            decision_id=CDA_DECISION_ID_PREFIX + decision_hash,
+        )
+    except (TypeError, ValueError, ValidationError) as exc:
+        if isinstance(exc, CanonicalDecisionArtifactBuildError):
+            raise
+        raise CanonicalDecisionArtifactBuildError(
+            CanonicalDecisionArtifactBuildReason.NON_CANONICAL_JSON_VALUE
+        ) from exc
+
+
+def verify_canonical_decision_artifact(
+    artifact: Mapping[str, Any] | CanonicalDecisionArtifact | None,
+) -> CanonicalDecisionArtifactVerificationResult:
+    """Verify internal CDA-v1 structure and identity without provenance claims."""
+    if artifact is None:
+        return _verification_failure("ARTIFACT_MISSING")
+    try:
+        parsed = (
+            artifact
+            if isinstance(artifact, CanonicalDecisionArtifact)
+            else CanonicalDecisionArtifact.model_validate(artifact)
+        )
+        serialized = strict_canonical_json_bytes(canonical_decision_preimage(parsed))
+        computed_hash = sha256_hex(serialized)
+    except (TypeError, ValueError, ValidationError):
+        return _verification_failure("ARTIFACT_SCHEMA_INVALID")
+    expected_id = CDA_DECISION_ID_PREFIX + computed_hash
+    reasons: list[str] = []
+    if parsed.decision_hash != computed_hash:
+        reasons.append("ARTIFACT_HASH_MISMATCH")
+    if parsed.decision_id != expected_id:
+        reasons.append("ARTIFACT_DECISION_ID_MISMATCH")
+    return CanonicalDecisionArtifactVerificationResult(
+        is_valid=not reasons,
+        reason_codes=tuple(reasons),
+        artifact=parsed,
+        computed_decision_hash=computed_hash,
+        expected_decision_id=expected_id,
+    )
+
+
+def _verification_failure(reason: str) -> CanonicalDecisionArtifactVerificationResult:
+    return CanonicalDecisionArtifactVerificationResult(
+        is_valid=False,
+        reason_codes=(reason,),
+        artifact=None,
+        computed_decision_hash=None,
+        expected_decision_id=None,
+    )
+
+
+def _validated_source_projection(source: DecideResponse) -> dict[str, Any]:
+    if not isinstance(source, DecideResponse):
+        raise CanonicalDecisionArtifactBuildError(
+            CanonicalDecisionArtifactBuildReason.SOURCE_NOT_DECIDE_RESPONSE
+        )
+    try:
+        # JSON-mode dumping can coerce non-finite floats under Pydantic's
+        # serialization policy.  Inspect the Python projection first so no
+        # hash-relevant non-finite or unsupported value can be laundered.
+        strict_canonical_json_bytes(
+            source.model_dump(mode="python", include=_SOURCE_FIELDS)
+        )
+    except (TypeError, ValueError) as exc:
+        raise CanonicalDecisionArtifactBuildError(
+            CanonicalDecisionArtifactBuildReason.NON_CANONICAL_JSON_VALUE
+        ) from exc
+    try:
+        extracted = source.model_dump(mode="json", include=_SOURCE_FIELDS)
+        revalidated = DecideResponse.model_validate(extracted)
+        normalized = revalidated.model_dump(mode="json", include=_SOURCE_FIELDS)
+    except (TypeError, ValueError, ValidationError) as exc:
+        raise CanonicalDecisionArtifactBuildError(
+            CanonicalDecisionArtifactBuildReason.SOURCE_NOT_NORMALIZED
+        ) from exc
+    if extracted != normalized:
+        raise CanonicalDecisionArtifactBuildError(
+            CanonicalDecisionArtifactBuildReason.SOURCE_NOT_NORMALIZED
+        )
+    return extracted
+
+
+def _normalize_builder_timestamp(value: datetime | str) -> str:
+    if not isinstance(value, (datetime, str)) or value == "":
+        raise CanonicalDecisionArtifactBuildError(
+            CanonicalDecisionArtifactBuildReason.INVALID_TIMESTAMP
+        )
+    try:
+        parsed = value if isinstance(value, datetime) else datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise CanonicalDecisionArtifactBuildError(
+            CanonicalDecisionArtifactBuildReason.INVALID_TIMESTAMP
+        ) from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise CanonicalDecisionArtifactBuildError(
+            CanonicalDecisionArtifactBuildReason.NAIVE_TIMESTAMP
+        )
+    return parsed.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def _normalize_timestamp(value: str) -> str:
+    parsed = datetime.fromisoformat(value)
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError("timestamp must be timezone-aware")
+    return parsed.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def _binding_digest(profile: str, value: Any) -> str:
+    return sha256_hex(strict_canonical_json_bytes({"profile": profile, "value": value}))
+
+
+def _build_projection(source: dict[str, Any]) -> CanonicalDecisionProjection:
+    governance = source["governance_identity"]
+    common = {
+        field: source[field]
+        for field in (
+            "decision_status",
+            "rejection_reason",
+            "gate_decision",
+            "business_decision",
+            "next_action",
+            "actionability_status",
+            "requires_bind_before_execution",
+            "human_review_required",
+            "required_evidence",
+            "missing_evidence",
+            "satisfied_evidence",
+            "rationale",
+            "refusal_reason",
+            "actionability_block_reason",
+            "actionability_refusal_type",
+        )
+    }
+    return CanonicalDecisionProjection(
+        formation_status="COMPLETE" if governance is not None else "INCOMPLETE",
+        chosen_binding=CanonicalDecisionChosenBinding(
+            profile=CDA_CHOSEN_BINDING_PROFILE,
+            sha256=_binding_digest(CDA_CHOSEN_BINDING_PROFILE, source["chosen"]),
+        ),
+        governance_identity_binding=(
+            CanonicalDecisionGovernanceIdentityBinding(
+                profile=CDA_GOVERNANCE_IDENTITY_BINDING_PROFILE,
+                sha256=_binding_digest(
+                    CDA_GOVERNANCE_IDENTITY_BINDING_PROFILE, governance
+                ),
+            )
+            if governance is not None
+            else None
+        ),
+        lineage_promotability_binding=_optional_binding(
+            CanonicalDecisionLineagePromotabilityBinding,
+            CDA_LINEAGE_PROMOTABILITY_BINDING_PROFILE,
+            source["lineage_promotability"],
+        ),
+        transition_refusal_binding=_optional_binding(
+            CanonicalDecisionTransitionRefusalBinding,
+            CDA_TRANSITION_REFUSAL_BINDING_PROFILE,
+            source["transition_refusal"],
+        ),
+        **common,
+    )
+
+
+def _optional_binding(model: type[_FrozenModel], profile: str, value: Any) -> Any:
+    if value is None:
+        return None
+    return model(profile=profile, sha256=_binding_digest(profile, value))
+
+
+def _validate_actionability_boundary(
+    status: str,
+    requires_bind: bool,
+    human_review_required: bool,
+) -> None:
+    if status not in PRE_BIND_ACTIONABILITY_STATES:
+        raise ValueError("actionability state is outside the pre-Bind boundary")
+    expected_bind = status in {
+        "reviewable_only",
+        "bind_required_before_execution",
+        "human_review_required",
+    }
+    if requires_bind is not expected_bind:
+        raise ValueError("actionability status contradicts bind requirement")
+    if status in {"human_review_required", "formation_transition_refused"}:
+        if not human_review_required:
+            raise ValueError("actionability status requires human review")

--- a/veritas_os/tests/test_canonical_decision_artifact_runtime.py
+++ b/veritas_os/tests/test_canonical_decision_artifact_runtime.py
@@ -1,0 +1,328 @@
+"""Runtime proofs for the pure Canonical Decision Artifact v1 primitive."""
+
+from __future__ import annotations
+
+import ast
+import json
+from copy import deepcopy
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator, FormatChecker
+from pydantic import ValidationError
+
+from veritas_os.api.schemas import DecideResponse
+from veritas_os.governance.canonical_decision_artifact import (
+    CDA_CHOSEN_BINDING_PROFILE,
+    CDA_DECISION_ID_PREFIX,
+    CDA_FORMAT_VERSION,
+    CDA_GOVERNANCE_IDENTITY_BINDING_PROFILE,
+    CDA_HASH_PROFILE,
+    CDA_LINEAGE_PROMOTABILITY_BINDING_PROFILE,
+    CDA_PROJECTION_VERSION,
+    CDA_SOURCE_TYPE,
+    CDA_TRANSITION_REFUSAL_BINDING_PROFILE,
+    POST_BIND_SOURCE_FIELDS,
+    CanonicalDecisionArtifact,
+    CanonicalDecisionArtifactBuildError,
+    build_canonical_decision_artifact,
+    canonical_decision_preimage,
+    strict_canonical_json_bytes,
+    verify_canonical_decision_artifact,
+)
+from veritas_os.security.hash import canonical_json_dumps, sha256_hex
+
+ROOT = Path(__file__).resolve().parents[2]
+VECTORS = ROOT / "docs/en/architecture/test-vectors/canonical-decision-artifact-v1"
+SCHEMA_PATH = ROOT / "schemas/canonical-decision-artifact-v1.schema.json"
+MODULE_PATH = ROOT / "veritas_os/governance/canonical_decision_artifact.py"
+TIMESTAMP = "2031-02-03T04:05:06.123456Z"
+GOLDEN_HASH = "1c6e265c50812c2b86eab04ef5523a7f1e56c45db4888ca527840ec94f0456a8"
+GOLDEN_ID = CDA_DECISION_ID_PREFIX + GOLDEN_HASH
+
+
+def _vector(number: int) -> dict:
+    return json.loads((VECTORS / f"vector-{number:02}.json").read_text())
+
+
+def _source() -> DecideResponse:
+    return DecideResponse.model_validate(_vector(1)["source_projection"])
+
+
+def _artifact() -> CanonicalDecisionArtifact:
+    return build_canonical_decision_artifact(_source(), decision_ts=TIMESTAMP)
+
+
+def _assert_build_reason(source: DecideResponse, reason: str) -> None:
+    with pytest.raises(CanonicalDecisionArtifactBuildError) as exc:
+        build_canonical_decision_artifact(source, decision_ts=TIMESTAMP)
+    assert exc.value.reason_code.value == reason
+
+
+def test_golden_runtime_artifact_is_exact() -> None:
+    vector = _vector(1)
+    artifact = _artifact()
+    assert artifact.model_dump(mode="json") == vector["artifact"]
+    assert artifact.decision_hash == GOLDEN_HASH
+    assert artifact.decision_id == GOLDEN_ID
+    assert (
+        strict_canonical_json_bytes(canonical_decision_preimage(artifact)).decode()
+        == vector["expected_canonical_serialized"]
+    )
+
+
+def test_timestamp_normalization_and_refusal() -> None:
+    offset = build_canonical_decision_artifact(
+        _source(), decision_ts="2031-02-03T05:05:06.123456+01:00"
+    )
+    assert offset.model_dump(mode="json") == _vector(1)["artifact"]
+    whole = build_canonical_decision_artifact(
+        _source(), decision_ts=datetime.fromisoformat("2031-02-03T04:05:06+00:00")
+    )
+    assert whole.decision_ts == "2031-02-03T04:05:06.000000Z"
+    for value, reason in (
+        (datetime(2031, 2, 3), "NAIVE_TIMESTAMP"),
+        ("2031-02-03T04:05:06", "NAIVE_TIMESTAMP"),
+        ("", "INVALID_TIMESTAMP"),
+        ("bad", "INVALID_TIMESTAMP"),
+    ):
+        with pytest.raises(CanonicalDecisionArtifactBuildError) as exc:
+            build_canonical_decision_artifact(_source(), decision_ts=value)
+        assert exc.value.reason_code.value == reason
+
+
+def test_v12_excluded_fields_are_identity_stable() -> None:
+    source = DecideResponse.model_validate(_vector(12)["source_projection"])
+    artifact = build_canonical_decision_artifact(source, decision_ts=TIMESTAMP)
+    assert (artifact.decision_hash, artifact.decision_id) == (GOLDEN_HASH, GOLDEN_ID)
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        {"chosen": {"id": "different"}},
+        {"request_id": "different-request"},
+        {"gate_decision": "block", "business_decision": "DENY"},
+        {"required_evidence": ["different_evidence"]},
+        {"governance_identity": {"digest": "different"}},
+        {"lineage_promotability": None},
+        {"transition_refusal": None},
+    ],
+)
+def test_included_fields_change_identity(mutation: dict) -> None:
+    payload = deepcopy(_vector(1)["source_projection"])
+    payload.update(mutation)
+    artifact = build_canonical_decision_artifact(
+        DecideResponse.model_validate(payload), decision_ts=TIMESTAMP
+    )
+    assert artifact.decision_hash != GOLDEN_HASH
+
+
+@pytest.mark.parametrize("field", POST_BIND_SOURCE_FIELDS)
+def test_every_post_bind_field_is_refused(field: str) -> None:
+    payload = deepcopy(_vector(1)["source_projection"])
+    value = (
+        "COMMITTED"
+        if field == "bind_outcome"
+        else (
+            {}
+            if field.endswith("result") or field.startswith("bind_operator")
+            else "present"
+        )
+    )
+    if field == "bind_summary":
+        value = {"bind_outcome": "BLOCKED"}
+    payload[field] = value
+    _assert_build_reason(
+        DecideResponse.model_validate(payload), "POST_BIND_SOURCE_REFUSED"
+    )
+
+
+@pytest.mark.parametrize("outcome", ["COMMITTED", "BLOCKED", "ROLLED_BACK"])
+def test_no_post_bind_outcome_is_exempt(outcome: str) -> None:
+    payload = deepcopy(_vector(1)["source_projection"])
+    payload["bind_outcome"] = outcome
+    _assert_build_reason(
+        DecideResponse.model_validate(payload), "POST_BIND_SOURCE_REFUSED"
+    )
+
+
+@pytest.mark.parametrize(
+    ("status", "requires_bind", "review"),
+    [
+        ("reviewable_only", False, False),
+        ("bind_required_before_execution", False, False),
+        ("human_review_required", False, True),
+        ("human_review_required", True, False),
+        ("blocked", True, False),
+        ("formation_transition_refused", True, True),
+    ],
+)
+def test_actionability_contradictions_are_refused(
+    status: str, requires_bind: bool, review: bool
+) -> None:
+    source = _source()
+    source.actionability_status = status
+    source.requires_bind_before_execution = requires_bind
+    source.human_review_required = review
+    _assert_build_reason(source, "ACTIONABILITY_BOUNDARY_INVALID")
+
+
+def test_post_bind_actionability_and_unresolved_gates_are_refused() -> None:
+    source = _source()
+    source.actionability_status = "actionable_after_bind"
+    _assert_build_reason(source, "POST_BIND_ACTIONABILITY_REFUSED")
+    source = _source()
+    source.gate_decision = "unknown"
+    _assert_build_reason(source, "UNRESOLVED_GATE_DECISION")
+    source.gate_decision = "allow"
+    _assert_build_reason(source, "SOURCE_NOT_NORMALIZED")
+
+
+@pytest.mark.parametrize("number", [float("nan"), float("inf"), float("-inf")])
+def test_non_finite_values_are_refused(number: float) -> None:
+    source = _source()
+    source.chosen = {"score": number}
+    _assert_build_reason(source, "NON_CANONICAL_JSON_VALUE")
+
+
+def test_source_type_is_strict() -> None:
+    with pytest.raises(CanonicalDecisionArtifactBuildError) as exc:
+        build_canonical_decision_artifact({}, decision_ts=TIMESTAMP)
+    assert exc.value.reason_code.value == "SOURCE_NOT_DECIDE_RESPONSE"
+
+
+def test_schema_runtime_coherence_and_constants() -> None:
+    schema = json.loads(SCHEMA_PATH.read_text())
+    Draft202012Validator(schema, format_checker=FormatChecker()).validate(
+        _artifact().model_dump(mode="json")
+    )
+    assert schema["properties"]["format_version"]["const"] == CDA_FORMAT_VERSION
+    assert schema["properties"]["hash_profile"]["const"] == CDA_HASH_PROFILE
+    source = schema["properties"]["source_contract"]["properties"]
+    assert source["type"]["const"] == CDA_SOURCE_TYPE
+    assert source["projection_version"]["const"] == CDA_PROJECTION_VERSION
+    defs = schema["$defs"]
+    expected = {
+        "chosenBinding": CDA_CHOSEN_BINDING_PROFILE,
+        "governanceIdentityBinding": CDA_GOVERNANCE_IDENTITY_BINDING_PROFILE,
+        "lineagePromotabilityBinding": CDA_LINEAGE_PROMOTABILITY_BINDING_PROFILE,
+        "transitionRefusalBinding": CDA_TRANSITION_REFUSAL_BINDING_PROFILE,
+    }
+    for name, profile in expected.items():
+        assert defs[name]["properties"]["profile"]["const"] == profile
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda value: value.update({"extra": True}),
+        lambda value: value.update({"format_version": "wrong"}),
+        lambda value: value.update({"hash_profile": "wrong"}),
+        lambda value: value["decision"]["chosen_binding"].update({"profile": "wrong"}),
+        lambda value: value["decision"].update(
+            {"actionability_status": "actionable_after_bind"}
+        ),
+        lambda value: value["decision"].update({"formation_status": "INCOMPLETE"}),
+        lambda value: value["decision"].update({"business_decision": "APPROVE"}),
+        lambda value: value.update({"decision_ts": "2031-02-03T04:05:06Z"}),
+    ],
+)
+def test_verifier_rejects_structure_and_semantic_mutations(mutation) -> None:
+    value = _artifact().model_dump(mode="json")
+    mutation(value)
+    assert verify_canonical_decision_artifact(value).reason_codes == (
+        "ARTIFACT_SCHEMA_INVALID",
+    )
+
+
+def test_verifier_integrity_mutations_are_independent() -> None:
+    valid = _artifact().model_dump(mode="json")
+    assert verify_canonical_decision_artifact(valid).is_valid
+    assert verify_canonical_decision_artifact(None).reason_codes == (
+        "ARTIFACT_MISSING",
+    )
+    changed = deepcopy(valid)
+    changed["decision"]["rationale"] = "tampered"
+    assert verify_canonical_decision_artifact(changed).reason_codes == (
+        "ARTIFACT_HASH_MISMATCH",
+        "ARTIFACT_DECISION_ID_MISMATCH",
+    )
+    wrong_hash = deepcopy(valid)
+    wrong_hash["decision_hash"] = "0" * 64
+    assert verify_canonical_decision_artifact(wrong_hash).reason_codes == (
+        "ARTIFACT_HASH_MISMATCH",
+    )
+    wrong_id = deepcopy(valid)
+    wrong_id["decision_id"] = CDA_DECISION_ID_PREFIX + "0" * 64
+    assert verify_canonical_decision_artifact(wrong_id).reason_codes == (
+        "ARTIFACT_DECISION_ID_MISMATCH",
+    )
+
+
+def test_determinism_serializer_compatibility_and_immutability() -> None:
+    artifacts = [_artifact() for _ in range(3)]
+    dumps = [item.model_dump(mode="json") for item in artifacts]
+    preimages = [
+        strict_canonical_json_bytes(canonical_decision_preimage(item))
+        for item in artifacts
+    ]
+    assert dumps[0] == dumps[1] == dumps[2]
+    assert preimages[0] == preimages[1] == preimages[2]
+    assert sha256_hex(preimages[0]) == GOLDEN_HASH
+    assert preimages[0].decode() == canonical_json_dumps(
+        canonical_decision_preimage(artifacts[0])
+    )
+    with pytest.raises(ValidationError):
+        artifacts[0].decision_hash = "0" * 64
+    with pytest.raises(ValidationError):
+        artifacts[0].decision.chosen_binding.sha256 = "0" * 64
+
+
+def test_static_side_effect_guard() -> None:
+    tree = ast.parse(MODULE_PATH.read_text())
+    forbidden = {
+        "requests",
+        "httpx",
+        "openai",
+        "subprocess",
+        "socket",
+        "random",
+        "secrets",
+        "uuid4",
+        "DecisionCandidate",
+        "CanonicalDecisionHandoff",
+        "ExecutionIntent",
+        "BindReceipt",
+        "WebhookBindAdapter",
+        "execute_bind_adjudication",
+        "execute_bind_boundary",
+        "open",
+    }
+    names = {
+        alias.name.split(".")[0]
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.Import, ast.ImportFrom))
+        for alias in node.names
+    } | {
+        node.func.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    attrs = {
+        f"{node.value.id}.{node.attr}"
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name)
+    }
+    assert not forbidden & names
+    assert (
+        not {
+            "datetime.now",
+            "datetime.utcnow",
+            "time.time",
+            "Path.read_text",
+            "Path.write_text",
+        }
+        & attrs
+    )

--- a/veritas_os/tests/test_canonical_decision_artifact_runtime.py
+++ b/veritas_os/tests/test_canonical_decision_artifact_runtime.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import ast
 import json
 from copy import deepcopy
+from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
 from pathlib import Path
@@ -198,6 +199,13 @@ class _UnsupportedPydanticValue(BaseModel):
     value: str
 
 
+@dataclass
+class _UnsupportedDataclassValue:
+    """Test-only dataclass that must not be converted into CDA identity."""
+
+    value: str
+
+
 @pytest.mark.parametrize(
     "value",
     [
@@ -218,6 +226,35 @@ def test_python_specific_chosen_values_are_refused_before_coercion(value) -> Non
 def test_nested_non_string_mapping_key_is_refused_before_coercion() -> None:
     source = _source()
     source.chosen = {"nested": {1: "value"}}
+    _assert_build_reason(source, "NON_CANONICAL_JSON_VALUE")
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        _UnsupportedPydanticValue(value="not-json"),
+        _UnsupportedDataclassValue(value="not-json"),
+    ],
+)
+def test_builder_rejects_nested_objects_before_pydantic_dump(value) -> None:
+    source = _source()
+    source.chosen = {"value": value}
+    _assert_build_reason(source, "NON_CANONICAL_JSON_VALUE")
+
+
+def test_governance_identity_rejects_nested_object_before_dump() -> None:
+    source = _source()
+    source.governance_identity = {"nested": _UnsupportedPydanticValue(value="not-json")}
+    _assert_build_reason(source, "NON_CANONICAL_JSON_VALUE")
+
+
+@pytest.mark.parametrize("field", ["lineage_promotability", "transition_refusal"])
+def test_typed_source_model_rejects_unsupported_extra(field: str) -> None:
+    source = _source()
+    typed_model = getattr(source, field)
+    typed_model.__pydantic_extra__["unsupported"] = _UnsupportedDataclassValue(
+        value="not-json"
+    )
     _assert_build_reason(source, "NON_CANONICAL_JSON_VALUE")
 
 

--- a/veritas_os/tests/test_canonical_decision_artifact_runtime.py
+++ b/veritas_os/tests/test_canonical_decision_artifact_runtime.py
@@ -6,11 +6,12 @@ import ast
 import json
 from copy import deepcopy
 from datetime import datetime
+from decimal import Decimal
 from pathlib import Path
 
 import pytest
 from jsonschema import Draft202012Validator, FormatChecker
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 
 from veritas_os.api.schemas import DecideResponse
 from veritas_os.governance.canonical_decision_artifact import (
@@ -187,6 +188,58 @@ def test_non_finite_values_are_refused(number: float) -> None:
     _assert_build_reason(source, "NON_CANONICAL_JSON_VALUE")
 
 
+class _UnsupportedChosenValue:
+    """Test-only Python object that must never be coerced into CDA identity."""
+
+
+class _UnsupportedPydanticValue(BaseModel):
+    """Test-only Pydantic value that strict CDA JSON must not auto-dump."""
+
+    value: str
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        (1, 2),
+        {1, 2},
+        frozenset({1, 2}),
+        b"bytes",
+        bytearray(b"bytes"),
+        _UnsupportedChosenValue(),
+    ],
+)
+def test_python_specific_chosen_values_are_refused_before_coercion(value) -> None:
+    source = _source()
+    source.chosen = {"values": value}
+    _assert_build_reason(source, "NON_CANONICAL_JSON_VALUE")
+
+
+def test_nested_non_string_mapping_key_is_refused_before_coercion() -> None:
+    source = _source()
+    source.chosen = {"nested": {1: "value"}}
+    _assert_build_reason(source, "NON_CANONICAL_JSON_VALUE")
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        Decimal("1.0"),
+        datetime.fromisoformat("2031-02-03T04:05:06+00:00"),
+        _UnsupportedPydanticValue(value="not-json"),
+    ],
+)
+def test_strict_serializer_rejects_non_json_objects(value) -> None:
+    with pytest.raises(TypeError):
+        strict_canonical_json_bytes({"value": value})
+
+
+def test_missing_request_id_is_refused_before_response_revalidation() -> None:
+    source = _source()
+    source.request_id = ""
+    _assert_build_reason(source, "SOURCE_REQUEST_ID_MISSING")
+
+
 def test_source_type_is_strict() -> None:
     with pytest.raises(CanonicalDecisionArtifactBuildError) as exc:
         build_canonical_decision_artifact({}, decision_ts=TIMESTAMP)
@@ -258,6 +311,33 @@ def test_verifier_integrity_mutations_are_independent() -> None:
     wrong_id["decision_id"] = CDA_DECISION_ID_PREFIX + "0" * 64
     assert verify_canonical_decision_artifact(wrong_id).reason_codes == (
         "ARTIFACT_DECISION_ID_MISMATCH",
+    )
+
+
+def test_verifier_revalidates_validation_bypassing_model_instances() -> None:
+    artifact = _artifact()
+
+    invalid_timestamp = artifact.model_copy(update={"decision_ts": "invalid"})
+    assert verify_canonical_decision_artifact(invalid_timestamp).reason_codes == (
+        "ARTIFACT_SCHEMA_INVALID",
+    )
+
+    post_bind_decision = artifact.decision.model_copy(
+        update={"actionability_status": "actionable_after_bind"}
+    )
+    post_bind_artifact = artifact.model_copy(update={"decision": post_bind_decision})
+    assert verify_canonical_decision_artifact(post_bind_artifact).reason_codes == (
+        "ARTIFACT_SCHEMA_INVALID",
+    )
+
+    contradictory_decision = artifact.decision.model_copy(
+        update={"formation_status": "INCOMPLETE"}
+    )
+    contradictory_artifact = artifact.model_copy(
+        update={"decision": contradictory_decision}
+    )
+    assert verify_canonical_decision_artifact(contradictory_artifact).reason_codes == (
+        "ARTIFACT_SCHEMA_INVALID",
     )
 
 


### PR DESCRIPTION
### Motivation

- Provide a production, deterministic, fail-closed runtime implementation of the merged Canonical Decision Artifact v1 specification so downstream pipeline integration can rely on a pure security primitive.  
- Prevent subtle normalization, timestamp, and canonicalization mismatches by enforcing strict JSON safety, timezone-aware timestamp normalization, and explicit pre-Bind boundaries.  
- Maintain a clear security boundary: the runtime primitive is side-effect-free and does not claim provenance, TrustLog, replay, or governance authority.  
- Note: this is governance-sensitive code and requires human maintainer review before pipeline wiring or operational trust decisions.

### Description

- Add `veritas_os/governance/canonical_decision_artifact.py` which implements frozen Pydantic runtime models and constants for CDA v1 and exports `build_canonical_decision_artifact(source: DecideResponse, *, decision_ts: datetime | str) -> CanonicalDecisionArtifact` and `verify_canonical_decision_artifact(artifact: Mapping[str, Any] | CanonicalDecisionArtifact | None) -> CanonicalDecisionArtifactVerificationResult`.  
- Enforce strict canonical JSON bytes for hashing (`ensure_ascii=False`, `sort_keys=True`, `separators=(',', ':')`, `allow_nan=False`) via a CDA-local serializer and compute `decision_hash` with `sha256_hex` and `decision_id` as `cda:v1:sha256:<hash>`.  
- Implement deterministic timestamp normalization that accepts only timezone-aware datetimes or aware ISO strings and normalizes to `YYYY-MM-DDTHH:MM:SS.ffffffZ`, and refuse naive/malformed timestamps.  
- Enforce source normalization guard that extracts only CDA-relevant fields, revalidates them through `DecideResponse`, refuses post-Bind populated fields, builds the exact projection with opaque bindings (profile + sha256), and fails closed with machine-readable `CanonicalDecisionArtifactBuildError` reason codes on contract violations.

### Testing

- Full GitHub CI completed successfully on head `4081464a0643d7193bc329dcb0440cc864090189` (CI run #5033).  
- Python 3.12 full suite: `9786 passed, 24 skipped, 41 warnings`; total coverage `88.88%` with the required 85% threshold satisfied.  
- Python 3.11 test job, PostgreSQL parity/contention tests, governance smoke, governance backend fast checks, lint, dependency audit, frontend lint/test/e2e, and future-dependency compatibility all completed successfully.  
- Required companion workflows also passed: Security Gates, CodeQL (custom), Runtime Proof Evidence, Runtime Pickle Guard, and Reviewer Evidence Packet Validation.  
- The CDA runtime tests cover exact V01 golden reproduction, V12 excluded-field stability, deterministic timestamp normalization, post-Bind refusal, pre-Bind actionability invariants, strict raw JSON-family validation before Pydantic coercion, nested BaseModel/dataclass rejection, non-string-key and non-finite-value refusal, request-ID fail-closed handling, verifier revalidation of validation-bypassing model instances, hash/ID mutation detection, immutability, and static side-effect guards.  
- Ruff, compile checks, schema/runtime coherence checks, and the existing CDA/handoff specification tests remain green in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a80493e72f08326b1aa707a506797b9)