### PR TITLE
Attach verified CDA v1 after persistence with decision-drift guard

### DIFF
--- a/docs/en/architecture/canonical-decision-artifact-v1.md
+++ b/docs/en/architecture/canonical-decision-artifact-v1.md
@@ -5,12 +5,11 @@
 This specification defines the immutable
 `CanonicalDecisionArtifact` representation of one finalized, normalized
 VERITAS decision event. It supplies a stable `decision_id`, `decision_hash`,
-and `decision_ts` for the decision side. The current `/v1/decide` response has
-`request_id`, but does **not** emit any of those three authoritative canonical
-values. A production standalone builder and integrity verifier now implement
-the v1 contract as a pure, independently testable runtime primitive. They are
-not yet wired to `/v1/decide`, pipeline finalization, persistence, TrustLog,
-replay, `CanonicalDecisionHandoff`, `ExecutionIntent`, or Bind.
+and `decision_ts` for the decision side. The `/v1/decide` pipeline emits the
+artifact only after its pre-persistence decision source passes canonical
+finalization and a post-persistence source-drift guard. The runtime integration
+does not link the artifact to TrustLog, replay, `CanonicalDecisionHandoff`,
+`ExecutionIntent`, or Bind.
 
 The processing boundary is exactly:
 
@@ -20,6 +19,23 @@ normalized pre-Bind DecideResponse snapshot
   -> versioned, domain-separated canonical serialization
   -> decision_hash -> decision_id -> CanonicalDecisionArtifact -> STOP
 ```
+
+The live pipeline sequence is exactly:
+
+```text
+Stage 7 source finalized
+  -> one decision_ts capture
+  -> CDA build + internal verification
+  -> Stage 8 receives no CDA field
+  -> full source-drift guard
+  -> attach CDA to outgoing response
+```
+
+The final drift guard rebuilds the artifact with the original `decision_ts`,
+independently verifies the rebuilt artifact, and requires exact JSON equality
+with the original artifact. The original artifact, not the rebuilt comparison
+value, is attached. Live CDA emission is not provenance proof, TrustLog proof,
+replay proof, handoff readiness, or execution authority.
 
 The artifact is not a `DecisionCandidate`, `CanonicalDecisionHandoff`,
 `ExecutionIntent`, Authority Evidence, Human Approval, `BindReceipt`, execution

--- a/veritas_os/api/schemas.py
+++ b/veritas_os/api/schemas.py
@@ -1143,8 +1143,11 @@ class DecideResponse(BaseModel):
     canonical_decision_artifact: Optional[Dict[str, Any]] = Field(
         default=None,
         description=(
-            "Verified Canonical Decision Artifact v1 attached only after "
-            "post-decision persistence completes without decision drift."
+            "Canonical Decision Artifact v1 captured at the pre-persistence "
+            "decision finalization boundary. The pipeline verifies its "
+            "internal structure, deterministic hash integrity, and "
+            "content-addressed identifier coherence. It does not establish "
+            "trusted provenance or execution authority."
         ),
     )
 

--- a/veritas_os/api/schemas.py
+++ b/veritas_os/api/schemas.py
@@ -1140,6 +1140,13 @@ class DecideResponse(BaseModel):
         default=None,
         description="Snapshot for deterministic replay of this decision.",
     )
+    canonical_decision_artifact: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description=(
+            "Verified Canonical Decision Artifact v1 attached only after "
+            "post-decision persistence completes without decision drift."
+        ),
+    )
 
     # Governance identity: which governance artifact was in force for this decision.
     governance_identity: Optional[Dict[str, Any]] = Field(

--- a/veritas_os/core/pipeline/__init__.py
+++ b/veritas_os/core/pipeline/__init__.py
@@ -90,11 +90,6 @@ from ..utils import (  # noqa: F401 – _redact_text/redact_payload re-exported 
     utc_now_iso_z,
 )
 from .. import self_healing  # noqa: F401 - tests monkeypatch pipeline.self_healing
-from ...governance.canonical_decision_artifact import (
-    CanonicalDecisionArtifact,
-    build_canonical_decision_artifact,
-    verify_canonical_decision_artifact,
-)
 
 # ---- pipeline サブモジュール（分割済み） ----
 from .pipeline_helpers import (
@@ -232,6 +227,12 @@ from .pipeline_decide_stages import (
     stage_value_learning_ema,
     stage_compute_metrics,
     stage_evidence_hardening,
+)
+from .canonical_decision_finalization import (
+    attach_canonical_decision_artifact,
+    finalize_canonical_decision_artifact,
+    require_stage_8_payload_without_canonical_artifact,
+    verify_canonical_decision_source_unchanged,
 )
 from .pipeline_replay import (
     _safe_filename_id,  # noqa: F401 – backward compat
@@ -576,38 +577,6 @@ def _build_decision_payload(ctx: PipelineContext) -> Dict[str, Any]:
     res = assemble_response(ctx, load_persona_fn=load_persona, plan=plan)
     payload = coerce_to_decide_response(res, DecideResponse=DecideResponse)
     return payload
-
-
-def _build_verified_canonical_decision_artifact(
-    payload: Dict[str, Any],
-) -> CanonicalDecisionArtifact:
-    """Create and internally verify a CDA at the finalized decision boundary."""
-    source = DecideResponse.model_validate(payload)
-    artifact = build_canonical_decision_artifact(source, decision_ts=utc_now())
-    verification = verify_canonical_decision_artifact(artifact)
-    if not verification.is_valid:
-        reasons = ",".join(verification.reason_codes)
-        raise RuntimeError(f"canonical decision artifact verification failed: {reasons}")
-    return artifact
-
-
-def _attach_canonical_decision_artifact_without_drift(
-    payload: Dict[str, Any],
-    artifact: CanonicalDecisionArtifact,
-) -> None:
-    """Attach a CDA only if persistence did not alter its decision projection.
-
-    This comparison is fail-closed: a post-decision mutation must never result
-    in a response carrying a CDA that identifies different decision semantics.
-    """
-    current_source = DecideResponse.model_validate(payload)
-    current_artifact = build_canonical_decision_artifact(
-        current_source,
-        decision_ts=artifact.decision_ts,
-    )
-    if current_artifact.decision_hash != artifact.decision_hash:
-        raise RuntimeError("decision drift detected after CDA finalization")
-    payload["canonical_decision_artifact"] = artifact.model_dump(mode="json")
 
 
 def _run_post_decision_persistence_phase(
@@ -1014,14 +983,17 @@ async def run_decide_pipeline(
     # =================================================================
         with trace_session.stage("build_response"):
             payload = _build_decision_payload(ctx)
-            canonical_decision_artifact = (
-                _build_verified_canonical_decision_artifact(payload)
+            decision_finalized_at = utc_now()
+            canonical_decision_artifact = finalize_canonical_decision_artifact(
+                payload,
+                decision_ts=decision_finalized_at,
             )
 
     # =================================================================
     # Stage 8: Post-decision persistence phase  (-> pipeline_persist)
     # - best-effort side effects and artifact generation only
     # =================================================================
+        require_stage_8_payload_without_canonical_artifact(payload)
         with trace_session.stage("persist"):
             _stage_started_at = time.perf_counter()
             _run_post_decision_persistence_phase(
@@ -1030,11 +1002,16 @@ async def run_decide_pipeline(
                 effective_get_memory_store=effective_get_memory_store,
                 stage_failures=_stage_failures,
             )
-            _attach_canonical_decision_artifact_without_drift(
-                payload,
-                canonical_decision_artifact,
-            )
             observe_pipeline_stage_duration("persist", time.perf_counter() - _stage_started_at)
+
+        verify_canonical_decision_source_unchanged(
+            payload,
+            canonical_decision_artifact,
+        )
+        attach_canonical_decision_artifact(
+            payload,
+            canonical_decision_artifact,
+        )
 
     # =================================================================
     # Observability: record pipeline health summary

--- a/veritas_os/core/pipeline/__init__.py
+++ b/veritas_os/core/pipeline/__init__.py
@@ -90,6 +90,11 @@ from ..utils import (  # noqa: F401 – _redact_text/redact_payload re-exported 
     utc_now_iso_z,
 )
 from .. import self_healing  # noqa: F401 - tests monkeypatch pipeline.self_healing
+from ...governance.canonical_decision_artifact import (
+    CanonicalDecisionArtifact,
+    build_canonical_decision_artifact,
+    verify_canonical_decision_artifact,
+)
 
 # ---- pipeline サブモジュール（分割済み） ----
 from .pipeline_helpers import (
@@ -573,6 +578,38 @@ def _build_decision_payload(ctx: PipelineContext) -> Dict[str, Any]:
     return payload
 
 
+def _build_verified_canonical_decision_artifact(
+    payload: Dict[str, Any],
+) -> CanonicalDecisionArtifact:
+    """Create and internally verify a CDA at the finalized decision boundary."""
+    source = DecideResponse.model_validate(payload)
+    artifact = build_canonical_decision_artifact(source, decision_ts=utc_now())
+    verification = verify_canonical_decision_artifact(artifact)
+    if not verification.is_valid:
+        reasons = ",".join(verification.reason_codes)
+        raise RuntimeError(f"canonical decision artifact verification failed: {reasons}")
+    return artifact
+
+
+def _attach_canonical_decision_artifact_without_drift(
+    payload: Dict[str, Any],
+    artifact: CanonicalDecisionArtifact,
+) -> None:
+    """Attach a CDA only if persistence did not alter its decision projection.
+
+    This comparison is fail-closed: a post-decision mutation must never result
+    in a response carrying a CDA that identifies different decision semantics.
+    """
+    current_source = DecideResponse.model_validate(payload)
+    current_artifact = build_canonical_decision_artifact(
+        current_source,
+        decision_ts=artifact.decision_ts,
+    )
+    if current_artifact.decision_hash != artifact.decision_hash:
+        raise RuntimeError("decision drift detected after CDA finalization")
+    payload["canonical_decision_artifact"] = artifact.model_dump(mode="json")
+
+
 def _run_post_decision_persistence_phase(
     ctx: PipelineContext,
     payload: Dict[str, Any],
@@ -977,6 +1014,9 @@ async def run_decide_pipeline(
     # =================================================================
         with trace_session.stage("build_response"):
             payload = _build_decision_payload(ctx)
+            canonical_decision_artifact = (
+                _build_verified_canonical_decision_artifact(payload)
+            )
 
     # =================================================================
     # Stage 8: Post-decision persistence phase  (-> pipeline_persist)
@@ -989,6 +1029,10 @@ async def run_decide_pipeline(
                 payload,
                 effective_get_memory_store=effective_get_memory_store,
                 stage_failures=_stage_failures,
+            )
+            _attach_canonical_decision_artifact_without_drift(
+                payload,
+                canonical_decision_artifact,
             )
             observe_pipeline_stage_duration("persist", time.perf_counter() - _stage_started_at)
 

--- a/veritas_os/core/pipeline/canonical_decision_finalization.py
+++ b/veritas_os/core/pipeline/canonical_decision_finalization.py
@@ -1,0 +1,193 @@
+"""Finalize and attach canonical decisions at the pipeline boundary.
+
+This adapter preserves the CDA runtime's strict source-class identity while
+bridging reloadable API schema modules. It owns no decision, persistence, or
+execution-authority semantics.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Any, MutableMapping
+
+from pydantic import ValidationError
+
+from veritas_os.api import schemas as api_schemas
+from veritas_os.governance import canonical_decision_artifact as cda_runtime
+
+
+class CanonicalDecisionFinalizationReason(str, Enum):
+    """Stable reason codes for canonical finalization boundary failures."""
+
+    SOURCE_REQUEST_ID_MISSING = "SOURCE_REQUEST_ID_MISSING"
+    SOURCE_VALIDATION_FAILED = "SOURCE_VALIDATION_FAILED"
+    SOURCE_CLASS_BRIDGE_FAILED = "SOURCE_CLASS_BRIDGE_FAILED"
+    ARTIFACT_BUILD_FAILED = "ARTIFACT_BUILD_FAILED"
+    ARTIFACT_VERIFICATION_FAILED = "ARTIFACT_VERIFICATION_FAILED"
+    REQUEST_ID_MISMATCH = "REQUEST_ID_MISMATCH"
+    DECISION_SOURCE_DRIFT = "DECISION_SOURCE_DRIFT"
+    PREEXISTING_CANONICAL_ARTIFACT_REFUSED = (
+        "PREEXISTING_CANONICAL_ARTIFACT_REFUSED"
+    )
+
+
+class CanonicalDecisionFinalizationError(ValueError):
+    """Fail-closed canonical finalization error without raw-source leakage."""
+
+    def __init__(self, reason_code: CanonicalDecisionFinalizationReason) -> None:
+        self.reason_code = reason_code
+        super().__init__(reason_code.value)
+
+
+def finalize_canonical_decision_artifact(
+    payload: MutableMapping[str, Any],
+    *,
+    decision_ts: datetime,
+) -> cda_runtime.CanonicalDecisionArtifact:
+    """Build and internally verify a CDA from a finalized Stage 7 payload.
+
+    The raw request identifier is checked before either response model can run
+    its compatibility UUID generation. A normalized API response is then
+    bridged through the exact ``DecideResponse`` class currently bound by the
+    CDA runtime module.
+
+    Args:
+        payload: Mutable Stage 7 response payload. A null preexisting CDA field
+            is removed so Stage 8 receives no CDA key.
+        decision_ts: The single timestamp captured by the orchestrator.
+
+    Returns:
+        The original, internally verified canonical decision artifact.
+
+    Raises:
+        CanonicalDecisionFinalizationError: If any canonical boundary
+            invariant fails.
+    """
+    raw_request_id = payload.get("request_id")
+    if type(raw_request_id) is not str or raw_request_id == "":
+        _fail(CanonicalDecisionFinalizationReason.SOURCE_REQUEST_ID_MISSING)
+
+    _remove_or_refuse_preexisting_artifact(payload)
+
+    try:
+        api_source = api_schemas.DecideResponse.model_validate(payload)
+        normalized = api_source.model_dump(mode="json")
+    except (TypeError, ValueError, ValidationError):
+        _fail(CanonicalDecisionFinalizationReason.SOURCE_VALIDATION_FAILED)
+
+    normalized.pop("canonical_decision_artifact", None)
+    if api_source.request_id != raw_request_id:
+        _fail(CanonicalDecisionFinalizationReason.REQUEST_ID_MISMATCH)
+
+    try:
+        runtime_source = cda_runtime.DecideResponse.model_validate(normalized)
+    except (TypeError, ValueError, ValidationError):
+        _fail(CanonicalDecisionFinalizationReason.SOURCE_CLASS_BRIDGE_FAILED)
+
+    if runtime_source.request_id != raw_request_id:
+        _fail(CanonicalDecisionFinalizationReason.REQUEST_ID_MISMATCH)
+
+    try:
+        artifact = cda_runtime.build_canonical_decision_artifact(
+            runtime_source,
+            decision_ts=decision_ts,
+        )
+    except (
+        cda_runtime.CanonicalDecisionArtifactBuildError,
+        TypeError,
+        ValidationError,
+    ):
+        _fail(CanonicalDecisionFinalizationReason.ARTIFACT_BUILD_FAILED)
+
+    if artifact.request_id != raw_request_id:
+        _fail(CanonicalDecisionFinalizationReason.REQUEST_ID_MISMATCH)
+
+    try:
+        verification = cda_runtime.verify_canonical_decision_artifact(artifact)
+    except (TypeError, ValueError, ValidationError):
+        _fail(CanonicalDecisionFinalizationReason.ARTIFACT_VERIFICATION_FAILED)
+    if not verification.is_valid:
+        _fail(CanonicalDecisionFinalizationReason.ARTIFACT_VERIFICATION_FAILED)
+    return artifact
+
+
+def verify_canonical_decision_source_unchanged(
+    payload: MutableMapping[str, Any],
+    artifact: cda_runtime.CanonicalDecisionArtifact,
+) -> None:
+    """Independently rebuild and exactly compare the post-Stage 8 CDA source."""
+    try:
+        current_artifact = finalize_canonical_decision_artifact(
+            payload,
+            decision_ts=artifact.decision_ts,
+        )
+    except CanonicalDecisionFinalizationError as exc:
+        if exc.reason_code in {
+            CanonicalDecisionFinalizationReason.SOURCE_REQUEST_ID_MISSING,
+            CanonicalDecisionFinalizationReason.REQUEST_ID_MISMATCH,
+        }:
+            raise CanonicalDecisionFinalizationError(
+                CanonicalDecisionFinalizationReason.REQUEST_ID_MISMATCH
+            ) from exc
+        if exc.reason_code is (
+            CanonicalDecisionFinalizationReason.PREEXISTING_CANONICAL_ARTIFACT_REFUSED
+        ):
+            raise
+        raise CanonicalDecisionFinalizationError(
+            CanonicalDecisionFinalizationReason.DECISION_SOURCE_DRIFT
+        ) from exc
+
+    try:
+        verification = cda_runtime.verify_canonical_decision_artifact(
+            current_artifact
+        )
+    except (TypeError, ValueError, ValidationError) as exc:
+        raise CanonicalDecisionFinalizationError(
+            CanonicalDecisionFinalizationReason.DECISION_SOURCE_DRIFT
+        ) from exc
+    if not verification.is_valid:
+        _fail(CanonicalDecisionFinalizationReason.DECISION_SOURCE_DRIFT)
+    if current_artifact.model_dump(mode="json") != artifact.model_dump(
+        mode="json"
+    ):
+        _fail(CanonicalDecisionFinalizationReason.DECISION_SOURCE_DRIFT)
+
+
+def attach_canonical_decision_artifact(
+    payload: MutableMapping[str, Any],
+    artifact: cda_runtime.CanonicalDecisionArtifact,
+) -> None:
+    """Attach the original CDA after source-drift verification succeeds."""
+    if "canonical_decision_artifact" in payload:
+        _fail(
+            CanonicalDecisionFinalizationReason.PREEXISTING_CANONICAL_ARTIFACT_REFUSED
+        )
+    payload["canonical_decision_artifact"] = artifact.model_dump(mode="json")
+
+
+def require_stage_8_payload_without_canonical_artifact(
+    payload: MutableMapping[str, Any],
+) -> None:
+    """Fail closed unless the Stage 8 payload has no CDA key at all."""
+    if "canonical_decision_artifact" in payload:
+        _fail(
+            CanonicalDecisionFinalizationReason.PREEXISTING_CANONICAL_ARTIFACT_REFUSED
+        )
+
+
+def _remove_or_refuse_preexisting_artifact(
+    payload: MutableMapping[str, Any],
+) -> None:
+    if "canonical_decision_artifact" not in payload:
+        return
+    if payload["canonical_decision_artifact"] is None:
+        del payload["canonical_decision_artifact"]
+        return
+    _fail(
+        CanonicalDecisionFinalizationReason.PREEXISTING_CANONICAL_ARTIFACT_REFUSED
+    )
+
+
+def _fail(reason_code: CanonicalDecisionFinalizationReason) -> None:
+    raise CanonicalDecisionFinalizationError(reason_code)

--- a/veritas_os/tests/integration/test_decide_e2e_ext.py
+++ b/veritas_os/tests/integration/test_decide_e2e_ext.py
@@ -20,11 +20,19 @@ pytestmark = pytest.mark.integration
 import json
 import sys
 import types
+from datetime import datetime, timezone
 from typing import Any, Dict, List
 
 import pytest
 
 from veritas_os.core import pipeline as api_pipeline
+from veritas_os.core.pipeline.canonical_decision_finalization import (
+    CanonicalDecisionFinalizationError,
+    CanonicalDecisionFinalizationReason,
+)
+from veritas_os.governance.canonical_decision_artifact import (
+    verify_canonical_decision_artifact,
+)
 
 # =========================================================
 # helper 関数のテスト
@@ -551,6 +559,9 @@ async def test_run_decide_pipeline_happy_path(patched_pipeline):
     assert isinstance(payload["evidence"], list) and payload["evidence"]
     assert "values" in payload and payload["values"]["scores"]
     assert payload["persona"]["name"] == "default"
+    assert verify_canonical_decision_artifact(
+        payload["canonical_decision_artifact"]
+    ).is_valid
 
     # metrics / extras contract（壊れやすいので最低限の存在を担保）
     extras = payload.get("extras") or {}
@@ -1150,6 +1161,8 @@ async def test_run_decide_pipeline_decision_boundary_calls_post_persist(
     pipeline = patched_pipeline
     call_order: List[str] = []
     persisted_payload: Dict[str, Any] = {}
+    finalized_at = datetime(2031, 2, 3, 4, 5, 6, tzinfo=timezone.utc)
+    clock_calls = 0
 
     def fake_build_decision_payload(ctx):
         call_order.append("build_decision")
@@ -1169,15 +1182,28 @@ async def test_run_decide_pipeline_decision_boundary_calls_post_persist(
 
     artifact = object()
 
-    def fake_build_cda(payload):
-        del payload
-        call_order.append("build_cda")
+    def fake_clock():
+        nonlocal clock_calls
+        clock_calls += 1
+        call_order.append("capture_timestamp")
+        return finalized_at
+
+    def fake_finalize_cda(payload, *, decision_ts):
+        assert decision_ts is finalized_at
+        assert "canonical_decision_artifact" not in payload
+        call_order.extend(["finalize_cda", "verify_cda"])
         return artifact
 
     def fake_post_persist(ctx, payload, *, effective_get_memory_store, stage_failures):
         del ctx, effective_get_memory_store, stage_failures
+        assert "canonical_decision_artifact" not in payload
         call_order.append("post_persist")
         persisted_payload.update(payload)
+
+    def fake_drift_check(payload, value):
+        assert value is artifact
+        assert "canonical_decision_artifact" not in payload
+        call_order.append("drift_check")
 
     def fake_attach_cda(payload, value):
         assert value is artifact
@@ -1198,13 +1224,25 @@ async def test_run_decide_pipeline_decision_boundary_calls_post_persist(
     )
     monkeypatch.setattr(
         pipeline,
-        "_build_verified_canonical_decision_artifact",
-        fake_build_cda,
+        "utc_now",
+        fake_clock,
         raising=False,
     )
     monkeypatch.setattr(
         pipeline,
-        "_attach_canonical_decision_artifact_without_drift",
+        "finalize_canonical_decision_artifact",
+        fake_finalize_cda,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        pipeline,
+        "verify_canonical_decision_source_unchanged",
+        fake_drift_check,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        pipeline,
+        "attach_canonical_decision_artifact",
         fake_attach_cda,
         raising=False,
     )
@@ -1214,13 +1252,107 @@ async def test_run_decide_pipeline_decision_boundary_calls_post_persist(
 
     assert call_order == [
         "build_decision",
-        "build_cda",
+        "capture_timestamp",
+        "finalize_cda",
+        "verify_cda",
         "post_persist",
+        "drift_check",
         "attach_cda",
     ]
+    assert clock_calls == 1
     assert persisted_payload["request_id"] == payload["request_id"]
     assert payload["query"] == "decision boundary test"
     assert payload["canonical_decision_artifact"] == {"decision_id": "test-cda"}
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "reason",
+    [
+        CanonicalDecisionFinalizationReason.ARTIFACT_BUILD_FAILED,
+        CanonicalDecisionFinalizationReason.ARTIFACT_VERIFICATION_FAILED,
+    ],
+)
+async def test_cda_finalization_failure_blocks_persistence(
+    monkeypatch,
+    patched_pipeline,
+    reason,
+):
+    """Canonical build and verification failures stop before Stage 8."""
+    pipeline = patched_pipeline
+    persistence_calls = 0
+
+    def fail_finalization(payload, *, decision_ts):
+        del payload, decision_ts
+        raise CanonicalDecisionFinalizationError(reason)
+
+    def count_persistence(*args, **kwargs):
+        del args, kwargs
+        nonlocal persistence_calls
+        persistence_calls += 1
+
+    monkeypatch.setattr(
+        pipeline,
+        "finalize_canonical_decision_artifact",
+        fail_finalization,
+    )
+    monkeypatch.setattr(
+        pipeline,
+        "_run_post_decision_persistence_phase",
+        count_persistence,
+    )
+
+    body = {"query": "finalization failure", "context": {"user_id": "u-fail"}}
+    with pytest.raises(CanonicalDecisionFinalizationError) as exc:
+        await pipeline.run_decide_pipeline(
+            DummyReqModel(body),
+            DummyRequest(),
+        )
+
+    assert exc.value.reason_code is reason
+    assert persistence_calls == 0
+
+
+@pytest.mark.anyio
+async def test_missing_request_id_blocks_persistence_before_compatibility_uuid(
+    monkeypatch,
+    patched_pipeline,
+):
+    """An empty raw request ID cannot become canonical through UUID fallback."""
+    pipeline = patched_pipeline
+    persistence_calls = 0
+
+    def empty_request_id_payload(ctx):
+        del ctx
+        return {"request_id": "", "canonical_decision_artifact": None}
+
+    def count_persistence(*args, **kwargs):
+        del args, kwargs
+        nonlocal persistence_calls
+        persistence_calls += 1
+
+    monkeypatch.setattr(
+        pipeline,
+        "_build_decision_payload",
+        empty_request_id_payload,
+    )
+    monkeypatch.setattr(
+        pipeline,
+        "_run_post_decision_persistence_phase",
+        count_persistence,
+    )
+
+    body = {"query": "missing request id", "context": {"user_id": "u-empty"}}
+    with pytest.raises(CanonicalDecisionFinalizationError) as exc:
+        await pipeline.run_decide_pipeline(
+            DummyReqModel(body),
+            DummyRequest(),
+        )
+
+    assert exc.value.reason_code is (
+        CanonicalDecisionFinalizationReason.SOURCE_REQUEST_ID_MISSING
+    )
+    assert persistence_calls == 0
 
 
 # ============================================================

--- a/veritas_os/tests/integration/test_decide_e2e_ext.py
+++ b/veritas_os/tests/integration/test_decide_e2e_ext.py
@@ -1167,10 +1167,22 @@ async def test_run_decide_pipeline_decision_boundary_calls_post_persist(
             "rejection_reason": None,
         }
 
+    artifact = object()
+
+    def fake_build_cda(payload):
+        del payload
+        call_order.append("build_cda")
+        return artifact
+
     def fake_post_persist(ctx, payload, *, effective_get_memory_store, stage_failures):
         del ctx, effective_get_memory_store, stage_failures
         call_order.append("post_persist")
         persisted_payload.update(payload)
+
+    def fake_attach_cda(payload, value):
+        assert value is artifact
+        call_order.append("attach_cda")
+        payload["canonical_decision_artifact"] = {"decision_id": "test-cda"}
 
     monkeypatch.setattr(
         pipeline,
@@ -1184,13 +1196,31 @@ async def test_run_decide_pipeline_decision_boundary_calls_post_persist(
         fake_post_persist,
         raising=False,
     )
+    monkeypatch.setattr(
+        pipeline,
+        "_build_verified_canonical_decision_artifact",
+        fake_build_cda,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        pipeline,
+        "_attach_canonical_decision_artifact_without_drift",
+        fake_attach_cda,
+        raising=False,
+    )
 
     body = {"query": "decision boundary test", "context": {"user_id": "u-boundary"}}
     payload = await pipeline.run_decide_pipeline(DummyReqModel(body), DummyRequest())
 
-    assert call_order == ["build_decision", "post_persist"]
+    assert call_order == [
+        "build_decision",
+        "build_cda",
+        "post_persist",
+        "attach_cda",
+    ]
     assert persisted_payload["request_id"] == payload["request_id"]
     assert payload["query"] == "decision boundary test"
+    assert payload["canonical_decision_artifact"] == {"decision_id": "test-cda"}
 
 
 # ============================================================

--- a/veritas_os/tests/test_api_decide.py
+++ b/veritas_os/tests/test_api_decide.py
@@ -2,6 +2,9 @@
 from fastapi.testclient import TestClient
 
 from veritas_os.api.server import app
+from veritas_os.governance.canonical_decision_artifact import (
+    verify_canonical_decision_artifact,
+)
 
 
 def test_decide_minimal(monkeypatch):
@@ -31,4 +34,6 @@ def test_decide_minimal(monkeypatch):
     assert "fuji" in data
     assert "gate" in data
     assert "trust_log" in data
-
+    assert verify_canonical_decision_artifact(
+        data["canonical_decision_artifact"]
+    ).is_valid

--- a/veritas_os/tests/test_canonical_decision_artifact_runtime.py
+++ b/veritas_os/tests/test_canonical_decision_artifact_runtime.py
@@ -33,10 +33,6 @@ from veritas_os.governance.canonical_decision_artifact import (
     strict_canonical_json_bytes,
     verify_canonical_decision_artifact,
 )
-from veritas_os.core.pipeline import (
-    _attach_canonical_decision_artifact_without_drift,
-    _build_verified_canonical_decision_artifact,
-)
 from veritas_os.security.hash import canonical_json_dumps, sha256_hex
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -76,28 +72,6 @@ def test_golden_runtime_artifact_is_exact() -> None:
         strict_canonical_json_bytes(canonical_decision_preimage(artifact)).decode()
         == vector["expected_canonical_serialized"]
     )
-
-
-def test_pipeline_attaches_cda_after_unchanged_decision() -> None:
-    payload = _source().model_dump(mode="json")
-    artifact = _build_verified_canonical_decision_artifact(payload)
-
-    _attach_canonical_decision_artifact_without_drift(payload, artifact)
-
-    attached = payload["canonical_decision_artifact"]
-    assert attached["decision_id"] == artifact.decision_id
-    assert verify_canonical_decision_artifact(attached).is_valid
-
-
-def test_pipeline_refuses_cda_attachment_after_decision_drift() -> None:
-    payload = _source().model_dump(mode="json")
-    artifact = _build_verified_canonical_decision_artifact(payload)
-    payload["chosen"]["title"] = "drifted decision"
-
-    with pytest.raises(RuntimeError, match="decision drift detected"):
-        _attach_canonical_decision_artifact_without_drift(payload, artifact)
-
-    assert "canonical_decision_artifact" not in payload
 
 
 def test_timestamp_normalization_and_refusal() -> None:

--- a/veritas_os/tests/test_canonical_decision_artifact_runtime.py
+++ b/veritas_os/tests/test_canonical_decision_artifact_runtime.py
@@ -33,6 +33,10 @@ from veritas_os.governance.canonical_decision_artifact import (
     strict_canonical_json_bytes,
     verify_canonical_decision_artifact,
 )
+from veritas_os.core.pipeline import (
+    _attach_canonical_decision_artifact_without_drift,
+    _build_verified_canonical_decision_artifact,
+)
 from veritas_os.security.hash import canonical_json_dumps, sha256_hex
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -72,6 +76,28 @@ def test_golden_runtime_artifact_is_exact() -> None:
         strict_canonical_json_bytes(canonical_decision_preimage(artifact)).decode()
         == vector["expected_canonical_serialized"]
     )
+
+
+def test_pipeline_attaches_cda_after_unchanged_decision() -> None:
+    payload = _source().model_dump(mode="json")
+    artifact = _build_verified_canonical_decision_artifact(payload)
+
+    _attach_canonical_decision_artifact_without_drift(payload, artifact)
+
+    attached = payload["canonical_decision_artifact"]
+    assert attached["decision_id"] == artifact.decision_id
+    assert verify_canonical_decision_artifact(attached).is_valid
+
+
+def test_pipeline_refuses_cda_attachment_after_decision_drift() -> None:
+    payload = _source().model_dump(mode="json")
+    artifact = _build_verified_canonical_decision_artifact(payload)
+    payload["chosen"]["title"] = "drifted decision"
+
+    with pytest.raises(RuntimeError, match="decision drift detected"):
+        _attach_canonical_decision_artifact_without_drift(payload, artifact)
+
+    assert "canonical_decision_artifact" not in payload
 
 
 def test_timestamp_normalization_and_refusal() -> None:

--- a/veritas_os/tests/test_canonical_decision_finalization.py
+++ b/veritas_os/tests/test_canonical_decision_finalization.py
@@ -1,0 +1,318 @@
+"""Canonical decision pipeline-finalization boundary tests."""
+
+from __future__ import annotations
+
+import json
+import inspect
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic import create_model
+
+from veritas_os.api.schemas import DecideResponse
+from veritas_os.core.pipeline import canonical_decision_finalization as finalization
+from veritas_os.governance import canonical_decision_artifact as cda_runtime
+
+ROOT = Path(__file__).resolve().parents[2]
+VECTOR = (
+    ROOT
+    / "docs/en/architecture/test-vectors/canonical-decision-artifact-v1"
+    / "vector-01.json"
+)
+DECISION_TS = datetime(2031, 2, 3, 4, 5, 6, 123456, tzinfo=timezone.utc)
+
+
+def _payload() -> dict[str, Any]:
+    vector = json.loads(VECTOR.read_text())
+    return DecideResponse.model_validate(vector["source_projection"]).model_dump(
+        mode="json"
+    )
+
+
+def _assert_reason(
+    exc: pytest.ExceptionInfo[finalization.CanonicalDecisionFinalizationError],
+    reason: finalization.CanonicalDecisionFinalizationReason,
+) -> None:
+    assert exc.value.reason_code is reason
+    assert str(exc.value) == reason.value
+
+
+def test_finalization_bridges_reloaded_response_class(monkeypatch) -> None:
+    """The builder receives its own exact class after API class separation."""
+    reloaded_response = create_model(
+        "ReloadedDecideResponse",
+        __base__=DecideResponse,
+    )
+    assert reloaded_response is not cda_runtime.DecideResponse
+    monkeypatch.setattr(finalization.api_schemas, "DecideResponse", reloaded_response)
+    original_builder = cda_runtime.build_canonical_decision_artifact
+    observed: list[bool] = []
+
+    def strict_builder(source, *, decision_ts):
+        observed.append(type(source) is cda_runtime.DecideResponse)
+        return original_builder(source, decision_ts=decision_ts)
+
+    monkeypatch.setattr(
+        cda_runtime,
+        "build_canonical_decision_artifact",
+        strict_builder,
+    )
+
+    artifact = finalization.finalize_canonical_decision_artifact(
+        _payload(),
+        decision_ts=DECISION_TS,
+    )
+
+    assert observed == [True]
+    assert artifact.request_id == "req-cda-golden-001"
+
+
+def test_request_id_is_refused_before_model_validation(monkeypatch) -> None:
+    payload = _payload()
+    payload["request_id"] = ""
+    validation_calls = 0
+
+    class ForbiddenResponse:
+        @classmethod
+        def model_validate(cls, value):
+            del cls, value
+            nonlocal validation_calls
+            validation_calls += 1
+            raise AssertionError("model validation must not run")
+
+    monkeypatch.setattr(
+        finalization.api_schemas,
+        "DecideResponse",
+        ForbiddenResponse,
+    )
+
+    with pytest.raises(finalization.CanonicalDecisionFinalizationError) as exc:
+        finalization.finalize_canonical_decision_artifact(
+            payload,
+            decision_ts=DECISION_TS,
+        )
+
+    _assert_reason(
+        exc,
+        finalization.CanonicalDecisionFinalizationReason.SOURCE_REQUEST_ID_MISSING,
+    )
+    assert validation_calls == 0
+
+
+def test_null_preexisting_artifact_is_removed_before_finalization() -> None:
+    payload = _payload()
+    assert payload["canonical_decision_artifact"] is None
+
+    artifact = finalization.finalize_canonical_decision_artifact(
+        payload,
+        decision_ts=DECISION_TS,
+    )
+
+    assert "canonical_decision_artifact" not in payload
+    assert artifact.decision_ts == "2031-02-03T04:05:06.123456Z"
+
+
+def test_finalization_helper_has_no_clock_lookup() -> None:
+    source = inspect.getsource(finalization.finalize_canonical_decision_artifact)
+
+    assert "utc_now" not in source
+    assert "datetime.now" not in source
+
+
+def test_non_null_preexisting_artifact_is_refused() -> None:
+    payload = _payload()
+    payload["canonical_decision_artifact"] = {"decision_id": "untrusted"}
+
+    with pytest.raises(finalization.CanonicalDecisionFinalizationError) as exc:
+        finalization.finalize_canonical_decision_artifact(
+            payload,
+            decision_ts=DECISION_TS,
+        )
+
+    _assert_reason(
+        exc,
+        finalization.CanonicalDecisionFinalizationReason.PREEXISTING_CANONICAL_ARTIFACT_REFUSED,
+    )
+
+
+def test_build_failure_has_stable_reason(monkeypatch) -> None:
+    def fail_build(source, *, decision_ts):
+        del source, decision_ts
+        raise cda_runtime.CanonicalDecisionArtifactBuildError(
+            cda_runtime.CanonicalDecisionArtifactBuildReason.NON_CANONICAL_JSON_VALUE
+        )
+
+    monkeypatch.setattr(
+        cda_runtime,
+        "build_canonical_decision_artifact",
+        fail_build,
+    )
+
+    with pytest.raises(finalization.CanonicalDecisionFinalizationError) as exc:
+        finalization.finalize_canonical_decision_artifact(
+            _payload(),
+            decision_ts=DECISION_TS,
+        )
+
+    _assert_reason(
+        exc,
+        finalization.CanonicalDecisionFinalizationReason.ARTIFACT_BUILD_FAILED,
+    )
+
+
+def test_verification_failure_has_stable_reason(monkeypatch) -> None:
+    monkeypatch.setattr(
+        cda_runtime,
+        "verify_canonical_decision_artifact",
+        lambda artifact: cda_runtime.CanonicalDecisionArtifactVerificationResult(
+            is_valid=False,
+            reason_codes=("ARTIFACT_HASH_MISMATCH",),
+            artifact=artifact,
+            computed_decision_hash=None,
+            expected_decision_id=None,
+        ),
+    )
+
+    with pytest.raises(finalization.CanonicalDecisionFinalizationError) as exc:
+        finalization.finalize_canonical_decision_artifact(
+            _payload(),
+            decision_ts=DECISION_TS,
+        )
+
+    _assert_reason(
+        exc,
+        finalization.CanonicalDecisionFinalizationReason.ARTIFACT_VERIFICATION_FAILED,
+    )
+
+
+def test_api_normalized_request_id_mismatch_is_refused(monkeypatch) -> None:
+    original_response = finalization.api_schemas.DecideResponse
+
+    class MismatchedResponse:
+        @classmethod
+        def model_validate(cls, value):
+            del cls
+            source = original_response.model_validate(value)
+            return source.model_copy(update={"request_id": "req-mismatch"})
+
+    monkeypatch.setattr(
+        finalization.api_schemas,
+        "DecideResponse",
+        MismatchedResponse,
+    )
+
+    with pytest.raises(finalization.CanonicalDecisionFinalizationError) as exc:
+        finalization.finalize_canonical_decision_artifact(
+            _payload(),
+            decision_ts=DECISION_TS,
+        )
+
+    _assert_reason(
+        exc,
+        finalization.CanonicalDecisionFinalizationReason.REQUEST_ID_MISMATCH,
+    )
+
+
+def test_artifact_request_id_mismatch_is_refused(monkeypatch) -> None:
+    original_builder = cda_runtime.build_canonical_decision_artifact
+
+    def mismatched_builder(source, *, decision_ts):
+        artifact = original_builder(source, decision_ts=decision_ts)
+        return artifact.model_copy(update={"request_id": "req-mismatch"})
+
+    monkeypatch.setattr(
+        cda_runtime,
+        "build_canonical_decision_artifact",
+        mismatched_builder,
+    )
+
+    with pytest.raises(finalization.CanonicalDecisionFinalizationError) as exc:
+        finalization.finalize_canonical_decision_artifact(
+            _payload(),
+            decision_ts=DECISION_TS,
+        )
+
+    _assert_reason(
+        exc,
+        finalization.CanonicalDecisionFinalizationReason.REQUEST_ID_MISMATCH,
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("reason", {"debug": "changed"}),
+        ("meta", {"latency": 42}),
+        ("deterministic_replay", {"snapshot": "changed"}),
+        ("trust_log", {"entry": "changed"}),
+        ("extras", {"metrics": {"pipeline_total_ms": 42}}),
+        ("user_summary", "changed presentation"),
+    ],
+)
+def test_excluded_field_drift_preserves_original_artifact(field, value) -> None:
+    payload = _payload()
+    artifact = finalization.finalize_canonical_decision_artifact(
+        payload,
+        decision_ts=DECISION_TS,
+    )
+    original = artifact.model_dump(mode="json")
+    payload[field] = value
+
+    finalization.verify_canonical_decision_source_unchanged(payload, artifact)
+    finalization.attach_canonical_decision_artifact(payload, artifact)
+
+    assert payload["canonical_decision_artifact"] == original
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda value: value["chosen"].update(title="changed choice"),
+        lambda value: value["required_evidence"].append("new_evidence"),
+        lambda value: value["governance_identity"].update(policy_version="v8"),
+        lambda value: value.update(
+            decision_status="block",
+            gate_decision="block",
+            business_decision="DENY",
+            actionability_status="blocked",
+            requires_bind_before_execution=False,
+        ),
+    ],
+)
+def test_included_field_drift_is_refused(mutation) -> None:
+    payload = _payload()
+    artifact = finalization.finalize_canonical_decision_artifact(
+        payload,
+        decision_ts=DECISION_TS,
+    )
+    mutation(payload)
+
+    with pytest.raises(finalization.CanonicalDecisionFinalizationError) as exc:
+        finalization.verify_canonical_decision_source_unchanged(payload, artifact)
+
+    _assert_reason(
+        exc,
+        finalization.CanonicalDecisionFinalizationReason.DECISION_SOURCE_DRIFT,
+    )
+    assert "canonical_decision_artifact" not in payload
+
+
+def test_response_model_preserves_attached_artifact() -> None:
+    payload = _payload()
+    artifact = finalization.finalize_canonical_decision_artifact(
+        payload,
+        decision_ts=DECISION_TS,
+    )
+    finalization.verify_canonical_decision_source_unchanged(payload, artifact)
+    finalization.attach_canonical_decision_artifact(payload, artifact)
+
+    round_trip = DecideResponse.model_validate(payload).model_dump(mode="json")
+
+    assert round_trip["canonical_decision_artifact"] == artifact.model_dump(
+        mode="json"
+    )
+    assert "decision_hash" not in round_trip
+    assert "decision_ts" not in round_trip
+    assert "verified" not in round_trip["canonical_decision_artifact"]

--- a/veritas_os/tests/test_canonical_decision_finalization.py
+++ b/veritas_os/tests/test_canonical_decision_finalization.py
@@ -66,7 +66,7 @@ def test_finalization_bridges_reloaded_response_class(monkeypatch) -> None:
     )
 
     assert observed == [True]
-    assert artifact.request_id == "req-cda-golden-001"
+    assert artifact.request_id == "req-cda-synthetic-001"
 
 
 def test_request_id_is_refused_before_model_validation(monkeypatch) -> None:


### PR DESCRIPTION
### Motivation
- Emit Canonical Decision Artifact (CDA) v1 from the real `/v1/decide` pipeline at the Stage 7 decision-finalization boundary.
- Ensure the canonical decision identity is fixed before post-decision persistence, while preventing a stale artifact from being returned if Stage 8 later changes any hash-significant decision field.
- Keep CDA integrity verification distinct from trusted provenance, TrustLog/replay proof, handoff readiness, or execution authority.

### Description
- Add optional `canonical_decision_artifact` to `DecideResponse` as an additive public response field.
- Add dedicated `veritas_os/core/pipeline/canonical_decision_finalization.py` integration logic with stable fail-closed reason codes.
- At Stage 7 completion, capture one explicit `decision_ts` in the orchestrator and pass it into the clock-free CDA finalization helper.
- Precheck the raw `request_id` before `DecideResponse` validation so compatibility UUID generation cannot create canonical request identity.
- Strictly validate the Stage 7 payload through the API `DecideResponse`, then bridge the normalized JSON through the exact `DecideResponse` class bound by the CDA runtime. This preserves the strict #2105 source-class boundary across module reload/class-identity differences without weakening the builder.
- Build the CDA with the merged #2105 production builder and immediately verify its internal structure, deterministic hash integrity, and content-addressed ID coherence before Stage 8 is allowed to run.
- Remove a preexisting `canonical_decision_artifact: null` before Stage 8 and fail closed on any preexisting non-null artifact. Stage 8 therefore receives no CDA key at all.
- Run the existing Stage 8 persistence path unchanged and without passing the CDA into MemoryOS, disk persistence, dataset persistence, TrustLog, or replay identity.
- After Stage 8, rebuild the CDA using the original `decision_ts`, independently verify it, and require exact JSON deep equality with the original Stage 7 artifact. Any included-field mutation fails closed as `DECISION_SOURCE_DRIFT`; excluded diagnostic/presentation fields may change without changing canonical identity.
- Attach only the original Stage 7 CDA to the outgoing response after the drift guard succeeds.
- Add real pipeline and authenticated `/v1/decide` tests proving the emitted CDA passes the #2105 verifier.
- Keep the existing golden CDA v1 contract unchanged, including the content-addressed hash/ID rules.

### Security / non-claims
This PR establishes live canonical decision identity emission only.

It does **not** establish:
- trusted producer provenance;
- CDA ↔ TrustLog cryptographic linkage;
- CDA ↔ deterministic replay cryptographic linkage;
- CanonicalDecisionHandoff readiness;
- DecisionCandidate promotion;
- Authority Evidence or Human Approval verification;
- ExecutionIntent creation;
- Bind authorization or execution authority.

No top-level canonical `decision_hash` or `decision_ts` aliases and no `verified=true` shortcut are introduced.

### Testing
Latest head: `e5b25e4312b7df355866a7edfd1b5d1ce6c9180b`.

GitHub CI #5037 completed successfully on the latest head. Confirmed successful jobs/workflows include:
- full test suite on Python 3.11;
- full test suite on Python 3.12;
- PostgreSQL parity/contention tests;
- slow tests;
- governance backend fast checks;
- governance smoke checks;
- lint and responsibility-boundary checks;
- dependency audit and future-dependency compatibility;
- frontend test, lint, and E2E;
- Security Gates;
- CodeQL (custom);
- Runtime Proof Evidence;
- Runtime Pickle Guard (Required);
- Reviewer Evidence Packet Validation.

Focused coverage includes:
- Stage 7 → timestamp capture → CDA build/verify → Stage 8 → drift check → attach ordering;
- exactly one canonical finalization timestamp capture;
- build/verification failure blocking persistence;
- empty request ID refusal before compatibility UUID generation;
- module reload/class-identity bridging while preserving the strict #2105 builder contract;
- Stage 8 receiving no `canonical_decision_artifact` key;
- exact post-persistence CDA deep-equality drift verification;
- excluded-field mutations preserving the original CDA;
- included-field mutations failing closed;
- response-model round-trip preservation;
- real pipeline CDA emission;
- real authenticated `/v1/decide` CDA emission and verifier success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a805c26d5cc83268b67c4ad146098ee)