### PR TITLE
feat(audit): link Canonical Decision Artifact v1 to TrustLog evidence

### DIFF
--- a/docs/en/architecture/canonical-decision-artifact-v1.md
+++ b/docs/en/architecture/canonical-decision-artifact-v1.md
@@ -308,12 +308,12 @@ separate future layer.
 
 ## Non-claims and remaining work
 
-This milestone provides no live `/v1/decide` emission, canonical candidate
-extraction, Authority Evidence, Human Approval verification, live policy
-verification, TrustLog verification, replay
-verification, `CanonicalDecisionHandoff` creation, guarded promotion,
-`ExecutionIntent`, Bind, external effect, or production/customer/regulatory
-certification. A later PR must define and review the finalization capture,
-pre-Bind producer, artifact persistence/reference, independent verification,
-TrustLog/replay matching, structured candidate/evidence inputs, and handoff
-consumer. It must not change the existing handoff validator implicitly.
+Live `/v1/decide` CDA emission exists. When its dedicated post-drift link append
+succeeds, the response also identifies the encrypted TrustLog row that commits
+to the exact compact CDA reference. Full-ledger chain and signed-witness
+verification remain independent operations, and receipt presence is not a
+trusted-provenance claim. Replay evidence linkage remains future work because a
+replay execution has its own CDA timestamp and identity. Authority Evidence,
+Human Approval, `CanonicalDecisionHandoff`, guarded promotion,
+`ExecutionIntent`, Bind, external effect, and production/customer/regulatory
+certification also remain outside this contract.

--- a/docs/en/architecture/canonical-decision-trust-link-v1.md
+++ b/docs/en/architecture/canonical-decision-trust-link-v1.md
@@ -1,0 +1,39 @@
+# Canonical Decision Trust Link v1
+
+The dedicated `canonical_decision_link` event means only that an exact,
+internally verified CDA identity survived post-decision persistence without
+canonical-source drift. It is appended after the drift guard and contains a
+compact reference—not the complete CDA or its rationale, evidence, query,
+chosen value, user data, or policy text.
+
+## Evidence layers
+
+Verification deliberately keeps separate domains:
+
+1. CDA verification proves the artifact's internal structure, `decision_hash`,
+   and content-addressed `decision_id` coherence.
+2. The canonical reference exactly copies CDA version, profile, request ID,
+   decision ID, decision hash, and decision timestamp.
+3. The encrypted full-ledger row commits to that reference with its own
+   `sha256` and `sha256_prev` chain domain.
+4. The existing compact signed witness commits to the exact full row through
+   `full_payload_hash` and an `artifact_ref` locator of
+   `sha256:<full-ledger-sha256>`.
+5. Existing witness signature and chain verification are separate checks.
+6. WORM or transparency evidence, when configured, is another independent
+   layer.
+
+The response receipt is only a locator confirming successful local append and
+exact validation of the returned full-ledger entry. By itself it does not prove
+the full ledger or witness chain is intact, the signature key or CDA producer
+is trusted, or WORM/transparency storage is valid. It grants no handoff
+readiness, execution intent, Bind permission, external effect, or regulatory
+certification.
+
+## Replay boundary
+
+Replay linkage remains future work. The replay snapshot is generated late in
+Stage 8 while decision disk persistence occurs earlier, and each replay run
+forms a distinct live CDA timestamp and identity. A future contract must
+separate original decision identity, replay source reference, replay execution
+identity, and semantic replay equivalence.

--- a/schemas/canonical-decision-trust-receipt-v1.schema.json
+++ b/schemas/canonical-decision-trust-receipt-v1.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://veritas-os.example/schemas/canonical-decision-trust-receipt-v1.schema.json",
+  "title": "Canonical Decision Trust Receipt v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "format_version", "request_id", "canonical_decision_id",
+    "canonical_decision_hash", "canonical_decision_ts",
+    "trust_log_entry_sha256", "trust_log_entry_sha256_prev",
+    "trust_log_created_at", "ledger", "event_type"
+  ],
+  "properties": {
+    "format_version": {"const": "canonical-decision-trust-receipt/v1"},
+    "request_id": {"type": "string", "minLength": 1},
+    "canonical_decision_id": {"type": "string", "pattern": "^cda:v1:sha256:[0-9a-f]{64}$"},
+    "canonical_decision_hash": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "canonical_decision_ts": {"type": "string", "pattern": "^[0-9]{4}-(0[1-9]|1[0-2])-([0-2][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]\\.[0-9]{6}Z$"},
+    "trust_log_entry_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "trust_log_entry_sha256_prev": {"oneOf": [{"type": "null"}, {"type": "string", "pattern": "^[0-9a-f]{64}$"}]},
+    "trust_log_created_at": {"type": "string", "minLength": 1},
+    "ledger": {"const": "encrypted_full_ledger"},
+    "event_type": {"const": "canonical_decision_link"}
+  },
+  "$defs": {
+    "canonical_decision_reference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["format_version", "artifact_format_version", "hash_profile", "request_id", "decision_id", "decision_hash", "decision_ts"],
+      "properties": {
+        "format_version": {"const": "canonical-decision-reference/v1"},
+        "artifact_format_version": {"const": "canonical-decision-artifact/v1"},
+        "hash_profile": {"const": "veritas.canonical-decision/v1"},
+        "request_id": {"type": "string", "minLength": 1},
+        "decision_id": {"type": "string", "pattern": "^cda:v1:sha256:[0-9a-f]{64}$"},
+        "decision_hash": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "decision_ts": {"type": "string", "pattern": "^[0-9]{4}-(0[1-9]|1[0-2])-([0-2][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]\\.[0-9]{6}Z$"}
+      }
+    }
+  }
+}

--- a/veritas_os/api/schemas.py
+++ b/veritas_os/api/schemas.py
@@ -1150,6 +1150,15 @@ class DecideResponse(BaseModel):
             "trusted provenance or execution authority."
         ),
     )
+    canonical_decision_trust_receipt: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description=(
+            "Receipt identifying the encrypted full-ledger TrustLog entry that "
+            "commits to the emitted Canonical Decision Artifact reference. "
+            "Presence confirms local append and exact returned-entry matching; "
+            "ledger-chain and signed-witness verification remain separate."
+        ),
+    )
 
     # Governance identity: which governance artifact was in force for this decision.
     governance_identity: Optional[Dict[str, Any]] = Field(

--- a/veritas_os/audit/canonical_decision_trust_link.py
+++ b/veritas_os/audit/canonical_decision_trust_link.py
@@ -1,0 +1,246 @@
+"""Bind a verified Canonical Decision Artifact to an existing TrustLog row.
+
+This module performs only cross-object evidence matching.  It neither grants
+execution authority nor proves that the ledger, witness signer, or producer is
+trusted.  Persistence remains owned by the injected production TrustLog.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Callable, Literal, Mapping
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from veritas_os.governance.canonical_decision_artifact import (
+    CanonicalDecisionArtifact,
+    verify_canonical_decision_artifact,
+)
+
+REFERENCE_VERSION = "canonical-decision-reference/v1"
+LINK_SCHEMA_VERSION = "canonical_decision_trust_link/v1"
+RECEIPT_VERSION = "canonical-decision-trust-receipt/v1"
+LINK_EVENT_TYPE = "canonical_decision_link"
+LINK_PIPELINE_PHASE = "post_persistence_drift_verified"
+FULL_LEDGER = "encrypted_full_ledger"
+_DIGEST_PATTERN = r"^[0-9a-f]{64}$"
+_DECISION_ID_PATTERN = r"^cda:v1:sha256:[0-9a-f]{64}$"
+_TIMESTAMP_PATTERN = (
+    r"^[0-9]{4}-(0[1-9]|1[0-2])-([0-2][0-9]|3[01])T"
+    r"([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]\.[0-9]{6}Z$"
+)
+
+
+class _FrozenModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class CanonicalDecisionTrustLinkReason(str, Enum):
+    """Stable, content-free trust-link refusal codes."""
+
+    CDA_INVALID = "CDA_INVALID"
+    REQUEST_ID_MISMATCH = "REQUEST_ID_MISMATCH"
+    TRUSTLOG_APPEND_FAILED = "TRUSTLOG_APPEND_FAILED"
+    TRUSTLOG_ENTRY_INVALID = "TRUSTLOG_ENTRY_INVALID"
+    TRUSTLOG_ENTRY_HASH_INVALID = "TRUSTLOG_ENTRY_HASH_INVALID"
+    TRUSTLOG_REFERENCE_MISMATCH = "TRUSTLOG_REFERENCE_MISMATCH"
+    TRUSTLOG_RECEIPT_INVALID = "TRUSTLOG_RECEIPT_INVALID"
+
+
+class CanonicalDecisionTrustLinkError(ValueError):
+    """Trust-link failure exposing a stable reason but no source content."""
+
+    def __init__(self, reason_code: CanonicalDecisionTrustLinkReason) -> None:
+        self.reason_code = reason_code
+        super().__init__(reason_code.value)
+
+
+class CanonicalDecisionReference(_FrozenModel):
+    """Compact exact identity copied from an internally verified CDA v1."""
+
+    format_version: Literal["canonical-decision-reference/v1"]
+    artifact_format_version: Literal["canonical-decision-artifact/v1"]
+    hash_profile: Literal["veritas.canonical-decision/v1"]
+    request_id: str = Field(min_length=1)
+    decision_id: str = Field(pattern=_DECISION_ID_PATTERN)
+    decision_hash: str = Field(pattern=_DIGEST_PATTERN)
+    decision_ts: str = Field(pattern=_TIMESTAMP_PATTERN)
+
+
+class CanonicalDecisionTrustReceipt(_FrozenModel):
+    """Locator for the matching encrypted full-ledger row."""
+
+    format_version: Literal["canonical-decision-trust-receipt/v1"]
+    request_id: str = Field(min_length=1)
+    canonical_decision_id: str = Field(pattern=_DECISION_ID_PATTERN)
+    canonical_decision_hash: str = Field(pattern=_DIGEST_PATTERN)
+    canonical_decision_ts: str = Field(pattern=_TIMESTAMP_PATTERN)
+    trust_log_entry_sha256: str = Field(pattern=_DIGEST_PATTERN)
+    trust_log_entry_sha256_prev: str | None = Field(
+        default=None, pattern=_DIGEST_PATTERN
+    )
+    trust_log_created_at: str = Field(min_length=1)
+    ledger: Literal["encrypted_full_ledger"]
+    event_type: Literal["canonical_decision_link"]
+
+
+class CanonicalDecisionTrustVerificationResult(_FrozenModel):
+    """Pure cross-object verification result; not a provenance assertion."""
+
+    ok: bool
+    cda_integrity_ok: bool
+    entry_link_match: bool
+    reason_codes: tuple[str, ...]
+
+
+def build_canonical_decision_reference(
+    artifact: CanonicalDecisionArtifact,
+) -> CanonicalDecisionReference:
+    """Build an exact compact reference only after CDA v1 verification."""
+    verification = verify_canonical_decision_artifact(artifact)
+    if not verification.is_valid or verification.artifact is None:
+        _fail(CanonicalDecisionTrustLinkReason.CDA_INVALID)
+    verified = verification.artifact
+    return CanonicalDecisionReference(
+        format_version=REFERENCE_VERSION,
+        artifact_format_version=verified.format_version,
+        hash_profile=verified.hash_profile,
+        request_id=verified.request_id,
+        decision_id=verified.decision_id,
+        decision_hash=verified.decision_hash,
+        decision_ts=verified.decision_ts,
+    )
+
+
+def build_canonical_decision_trust_event(
+    artifact: CanonicalDecisionArtifact,
+) -> dict[str, Any]:
+    """Construct the dedicated post-drift TrustLog event."""
+    reference = build_canonical_decision_reference(artifact)
+    return {
+        "event_type": LINK_EVENT_TYPE,
+        "audit_schema_version": LINK_SCHEMA_VERSION,
+        "request_id": artifact.request_id,
+        "pipeline_phase": LINK_PIPELINE_PHASE,
+        "canonical_decision_ref": reference.model_dump(mode="json"),
+    }
+
+
+def record_canonical_decision_trust_link(
+    artifact: CanonicalDecisionArtifact,
+    *,
+    append_trust_log_fn: Callable[[dict[str, Any]], Mapping[str, Any]],
+) -> CanonicalDecisionTrustReceipt:
+    """Append and validate the actual returned full-ledger link entry."""
+    reference = build_canonical_decision_reference(artifact)
+    event = build_canonical_decision_trust_event(artifact)
+    try:
+        entry = append_trust_log_fn(event)
+    except Exception as exc:
+        raise CanonicalDecisionTrustLinkError(
+            CanonicalDecisionTrustLinkReason.TRUSTLOG_APPEND_FAILED
+        ) from exc
+    _validate_entry(entry, artifact, reference)
+    return CanonicalDecisionTrustReceipt(
+        format_version=RECEIPT_VERSION,
+        request_id=artifact.request_id,
+        canonical_decision_id=artifact.decision_id,
+        canonical_decision_hash=artifact.decision_hash,
+        canonical_decision_ts=artifact.decision_ts,
+        trust_log_entry_sha256=entry["sha256"],
+        trust_log_entry_sha256_prev=entry["sha256_prev"],
+        trust_log_created_at=entry["created_at"],
+        ledger=FULL_LEDGER,
+        event_type=LINK_EVENT_TYPE,
+    )
+
+
+def verify_canonical_decision_trust_entry(
+    artifact: CanonicalDecisionArtifact | Mapping[str, Any],
+    receipt: CanonicalDecisionTrustReceipt | Mapping[str, Any],
+    trust_entry: Mapping[str, Any],
+) -> CanonicalDecisionTrustVerificationResult:
+    """Verify exact CDA, receipt, and full-entry matching without file I/O."""
+    cda_result = verify_canonical_decision_artifact(artifact)
+    if not cda_result.is_valid or cda_result.artifact is None:
+        return _result(False, False, CanonicalDecisionTrustLinkReason.CDA_INVALID)
+    verified = cda_result.artifact
+    try:
+        parsed_receipt = CanonicalDecisionTrustReceipt.model_validate(receipt)
+        reference = build_canonical_decision_reference(verified)
+        _validate_entry(trust_entry, verified, reference)
+    except CanonicalDecisionTrustLinkError as exc:
+        return _result(True, False, exc.reason_code)
+    except (ValidationError, TypeError):
+        return _result(
+            True, False, CanonicalDecisionTrustLinkReason.TRUSTLOG_RECEIPT_INVALID
+        )
+    matches = (
+        parsed_receipt.request_id == verified.request_id
+        and parsed_receipt.canonical_decision_id == verified.decision_id
+        and parsed_receipt.canonical_decision_hash == verified.decision_hash
+        and parsed_receipt.canonical_decision_ts == verified.decision_ts
+        and parsed_receipt.trust_log_entry_sha256 == trust_entry.get("sha256")
+        and parsed_receipt.trust_log_entry_sha256_prev == trust_entry.get("sha256_prev")
+        and parsed_receipt.trust_log_created_at == trust_entry.get("created_at")
+    )
+    return _result(
+        True,
+        matches,
+        None
+        if matches
+        else CanonicalDecisionTrustLinkReason.TRUSTLOG_REFERENCE_MISMATCH,
+    )
+
+
+def _validate_entry(
+    entry: Mapping[str, Any],
+    artifact: CanonicalDecisionArtifact,
+    reference: CanonicalDecisionReference,
+) -> None:
+    if not isinstance(entry, Mapping):
+        _fail(CanonicalDecisionTrustLinkReason.TRUSTLOG_ENTRY_INVALID)
+    if entry.get("request_id") != artifact.request_id:
+        _fail(CanonicalDecisionTrustLinkReason.REQUEST_ID_MISMATCH)
+    if (
+        entry.get("event_type") != LINK_EVENT_TYPE
+        or entry.get("audit_schema_version") != LINK_SCHEMA_VERSION
+        or entry.get("pipeline_phase") != LINK_PIPELINE_PHASE
+        or entry.get("canonical_decision_ref") != reference.model_dump(mode="json")
+    ):
+        _fail(CanonicalDecisionTrustLinkReason.TRUSTLOG_REFERENCE_MISMATCH)
+    try:
+        digest = entry["sha256"]
+        previous = entry["sha256_prev"]
+        created_at = entry["created_at"]
+    except KeyError:
+        _fail(CanonicalDecisionTrustLinkReason.TRUSTLOG_ENTRY_INVALID)
+    if not _is_digest(digest) or (previous is not None and not _is_digest(previous)):
+        _fail(CanonicalDecisionTrustLinkReason.TRUSTLOG_ENTRY_HASH_INVALID)
+    if type(created_at) is not str or not created_at:
+        _fail(CanonicalDecisionTrustLinkReason.TRUSTLOG_ENTRY_INVALID)
+
+
+def _is_digest(value: Any) -> bool:
+    return (
+        type(value) is str
+        and len(value) == 64
+        and all(character in "0123456789abcdef" for character in value)
+    )
+
+
+def _result(
+    cda_ok: bool,
+    entry_ok: bool,
+    reason: CanonicalDecisionTrustLinkReason | None,
+) -> CanonicalDecisionTrustVerificationResult:
+    return CanonicalDecisionTrustVerificationResult(
+        ok=cda_ok and entry_ok,
+        cda_integrity_ok=cda_ok,
+        entry_link_match=entry_ok,
+        reason_codes=() if reason is None else (reason.value,),
+    )
+
+
+def _fail(reason: CanonicalDecisionTrustLinkReason) -> None:
+    raise CanonicalDecisionTrustLinkError(reason)

--- a/veritas_os/audit/canonical_decision_trust_link.py
+++ b/veritas_os/audit/canonical_decision_trust_link.py
@@ -166,7 +166,18 @@ def verify_canonical_decision_trust_entry(
         return _result(False, False, CanonicalDecisionTrustLinkReason.CDA_INVALID)
     verified = cda_result.artifact
     try:
-        parsed_receipt = CanonicalDecisionTrustReceipt.model_validate(receipt)
+        receipt_raw = (
+            receipt.model_dump(mode="json")
+            if isinstance(receipt, CanonicalDecisionTrustReceipt)
+            else receipt
+        )
+        parsed_receipt = CanonicalDecisionTrustReceipt.model_validate(receipt_raw)
+        if (
+            parsed_receipt.format_version != RECEIPT_VERSION
+            or parsed_receipt.ledger != FULL_LEDGER
+            or parsed_receipt.event_type != LINK_EVENT_TYPE
+        ):
+            _fail(CanonicalDecisionTrustLinkReason.TRUSTLOG_RECEIPT_INVALID)
         reference = build_canonical_decision_reference(verified)
         _validate_entry(trust_entry, verified, reference)
     except CanonicalDecisionTrustLinkError as exc:

--- a/veritas_os/core/pipeline/__init__.py
+++ b/veritas_os/core/pipeline/__init__.py
@@ -234,6 +234,10 @@ from .canonical_decision_finalization import (
     require_stage_8_payload_without_canonical_artifact,
     verify_canonical_decision_source_unchanged,
 )
+from ...audit.canonical_decision_trust_link import (
+    CanonicalDecisionTrustLinkError,
+    record_canonical_decision_trust_link,
+)
 from .pipeline_replay import (
     _safe_filename_id,  # noqa: F401 – backward compat
     _sanitize_for_diff,  # noqa: F401 – backward compat
@@ -1008,10 +1012,29 @@ async def run_decide_pipeline(
             payload,
             canonical_decision_artifact,
         )
+        trust_receipt_payload = None
+        with trace_session.stage("canonical_trust_link"):
+            try:
+                trust_receipt = record_canonical_decision_trust_link(
+                    canonical_decision_artifact,
+                    append_trust_log_fn=append_trust_log,
+                )
+            except CanonicalDecisionTrustLinkError as exc:
+                _stage_failures.append(
+                    f"canonical_trust_link:{exc.reason_code.value}"
+                )
+                logger.warning(
+                    "[pipeline] canonical trust link unavailable: %s",
+                    exc.reason_code.value,
+                )
+            else:
+                trust_receipt_payload = trust_receipt.model_dump(mode="json")
         attach_canonical_decision_artifact(
             payload,
             canonical_decision_artifact,
         )
+        if trust_receipt_payload is not None:
+            payload["canonical_decision_trust_receipt"] = trust_receipt_payload
 
     # =================================================================
     # Observability: record pipeline health summary

--- a/veritas_os/core/pipeline/canonical_decision_finalization.py
+++ b/veritas_os/core/pipeline/canonical_decision_finalization.py
@@ -30,6 +30,7 @@ class CanonicalDecisionFinalizationReason(str, Enum):
     PREEXISTING_CANONICAL_ARTIFACT_REFUSED = (
         "PREEXISTING_CANONICAL_ARTIFACT_REFUSED"
     )
+    PREEXISTING_TRUST_RECEIPT_REFUSED = "PREEXISTING_TRUST_RECEIPT_REFUSED"
 
 
 class CanonicalDecisionFinalizationError(ValueError):
@@ -69,6 +70,7 @@ def finalize_canonical_decision_artifact(
         _fail(CanonicalDecisionFinalizationReason.SOURCE_REQUEST_ID_MISSING)
 
     _remove_or_refuse_preexisting_artifact(payload)
+    _remove_or_refuse_preexisting_receipt(payload)
 
     try:
         api_source = api_schemas.DecideResponse.model_validate(payload)
@@ -77,6 +79,7 @@ def finalize_canonical_decision_artifact(
         _fail(CanonicalDecisionFinalizationReason.SOURCE_VALIDATION_FAILED)
 
     normalized.pop("canonical_decision_artifact", None)
+    normalized.pop("canonical_decision_trust_receipt", None)
     if api_source.request_id != raw_request_id:
         _fail(CanonicalDecisionFinalizationReason.REQUEST_ID_MISMATCH)
 
@@ -134,6 +137,10 @@ def verify_canonical_decision_source_unchanged(
             CanonicalDecisionFinalizationReason.PREEXISTING_CANONICAL_ARTIFACT_REFUSED
         ):
             raise
+        if exc.reason_code is (
+            CanonicalDecisionFinalizationReason.PREEXISTING_TRUST_RECEIPT_REFUSED
+        ):
+            raise
         raise CanonicalDecisionFinalizationError(
             CanonicalDecisionFinalizationReason.DECISION_SOURCE_DRIFT
         ) from exc
@@ -163,6 +170,8 @@ def attach_canonical_decision_artifact(
         _fail(
             CanonicalDecisionFinalizationReason.PREEXISTING_CANONICAL_ARTIFACT_REFUSED
         )
+    if "canonical_decision_trust_receipt" in payload:
+        _fail(CanonicalDecisionFinalizationReason.PREEXISTING_TRUST_RECEIPT_REFUSED)
     payload["canonical_decision_artifact"] = artifact.model_dump(mode="json")
 
 
@@ -174,6 +183,8 @@ def require_stage_8_payload_without_canonical_artifact(
         _fail(
             CanonicalDecisionFinalizationReason.PREEXISTING_CANONICAL_ARTIFACT_REFUSED
         )
+    if "canonical_decision_trust_receipt" in payload:
+        _fail(CanonicalDecisionFinalizationReason.PREEXISTING_TRUST_RECEIPT_REFUSED)
 
 
 def _remove_or_refuse_preexisting_artifact(
@@ -191,3 +202,14 @@ def _remove_or_refuse_preexisting_artifact(
 
 def _fail(reason_code: CanonicalDecisionFinalizationReason) -> None:
     raise CanonicalDecisionFinalizationError(reason_code)
+
+
+def _remove_or_refuse_preexisting_receipt(
+    payload: MutableMapping[str, Any],
+) -> None:
+    if "canonical_decision_trust_receipt" not in payload:
+        return
+    if payload["canonical_decision_trust_receipt"] is None:
+        del payload["canonical_decision_trust_receipt"]
+        return
+    _fail(CanonicalDecisionFinalizationReason.PREEXISTING_TRUST_RECEIPT_REFUSED)

--- a/veritas_os/tests/integration/test_decide_e2e_ext.py
+++ b/veritas_os/tests/integration/test_decide_e2e_ext.py
@@ -342,9 +342,14 @@ def patched_pipeline(monkeypatch, tmp_path):
     monkeypatch.setattr(api_pipeline, "build_dataset_record", fake_build_dataset_record, raising=False)
     monkeypatch.setattr(api_pipeline, "append_dataset_record", fake_append_dataset_record, raising=False)
 
-    # TrustLog → no-op
-    def fake_append_trust_log(entry: Dict[str, Any]) -> None:
-        return None
+    # TrustLog → deterministic returned-entry contract without filesystem I/O.
+    def fake_append_trust_log(entry: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            **entry,
+            "created_at": "2031-02-03T04:05:07+00:00",
+            "sha256_prev": None,
+            "sha256": "a" * 64,
+        }
 
     def fake_write_shadow_decide(
         request_id: str,
@@ -562,6 +567,12 @@ async def test_run_decide_pipeline_happy_path(patched_pipeline):
     assert verify_canonical_decision_artifact(
         payload["canonical_decision_artifact"]
     ).is_valid
+    receipt = payload["canonical_decision_trust_receipt"]
+    artifact = payload["canonical_decision_artifact"]
+    assert receipt["request_id"] == artifact["request_id"]
+    assert receipt["canonical_decision_id"] == artifact["decision_id"]
+    assert receipt["canonical_decision_hash"] == artifact["decision_hash"]
+    assert receipt["canonical_decision_ts"] == artifact["decision_ts"]
 
     # metrics / extras contract（壊れやすいので最低限の存在を担保）
     extras = payload.get("extras") or {}
@@ -1142,6 +1153,12 @@ async def test_run_decide_pipeline_trustlog_and_shadow_exception_swallowed(monke
 
     assert isinstance(payload, dict)
     assert payload.get("ok") is True
+    assert verify_canonical_decision_artifact(
+        payload["canonical_decision_artifact"]
+    ).is_valid
+    assert "canonical_decision_trust_receipt" not in payload
+    degraded = payload["extras"]["metrics"]["degraded_stages"]
+    assert "canonical_trust_link:TRUSTLOG_APPEND_FAILED" in degraded
 
     extras = payload.get("extras") or {}
     metrics = extras.get("metrics") or {}
@@ -1311,6 +1328,52 @@ async def test_cda_finalization_failure_blocks_persistence(
 
     assert exc.value.reason_code is reason
     assert persistence_calls == 0
+
+
+@pytest.mark.anyio
+async def test_cda_source_drift_blocks_canonical_trust_link(
+    monkeypatch,
+    patched_pipeline,
+):
+    """A failed post-persistence drift guard prevents every link attempt."""
+    pipeline = patched_pipeline
+    link_calls = 0
+
+    def fail_drift(payload, artifact):
+        del payload, artifact
+        raise CanonicalDecisionFinalizationError(
+            CanonicalDecisionFinalizationReason.DECISION_SOURCE_DRIFT
+        )
+
+    def count_link(*args, **kwargs):
+        del args, kwargs
+        nonlocal link_calls
+        link_calls += 1
+
+    monkeypatch.setattr(
+        pipeline,
+        "verify_canonical_decision_source_unchanged",
+        fail_drift,
+    )
+    monkeypatch.setattr(
+        pipeline,
+        "record_canonical_decision_trust_link",
+        count_link,
+    )
+
+    with pytest.raises(CanonicalDecisionFinalizationError) as exc:
+        await pipeline.run_decide_pipeline(
+            DummyReqModel(
+                {"query": "drift before link", "context": {"user_id": "u-drift"}}
+            ),
+            DummyRequest(),
+        )
+
+    assert (
+        exc.value.reason_code
+        is CanonicalDecisionFinalizationReason.DECISION_SOURCE_DRIFT
+    )
+    assert link_calls == 0
 
 
 @pytest.mark.anyio

--- a/veritas_os/tests/test_canonical_decision_finalization.py
+++ b/veritas_os/tests/test_canonical_decision_finalization.py
@@ -101,6 +101,54 @@ def test_request_id_is_refused_before_model_validation(monkeypatch) -> None:
     assert validation_calls == 0
 
 
+def test_null_canonical_fields_are_removed_before_stage_8() -> None:
+    """Optional response nulls must not cross the persistence boundary."""
+    payload = _payload()
+    payload["canonical_decision_artifact"] = None
+    payload["canonical_decision_trust_receipt"] = None
+
+    finalization.finalize_canonical_decision_artifact(
+        payload,
+        decision_ts=DECISION_TS,
+    )
+    finalization.require_stage_8_payload_without_canonical_artifact(payload)
+
+    assert "canonical_decision_artifact" not in payload
+    assert "canonical_decision_trust_receipt" not in payload
+
+
+def test_non_null_trust_receipt_is_refused_before_stage_8() -> None:
+    """A preexisting receipt cannot be silently accepted or overwritten."""
+    payload = _payload()
+    payload["canonical_decision_trust_receipt"] = {"unexpected": "receipt"}
+
+    with pytest.raises(finalization.CanonicalDecisionFinalizationError) as exc:
+        finalization.finalize_canonical_decision_artifact(
+            payload,
+            decision_ts=DECISION_TS,
+        )
+
+    _assert_reason(
+        exc,
+        finalization.CanonicalDecisionFinalizationReason.PREEXISTING_TRUST_RECEIPT_REFUSED,
+    )
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["canonical_decision_artifact", "canonical_decision_trust_receipt"],
+)
+def test_stage_8_guard_rejects_canonical_keys_even_when_null(field: str) -> None:
+    """The explicit Stage 8 guard rejects presence, not merely non-null data."""
+    payload = _payload()
+    payload.pop("canonical_decision_artifact", None)
+    payload.pop("canonical_decision_trust_receipt", None)
+    payload[field] = None
+
+    with pytest.raises(finalization.CanonicalDecisionFinalizationError):
+        finalization.require_stage_8_payload_without_canonical_artifact(payload)
+
+
 def test_null_preexisting_artifact_is_removed_before_finalization() -> None:
     payload = _payload()
     assert payload["canonical_decision_artifact"] is None

--- a/veritas_os/tests/test_canonical_decision_trust_link.py
+++ b/veritas_os/tests/test_canonical_decision_trust_link.py
@@ -8,8 +8,10 @@ from pathlib import Path
 
 import pytest
 
+from veritas_os.audit import trustlog_signed
 from veritas_os.api.schemas import DecideResponse
 from veritas_os.audit.canonical_decision_trust_link import (
+    CanonicalDecisionTrustReceipt,
     CanonicalDecisionTrustLinkError,
     CanonicalDecisionTrustLinkReason,
     build_canonical_decision_reference,
@@ -19,6 +21,10 @@ from veritas_os.audit.canonical_decision_trust_link import (
 from veritas_os.governance.canonical_decision_artifact import (
     build_canonical_decision_artifact,
 )
+from veritas_os.audit.trustlog_verify import verify_full_ledger, verify_trustlogs
+from veritas_os.logging import paths as log_paths
+from veritas_os.logging import trust_log
+from veritas_os.logging.encryption import decrypt, encrypt, generate_key
 
 ROOT = Path(__file__).resolve().parents[2]
 VECTOR = (
@@ -119,6 +125,72 @@ def test_receipt_hash_substitution_is_detected() -> None:
     assert not verify_canonical_decision_trust_entry(artifact, changed, entry).ok
 
 
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("format_version", "invalid"),
+        ("ledger", "invalid"),
+        ("event_type", "invalid"),
+    ],
+)
+def test_invalid_copied_receipt_model_is_revalidated(
+    field: str,
+    value: str,
+) -> None:
+    """Typed model copies cannot bypass receipt constant validation."""
+    artifact = _artifact()
+    receipt = record_canonical_decision_trust_link(
+        artifact, append_trust_log_fn=_append
+    )
+    invalid_model = receipt.model_copy(update={field: value})
+    entry = _append(
+        {
+            "event_type": "canonical_decision_link",
+            "audit_schema_version": "canonical_decision_trust_link/v1",
+            "request_id": artifact.request_id,
+            "pipeline_phase": "post_persistence_drift_verified",
+            "canonical_decision_ref": build_canonical_decision_reference(
+                artifact
+            ).model_dump(mode="json"),
+        }
+    )
+
+    result = verify_canonical_decision_trust_entry(artifact, invalid_model, entry)
+
+    assert result.ok is False
+    assert result.reason_codes == ("TRUSTLOG_RECEIPT_INVALID",)
+
+
+def test_constructed_receipt_model_is_revalidated() -> None:
+    """A model_construct instance is normalized and validated from raw JSON."""
+    artifact = _artifact()
+    valid = record_canonical_decision_trust_link(
+        artifact, append_trust_log_fn=_append
+    )
+    invalid_model = CanonicalDecisionTrustReceipt.model_construct(
+        **{
+            **valid.model_dump(mode="json"),
+            "format_version": "invalid",
+        }
+    )
+    entry = _append(
+        {
+            "event_type": "canonical_decision_link",
+            "audit_schema_version": "canonical_decision_trust_link/v1",
+            "request_id": artifact.request_id,
+            "pipeline_phase": "post_persistence_drift_verified",
+            "canonical_decision_ref": build_canonical_decision_reference(
+                artifact
+            ).model_dump(mode="json"),
+        }
+    )
+
+    result = verify_canonical_decision_trust_entry(artifact, invalid_model, entry)
+
+    assert result.ok is False
+    assert result.reason_codes == ("TRUSTLOG_RECEIPT_INVALID",)
+
+
 def test_redaction_change_refuses_receipt() -> None:
     artifact = _artifact()
 
@@ -133,3 +205,110 @@ def test_redaction_change_refuses_receipt() -> None:
         exc.value.reason_code
         is CanonicalDecisionTrustLinkReason.TRUSTLOG_REFERENCE_MISMATCH
     )
+
+
+def _isolate_real_trustlog(tmp_path: Path, monkeypatch) -> tuple[Path, Path]:
+    """Redirect the production full and witness ledgers into a temporary root."""
+    log_dir = tmp_path / "logs"
+    full_path = log_dir / "trust_log.jsonl"
+    aggregate_path = log_dir / "trust_log.json"
+    witness_path = log_dir / "trustlog.jsonl"
+    key_dir = log_dir / "keys"
+    monkeypatch.setenv("VERITAS_ENCRYPTION_KEY", generate_key())
+    monkeypatch.setenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", "file")
+    monkeypatch.setattr(log_paths, "LOG_DIR", log_dir)
+    monkeypatch.setattr(log_paths, "LOG_JSONL", full_path)
+    monkeypatch.setattr(log_paths, "LOG_JSON", aggregate_path)
+    monkeypatch.setattr(trust_log, "LOG_DIR", log_dir)
+    monkeypatch.setattr(trust_log, "LOG_JSONL", full_path)
+    monkeypatch.setattr(trust_log, "LOG_JSON", aggregate_path)
+    monkeypatch.setattr(trustlog_signed, "SIGNED_TRUSTLOG_JSONL", witness_path)
+    monkeypatch.setattr(trustlog_signed, "SIGNED_TRUSTLOG_KEYS", key_dir)
+    monkeypatch.setattr(
+        trustlog_signed,
+        "PRIVATE_KEY_PATH",
+        key_dir / "trustlog_ed25519_private.key",
+    )
+    monkeypatch.setattr(
+        trustlog_signed,
+        "PUBLIC_KEY_PATH",
+        key_dir / "trustlog_ed25519_public.key",
+    )
+    return full_path, witness_path
+
+
+def _read_full_rows(path: Path) -> list[dict]:
+    return [
+        json.loads(decrypt(line))
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line
+    ]
+
+
+def _read_witness_rows(path: Path) -> list[dict]:
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line
+    ]
+
+
+def test_real_full_ledger_and_signed_witness_linkage(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Exercise the encrypted production append and exact signed-row linkage."""
+    full_path, witness_path = _isolate_real_trustlog(tmp_path, monkeypatch)
+    artifact = _artifact()
+
+    receipt = record_canonical_decision_trust_link(
+        artifact,
+        append_trust_log_fn=trust_log.append_trust_log,
+    )
+    full_rows = _read_full_rows(full_path)
+    link_row = next(
+        row for row in full_rows if row["sha256"] == receipt.trust_log_entry_sha256
+    )
+    reference = build_canonical_decision_reference(artifact).model_dump(mode="json")
+    witness_rows = _read_witness_rows(witness_path)
+    locator = "sha256:" + receipt.trust_log_entry_sha256
+    witness_row = next(
+        row
+        for row in witness_rows
+        if row.get("artifact_ref", {}).get("artifact_storage_backend")
+        == "trustlog_full_ledger"
+        and row.get("artifact_ref", {}).get("artifact_locator") == locator
+    )
+
+    assert receipt.trust_log_entry_sha256 == link_row["sha256"]
+    assert receipt.trust_log_entry_sha256_prev == link_row["sha256_prev"]
+    assert receipt.trust_log_created_at == link_row["created_at"]
+    assert receipt.trust_log_entry_sha256 != artifact.decision_hash
+    assert link_row["canonical_decision_ref"] == reference
+    assert witness_row["artifact_ref"]["artifact_locator"] == locator
+    full_result = verify_full_ledger(full_path)
+    assert full_result["ok"] is True
+    assert full_result["chain_ok"] is True
+    unified = verify_trustlogs(
+        full_log_path=full_path,
+        witness_entries=witness_rows,
+        verify_signature_fn=trustlog_signed.verify_signature,
+        artifact_search_roots=[full_path.parent],
+    )
+    assert unified["signature_ok"] is True
+    assert unified["linkage_ok"] is True
+
+    link_row["canonical_decision_ref"]["decision_hash"] = "0" * 64
+    full_path.write_text(
+        "\n".join(encrypt(json.dumps(row)) for row in full_rows) + "\n",
+        encoding="utf-8",
+    )
+    tampered = verify_trustlogs(
+        full_log_path=full_path,
+        witness_entries=witness_rows,
+        verify_signature_fn=trustlog_signed.verify_signature,
+        artifact_search_roots=[full_path.parent],
+    )
+    assert tampered["ok"] is False
+    assert tampered["full_ledger"]["chain_ok"] is False
+    assert tampered["witness_ledger"]["linkage_ok"] is False

--- a/veritas_os/tests/test_canonical_decision_trust_link.py
+++ b/veritas_os/tests/test_canonical_decision_trust_link.py
@@ -1,0 +1,135 @@
+"""Canonical Decision Artifact to TrustLog exact-link tests."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from veritas_os.api.schemas import DecideResponse
+from veritas_os.audit.canonical_decision_trust_link import (
+    CanonicalDecisionTrustLinkError,
+    CanonicalDecisionTrustLinkReason,
+    build_canonical_decision_reference,
+    record_canonical_decision_trust_link,
+    verify_canonical_decision_trust_entry,
+)
+from veritas_os.governance.canonical_decision_artifact import (
+    build_canonical_decision_artifact,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+VECTOR = (
+    ROOT
+    / "docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-01.json"
+)
+
+
+def _artifact():
+    vector = json.loads(VECTOR.read_text())
+    source = DecideResponse.model_validate(vector["source_projection"])
+    return build_canonical_decision_artifact(
+        source,
+        decision_ts=datetime(2031, 2, 3, 4, 5, 6, 123456, tzinfo=timezone.utc),
+    )
+
+
+def _append(event):
+    return {
+        **event,
+        "created_at": "2031-02-03T04:05:07+00:00",
+        "sha256_prev": None,
+        "sha256": "a" * 64,
+    }
+
+
+def test_record_builds_exact_reference_and_domain_separated_receipt() -> None:
+    artifact = _artifact()
+    reference = build_canonical_decision_reference(artifact)
+    receipt = record_canonical_decision_trust_link(
+        artifact, append_trust_log_fn=_append
+    )
+    entry = _append(
+        {
+            "event_type": "canonical_decision_link",
+            "audit_schema_version": "canonical_decision_trust_link/v1",
+            "request_id": artifact.request_id,
+            "pipeline_phase": "post_persistence_drift_verified",
+            "canonical_decision_ref": reference.model_dump(mode="json"),
+        }
+    )
+
+    assert reference.request_id == artifact.request_id
+    assert receipt.canonical_decision_hash == artifact.decision_hash
+    assert receipt.trust_log_entry_sha256 != artifact.decision_hash
+    assert verify_canonical_decision_trust_entry(artifact, receipt, entry).ok
+
+
+@pytest.mark.parametrize("field", ["decision_hash", "decision_id", "decision_ts"])
+def test_reference_substitution_is_detected(field: str) -> None:
+    artifact = _artifact()
+    captured = _append(
+        {
+            "event_type": "canonical_decision_link",
+            "audit_schema_version": "canonical_decision_trust_link/v1",
+            "request_id": artifact.request_id,
+            "pipeline_phase": "post_persistence_drift_verified",
+            "canonical_decision_ref": build_canonical_decision_reference(
+                artifact
+            ).model_dump(mode="json"),
+        }
+    )
+    receipt = record_canonical_decision_trust_link(
+        artifact, append_trust_log_fn=_append
+    )
+    captured["canonical_decision_ref"][field] = "0" * 64
+
+    assert not verify_canonical_decision_trust_entry(artifact, receipt, captured).ok
+
+
+def test_request_substitution_refuses_receipt() -> None:
+    artifact = _artifact()
+
+    def substitute(event):
+        return _append({**event, "request_id": "substituted"})
+
+    with pytest.raises(CanonicalDecisionTrustLinkError) as exc:
+        record_canonical_decision_trust_link(artifact, append_trust_log_fn=substitute)
+    assert exc.value.reason_code is CanonicalDecisionTrustLinkReason.REQUEST_ID_MISMATCH
+
+
+def test_receipt_hash_substitution_is_detected() -> None:
+    artifact = _artifact()
+    event = {
+        "event_type": "canonical_decision_link",
+        "audit_schema_version": "canonical_decision_trust_link/v1",
+        "request_id": artifact.request_id,
+        "pipeline_phase": "post_persistence_drift_verified",
+        "canonical_decision_ref": build_canonical_decision_reference(
+            artifact
+        ).model_dump(mode="json"),
+    }
+    entry = _append(event)
+    receipt = record_canonical_decision_trust_link(
+        artifact, append_trust_log_fn=_append
+    )
+    changed = receipt.model_copy(update={"trust_log_entry_sha256": "b" * 64})
+    assert not verify_canonical_decision_trust_entry(artifact, changed, entry).ok
+
+
+def test_redaction_change_refuses_receipt() -> None:
+    artifact = _artifact()
+
+    def redact(event):
+        entry = _append(event)
+        entry["canonical_decision_ref"]["request_id"] = "[REDACTED]"
+        return entry
+
+    with pytest.raises(CanonicalDecisionTrustLinkError) as exc:
+        record_canonical_decision_trust_link(artifact, append_trust_log_fn=redact)
+    assert (
+        exc.value.reason_code
+        is CanonicalDecisionTrustLinkReason.TRUSTLOG_REFERENCE_MISMATCH
+    )


### PR DESCRIPTION
### Motivation

- Provide an independently verifiable evidence link between a verified Canonical Decision Artifact v1 (CDA) and the existing encrypted TrustLog without persisting the full CDA into the ledger.
- Ensure the TrustLog commitment is written only after the post-persistence CDA source-drift guard (`verify_canonical_decision_source_unchanged`) succeeds.
- Preserve existing CDA hash/ID semantics and pipeline/replay/handoff boundaries while enabling offline cross-object verification.

### Description

- Add a new trust-link module `veritas_os.audit.canonical_decision_trust_link` that defines strict frozen models `CanonicalDecisionReference` and `CanonicalDecisionTrustReceipt`, stable error reasons, `build_canonical_decision_reference`, `record_canonical_decision_trust_link`, and pure verifier `verify_canonical_decision_trust_entry`.
- Build a compact `canonical-decision-reference/v1` only from an internally verified CDA and bind the exact CDA `request_id`, `decision_id`, `decision_hash`, `decision_ts`, artifact format version, and hash profile.
- Revalidate every receipt input from raw JSON even when the caller supplies an existing Pydantic model instance, preventing `model_copy(...)` / `model_construct(...)` instances from bypassing receipt validation. The verifier also explicitly rechecks receipt version, ledger, and event-type constants.
- Append a dedicated TrustLog event `canonical_decision_link` containing only the compact CDA reference—not the full CDA—through the existing production `append_trust_log` path.
- Validate the actual returned encrypted full-ledger entry after append, including exact reference matching, `request_id`, event/schema/phase, `sha256`, `sha256_prev`, and `created_at`, before issuing any receipt.
- Return a `canonical-decision-trust-receipt/v1` that identifies the actual encrypted full-ledger row while keeping CDA `decision_hash`, TrustLog chain `sha256`, signed-witness `payload_hash`, and signed-witness `full_payload_hash` as separate cryptographic domains.
- Integrate at the pipeline post-Stage-8 boundary: after `verify_canonical_decision_source_unchanged(...)` the pipeline runs a dedicated `trace_session.stage("canonical_trust_link")`, records a degraded-stage indicator on link failure, then attaches the original CDA and attaches the trust receipt only when the link succeeded.
- Extend the Stage 8 boundary so neither `canonical_decision_artifact` nor `canonical_decision_trust_receipt` may enter persistence, even as null-valued keys. Null compatibility fields are removed before Stage 8 and preexisting non-null receipts fail closed.
- Reuse the existing TrustLog architecture rather than creating a new ledger: encrypted full-ledger hash chaining remains authoritative for the row, and the existing signed witness continues to commit to that exact full row through `full_payload_hash` plus `artifact_ref = sha256:<full-ledger-sha256>`.
- Add closed JSON Schema `schemas/canonical-decision-trust-receipt-v1.schema.json`, architecture documentation, focused trust-link tests, real production TrustLog integration coverage, and pipeline integration coverage.
- Keep replay semantics unchanged. Replay evidence linkage remains a separate future milestone because replay executions form distinct live CDA timestamps/identities.

### Security / non-claims

Receipt presence means only that the dedicated canonical-decision link was appended to the local encrypted full ledger and that the returned row exactly matched the expected CDA reference.

It does **not** by itself establish:
- trusted producer provenance;
- complete full-ledger chain integrity;
- signed-witness signer trust or chain integrity;
- WORM/object-lock integrity;
- transparency-anchor validity;
- replay equivalence or replay proof;
- `CanonicalDecisionHandoff` readiness;
- Authority Evidence or Human Approval verification;
- `ExecutionIntent` creation;
- Bind authorization or execution authority;
- production/customer/regulatory certification.

The CDA decision hash, encrypted full-ledger row hash, signed-witness compact-payload hash, and signed-witness full-payload hash remain intentionally separate domains.

### Testing

Latest head: `70feed1657930c184ad38cce8122ee286d042962`.

GitHub CI #5040 completed successfully on the latest head. Confirmed successful jobs/workflows include:
- full test suite on Python 3.11;
- full test suite on Python 3.12;
- PostgreSQL parity/contention tests;
- slow tests;
- governance backend fast checks;
- governance smoke checks;
- lint and responsibility-boundary checks;
- dependency audit and future-dependency compatibility;
- frontend test, lint, and E2E;
- Security Gates;
- CodeQL (custom);
- Runtime Proof Evidence;
- Runtime Pickle Guard (Required);
- Reviewer Evidence Packet Validation.

Focused coverage now includes:
- receipt revalidation for adversarial `model_copy(...)` mutations of `format_version`, `ledger`, and `event_type`;
- receipt revalidation for a `model_construct(...)` validation-bypass instance;
- request ID, decision hash, decision ID, decision timestamp, receipt hash, and returned-entry/reference substitution detection;
- TrustLog redaction/reference mutation refusal;
- real production `append_trust_log` execution against isolated encrypted full-ledger storage;
- exact receipt binding to the real full-ledger `sha256`, `sha256_prev`, and `created_at`;
- explicit CDA hash vs. TrustLog row-hash domain separation;
- real `verify_full_ledger(...)` success and chain integrity;
- exact signed-witness correlation through `artifact_ref.artifact_locator = sha256:<full-ledger-sha256>`;
- signed-witness signature and artifact-linkage verification through the existing unified verifier;
- controlled tampering detection causing both full-ledger chain failure and signed-witness linkage failure;
- real pipeline CDA/trust-receipt cross-binding;
- canonical TrustLog append failure preserving the CDA, emitting no fabricated receipt, and recording `canonical_trust_link:<REASON>` degradation;
- source-drift failure preventing any canonical trust-link append;
- Stage 8 receiving neither CDA nor trust-receipt keys, including null-valued compatibility fields;
- preexisting non-null trust receipt fail-closed behavior.

Replay, handoff, `ExecutionIntent`, and Bind behavior are intentionally unchanged by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a807553ddb0832687cc6a9c49e363a0)