### PR TITLE
feat(replay): add canonical replay source and evidence linkage v1

### DIFF
--- a/veritas_os/api/routes_decide.py
+++ b/veritas_os/api/routes_decide.py
@@ -42,6 +42,7 @@ from veritas_os.security.wat_token import (
 from veritas_os.security.wat_verifier import validate_local
 from veritas_os.security.signing import Signer, build_trustlog_signer
 from veritas_os.logging.paths import LOG_DIR
+from veritas_os.replay.canonical_replay import CanonicalReplayError
 from veritas_os.api.utils import (
     _classify_decide_failure,
     _coerce_decide_payload,
@@ -645,10 +646,32 @@ async def replay_endpoint(decision_id: str, request: Request):
     )
     try:
         result = await srv.run_replay(decision_id=decision_id)
-    except ValueError:
+    except CanonicalReplayError:
         return JSONResponse(
-            status_code=404,
-            content={"ok": False, "decision_id": decision_id, "error": "decision_not_found"},
+            status_code=409,
+            content={
+                "ok": False,
+                "decision_id": decision_id,
+                "error": "canonical_replay_source_invalid",
+            },
+        )
+    except ValueError as exc:
+        reason = str(exc)
+        if reason.startswith("decision_not_found") or reason == "not found":
+            status_code = 404
+            error = "decision_not_found"
+        elif reason.startswith("replay_model_version"):
+            status_code = 409
+            error = "model_version_mismatch"
+        elif reason.startswith("replay_retrieval_snapshot_checksum"):
+            status_code = 409
+            error = "retrieval_checksum_mismatch"
+        else:
+            status_code = 500
+            error = "replay_internal_failure"
+        return JSONResponse(
+            status_code=status_code,
+            content={"ok": False, "decision_id": decision_id, "error": error},
         )
     except Exception as e:
         logger.error("replay endpoint failed: %s", _errstr(e))

--- a/veritas_os/api/routes_decide.py
+++ b/veritas_os/api/routes_decide.py
@@ -657,7 +657,12 @@ async def replay_endpoint(decision_id: str, request: Request):
         )
     except ValueError as exc:
         reason = str(exc)
-        if reason.startswith("decision_not_found") or reason == "not found":
+        normalized_reason = reason.strip().lower()
+        if (
+            normalized_reason.startswith("decision_not_found")
+            or normalized_reason.startswith("decision not found")
+            or normalized_reason == "not found"
+        ):
             status_code = 404
             error = "decision_not_found"
         elif reason.startswith("replay_model_version"):
@@ -691,9 +696,13 @@ async def replay_endpoint(decision_id: str, request: Request):
         "severity": result.severity,
         "divergence_level": result.divergence_level,
         "audit_summary": result.audit_summary,
-        "replay_request_id": result.replay_request_id,
-        "replay_cda_id": result.replay_cda_id,
-        "canonical_replay_evidence": result.canonical_replay_evidence,
+        "replay_request_id": getattr(result, "replay_request_id", ""),
+        "replay_cda_id": getattr(result, "replay_cda_id", ""),
+        "canonical_replay_evidence": getattr(
+            result,
+            "canonical_replay_evidence",
+            None,
+        ),
     }
 
 

--- a/veritas_os/api/routes_decide.py
+++ b/veritas_os/api/routes_decide.py
@@ -668,6 +668,9 @@ async def replay_endpoint(decision_id: str, request: Request):
         "severity": result.severity,
         "divergence_level": result.divergence_level,
         "audit_summary": result.audit_summary,
+        "replay_request_id": result.replay_request_id,
+        "replay_cda_id": result.replay_cda_id,
+        "canonical_replay_evidence": result.canonical_replay_evidence,
     }
 
 

--- a/veritas_os/api/schemas.py
+++ b/veritas_os/api/schemas.py
@@ -1159,6 +1159,13 @@ class DecideResponse(BaseModel):
             "ledger-chain and signed-witness verification remain separate."
         ),
     )
+    canonical_replay_source_receipt: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description=(
+            "Canonical Replay Source v1 encrypted-persistence receipt. It "
+            "contains no filesystem location and grants no authority."
+        ),
+    )
 
     # Governance identity: which governance artifact was in force for this decision.
     governance_identity: Optional[Dict[str, Any]] = Field(

--- a/veritas_os/core/pipeline/__init__.py
+++ b/veritas_os/core/pipeline/__init__.py
@@ -238,6 +238,11 @@ from ...audit.canonical_decision_trust_link import (
     CanonicalDecisionTrustLinkError,
     record_canonical_decision_trust_link,
 )
+from ...replay.canonical_replay import (
+    build_replay_source,
+    load_replay_source,
+    persist_replay_source,
+)
 from .pipeline_replay import (
     _safe_filename_id,  # noqa: F401 – backward compat
     _sanitize_for_diff,  # noqa: F401 – backward compat
@@ -417,6 +422,7 @@ def _get_memory_store() -> Optional[Any]:
 # _safe_paths, EVIDENCE_MAX, _SAFE_FILENAME_RE -> pipeline_persistence.py に移動済み
 LOG_DIR, DATASET_DIR, VAL_JSON, META_LOG = _safe_paths(_warn=_warn)
 REPLAY_REPORT_DIR = (REPO_ROOT / "audit" / "replay_reports").resolve()
+REPLAY_SOURCE_DIR = (REPO_ROOT / "audit" / "replay_sources").resolve()
 EVIDENCE_MAX = _resolve_evidence_max()
 
 # ★ Replay functions moved to pipeline_replay.py.
@@ -454,6 +460,10 @@ async def replay_decision(
         _HAS_ATOMIC_IO=_HAS_ATOMIC_IO,
         _atomic_write_json=_atomic_write_json,
         _load_decision_fn=_load_persisted_decision,
+        _load_replay_source_fn=lambda source_id: load_replay_source(
+            source_id,
+            REPLAY_SOURCE_DIR,
+        ),
     )
 
 
@@ -1035,6 +1045,27 @@ async def run_decide_pipeline(
         )
         if trust_receipt_payload is not None:
             payload["canonical_decision_trust_receipt"] = trust_receipt_payload
+        try:
+            replay_source = build_replay_source(payload)
+            replay_source_path = persist_replay_source(
+                replay_source,
+                REPLAY_SOURCE_DIR,
+            )
+        except (KeyError, TypeError, ValueError, OSError, RuntimeError) as exc:
+            _stage_failures.append(
+                f"canonical_replay_source:{type(exc).__name__}"
+            )
+            logger.warning(
+                "[pipeline] canonical replay source unavailable: %s",
+                type(exc).__name__,
+            )
+        else:
+            payload["canonical_replay_source"] = {
+                "format_version": replay_source.format_version,
+                "source_id": replay_source.source_id,
+                "storage": "encrypted",
+                "path": str(replay_source_path),
+            }
 
     # =================================================================
     # Observability: record pipeline health summary

--- a/veritas_os/core/pipeline/__init__.py
+++ b/veritas_os/core/pipeline/__init__.py
@@ -467,6 +467,29 @@ async def replay_decision(
     )
 
 
+def _persist_canonical_replay_source(
+    ctx: PipelineContext,
+    payload: Dict[str, Any],
+    stage_failures: List[str],
+) -> None:
+    """Persist an original-decision replay source, never a nested replay source."""
+    if ctx.replay_mode:
+        return
+    try:
+        replay_source = build_replay_source(payload)
+        receipt = persist_replay_source(replay_source, REPLAY_SOURCE_DIR)
+    except (KeyError, TypeError, ValueError, OSError, RuntimeError) as exc:
+        stage_failures.append(f"canonical_replay_source:{type(exc).__name__}")
+        logger.warning(
+            "[pipeline] canonical replay source unavailable: %s",
+            type(exc).__name__,
+        )
+    else:
+        payload["canonical_replay_source_receipt"] = receipt.model_dump(
+            mode="json"
+        )
+
+
 # =========================================================
 # Safe dataset writer (optional) -> pipeline_persistence.py に移動済み
 # =========================================================
@@ -1045,27 +1068,7 @@ async def run_decide_pipeline(
         )
         if trust_receipt_payload is not None:
             payload["canonical_decision_trust_receipt"] = trust_receipt_payload
-        try:
-            replay_source = build_replay_source(payload)
-            replay_source_path = persist_replay_source(
-                replay_source,
-                REPLAY_SOURCE_DIR,
-            )
-        except (KeyError, TypeError, ValueError, OSError, RuntimeError) as exc:
-            _stage_failures.append(
-                f"canonical_replay_source:{type(exc).__name__}"
-            )
-            logger.warning(
-                "[pipeline] canonical replay source unavailable: %s",
-                type(exc).__name__,
-            )
-        else:
-            payload["canonical_replay_source"] = {
-                "format_version": replay_source.format_version,
-                "source_id": replay_source.source_id,
-                "storage": "encrypted",
-                "path": str(replay_source_path),
-            }
+        _persist_canonical_replay_source(ctx, payload, _stage_failures)
 
     # =================================================================
     # Observability: record pipeline health summary

--- a/veritas_os/core/pipeline/canonical_decision_finalization.py
+++ b/veritas_os/core/pipeline/canonical_decision_finalization.py
@@ -31,6 +31,9 @@ class CanonicalDecisionFinalizationReason(str, Enum):
         "PREEXISTING_CANONICAL_ARTIFACT_REFUSED"
     )
     PREEXISTING_TRUST_RECEIPT_REFUSED = "PREEXISTING_TRUST_RECEIPT_REFUSED"
+    PREEXISTING_REPLAY_SOURCE_RECEIPT_REFUSED = (
+        "PREEXISTING_REPLAY_SOURCE_RECEIPT_REFUSED"
+    )
 
 
 class CanonicalDecisionFinalizationError(ValueError):
@@ -71,6 +74,7 @@ def finalize_canonical_decision_artifact(
 
     _remove_or_refuse_preexisting_artifact(payload)
     _remove_or_refuse_preexisting_receipt(payload)
+    _remove_or_refuse_preexisting_replay_source_receipt(payload)
 
     try:
         api_source = api_schemas.DecideResponse.model_validate(payload)
@@ -80,6 +84,7 @@ def finalize_canonical_decision_artifact(
 
     normalized.pop("canonical_decision_artifact", None)
     normalized.pop("canonical_decision_trust_receipt", None)
+    normalized.pop("canonical_replay_source_receipt", None)
     if api_source.request_id != raw_request_id:
         _fail(CanonicalDecisionFinalizationReason.REQUEST_ID_MISMATCH)
 
@@ -172,6 +177,10 @@ def attach_canonical_decision_artifact(
         )
     if "canonical_decision_trust_receipt" in payload:
         _fail(CanonicalDecisionFinalizationReason.PREEXISTING_TRUST_RECEIPT_REFUSED)
+    if "canonical_replay_source_receipt" in payload:
+        _fail(
+            CanonicalDecisionFinalizationReason.PREEXISTING_REPLAY_SOURCE_RECEIPT_REFUSED
+        )
     payload["canonical_decision_artifact"] = artifact.model_dump(mode="json")
 
 
@@ -185,6 +194,10 @@ def require_stage_8_payload_without_canonical_artifact(
         )
     if "canonical_decision_trust_receipt" in payload:
         _fail(CanonicalDecisionFinalizationReason.PREEXISTING_TRUST_RECEIPT_REFUSED)
+    if "canonical_replay_source_receipt" in payload:
+        _fail(
+            CanonicalDecisionFinalizationReason.PREEXISTING_REPLAY_SOURCE_RECEIPT_REFUSED
+        )
 
 
 def _remove_or_refuse_preexisting_artifact(
@@ -213,3 +226,17 @@ def _remove_or_refuse_preexisting_receipt(
         del payload["canonical_decision_trust_receipt"]
         return
     _fail(CanonicalDecisionFinalizationReason.PREEXISTING_TRUST_RECEIPT_REFUSED)
+
+
+def _remove_or_refuse_preexisting_replay_source_receipt(
+    payload: MutableMapping[str, Any],
+) -> None:
+    """Remove null source receipts and refuse non-null preexisting values."""
+    if "canonical_replay_source_receipt" not in payload:
+        return
+    if payload["canonical_replay_source_receipt"] is None:
+        del payload["canonical_replay_source_receipt"]
+        return
+    _fail(
+        CanonicalDecisionFinalizationReason.PREEXISTING_REPLAY_SOURCE_RECEIPT_REFUSED
+    )

--- a/veritas_os/core/pipeline/pipeline_inputs.py
+++ b/veritas_os/core/pipeline/pipeline_inputs.py
@@ -30,6 +30,7 @@ _PIPELINE_PRIVATE_PREFIXES = (
     "_world_sim_result",
 )
 _TEST_ONLY_PRE_BIND_SIGNAL_KEY = "pre_bind_participation_signal"
+_EXTERNAL_REPLAY_KEYS = {"_replay_mode", "_mock_external_apis"}
 
 
 def _to_bool(v: Any) -> bool:
@@ -92,7 +93,11 @@ def normalize_pipeline_inputs(
     injected = [
         k
         for k in list(context.keys())
-        if isinstance(k, str) and any(k.startswith(p) for p in _PIPELINE_PRIVATE_PREFIXES)
+        if isinstance(k, str)
+        and (
+            k in _EXTERNAL_REPLAY_KEYS
+            or any(k.startswith(p) for p in _PIPELINE_PRIVATE_PREFIXES)
+        )
     ]
     if injected:
         logger.warning(
@@ -102,8 +107,16 @@ def normalize_pipeline_inputs(
         for k in injected:
             context.pop(k, None)
 
-    replay_mode = bool(context.get("_replay_mode", False))
-    mock_external_apis = bool(context.get("_mock_external_apis", replay_mode))
+    from veritas_os.replay.canonical_replay import TRUSTED_REPLAY_MARKER
+
+    trusted_replay = (
+        getattr(request, "_veritas_replay_marker", None)
+        is TRUSTED_REPLAY_MARKER
+    )
+    replay_mode = trusted_replay
+    mock_external_apis = bool(
+        getattr(request, "_veritas_mock_external_apis", replay_mode)
+    ) if trusted_replay else False
     if replay_mode:
         body["temperature"] = body.get("temperature", 0)
 

--- a/veritas_os/core/pipeline/pipeline_replay.py
+++ b/veritas_os/core/pipeline/pipeline_replay.py
@@ -17,6 +17,7 @@ from typing import Any, Dict, Optional
 from ..utils import utc_now_iso_z
 from veritas_os.replay.canonical_replay import TRUSTED_REPLAY_MARKER
 from veritas_os.replay.canonical_replay import ReplayControls, build_replay_evidence
+from veritas_os.replay.semantic_profile import semantic_projection
 
 
 # ★ パストラバーサル防止
@@ -41,6 +42,7 @@ def _sanitize_for_diff(value: Any) -> Any:
             "canonical_decision_artifact",
             "canonical_decision_trust_receipt",
             "canonical_replay_source",
+            "canonical_replay_source_receipt",
         }
         return {
             str(k): _sanitize_for_diff(v)
@@ -75,6 +77,8 @@ def _build_replay_diff(
         "decision": "critical",
         "fuji": "critical",
         "value_scores": "warning",
+        "continuation_state": "warning",
+        "continuation_receipt": "warning",
     }
     field_severities = [_severity_map.get(k, "info") for k in changed_keys]
     max_severity = (
@@ -202,7 +206,10 @@ async def replay_decision(
     original_output = replay_meta.get("final_output") or {}
     if not isinstance(original_output, dict):
         original_output = {}
-    diff = _build_replay_diff(original_output, replay_output)
+    diff = _build_replay_diff(
+        semantic_projection(original_output),
+        semantic_projection(replay_output),
+    )
     match = not bool(diff.get("changed"))
 
     report = {
@@ -219,11 +226,19 @@ async def replay_decision(
             seed=int(req_body.get("seed", 0) or 0),
             temperature=float(req_body.get("temperature", 0) or 0),
         )
-        report["canonical_replay_evidence"] = build_replay_evidence(
+        evidence = build_replay_evidence(
             source,
             replay_output,
             controls,
-        ).model_dump(mode="json")
+        )
+        if (
+            evidence.semantic_match != match
+            or list(evidence.fields_changed) != diff["keys"]
+            or evidence.severity != diff["severity"]
+            or evidence.divergence_level != diff["divergence_level"]
+        ):
+            raise ValueError("canonical replay semantic comparison mismatch")
+        report["canonical_replay_evidence"] = evidence.model_dump(mode="json")
 
     try:
         Path(REPLAY_REPORT_DIR).mkdir(parents=True, exist_ok=True)

--- a/veritas_os/core/pipeline/pipeline_replay.py
+++ b/veritas_os/core/pipeline/pipeline_replay.py
@@ -10,10 +10,13 @@ from __future__ import annotations
 import json
 import re
 import time
+from uuid import uuid4
 from pathlib import Path
 from typing import Any, Dict, Optional
 
 from ..utils import utc_now_iso_z
+from veritas_os.replay.canonical_replay import TRUSTED_REPLAY_MARKER
+from veritas_os.replay.canonical_replay import ReplayControls, build_replay_evidence
 
 
 # ★ パストラバーサル防止
@@ -34,6 +37,10 @@ def _sanitize_for_diff(value: Any) -> Any:
             "stage_latency",
             "replay_time_ms",
             "ts",
+            "request_id",
+            "canonical_decision_artifact",
+            "canonical_decision_trust_receipt",
+            "canonical_replay_source",
         }
         return {
             str(k): _sanitize_for_diff(v)
@@ -119,8 +126,10 @@ def _load_persisted_decision(
 class _ReplayRequest:
     """Minimal Request-like object accepted by run_decide_pipeline during replay."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, mock_external_apis: bool = True) -> None:
         self.query_params: Dict[str, Any] = {}
+        self._veritas_replay_marker = TRUSTED_REPLAY_MARKER
+        self._veritas_mock_external_apis = mock_external_apis
 
 
 async def replay_decision(
@@ -134,10 +143,20 @@ async def replay_decision(
     _HAS_ATOMIC_IO: bool = False,
     _atomic_write_json: Any = None,
     _load_decision_fn: Any = None,
+    _load_replay_source_fn: Any = None,
 ) -> Dict[str, Any]:
     """Replay a persisted decision deterministically and generate an audit diff report."""
     started_at = time.time()
-    if _load_decision_fn is not None:
+    source = (
+        _load_replay_source_fn(decision_id)
+        if _load_replay_source_fn is not None
+        else None
+    )
+    if source is not None:
+        replay_meta = source.deterministic_replay
+        source_output = replay_meta.get("final_output")
+        snapshot = source_output if isinstance(source_output, dict) else {}
+    elif _load_decision_fn is not None:
         snapshot = _load_decision_fn(decision_id)
     else:
         snapshot = _load_persisted_decision(decision_id, LOG_DIR=LOG_DIR)
@@ -148,7 +167,11 @@ async def replay_decision(
             "replay_time_ms": max(1, int((time.time() - started_at) * 1000)),
         }
 
-    replay_meta = snapshot.get("deterministic_replay") or {}
+    replay_meta = (
+        source.deterministic_replay
+        if source is not None
+        else snapshot.get("deterministic_replay") or {}
+    )
     req_body = replay_meta.get("request_body") or {}
     if not isinstance(req_body, dict):
         req_body = {}
@@ -159,7 +182,7 @@ async def replay_decision(
         ctx = {}
         req_body["context"] = ctx
 
-    req_body["request_id"] = str(snapshot.get("request_id") or decision_id)
+    req_body["request_id"] = str(uuid4())
     req_body["seed"] = replay_meta.get("seed", req_body.get("seed", 0))
     req_body["temperature"] = replay_meta.get(
         "temperature", req_body.get("temperature", 0)
@@ -172,7 +195,10 @@ async def replay_decision(
     else:
         replay_req = req_body
 
-    replay_output = await run_decide_pipeline_fn(replay_req, _ReplayRequest())
+    replay_output = await run_decide_pipeline_fn(
+        replay_req,
+        _ReplayRequest(mock_external_apis=bool(mock_external_apis)),
+    )
     original_output = replay_meta.get("final_output") or {}
     if not isinstance(original_output, dict):
         original_output = {}
@@ -186,6 +212,18 @@ async def replay_decision(
         "replay_time_ms": max(1, int((time.time() - started_at) * 1000)),
         "created_at": utc_now_iso_z(),
     }
+    if source is not None and isinstance(replay_output, dict):
+        controls = ReplayControls(
+            strict=bool(mock_external_apis),
+            mock_external_apis=bool(mock_external_apis),
+            seed=int(req_body.get("seed", 0) or 0),
+            temperature=float(req_body.get("temperature", 0) or 0),
+        )
+        report["canonical_replay_evidence"] = build_replay_evidence(
+            source,
+            replay_output,
+            controls,
+        ).model_dump(mode="json")
 
     try:
         Path(REPLAY_REPORT_DIR).mkdir(parents=True, exist_ok=True)
@@ -206,4 +244,5 @@ async def replay_decision(
         "match": report["match"],
         "diff": report["diff"],
         "replay_time_ms": report["replay_time_ms"],
+        "canonical_replay_evidence": report.get("canonical_replay_evidence"),
     }

--- a/veritas_os/replay/canonical_replay.py
+++ b/veritas_os/replay/canonical_replay.py
@@ -1,29 +1,35 @@
-"""Canonical Replay Source and Evidence v1.
-
-These content-addressed artifacts prove replay linkage and semantic comparison
-only.  They confer no execution authority and deliberately keep the original
-decision identity separate from the replay execution identity.
-"""
+"""Canonical Replay Source and Evidence v1 without execution authority."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+from enum import Enum
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
+from veritas_os.audit.canonical_decision_trust_link import (
+    CanonicalDecisionTrustReceipt,
+)
 from veritas_os.core.atomic_io import atomic_write_text
 from veritas_os.governance.canonical_decision_artifact import (
     CanonicalDecisionArtifact,
     verify_canonical_decision_artifact,
 )
 from veritas_os.logging.encryption import decrypt, encrypt
+from veritas_os.replay.semantic_profile import (
+    SEMANTIC_PROFILE,
+    semantic_hash,
+    semantic_projection,
+    strict_canonical_json,
+)
 
 SOURCE_VERSION = "canonical-replay-source/v1"
 SOURCE_HASH_PROFILE = "veritas.canonical-replay-source/v1"
 BASELINE_VERSION = "canonical-replay-semantic-baseline/v1"
+SOURCE_RECEIPT_VERSION = "canonical-replay-source-receipt/v1"
 EVIDENCE_VERSION = "canonical-replay-evidence/v1"
 EVIDENCE_HASH_PROFILE = "veritas.canonical-replay-evidence/v1"
 SOURCE_ID_PREFIX = "crs:v1:sha256:"
@@ -32,54 +38,59 @@ _DIGEST_PATTERN = r"^[0-9a-f]{64}$"
 TRUSTED_REPLAY_MARKER = object()
 
 
+class CanonicalReplayError(ValueError):
+    """Stable canonical replay refusal without source content."""
+
+
+class ReplaySourceCollisionError(CanonicalReplayError):
+    """Refuse overwriting different verified content at a canonical locator."""
+
+    def __init__(self) -> None:
+        super().__init__("REPLAY_SOURCE_COLLISION")
+
+
+class ReplaySourceLoadStatus(str, Enum):
+    ABSENT = "absent"
+    FOUND = "found"
+
+
 class _FrozenModel(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
 
-def _canonical_json(value: Any) -> str:
-    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
-
-
-def _hash(value: Any) -> str:
-    return hashlib.sha256(_canonical_json(value).encode("utf-8")).hexdigest()
-
-
 class SemanticBaseline(_FrozenModel):
-    """Versioned projection compared independently of decision identity."""
+    """Versioned semantic projection and its domain-separated digest."""
 
     format_version: Literal["canonical-replay-semantic-baseline/v1"]
-    payload: dict[str, Any]
+    profile: Literal["veritas.replay-semantic/v1"]
+    projection: dict[str, Any]
     semantic_hash: str = Field(pattern=_DIGEST_PATTERN)
-
-    @model_validator(mode="after")
-    def verify_hash(self) -> "SemanticBaseline":
-        if self.semantic_hash != _hash(self.payload):
-            raise ValueError("semantic baseline hash mismatch")
-        return self
 
 
 class CanonicalReplaySource(_FrozenModel):
-    """Encrypted-at-rest source binding a verified CDA to replay inputs."""
+    """Content-addressed input for one original verified decision."""
 
     format_version: Literal["canonical-replay-source/v1"]
     hash_profile: Literal["veritas.canonical-replay-source/v1"]
     source_id: str
     source_hash: str = Field(pattern=_DIGEST_PATTERN)
     original_cda: CanonicalDecisionArtifact
-    original_cda_trust_receipt: dict[str, Any] | None = None
+    original_cda_trust_receipt: CanonicalDecisionTrustReceipt | None = None
     deterministic_replay: dict[str, Any]
     semantic_baseline: SemanticBaseline
 
-    @model_validator(mode="after")
-    def verify_identity(self) -> "CanonicalReplaySource":
-        verification = verify_canonical_decision_artifact(self.original_cda)
-        if not verification.is_valid:
-            raise ValueError("original CDA invalid")
-        content = self.model_dump(mode="json", exclude={"source_id", "source_hash"})
-        expected = _hash(content)
-        if self.source_hash != expected or self.source_id != SOURCE_ID_PREFIX + expected:
-            raise ValueError("replay source identity mismatch")
-        return self
+
+class CanonicalReplaySourceReceipt(_FrozenModel):
+    """Receipt for encrypted persistence and successful read-back only."""
+
+    format_version: Literal["canonical-replay-source-receipt/v1"]
+    replay_source_id: str
+    replay_source_hash: str = Field(pattern=_DIGEST_PATTERN)
+    original_request_id: str
+    original_decision_id: str
+    original_decision_hash: str = Field(pattern=_DIGEST_PATTERN)
+    original_decision_ts: str
+    storage_backend: Literal["encrypted_local_file"]
 
 
 class ReplayControls(_FrozenModel):
@@ -92,103 +103,232 @@ class ReplayControls(_FrozenModel):
 
 
 class CanonicalReplayEvidence(_FrozenModel):
-    """Content-addressed linkage between source, original CDA, and replay CDA."""
+    """Content-addressed proof of a distinct replay execution."""
 
     format_version: Literal["canonical-replay-evidence/v1"]
     hash_profile: Literal["veritas.canonical-replay-evidence/v1"]
     evidence_id: str
     evidence_hash: str = Field(pattern=_DIGEST_PATTERN)
     replay_source_id: str
-    original_cda_id: str
-    replay_cda_id: str
+    replay_source_hash: str = Field(pattern=_DIGEST_PATTERN)
     original_request_id: str
+    original_decision_id: str
+    original_decision_hash: str = Field(pattern=_DIGEST_PATTERN)
+    original_decision_ts: str
     replay_request_id: str
+    replay_cda: CanonicalDecisionArtifact
+    replay_cda_trust_receipt: CanonicalDecisionTrustReceipt | None = None
     controls: ReplayControls
-    semantic_comparison_version: Literal[
-        "canonical-replay-semantic-baseline/v1"
-    ]
+    semantic_profile: Literal["veritas.replay-semantic/v1"]
     original_semantic_hash: str = Field(pattern=_DIGEST_PATTERN)
     replay_semantic_hash: str = Field(pattern=_DIGEST_PATTERN)
-    semantic_hash: str = Field(pattern=_DIGEST_PATTERN)
+    replay_semantic_projection: dict[str, Any]
     semantic_match: bool
+    fields_changed: tuple[str, ...]
+    severity: Literal["info", "warning", "critical"]
+    divergence_level: Literal[
+        "no_divergence",
+        "acceptable_divergence",
+        "critical_divergence",
+    ]
 
-    @model_validator(mode="after")
-    def verify_identity_separation(self) -> "CanonicalReplayEvidence":
-        if self.original_request_id == self.replay_request_id:
-            raise ValueError("replay request identity reused")
-        if self.original_cda_id == self.replay_cda_id:
-            raise ValueError("replay CDA identity reused")
-        content = self.model_dump(mode="json", exclude={"evidence_id", "evidence_hash"})
-        expected = _hash(content)
-        if self.evidence_hash != expected or self.evidence_id != EVIDENCE_ID_PREFIX + expected:
-            raise ValueError("replay evidence identity mismatch")
-        return self
+
+def _raw(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        return value.model_dump(mode="json")
+    return value
+
+
+def _digest(value: Any) -> str:
+    return hashlib.sha256(strict_canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def _validate_receipt_binding(
+    value: Any,
+    cda: CanonicalDecisionArtifact,
+) -> CanonicalDecisionTrustReceipt | None:
+    if value is None:
+        return None
+    receipt = CanonicalDecisionTrustReceipt.model_validate(_raw(value))
+    expected = (
+        cda.request_id,
+        cda.decision_id,
+        cda.decision_hash,
+        cda.decision_ts,
+    )
+    actual = (
+        receipt.request_id,
+        receipt.canonical_decision_id,
+        receipt.canonical_decision_hash,
+        receipt.canonical_decision_ts,
+    )
+    if actual != expected:
+        raise CanonicalReplayError("TRUST_RECEIPT_BINDING_MISMATCH")
+    return receipt
+
+
+def _verified_cda(value: Any) -> CanonicalDecisionArtifact:
+    cda = CanonicalDecisionArtifact.model_validate(_raw(value))
+    result = verify_canonical_decision_artifact(cda)
+    if not result.is_valid or result.artifact is None:
+        raise CanonicalReplayError("CDA_INVALID")
+    return result.artifact
 
 
 def build_semantic_baseline(payload: dict[str, Any]) -> SemanticBaseline:
-    """Build the v1 semantic projection without volatile or identity fields."""
-    decision = payload.get("decision") if isinstance(payload.get("decision"), dict) else {}
-    fuji = payload.get("fuji") if isinstance(payload.get("fuji"), dict) else {}
-    projection = {
-        "chosen": payload.get("chosen"),
-        "decision_status": payload.get("decision_status"),
-        "business_decision": payload.get("business_decision"),
-        "gate_decision": payload.get("gate_decision"),
-        "decision": {"output": decision.get("output"), "answer": decision.get("answer")},
-        "fuji": {"result": fuji.get("result"), "status": fuji.get("status")},
-        "value_scores": payload.get("value_scores"),
-    }
+    """Build the single v1 replay semantic baseline."""
+    projection = semantic_projection(payload)
     return SemanticBaseline(
         format_version=BASELINE_VERSION,
-        payload=projection,
-        semantic_hash=_hash(projection),
+        profile=SEMANTIC_PROFILE,
+        projection=projection,
+        semantic_hash=semantic_hash(projection),
     )
 
 
+def _verify_retrieval_checksum(replay: dict[str, Any]) -> None:
+    expected = replay.get("retrieval_snapshot_checksum")
+    if expected is None:
+        return
+    snapshot = replay.get("retrieval_snapshot")
+    if not isinstance(snapshot, dict) or str(expected) != _digest(snapshot):
+        raise CanonicalReplayError("RETRIEVAL_CHECKSUM_MISMATCH")
+
+
+def verify_canonical_replay_source(value: Any) -> CanonicalReplaySource:
+    """Independently revalidate every canonical replay source commitment."""
+    raw = _raw(value)
+    try:
+        source = CanonicalReplaySource.model_validate(raw)
+    except ValidationError as exc:
+        raise CanonicalReplayError("REPLAY_SOURCE_INVALID") from exc
+    cda = _verified_cda(source.original_cda)
+    _validate_receipt_binding(source.original_cda_trust_receipt, cda)
+    baseline = SemanticBaseline.model_validate(
+        source.semantic_baseline.model_dump(mode="json")
+    )
+    if baseline.semantic_hash != semantic_hash(baseline.projection):
+        raise CanonicalReplayError("SEMANTIC_HASH_MISMATCH")
+    final_output = source.deterministic_replay.get("final_output")
+    if not isinstance(final_output, dict):
+        raise CanonicalReplayError("REPLAY_FINAL_OUTPUT_MISSING")
+    if semantic_projection(final_output) != baseline.projection:
+        raise CanonicalReplayError("SEMANTIC_BASELINE_MISMATCH")
+    _verify_retrieval_checksum(source.deterministic_replay)
+    content = source.model_dump(mode="json", exclude={"source_id", "source_hash"})
+    digest = _digest(content)
+    if source.source_hash != digest or source.source_id != SOURCE_ID_PREFIX + digest:
+        raise CanonicalReplayError("REPLAY_SOURCE_IDENTITY_MISMATCH")
+    if strict_canonical_json(raw) != strict_canonical_json(source.model_dump(mode="json")):
+        raise CanonicalReplayError("REPLAY_SOURCE_NOT_EXACT")
+    return source
+
+
 def build_replay_source(payload: dict[str, Any]) -> CanonicalReplaySource:
-    """Build a source only from a verified CDA and deterministic snapshot."""
-    cda = CanonicalDecisionArtifact.model_validate(payload["canonical_decision_artifact"])
+    """Build a canonical source from verified decision and replay inputs."""
+    cda = _verified_cda(payload["canonical_decision_artifact"])
+    receipt = _validate_receipt_binding(
+        payload.get("canonical_decision_trust_receipt"), cda
+    )
     replay = payload.get("deterministic_replay")
     if not isinstance(replay, dict):
-        raise ValueError("deterministic replay snapshot missing")
+        raise CanonicalReplayError("DETERMINISTIC_REPLAY_MISSING")
+    _verify_retrieval_checksum(replay)
     fields = {
         "format_version": SOURCE_VERSION,
         "hash_profile": SOURCE_HASH_PROFILE,
         "original_cda": cda.model_dump(mode="json"),
-        "original_cda_trust_receipt": payload.get("canonical_decision_trust_receipt"),
+        "original_cda_trust_receipt": _raw(receipt),
         "deterministic_replay": replay,
         "semantic_baseline": build_semantic_baseline(payload).model_dump(mode="json"),
     }
-    digest = _hash(fields)
-    return CanonicalReplaySource(
-        **fields, source_id=SOURCE_ID_PREFIX + digest, source_hash=digest
+    digest = _digest(fields)
+    return verify_canonical_replay_source(
+        {**fields, "source_id": SOURCE_ID_PREFIX + digest, "source_hash": digest}
     )
 
 
-def persist_replay_source(source: CanonicalReplaySource, directory: Path) -> Path:
-    """Atomically persist ciphertext and verify it by decrypting and validating."""
+def _source_path(source: CanonicalReplaySource, directory: Path) -> Path:
+    return directory / f"replay_source_{source.original_cda.decision_hash}.enc"
+
+
+def persist_replay_source(
+    source: CanonicalReplaySource,
+    directory: Path,
+) -> CanonicalReplaySourceReceipt:
+    """Persist encrypted source atomically with idempotent collision refusal."""
+    verified = verify_canonical_replay_source(source)
     directory.mkdir(parents=True, exist_ok=True)
-    path = directory / f"{source.source_id.replace(':', '_')}.enc"
-    ciphertext = encrypt(_canonical_json(source.model_dump(mode="json")))
-    if not ciphertext.startswith("ENC:"):
-        raise ValueError("replay source encryption refused")
-    atomic_write_text(path, ciphertext)
-    loaded = CanonicalReplaySource.model_validate_json(decrypt(path.read_text().strip()))
-    if loaded != source:
-        path.unlink(missing_ok=True)
-        raise ValueError("replay source read-back mismatch")
-    return path
+    path = _source_path(verified, directory)
+    if path.exists():
+        existing = verify_canonical_replay_source(
+            json.loads(decrypt(path.read_text(encoding="utf-8").strip()))
+        )
+        if existing != verified:
+            raise ReplaySourceCollisionError()
+    else:
+        ciphertext = encrypt(strict_canonical_json(verified.model_dump(mode="json")))
+        if not ciphertext.startswith("ENC:"):
+            raise CanonicalReplayError("REPLAY_SOURCE_ENCRYPTION_REFUSED")
+        atomic_write_text(path, ciphertext)
+    read_back = verify_canonical_replay_source(
+        json.loads(decrypt(path.read_text(encoding="utf-8").strip()))
+    )
+    if read_back != verified:
+        raise CanonicalReplayError("REPLAY_SOURCE_READ_BACK_MISMATCH")
+    return CanonicalReplaySourceReceipt(
+        format_version=SOURCE_RECEIPT_VERSION,
+        replay_source_id=verified.source_id,
+        replay_source_hash=verified.source_hash,
+        original_request_id=verified.original_cda.request_id,
+        original_decision_id=verified.original_cda.decision_id,
+        original_decision_hash=verified.original_cda.decision_hash,
+        original_decision_ts=verified.original_cda.decision_ts,
+        storage_backend="encrypted_local_file",
+    )
 
 
-def load_replay_source(decision_id: str, directory: Path) -> CanonicalReplaySource | None:
-    """Load and verify the encrypted source for an original CDA identity."""
-    if not directory.exists():
+def load_replay_source(
+    decision_id: str,
+    directory: Path,
+) -> CanonicalReplaySource | None:
+    """Load the identity-specific source; corruption never becomes absence."""
+    prefix = "cda:v1:sha256:"
+    if not decision_id.startswith(prefix):
         return None
-    for path in directory.glob("crs_v1_sha256_*.enc"):
-        source = CanonicalReplaySource.model_validate_json(decrypt(path.read_text().strip()))
-        if source.original_cda.decision_id == decision_id:
-            return source
-    return None
+    digest = decision_id.removeprefix(prefix)
+    path = directory / f"replay_source_{digest}.enc"
+    if not path.exists():
+        return None
+    try:
+        raw = json.loads(decrypt(path.read_text(encoding="utf-8").strip()))
+        source = verify_canonical_replay_source(raw)
+    except (OSError, RuntimeError, ValueError, TypeError, json.JSONDecodeError) as exc:
+        raise CanonicalReplayError("CANONICAL_REPLAY_SOURCE_CORRUPT") from exc
+    if source.original_cda.decision_id != decision_id:
+        raise CanonicalReplayError("CANONICAL_REPLAY_SOURCE_SUBSTITUTION")
+    return source
+
+
+def _diff_metadata(
+    original: dict[str, Any],
+    replayed: dict[str, Any],
+) -> tuple[tuple[str, ...], str, str]:
+    fields = tuple(
+        key for key in sorted(set(original) | set(replayed))
+        if original.get(key) != replayed.get(key)
+    )
+    severities = {
+        "decision": "critical",
+        "fuji": "critical",
+        "value_scores": "warning",
+        "continuation_state": "warning",
+        "continuation_receipt": "warning",
+    }
+    levels = [severities.get(key, "info") for key in fields]
+    severity = "critical" if "critical" in levels else "warning" if "warning" in levels else "info"
+    divergence = "critical_divergence" if severity == "critical" else "acceptable_divergence" if fields else "no_divergence"
+    return fields, severity, divergence
 
 
 def build_replay_evidence(
@@ -196,31 +336,119 @@ def build_replay_evidence(
     replay_payload: dict[str, Any],
     controls: ReplayControls,
 ) -> CanonicalReplayEvidence:
-    """Build evidence while enforcing distinct original and replay identities."""
-    replay_cda = CanonicalDecisionArtifact.model_validate(
-        replay_payload["canonical_decision_artifact"]
+    """Build evidence only from independently verified source and replay CDA."""
+    verified_source = verify_canonical_replay_source(source)
+    replay_cda = _verified_cda(replay_payload["canonical_decision_artifact"])
+    if replay_cda.request_id != str(replay_payload.get("request_id") or ""):
+        raise CanonicalReplayError("REPLAY_REQUEST_ID_MISMATCH")
+    if (
+        replay_cda.request_id == verified_source.original_cda.request_id
+        or replay_cda.decision_id == verified_source.original_cda.decision_id
+    ):
+        raise CanonicalReplayError("REPLAY_IDENTITY_REUSED")
+    replay_receipt = _validate_receipt_binding(
+        replay_payload.get("canonical_decision_trust_receipt"), replay_cda
     )
-    replay_baseline = build_semantic_baseline(replay_payload)
-    original_hash = source.semantic_baseline.semantic_hash
-    comparison_hash = _hash(
-        {"original": original_hash, "replay": replay_baseline.semantic_hash}
+    original_projection = verified_source.semantic_baseline.projection
+    replay_projection = semantic_projection(replay_payload)
+    fields_changed, severity, divergence = _diff_metadata(
+        original_projection, replay_projection
     )
     fields = {
         "format_version": EVIDENCE_VERSION,
         "hash_profile": EVIDENCE_HASH_PROFILE,
-        "replay_source_id": source.source_id,
-        "original_cda_id": source.original_cda.decision_id,
-        "replay_cda_id": replay_cda.decision_id,
-        "original_request_id": source.original_cda.request_id,
+        "replay_source_id": verified_source.source_id,
+        "replay_source_hash": verified_source.source_hash,
+        "original_request_id": verified_source.original_cda.request_id,
+        "original_decision_id": verified_source.original_cda.decision_id,
+        "original_decision_hash": verified_source.original_cda.decision_hash,
+        "original_decision_ts": verified_source.original_cda.decision_ts,
         "replay_request_id": replay_cda.request_id,
+        "replay_cda": replay_cda.model_dump(mode="json"),
+        "replay_cda_trust_receipt": _raw(replay_receipt),
         "controls": controls.model_dump(mode="json"),
-        "semantic_comparison_version": BASELINE_VERSION,
-        "original_semantic_hash": original_hash,
-        "replay_semantic_hash": replay_baseline.semantic_hash,
-        "semantic_hash": comparison_hash,
-        "semantic_match": original_hash == replay_baseline.semantic_hash,
+        "semantic_profile": SEMANTIC_PROFILE,
+        "original_semantic_hash": semantic_hash(original_projection),
+        "replay_semantic_hash": semantic_hash(replay_projection),
+        "replay_semantic_projection": replay_projection,
+        "semantic_match": not fields_changed,
+        "fields_changed": fields_changed,
+        "severity": severity,
+        "divergence_level": divergence,
     }
-    digest = _hash(fields)
-    return CanonicalReplayEvidence(
-        **fields, evidence_id=EVIDENCE_ID_PREFIX + digest, evidence_hash=digest
+    digest = _digest(fields)
+    evidence = CanonicalReplayEvidence.model_validate(
+        {**fields, "evidence_id": EVIDENCE_ID_PREFIX + digest, "evidence_hash": digest}
     )
+    return verify_canonical_replay_evidence(verified_source, evidence)
+
+
+def verify_canonical_replay_evidence(
+    source: Any,
+    evidence: Any,
+) -> CanonicalReplayEvidence:
+    """Independently verify source linkage and all replay event commitments."""
+    verified_source = verify_canonical_replay_source(source)
+    raw = _raw(evidence)
+    try:
+        candidate = CanonicalReplayEvidence.model_validate(raw)
+    except ValidationError as exc:
+        raise CanonicalReplayError("REPLAY_EVIDENCE_INVALID") from exc
+    replay_cda = _verified_cda(candidate.replay_cda)
+    _validate_receipt_binding(candidate.replay_cda_trust_receipt, replay_cda)
+    if (
+        candidate.replay_source_id != verified_source.source_id
+        or candidate.replay_source_hash != verified_source.source_hash
+        or candidate.original_request_id != verified_source.original_cda.request_id
+        or candidate.original_decision_id != verified_source.original_cda.decision_id
+        or candidate.original_decision_hash != verified_source.original_cda.decision_hash
+        or candidate.original_decision_ts != verified_source.original_cda.decision_ts
+        or candidate.replay_request_id != replay_cda.request_id
+        or candidate.replay_request_id == candidate.original_request_id
+        or replay_cda.decision_id == candidate.original_decision_id
+    ):
+        raise CanonicalReplayError("REPLAY_EVIDENCE_LINK_MISMATCH")
+    replay_projection = semantic_projection(
+        {
+            **candidate.replay_semantic_projection,
+            "continuation": {
+                "state": candidate.replay_semantic_projection.get(
+                    "continuation_state"
+                ),
+                "receipt": candidate.replay_semantic_projection.get(
+                    "continuation_receipt"
+                ),
+            }
+            if "continuation_state" in candidate.replay_semantic_projection
+            else None,
+        }
+    )
+    if replay_projection != candidate.replay_semantic_projection:
+        raise CanonicalReplayError("REPLAY_SEMANTIC_PROJECTION_INVALID")
+    original_projection = verified_source.semantic_baseline.projection
+    changed, severity, divergence = _diff_metadata(original_projection, replay_projection)
+    expected = (
+        semantic_hash(original_projection),
+        semantic_hash(replay_projection),
+        not changed,
+        changed,
+        severity,
+        divergence,
+    )
+    actual = (
+        candidate.original_semantic_hash,
+        candidate.replay_semantic_hash,
+        candidate.semantic_match,
+        candidate.fields_changed,
+        candidate.severity,
+        candidate.divergence_level,
+    )
+    if actual != expected:
+        raise CanonicalReplayError("REPLAY_EVIDENCE_SEMANTIC_MISMATCH")
+    content = candidate.model_dump(mode="json", exclude={"evidence_id", "evidence_hash"})
+    digest = _digest(content)
+    if candidate.evidence_hash != digest or candidate.evidence_id != EVIDENCE_ID_PREFIX + digest:
+        raise CanonicalReplayError("REPLAY_EVIDENCE_IDENTITY_MISMATCH")
+    if strict_canonical_json(raw) != strict_canonical_json(candidate.model_dump(mode="json")):
+        raise CanonicalReplayError("REPLAY_EVIDENCE_NOT_EXACT")
+    return candidate

--- a/veritas_os/replay/canonical_replay.py
+++ b/veritas_os/replay/canonical_replay.py
@@ -124,7 +124,7 @@ class CanonicalReplayEvidence(_FrozenModel):
     replay_semantic_hash: str = Field(pattern=_DIGEST_PATTERN)
     replay_semantic_projection: dict[str, Any]
     semantic_match: bool
-    fields_changed: tuple[str, ...]
+    fields_changed: list[str]
     severity: Literal["info", "warning", "critical"]
     divergence_level: Literal[
         "no_divergence",
@@ -313,11 +313,11 @@ def load_replay_source(
 def _diff_metadata(
     original: dict[str, Any],
     replayed: dict[str, Any],
-) -> tuple[tuple[str, ...], str, str]:
-    fields = tuple(
+) -> tuple[list[str], str, str]:
+    fields = [
         key for key in sorted(set(original) | set(replayed))
         if original.get(key) != replayed.get(key)
-    )
+    ]
     severities = {
         "decision": "critical",
         "fuji": "critical",

--- a/veritas_os/replay/canonical_replay.py
+++ b/veritas_os/replay/canonical_replay.py
@@ -1,0 +1,226 @@
+"""Canonical Replay Source and Evidence v1.
+
+These content-addressed artifacts prove replay linkage and semantic comparison
+only.  They confer no execution authority and deliberately keep the original
+decision identity separate from the replay execution identity.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from veritas_os.core.atomic_io import atomic_write_text
+from veritas_os.governance.canonical_decision_artifact import (
+    CanonicalDecisionArtifact,
+    verify_canonical_decision_artifact,
+)
+from veritas_os.logging.encryption import decrypt, encrypt
+
+SOURCE_VERSION = "canonical-replay-source/v1"
+SOURCE_HASH_PROFILE = "veritas.canonical-replay-source/v1"
+BASELINE_VERSION = "canonical-replay-semantic-baseline/v1"
+EVIDENCE_VERSION = "canonical-replay-evidence/v1"
+EVIDENCE_HASH_PROFILE = "veritas.canonical-replay-evidence/v1"
+SOURCE_ID_PREFIX = "crs:v1:sha256:"
+EVIDENCE_ID_PREFIX = "cre:v1:sha256:"
+_DIGEST_PATTERN = r"^[0-9a-f]{64}$"
+TRUSTED_REPLAY_MARKER = object()
+
+
+class _FrozenModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _hash(value: Any) -> str:
+    return hashlib.sha256(_canonical_json(value).encode("utf-8")).hexdigest()
+
+
+class SemanticBaseline(_FrozenModel):
+    """Versioned projection compared independently of decision identity."""
+
+    format_version: Literal["canonical-replay-semantic-baseline/v1"]
+    payload: dict[str, Any]
+    semantic_hash: str = Field(pattern=_DIGEST_PATTERN)
+
+    @model_validator(mode="after")
+    def verify_hash(self) -> "SemanticBaseline":
+        if self.semantic_hash != _hash(self.payload):
+            raise ValueError("semantic baseline hash mismatch")
+        return self
+
+
+class CanonicalReplaySource(_FrozenModel):
+    """Encrypted-at-rest source binding a verified CDA to replay inputs."""
+
+    format_version: Literal["canonical-replay-source/v1"]
+    hash_profile: Literal["veritas.canonical-replay-source/v1"]
+    source_id: str
+    source_hash: str = Field(pattern=_DIGEST_PATTERN)
+    original_cda: CanonicalDecisionArtifact
+    original_cda_trust_receipt: dict[str, Any] | None = None
+    deterministic_replay: dict[str, Any]
+    semantic_baseline: SemanticBaseline
+
+    @model_validator(mode="after")
+    def verify_identity(self) -> "CanonicalReplaySource":
+        verification = verify_canonical_decision_artifact(self.original_cda)
+        if not verification.is_valid:
+            raise ValueError("original CDA invalid")
+        content = self.model_dump(mode="json", exclude={"source_id", "source_hash"})
+        expected = _hash(content)
+        if self.source_hash != expected or self.source_id != SOURCE_ID_PREFIX + expected:
+            raise ValueError("replay source identity mismatch")
+        return self
+
+
+class ReplayControls(_FrozenModel):
+    """Deterministic controls applied at the trusted replay boundary."""
+
+    strict: bool
+    mock_external_apis: bool
+    seed: int
+    temperature: float
+
+
+class CanonicalReplayEvidence(_FrozenModel):
+    """Content-addressed linkage between source, original CDA, and replay CDA."""
+
+    format_version: Literal["canonical-replay-evidence/v1"]
+    hash_profile: Literal["veritas.canonical-replay-evidence/v1"]
+    evidence_id: str
+    evidence_hash: str = Field(pattern=_DIGEST_PATTERN)
+    replay_source_id: str
+    original_cda_id: str
+    replay_cda_id: str
+    original_request_id: str
+    replay_request_id: str
+    controls: ReplayControls
+    semantic_comparison_version: Literal[
+        "canonical-replay-semantic-baseline/v1"
+    ]
+    original_semantic_hash: str = Field(pattern=_DIGEST_PATTERN)
+    replay_semantic_hash: str = Field(pattern=_DIGEST_PATTERN)
+    semantic_hash: str = Field(pattern=_DIGEST_PATTERN)
+    semantic_match: bool
+
+    @model_validator(mode="after")
+    def verify_identity_separation(self) -> "CanonicalReplayEvidence":
+        if self.original_request_id == self.replay_request_id:
+            raise ValueError("replay request identity reused")
+        if self.original_cda_id == self.replay_cda_id:
+            raise ValueError("replay CDA identity reused")
+        content = self.model_dump(mode="json", exclude={"evidence_id", "evidence_hash"})
+        expected = _hash(content)
+        if self.evidence_hash != expected or self.evidence_id != EVIDENCE_ID_PREFIX + expected:
+            raise ValueError("replay evidence identity mismatch")
+        return self
+
+
+def build_semantic_baseline(payload: dict[str, Any]) -> SemanticBaseline:
+    """Build the v1 semantic projection without volatile or identity fields."""
+    decision = payload.get("decision") if isinstance(payload.get("decision"), dict) else {}
+    fuji = payload.get("fuji") if isinstance(payload.get("fuji"), dict) else {}
+    projection = {
+        "chosen": payload.get("chosen"),
+        "decision_status": payload.get("decision_status"),
+        "business_decision": payload.get("business_decision"),
+        "gate_decision": payload.get("gate_decision"),
+        "decision": {"output": decision.get("output"), "answer": decision.get("answer")},
+        "fuji": {"result": fuji.get("result"), "status": fuji.get("status")},
+        "value_scores": payload.get("value_scores"),
+    }
+    return SemanticBaseline(
+        format_version=BASELINE_VERSION,
+        payload=projection,
+        semantic_hash=_hash(projection),
+    )
+
+
+def build_replay_source(payload: dict[str, Any]) -> CanonicalReplaySource:
+    """Build a source only from a verified CDA and deterministic snapshot."""
+    cda = CanonicalDecisionArtifact.model_validate(payload["canonical_decision_artifact"])
+    replay = payload.get("deterministic_replay")
+    if not isinstance(replay, dict):
+        raise ValueError("deterministic replay snapshot missing")
+    fields = {
+        "format_version": SOURCE_VERSION,
+        "hash_profile": SOURCE_HASH_PROFILE,
+        "original_cda": cda.model_dump(mode="json"),
+        "original_cda_trust_receipt": payload.get("canonical_decision_trust_receipt"),
+        "deterministic_replay": replay,
+        "semantic_baseline": build_semantic_baseline(payload).model_dump(mode="json"),
+    }
+    digest = _hash(fields)
+    return CanonicalReplaySource(
+        **fields, source_id=SOURCE_ID_PREFIX + digest, source_hash=digest
+    )
+
+
+def persist_replay_source(source: CanonicalReplaySource, directory: Path) -> Path:
+    """Atomically persist ciphertext and verify it by decrypting and validating."""
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / f"{source.source_id.replace(':', '_')}.enc"
+    ciphertext = encrypt(_canonical_json(source.model_dump(mode="json")))
+    if not ciphertext.startswith("ENC:"):
+        raise ValueError("replay source encryption refused")
+    atomic_write_text(path, ciphertext)
+    loaded = CanonicalReplaySource.model_validate_json(decrypt(path.read_text().strip()))
+    if loaded != source:
+        path.unlink(missing_ok=True)
+        raise ValueError("replay source read-back mismatch")
+    return path
+
+
+def load_replay_source(decision_id: str, directory: Path) -> CanonicalReplaySource | None:
+    """Load and verify the encrypted source for an original CDA identity."""
+    if not directory.exists():
+        return None
+    for path in directory.glob("crs_v1_sha256_*.enc"):
+        source = CanonicalReplaySource.model_validate_json(decrypt(path.read_text().strip()))
+        if source.original_cda.decision_id == decision_id:
+            return source
+    return None
+
+
+def build_replay_evidence(
+    source: CanonicalReplaySource,
+    replay_payload: dict[str, Any],
+    controls: ReplayControls,
+) -> CanonicalReplayEvidence:
+    """Build evidence while enforcing distinct original and replay identities."""
+    replay_cda = CanonicalDecisionArtifact.model_validate(
+        replay_payload["canonical_decision_artifact"]
+    )
+    replay_baseline = build_semantic_baseline(replay_payload)
+    original_hash = source.semantic_baseline.semantic_hash
+    comparison_hash = _hash(
+        {"original": original_hash, "replay": replay_baseline.semantic_hash}
+    )
+    fields = {
+        "format_version": EVIDENCE_VERSION,
+        "hash_profile": EVIDENCE_HASH_PROFILE,
+        "replay_source_id": source.source_id,
+        "original_cda_id": source.original_cda.decision_id,
+        "replay_cda_id": replay_cda.decision_id,
+        "original_request_id": source.original_cda.request_id,
+        "replay_request_id": replay_cda.request_id,
+        "controls": controls.model_dump(mode="json"),
+        "semantic_comparison_version": BASELINE_VERSION,
+        "original_semantic_hash": original_hash,
+        "replay_semantic_hash": replay_baseline.semantic_hash,
+        "semantic_hash": comparison_hash,
+        "semantic_match": original_hash == replay_baseline.semantic_hash,
+    }
+    digest = _hash(fields)
+    return CanonicalReplayEvidence(
+        **fields, evidence_id=EVIDENCE_ID_PREFIX + digest, evidence_hash=digest
+    )

--- a/veritas_os/replay/replay_engine.py
+++ b/veritas_os/replay/replay_engine.py
@@ -12,9 +12,16 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List
+from uuid import uuid4
 
 from veritas_os.api.schemas import DecideRequest
 from veritas_os.core import pipeline
+from veritas_os.replay.canonical_replay import (
+    ReplayControls,
+    TRUSTED_REPLAY_MARKER,
+    build_replay_evidence,
+    load_replay_source,
+)
 
 # ★ パストラバーサル防止: ファイル名に使用する ID から危険文字を除去
 _SAFE_FILENAME_RE = re.compile(r"[^A-Za-z0-9_\-]")
@@ -82,6 +89,9 @@ class ReplayResult:
     severity: str = SEVERITY_INFO
     divergence_level: str = DIVERGENCE_NONE
     audit_summary: str = ""
+    replay_request_id: str = ""
+    replay_cda_id: str = ""
+    canonical_replay_evidence: Dict[str, Any] | None = None
 
 
 def _strict_mode_enabled() -> bool:
@@ -362,11 +372,18 @@ async def run_replay(decision_id: str, strict: bool | None = None) -> ReplayResu
     started = time.time()
     strict_mode = _strict_mode_enabled() if strict is None else bool(strict)
 
+    replay_source = load_replay_source(decision_id, pipeline.REPLAY_SOURCE_DIR)
     snapshot = pipeline._load_persisted_decision(decision_id)
-    if snapshot is None:
+    if replay_source is None and snapshot is None:
         raise ValueError(f"decision_not_found: {decision_id}")
 
-    replay_meta = snapshot.get("deterministic_replay") if isinstance(snapshot.get("deterministic_replay"), dict) else {}
+    if replay_source is not None:
+        replay_meta = replay_source.deterministic_replay
+        source_snapshot = replay_meta.get("final_output")
+        snapshot = source_snapshot if isinstance(source_snapshot, dict) else {}
+    else:
+        assert snapshot is not None
+        replay_meta = snapshot.get("deterministic_replay") if isinstance(snapshot.get("deterministic_replay"), dict) else {}
     _assert_model_version(replay_meta.get("model_version"))
 
     expected_retrieval_checksum = replay_meta.get("retrieval_snapshot_checksum")
@@ -388,7 +405,6 @@ async def run_replay(decision_id: str, strict: bool | None = None) -> ReplayResu
     req_body["context"] = dict(context)
     req_body["context"]["_replay_mode"] = True
     req_body["context"]["_mock_external_apis"] = strict_mode
-
     if strict_mode:
         req_body["temperature"] = 0
         req_body["seed"] = int(replay_meta.get("seed", req_body.get("seed", 0)) or 0)
@@ -396,15 +412,18 @@ async def run_replay(decision_id: str, strict: bool | None = None) -> ReplayResu
         req_body.setdefault("temperature", replay_meta.get("temperature", 0))
         req_body.setdefault("seed", replay_meta.get("seed", 0))
 
-    req_body["request_id"] = str(snapshot.get("request_id") or decision_id)
+    replay_request_id = str(uuid4())
+    req_body["request_id"] = replay_request_id
 
     replay_req = DecideRequest.model_validate(req_body)
 
     replay_kwargs: Dict[str, Any] = {}
     if strict_mode:
         replay_kwargs["memory_store_getter"] = _noop_memory_store
+    replay_request = pipeline._ReplayRequest(mock_external_apis=strict_mode)
+    replay_request._veritas_replay_marker = TRUSTED_REPLAY_MARKER
     replay_output = await pipeline.run_decide_pipeline(
-        replay_req, pipeline._ReplayRequest(), **replay_kwargs
+        replay_req, replay_request, **replay_kwargs
     )
 
     original_output = replay_meta.get("final_output") if isinstance(replay_meta.get("final_output"), dict) else snapshot
@@ -415,7 +434,7 @@ async def run_replay(decision_id: str, strict: bool | None = None) -> ReplayResu
 
     replay_time_ms = max(1, int((time.time() - started) * 1000))
 
-    resolved_id = str(snapshot.get("request_id") or decision_id)
+    resolved_id = decision_id
     max_severity = diff.get("max_severity", SEVERITY_INFO)
     divergence = diff.get("divergence_level", DIVERGENCE_NONE)
     summary = _audit_summary(
@@ -442,6 +461,19 @@ async def run_replay(decision_id: str, strict: bool | None = None) -> ReplayResu
             "external_dependency_versions": replay_dependency_evidence,
         },
     }
+    canonical_evidence = None
+    replay_cda_id = ""
+    if replay_source is not None and isinstance(replay_output, dict):
+        controls = ReplayControls(
+            strict=strict_mode,
+            mock_external_apis=strict_mode,
+            seed=int(req_body.get("seed", 0) or 0),
+            temperature=float(req_body.get("temperature", 0) or 0),
+        )
+        evidence = build_replay_evidence(replay_source, replay_output, controls)
+        canonical_evidence = evidence.model_dump(mode="json")
+        replay_cda_id = evidence.replay_cda_id
+        report_payload["canonical_replay_evidence"] = canonical_evidence
 
     pipeline.REPLAY_REPORT_DIR.mkdir(parents=True, exist_ok=True)
     report_path = pipeline.REPLAY_REPORT_DIR / _replay_file_name(resolved_id)
@@ -459,4 +491,7 @@ async def run_replay(decision_id: str, strict: bool | None = None) -> ReplayResu
         severity=max_severity,
         divergence_level=divergence,
         audit_summary=summary,
+        replay_request_id=replay_request_id,
+        replay_cda_id=replay_cda_id,
+        canonical_replay_evidence=canonical_evidence,
     )

--- a/veritas_os/replay/replay_engine.py
+++ b/veritas_os/replay/replay_engine.py
@@ -420,7 +420,7 @@ async def run_replay(decision_id: str, strict: bool | None = None) -> ReplayResu
         ):
             raise CanonicalReplayError("REPLAY_SEMANTIC_COMPARISON_MISMATCH")
         canonical_evidence = evidence.model_dump(mode="json")
-        replay_cda_id = evidence.replay_cda_id
+        replay_cda_id = evidence.replay_cda.decision_id
         report_payload["canonical_replay_evidence"] = canonical_evidence
 
     pipeline.REPLAY_REPORT_DIR.mkdir(parents=True, exist_ok=True)

--- a/veritas_os/replay/replay_engine.py
+++ b/veritas_os/replay/replay_engine.py
@@ -17,11 +17,13 @@ from uuid import uuid4
 from veritas_os.api.schemas import DecideRequest
 from veritas_os.core import pipeline
 from veritas_os.replay.canonical_replay import (
+    CanonicalReplayError,
     ReplayControls,
     TRUSTED_REPLAY_MARKER,
     build_replay_evidence,
     load_replay_source,
 )
+from veritas_os.replay.semantic_profile import semantic_projection
 
 # ★ パストラバーサル防止: ファイル名に使用する ID から危険文字を除去
 _SAFE_FILENAME_RE = re.compile(r"[^A-Za-z0-9_\-]")
@@ -29,7 +31,7 @@ _SAFE_FILENAME_RE = re.compile(r"[^A-Za-z0-9_\-]")
 # ── Replay artifact schema version ──────────────────────────────────
 # Bump when the replay report JSON structure changes so that downstream
 # audit tooling can detect and handle schema evolution.
-REPLAY_SCHEMA_VERSION = "1.0.0"
+REPLAY_SCHEMA_VERSION = "1.1.0"
 
 # ── Diff severity constants ─────────────────────────────────────────
 SEVERITY_CRITICAL = "critical"
@@ -216,69 +218,8 @@ def _sort_evidence(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
 
 
 def _normalized_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
-    """Extract stable fields for replay comparison."""
-    decision = payload.get("decision") if isinstance(payload.get("decision"), dict) else {}
-    fuji = payload.get("fuji") if isinstance(payload.get("fuji"), dict) else {}
-    extras = payload.get("extras") if isinstance(payload.get("extras"), dict) else {}
-
-    decision_output = decision.get("output")
-    decision_answer = decision.get("answer")
-    fuji_result = fuji.get("result")
-    value_scores = payload.get("value_scores")
-    evidence = payload.get("evidence")
-
-    if not isinstance(evidence, list):
-        evidence = extras.get("evidence") if isinstance(extras.get("evidence"), list) else []
-
-    stable_evidence = []
-    for item in evidence:
-        if not isinstance(item, dict):
-            continue
-        stable_evidence.append(
-            {
-                "id": item.get("id"),
-                "title": item.get("title"),
-                "url": item.get("url") or item.get("uri"),
-                "source": item.get("source"),
-                "snippet": item.get("snippet"),
-            }
-        )
-
-    # ── Continuation runtime (shadow/observe) ──────────────────────
-    # Extract concise continuation fields for replay comparison.
-    # When continuation is absent (flag off), these keys are omitted
-    # entirely so that replay diffs remain clean.
-    continuation_block = payload.get("continuation") if isinstance(payload.get("continuation"), dict) else None
-    result: Dict[str, Any] = {
-        "decision": {
-            "output": decision_output,
-            "answer": decision_answer,
-        },
-        "fuji": {
-            "result": fuji_result,
-            "status": fuji.get("status"),
-        },
-        "value_scores": value_scores,
-        "evidence": _sort_evidence(stable_evidence),
-    }
-    if continuation_block is not None:
-        c_state = continuation_block.get("state") if isinstance(continuation_block.get("state"), dict) else {}
-        c_receipt = continuation_block.get("receipt") if isinstance(continuation_block.get("receipt"), dict) else {}
-        result["continuation_state"] = {
-            "claim_lineage_id": c_state.get("claim_lineage_id"),
-            "claim_status": c_state.get("claim_status"),
-            "law_version": c_state.get("law_version"),
-            "snapshot_id": c_state.get("snapshot_id"),
-        }
-        result["continuation_receipt"] = {
-            "receipt_id": c_receipt.get("receipt_id"),
-            "revalidation_status": c_receipt.get("revalidation_status"),
-            "revalidation_outcome": c_receipt.get("revalidation_outcome"),
-            "divergence_flag": c_receipt.get("divergence_flag"),
-            "should_refuse_before_effect": c_receipt.get("should_refuse_before_effect"),
-            "reason_codes": c_receipt.get("revalidation_reason_codes"),
-        }
-    return result
+    """Compatibility wrapper for the canonical v1 semantic profile."""
+    return semantic_projection(payload)
 
 
 def _build_diff(before: Dict[str, Any], after: Dict[str, Any]) -> Dict[str, Any]:
@@ -471,6 +412,13 @@ async def run_replay(decision_id: str, strict: bool | None = None) -> ReplayResu
             temperature=float(req_body.get("temperature", 0) or 0),
         )
         evidence = build_replay_evidence(replay_source, replay_output, controls)
+        if (
+            evidence.semantic_match != match
+            or list(evidence.fields_changed) != diff["fields_changed"]
+            or evidence.severity != max_severity
+            or evidence.divergence_level != divergence
+        ):
+            raise CanonicalReplayError("REPLAY_SEMANTIC_COMPARISON_MISMATCH")
         canonical_evidence = evidence.model_dump(mode="json")
         replay_cda_id = evidence.replay_cda_id
         report_payload["canonical_replay_evidence"] = canonical_evidence

--- a/veritas_os/replay/semantic_profile.py
+++ b/veritas_os/replay/semantic_profile.py
@@ -1,0 +1,110 @@
+"""Canonical replay semantic profile shared by reports and evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from typing import Any
+
+SEMANTIC_PROFILE = "veritas.replay-semantic/v1"
+
+
+def strict_canonical_json(value: Any) -> str:
+    """Serialize exact JSON values, rejecting ambiguous Python values."""
+    _validate_json(value)
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
+
+
+def _validate_json(value: Any) -> None:
+    if value is None or isinstance(value, (str, bool, int)):
+        return
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError("non-finite JSON number")
+        return
+    if isinstance(value, list):
+        for item in value:
+            _validate_json(item)
+        return
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError("JSON object keys must be strings")
+            _validate_json(item)
+        return
+    raise TypeError("unsupported canonical JSON value")
+
+
+def semantic_projection(payload: dict[str, Any]) -> dict[str, Any]:
+    """Project the stable replay fields used by all v1 comparisons."""
+    decision = payload.get("decision") if isinstance(payload.get("decision"), dict) else {}
+    fuji = payload.get("fuji") if isinstance(payload.get("fuji"), dict) else {}
+    extras = payload.get("extras") if isinstance(payload.get("extras"), dict) else {}
+    evidence = payload.get("evidence")
+    if not isinstance(evidence, list):
+        evidence = extras.get("evidence") if isinstance(extras.get("evidence"), list) else []
+    stable_evidence = []
+    for item in evidence:
+        if isinstance(item, dict):
+            stable_evidence.append(
+                {
+                    "id": item.get("id"),
+                    "title": item.get("title"),
+                    "url": item.get("url") or item.get("uri"),
+                    "source": item.get("source"),
+                    "snippet": item.get("snippet"),
+                }
+            )
+    stable_evidence.sort(
+        key=lambda item: str(
+            item.get("id")
+            or item.get("title")
+            or item.get("url")
+            or item.get("source")
+            or ""
+        ).lower()
+    )
+    projection: dict[str, Any] = {
+        "decision": {
+            "output": decision.get("output"),
+            "answer": decision.get("answer"),
+        },
+        "fuji": {"result": fuji.get("result"), "status": fuji.get("status")},
+        "value_scores": payload.get("value_scores"),
+        "evidence": stable_evidence,
+    }
+    continuation = payload.get("continuation")
+    if isinstance(continuation, dict):
+        state = continuation.get("state") if isinstance(continuation.get("state"), dict) else {}
+        receipt = continuation.get("receipt") if isinstance(continuation.get("receipt"), dict) else {}
+        projection["continuation_state"] = {
+            "claim_lineage_id": state.get("claim_lineage_id"),
+            "claim_status": state.get("claim_status"),
+            "law_version": state.get("law_version"),
+            "snapshot_id": state.get("snapshot_id"),
+        }
+        projection["continuation_receipt"] = {
+            "receipt_id": receipt.get("receipt_id"),
+            "revalidation_status": receipt.get("revalidation_status"),
+            "revalidation_outcome": receipt.get("revalidation_outcome"),
+            "divergence_flag": receipt.get("divergence_flag"),
+            "should_refuse_before_effect": receipt.get(
+                "should_refuse_before_effect"
+            ),
+            "reason_codes": receipt.get("revalidation_reason_codes"),
+        }
+    _validate_json(projection)
+    return projection
+
+
+def semantic_hash(projection: dict[str, Any]) -> str:
+    """Hash a semantic projection with explicit profile domain separation."""
+    preimage = {"profile": SEMANTIC_PROFILE, "projection": projection}
+    return hashlib.sha256(strict_canonical_json(preimage).encode("utf-8")).hexdigest()

--- a/veritas_os/tests/test_canonical_decision_finalization.py
+++ b/veritas_os/tests/test_canonical_decision_finalization.py
@@ -106,6 +106,7 @@ def test_null_canonical_fields_are_removed_before_stage_8() -> None:
     payload = _payload()
     payload["canonical_decision_artifact"] = None
     payload["canonical_decision_trust_receipt"] = None
+    payload["canonical_replay_source_receipt"] = None
 
     finalization.finalize_canonical_decision_artifact(
         payload,
@@ -115,6 +116,7 @@ def test_null_canonical_fields_are_removed_before_stage_8() -> None:
 
     assert "canonical_decision_artifact" not in payload
     assert "canonical_decision_trust_receipt" not in payload
+    assert "canonical_replay_source_receipt" not in payload
 
 
 def test_non_null_trust_receipt_is_refused_before_stage_8() -> None:
@@ -134,9 +136,30 @@ def test_non_null_trust_receipt_is_refused_before_stage_8() -> None:
     )
 
 
+def test_non_null_replay_source_receipt_is_refused_before_stage_8() -> None:
+    """A caller cannot inject a replay-source persistence receipt."""
+    payload = _payload()
+    payload["canonical_replay_source_receipt"] = {"unexpected": "receipt"}
+
+    with pytest.raises(finalization.CanonicalDecisionFinalizationError) as exc:
+        finalization.finalize_canonical_decision_artifact(
+            payload,
+            decision_ts=DECISION_TS,
+        )
+
+    _assert_reason(
+        exc,
+        finalization.CanonicalDecisionFinalizationReason.PREEXISTING_REPLAY_SOURCE_RECEIPT_REFUSED,
+    )
+
+
 @pytest.mark.parametrize(
     "field",
-    ["canonical_decision_artifact", "canonical_decision_trust_receipt"],
+    [
+        "canonical_decision_artifact",
+        "canonical_decision_trust_receipt",
+        "canonical_replay_source_receipt",
+    ],
 )
 def test_stage_8_guard_rejects_canonical_keys_even_when_null(field: str) -> None:
     """The explicit Stage 8 guard rejects presence, not merely non-null data."""

--- a/veritas_os/tests/test_canonical_replay.py
+++ b/veritas_os/tests/test_canonical_replay.py
@@ -1,0 +1,119 @@
+"""Focused security and identity tests for Canonical Replay Evidence v1."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from veritas_os.api.schemas import DecideResponse
+from veritas_os.governance.canonical_decision_artifact import (
+    build_canonical_decision_artifact,
+)
+from veritas_os.replay.canonical_replay import (
+    ReplayControls,
+    build_replay_evidence,
+    build_replay_source,
+    load_replay_source,
+    persist_replay_source,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+VECTOR = ROOT / "docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-01.json"
+TIMESTAMP = "2031-02-03T04:05:06.123456Z"
+
+
+def _payload(request_id: str) -> dict:
+    vector = json.loads(VECTOR.read_text())
+    projection = dict(vector["source_projection"])
+    projection["request_id"] = request_id
+    response = DecideResponse.model_validate(projection)
+    artifact = build_canonical_decision_artifact(
+        response,
+        decision_ts=TIMESTAMP,
+    )
+    payload = response.model_dump(mode="json")
+    payload["canonical_decision_artifact"] = artifact.model_dump(mode="json")
+    payload["deterministic_replay"] = {
+        "request_body": {"query": "controlled", "request_id": request_id},
+        "final_output": response.model_dump(mode="json"),
+        "seed": 7,
+        "temperature": 0,
+    }
+    return payload
+
+
+def test_source_is_encrypted_and_read_back_verified(monkeypatch, tmp_path: Path) -> None:
+    """Canonical replay source must never expose plaintext on disk."""
+    monkeypatch.setenv(
+        "VERITAS_ENCRYPTION_KEY",
+        "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
+    )
+    source = build_replay_source(_payload("original-request"))
+
+    path = persist_replay_source(source, tmp_path)
+
+    stored = path.read_text()
+    assert stored.startswith("ENC:")
+    assert source.original_cda.decision_id not in stored
+    assert load_replay_source(source.original_cda.decision_id, tmp_path) == source
+
+
+def test_source_ciphertext_tampering_fails_closed(monkeypatch, tmp_path: Path) -> None:
+    """Authenticated encryption must reject a modified replay source."""
+    monkeypatch.setenv(
+        "VERITAS_ENCRYPTION_KEY",
+        "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
+    )
+    source = build_replay_source(_payload("original-request"))
+    path = persist_replay_source(source, tmp_path)
+    ciphertext = path.read_text().strip()
+    path.write_text(ciphertext[:-1] + ("A" if ciphertext[-1] != "A" else "B"))
+
+    with pytest.raises((RuntimeError, ValueError, ValidationError)):
+        load_replay_source(source.original_cda.decision_id, tmp_path)
+
+
+def test_semantic_match_preserves_distinct_execution_identity() -> None:
+    """A semantic match must not imply request or CDA identity equality."""
+    source = build_replay_source(_payload("original-request"))
+    replay_payload = _payload("new-replay-request")
+
+    evidence = build_replay_evidence(
+        source,
+        replay_payload,
+        ReplayControls(
+            strict=True,
+            mock_external_apis=True,
+            seed=7,
+            temperature=0,
+        ),
+    )
+
+    assert evidence.semantic_match is True
+    assert evidence.original_request_id != evidence.replay_request_id
+    assert evidence.original_cda_id != evidence.replay_cda_id
+
+
+def test_external_context_cannot_enable_replay_mode() -> None:
+    """User-controlled context flags are stripped at the pipeline boundary."""
+    from veritas_os.core.pipeline_inputs import normalize_pipeline_inputs
+
+    class Request:
+        query_params: dict = {}
+
+    ctx = normalize_pipeline_inputs(
+        {
+            "query": "normal",
+            "context": {
+                "_replay_mode": True,
+                "_mock_external_apis": True,
+            },
+        },
+        Request(),
+    )
+
+    assert ctx.replay_mode is False
+    assert ctx.mock_external_apis is False

--- a/veritas_os/tests/test_canonical_replay.py
+++ b/veritas_os/tests/test_canonical_replay.py
@@ -1,109 +1,326 @@
-"""Focused security and identity tests for Canonical Replay Evidence v1."""
+"""Security, identity, and verifier tests for Canonical Replay Evidence v1."""
 
 from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
-from pydantic import ValidationError
 
 from veritas_os.api.schemas import DecideResponse
+from veritas_os.audit.canonical_decision_trust_link import (
+    CanonicalDecisionTrustReceipt,
+)
 from veritas_os.governance.canonical_decision_artifact import (
+    CanonicalDecisionArtifact,
     build_canonical_decision_artifact,
 )
+from veritas_os.logging.encryption import EncryptionKeyMissing, encrypt
 from veritas_os.replay.canonical_replay import (
+    CanonicalReplayError,
+    CanonicalReplayEvidence,
     ReplayControls,
+    ReplaySourceCollisionError,
     build_replay_evidence,
     build_replay_source,
     load_replay_source,
     persist_replay_source,
+    verify_canonical_replay_evidence,
+    verify_canonical_replay_source,
 )
+from veritas_os.replay.semantic_profile import strict_canonical_json
 
 ROOT = Path(__file__).resolve().parents[2]
 VECTOR = ROOT / "docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-01.json"
 TIMESTAMP = "2031-02-03T04:05:06.123456Z"
+KEY = "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY="
 
 
-def _payload(request_id: str) -> dict:
+def _payload(request_id: str, *, query: str = "known plaintext query") -> dict:
     vector = json.loads(VECTOR.read_text())
     projection = dict(vector["source_projection"])
     projection["request_id"] = request_id
     response = DecideResponse.model_validate(projection)
-    artifact = build_canonical_decision_artifact(
-        response,
-        decision_ts=TIMESTAMP,
-    )
+    artifact = build_canonical_decision_artifact(response, decision_ts=TIMESTAMP)
     payload = response.model_dump(mode="json")
+    payload["query"] = query
     payload["canonical_decision_artifact"] = artifact.model_dump(mode="json")
     payload["deterministic_replay"] = {
-        "request_body": {"query": "controlled", "request_id": request_id},
+        "request_body": {"query": query, "request_id": request_id},
         "final_output": response.model_dump(mode="json"),
+        "retrieval_snapshot": {},
+        "retrieval_snapshot_checksum": (
+            "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
+        ),
         "seed": 7,
         "temperature": 0,
     }
     return payload
 
 
-def test_source_is_encrypted_and_read_back_verified(monkeypatch, tmp_path: Path) -> None:
-    """Canonical replay source must never expose plaintext on disk."""
-    monkeypatch.setenv(
-        "VERITAS_ENCRYPTION_KEY",
-        "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
-    )
+def _receipt(cda: CanonicalDecisionArtifact, marker: str = "a") -> dict:
+    return CanonicalDecisionTrustReceipt(
+        format_version="canonical-decision-trust-receipt/v1",
+        request_id=cda.request_id,
+        canonical_decision_id=cda.decision_id,
+        canonical_decision_hash=cda.decision_hash,
+        canonical_decision_ts=cda.decision_ts,
+        trust_log_entry_sha256=marker * 64,
+        trust_log_entry_sha256_prev=None,
+        trust_log_created_at="2031-02-03T04:05:07+00:00",
+        ledger="encrypted_full_ledger",
+        event_type="canonical_decision_link",
+    ).model_dump(mode="json")
+
+
+def _source_and_replay() -> tuple[object, dict]:
     source = build_replay_source(_payload("original-request"))
+    return source, _payload("new-replay-request")
 
-    path = persist_replay_source(source, tmp_path)
 
-    stored = path.read_text()
-    assert stored.startswith("ENC:")
-    assert source.original_cda.decision_id not in stored
+def test_source_encrypted_read_back_and_receipt_has_no_path(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("VERITAS_ENCRYPTION_KEY", KEY)
+    source = build_replay_source(_payload("original-request"))
+    receipt = persist_replay_source(source, tmp_path)
+    raw = next(tmp_path.glob("replay_source_*.enc")).read_text()
+
+    assert raw.startswith("ENC:")
+    assert "known plaintext query" not in raw
+    assert source.original_cda.decision_id not in raw
+    assert "path" not in receipt.model_dump(mode="json")
     assert load_replay_source(source.original_cda.decision_id, tmp_path) == source
 
-
-def test_source_ciphertext_tampering_fails_closed(monkeypatch, tmp_path: Path) -> None:
-    """Authenticated encryption must reject a modified replay source."""
-    monkeypatch.setenv(
-        "VERITAS_ENCRYPTION_KEY",
-        "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
+    response = DecideResponse.model_validate(
+        {
+            **_payload("response-request"),
+            "canonical_replay_source_receipt": receipt.model_dump(mode="json"),
+        }
     )
+    dumped = response.model_dump(mode="json")
+    assert dumped["canonical_replay_source_receipt"] == receipt.model_dump(
+        mode="json"
+    )
+    assert "path" not in dumped["canonical_replay_source_receipt"]
+
+
+def test_missing_key_creates_no_plaintext_fallback(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("VERITAS_ENCRYPTION_KEY", raising=False)
     source = build_replay_source(_payload("original-request"))
-    path = persist_replay_source(source, tmp_path)
-    ciphertext = path.read_text().strip()
+
+    with pytest.raises(EncryptionKeyMissing):
+        persist_replay_source(source, tmp_path)
+
+    assert not list(tmp_path.glob("*.enc"))
+
+
+def test_tampered_target_source_fails_closed(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("VERITAS_ENCRYPTION_KEY", KEY)
+    source = build_replay_source(_payload("original-request"))
+    persist_replay_source(source, tmp_path)
+    path = next(tmp_path.glob("replay_source_*.enc"))
+    ciphertext = path.read_text()
     path.write_text(ciphertext[:-1] + ("A" if ciphertext[-1] != "A" else "B"))
 
-    with pytest.raises((RuntimeError, ValueError, ValidationError)):
+    with pytest.raises(CanonicalReplayError, match="CANONICAL_REPLAY_SOURCE_CORRUPT"):
         load_replay_source(source.original_cda.decision_id, tmp_path)
 
 
-def test_semantic_match_preserves_distinct_execution_identity() -> None:
-    """A semantic match must not imply request or CDA identity equality."""
+def test_unrelated_corrupt_source_cannot_substitute(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("VERITAS_ENCRYPTION_KEY", KEY)
     source = build_replay_source(_payload("original-request"))
+    persist_replay_source(source, tmp_path)
+    unrelated = tmp_path / f"replay_source_{'f' * 64}.enc"
+    unrelated.write_text("corrupt")
+
+    assert load_replay_source(source.original_cda.decision_id, tmp_path) == source
+
+
+def test_idempotence_and_collision_refusal(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("VERITAS_ENCRYPTION_KEY", KEY)
+    source = build_replay_source(_payload("original-request"))
+    assert persist_replay_source(source, tmp_path) == persist_replay_source(
+        source, tmp_path
+    )
+    different = build_replay_source(_payload("different-request"))
+    path = next(tmp_path.glob("replay_source_*.enc"))
+    path.write_text(encrypt(json.dumps(different.model_dump(mode="json"))))
+
+    with pytest.raises(ReplaySourceCollisionError):
+        persist_replay_source(source, tmp_path)
+
+
+def test_original_trust_receipt_substitution_is_rejected() -> None:
+    original = _payload("original-request")
+    other = _payload("other-request")
+    other_cda = CanonicalDecisionArtifact.model_validate(
+        other["canonical_decision_artifact"]
+    )
+    original["canonical_decision_trust_receipt"] = _receipt(other_cda)
+
+    with pytest.raises(CanonicalReplayError, match="TRUST_RECEIPT_BINDING_MISMATCH"):
+        build_replay_source(original)
+
+
+def test_semantic_match_and_independent_evidence_verification() -> None:
+    source, replay_payload = _source_and_replay()
+    evidence = build_replay_evidence(
+        source,
+        replay_payload,
+        ReplayControls(
+            strict=True, mock_external_apis=True, seed=7, temperature=0
+        ),
+    )
+
+    assert evidence.semantic_match is True
+    assert evidence.fields_changed == ()
+    assert evidence.original_request_id != evidence.replay_request_id
+    assert evidence.original_decision_id != evidence.replay_cda.decision_id
+    assert verify_canonical_replay_evidence(source, evidence) == evidence
+
+
+@pytest.mark.parametrize("method", ["copy", "construct"])
+def test_source_model_instance_bypasses_are_rejected(method: str) -> None:
+    source = build_replay_source(_payload("original-request"))
+    if method == "copy":
+        corrupt = source.model_copy(update={"source_hash": "f" * 64})
+    else:
+        raw = source.model_dump(mode="json")
+        raw["format_version"] = "forged"
+        corrupt = type(source).model_construct(**raw)
+
+    with pytest.raises(CanonicalReplayError):
+        verify_canonical_replay_source(corrupt)
+
+
+@pytest.mark.parametrize(
+    "update",
+    [
+        {"evidence_hash": "f" * 64},
+        {"semantic_match": False},
+        {"format_version": "forged"},
+    ],
+)
+def test_evidence_model_copy_bypasses_are_rejected(update: dict) -> None:
+    source, replay_payload = _source_and_replay()
+    evidence = build_replay_evidence(
+        source,
+        replay_payload,
+        ReplayControls(
+            strict=True, mock_external_apis=True, seed=7, temperature=0
+        ),
+    ).model_copy(update=update)
+
+    with pytest.raises(CanonicalReplayError):
+        verify_canonical_replay_evidence(source, evidence)
+
+
+def test_evidence_model_construct_bypass_is_rejected() -> None:
+    source, replay_payload = _source_and_replay()
+    evidence = build_replay_evidence(
+        source,
+        replay_payload,
+        ReplayControls(
+            strict=True, mock_external_apis=True, seed=7, temperature=0
+        ),
+    )
+    raw = evidence.model_dump(mode="json")
+    raw["format_version"] = "forged"
+    corrupt = CanonicalReplayEvidence.model_construct(**raw)
+
+    with pytest.raises(CanonicalReplayError):
+        verify_canonical_replay_evidence(source, corrupt)
+
+
+def test_replay_cda_model_copy_substitution_is_rejected() -> None:
+    source, replay_payload = _source_and_replay()
+    evidence = build_replay_evidence(
+        source,
+        replay_payload,
+        ReplayControls(
+            strict=True, mock_external_apis=True, seed=7, temperature=0
+        ),
+    )
+    other = CanonicalDecisionArtifact.model_validate(
+        _payload("third-request")["canonical_decision_artifact"]
+    )
+    corrupt = evidence.model_copy(update={"replay_cda": other})
+
+    with pytest.raises(CanonicalReplayError):
+        verify_canonical_replay_evidence(source, corrupt)
+
+
+def test_replay_cda_and_receipt_substitution_are_rejected() -> None:
+    source, replay_payload = _source_and_replay()
+    other = _payload("third-request")
+    replay_payload["canonical_decision_trust_receipt"] = _receipt(
+        CanonicalDecisionArtifact.model_validate(other["canonical_decision_artifact"])
+    )
+
+    with pytest.raises(CanonicalReplayError, match="TRUST_RECEIPT_BINDING_MISMATCH"):
+        build_replay_evidence(
+            source,
+            replay_payload,
+            ReplayControls(
+                strict=True, mock_external_apis=True, seed=7, temperature=0
+            ),
+        )
+
+
+def test_replay_trust_receipt_binds_replay_cda_not_original() -> None:
+    original = _payload("original-request")
+    original_cda = CanonicalDecisionArtifact.model_validate(
+        original["canonical_decision_artifact"]
+    )
+    original["canonical_decision_trust_receipt"] = _receipt(original_cda, "a")
+    source = build_replay_source(original)
     replay_payload = _payload("new-replay-request")
+    replay_cda = CanonicalDecisionArtifact.model_validate(
+        replay_payload["canonical_decision_artifact"]
+    )
+    replay_payload["canonical_decision_trust_receipt"] = _receipt(replay_cda, "b")
 
     evidence = build_replay_evidence(
         source,
         replay_payload,
         ReplayControls(
-            strict=True,
-            mock_external_apis=True,
-            seed=7,
-            temperature=0,
+            strict=True, mock_external_apis=True, seed=7, temperature=0
         ),
     )
 
-    assert evidence.semantic_match is True
-    assert evidence.original_request_id != evidence.replay_request_id
-    assert evidence.original_cda_id != evidence.replay_cda_id
+    assert evidence.replay_cda_trust_receipt is not None
+    assert evidence.replay_cda_trust_receipt.canonical_decision_id == replay_cda.decision_id
+    assert (
+        evidence.replay_cda_trust_receipt.trust_log_entry_sha256
+        != source.original_cda_trust_receipt.trust_log_entry_sha256
+    )
+
+
+def test_trusted_replay_never_persists_nested_source(monkeypatch) -> None:
+    from veritas_os.core import pipeline
+
+    calls = 0
+
+    def persist(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+
+    monkeypatch.setattr(pipeline, "persist_replay_source", persist)
+    payload: dict = {}
+    pipeline._persist_canonical_replay_source(
+        SimpleNamespace(replay_mode=True), payload, []
+    )
+
+    assert calls == 0
+    assert "canonical_replay_source_receipt" not in payload
 
 
 def test_external_context_cannot_enable_replay_mode() -> None:
-    """User-controlled context flags are stripped at the pipeline boundary."""
     from veritas_os.core.pipeline_inputs import normalize_pipeline_inputs
 
-    class Request:
-        query_params: dict = {}
-
+    request = SimpleNamespace(query_params={})
     ctx = normalize_pipeline_inputs(
         {
             "query": "normal",
@@ -112,8 +329,14 @@ def test_external_context_cannot_enable_replay_mode() -> None:
                 "_mock_external_apis": True,
             },
         },
-        Request(),
+        request,
     )
-
     assert ctx.replay_mode is False
     assert ctx.mock_external_apis is False
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), {1: "value"}, (1,)])
+def test_strict_replay_canonicalization_rejects_non_json_values(value) -> None:
+    """Replay hashing never stringifies ambiguous or non-finite values."""
+    with pytest.raises((TypeError, ValueError)):
+        strict_canonical_json(value)

--- a/veritas_os/tests/test_canonical_replay.py
+++ b/veritas_os/tests/test_canonical_replay.py
@@ -175,7 +175,7 @@ def test_semantic_match_and_independent_evidence_verification() -> None:
     )
 
     assert evidence.semantic_match is True
-    assert evidence.fields_changed == ()
+    assert evidence.fields_changed == []
     assert evidence.original_request_id != evidence.replay_request_id
     assert evidence.original_decision_id != evidence.replay_cda.decision_id
     assert verify_canonical_replay_evidence(source, evidence) == evidence

--- a/veritas_os/tests/test_decision_replay_extra.py
+++ b/veritas_os/tests/test_decision_replay_extra.py
@@ -54,7 +54,10 @@ async def test_replay_decision_handles_non_dict_replay_meta_and_save_error(
 
     async def _fake_run_decide_pipeline(req, _request):
         captured["req"] = req
-        return {"decision": "allow", "meta": {"confidence": 0.9}}
+        return {
+            "decision": {"output": "reject"},
+            "meta": {"confidence": 0.9},
+        }
 
     def _raise_value_error(*_args, **_kwargs):
         raise ValueError("simulated write failure")

--- a/veritas_os/tests/test_decision_replay_extra.py
+++ b/veritas_os/tests/test_decision_replay_extra.py
@@ -73,7 +73,7 @@ async def test_replay_decision_handles_non_dict_replay_meta_and_save_error(
     assert result["replay_time_ms"] >= 1
 
     req = captured["req"]
-    assert req["request_id"] == "rid-42"
+    assert req["request_id"] != "rid-42"
     assert req["query"] == "What should we do?"
     assert req["seed"] == 3
     assert req["temperature"] == 0

--- a/veritas_os/tests/test_replay_engine.py
+++ b/veritas_os/tests/test_replay_engine.py
@@ -67,6 +67,7 @@ async def test_run_replay_strict_mode_skips_tools_and_matches(monkeypatch, tmp_p
 
     async def _fake_run(req, _request, **_kw):
         body = req.model_dump()
+        captured["request_id"] = body.get("request_id")
         captured["temperature"] = body.get("temperature")
         captured["seed"] = body.get("seed")
         captured["mock_external"] = body.get("context", {}).get("_mock_external_apis")
@@ -87,6 +88,7 @@ async def test_run_replay_strict_mode_skips_tools_and_matches(monkeypatch, tmp_p
     assert result.match is True
     assert captured["temperature"] == 0
     assert captured["seed"] == 42
+    assert captured["request_id"] != "dec-100"
     assert captured["mock_external"] is True
     reports = list(tmp_path.glob("replay_dec-100_*.json"))
     assert len(reports) == 1

--- a/veritas_os/tests/unit/test_pipeline_stages_ext.py
+++ b/veritas_os/tests/unit/test_pipeline_stages_ext.py
@@ -108,17 +108,39 @@ class TestNormalizePipelineInputs:
         ctx = normalize_pipeline_inputs(DummyReq(), DummyRequest())
         assert ctx.fast_mode is True
 
-    def test_replay_mode_from_context(self) -> None:
+    def test_replay_mode_cannot_be_enabled_from_context(self) -> None:
         from veritas_os.core.pipeline_inputs import normalize_pipeline_inputs
 
         class DummyReq:
             def model_dump(self):
-                return {"query": "test", "context": {"_replay_mode": True}}
+                return {
+                    "query": "test",
+                    "context": {
+                        "_replay_mode": True,
+                        "_mock_external_apis": True,
+                    },
+                }
 
         class DummyRequest:
             query_params: Dict[str, Any] = {}
 
         ctx = normalize_pipeline_inputs(DummyReq(), DummyRequest())
+        assert ctx.replay_mode is False
+        assert ctx.mock_external_apis is False
+
+    def test_replay_mode_requires_internal_marker(self) -> None:
+        from veritas_os.core.pipeline_inputs import normalize_pipeline_inputs
+        from veritas_os.core.pipeline.pipeline_replay import _ReplayRequest
+
+        class DummyReq:
+            def model_dump(self):
+                return {"query": "test", "context": {}}
+
+        ctx = normalize_pipeline_inputs(
+            DummyReq(),
+            _ReplayRequest(mock_external_apis=True),
+        )
+
         assert ctx.replay_mode is True
         assert ctx.mock_external_apis is True
 

--- a/veritas_os/tests/unit/test_plan9_pipeline_routes_rate_edges.py
+++ b/veritas_os/tests/unit/test_plan9_pipeline_routes_rate_edges.py
@@ -204,10 +204,22 @@ async def test_stage_core_execute_kernel_missing_sets_env_flag() -> None:
 
 
 @pytest.mark.anyio
-async def test_replay_endpoint_decision_not_found_returns_404(
+@pytest.mark.parametrize(
+    ("reason", "expected_status", "expected_error"),
+    [
+        ("decision_not_found: abc", 404, "decision_not_found"),
+        ("decision not found", 404, "decision_not_found"),
+        ("missing", 500, "replay_internal_failure"),
+        ("unexpected internal failure", 500, "replay_internal_failure"),
+    ],
+)
+async def test_replay_endpoint_value_error_classification(
     monkeypatch: pytest.MonkeyPatch,
+    reason: str,
+    expected_status: int,
+    expected_error: str,
 ) -> None:
-    """Replay endpoint should translate missing decision into stable 404 payload."""
+    """Only stable decision-not-found reasons map to the public 404 response."""
 
     class _DummyServer:
         @staticmethod
@@ -216,7 +228,7 @@ async def test_replay_endpoint_decision_not_found_returns_404(
 
         @staticmethod
         async def run_replay(*_args: Any, **_kwargs: Any) -> Any:
-            raise ValueError("missing")
+            raise ValueError(reason)
 
     class _DummyRequest:
         headers: dict[str, str] = {}
@@ -225,8 +237,8 @@ async def test_replay_endpoint_decision_not_found_returns_404(
 
     resp = await rd.replay_endpoint("missing-id", _DummyRequest())
 
-    assert resp.status_code == 404
-    assert resp.body
+    assert resp.status_code == expected_status
+    assert expected_error.encode("utf-8") in resp.body
 
 
 def test_start_rate_cleanup_scheduler_is_idempotent(


### PR DESCRIPTION
### Motivation
- Provide a content-addressed, encrypted Canonical Replay Source v1 and a Canonical Replay Evidence v1 to prove linkage between an original verified CDA and a replay execution while preserving the invariant that original Decision Identity != Replay Execution Identity.
- Enforce a trusted replay boundary so external callers cannot enable replay by setting `context._replay_mode` or `context._mock_external_apis`, and ensure every replay uses a fresh request identity and produces a new CDA identity.
- Keep legacy replay compatibility (no canonical evidence emitted when no valid encrypted source exists) and fail safely if encryption or storage fails.

### Description
- Added a new module `veritas_os/replay/canonical_replay.py` implementing `CanonicalReplaySource v1` (encrypted-at-rest, content-addressed, atomic write + read-back verification) and `CanonicalReplayEvidence v1` (links replay source id, original CDA id, replay CDA id, original/replay request ids, replay controls, semantic hashes, and a semantic match flag).
- Integrated source generation and persistence into the pipeline after CDA finalization in `veritas_os/core/pipeline/__init__.py` while recording failures as degraded stages and never persisting plaintext.
- Enforced a trusted replay marker and stripped user-supplied replay flags in `veritas_os/core/pipeline/pipeline_inputs.py`, and updated both replay codepaths (`veritas_os/replay/replay_engine.py` and `veritas_os/core/pipeline/pipeline_replay.py`) to use new replay request IDs (UUIDs) and to generate canonical evidence only when a valid `CanonicalReplaySource` is available.
- Added focused tests `veritas_os/tests/test_canonical_replay.py` and small adjustments to existing replay tests to assert fresh request/CDA identity semantics and to exercise encryption read-back and tamper-detection logic.

### Testing
- Final head SHA: `5206a38028748a3062c22ed18f4f32114ea032d9`.
- GitHub Actions CI #5045 passed on the final head.
- Python 3.11 full test suite: **SUCCESS**.
- Python 3.12 full test suite: **9861 passed, 24 skipped**, total coverage **88.82%** — **SUCCESS**.
- PostgreSQL Python 3.12 tests: **SUCCESS**.
- Slow tests: **SUCCESS**.
- Governance smoke and governance backend invariant gates: **SUCCESS**.
- Lint, dependency audit, future-dependency compatibility, and frontend lint/test/e2e: **SUCCESS**.
- Companion required workflows passed on the final head: Runtime Pickle Guard, Runtime Proof Evidence, Security Gates, Reviewer Evidence Packet Validation, and CodeQL.
- Added Canonical Replay tests cover encrypted-at-rest source persistence with read-back verification, ciphertext tamper rejection, semantic-match vs identity separation, trusted replay-boundary enforcement, fresh replay request/CDA identity semantics, and Pydantic model-instance validation-bypass attempts.
- The final compatibility fix aligned the stale replay-not-found test fixture with the stable production contract: `decision_not_found:<decision_id>` maps to HTTP 404, while unrelated `ValueError` values remain HTTP 500. The production error classifier was not broadened.

### Security / authority boundary
Canonical replay evidence proves linkage between an original verified CDA, a persisted replay source, and a distinct replay execution identity. It does **not** convert replay into execution authority, does not make the replay CDA identical to the original CDA, and does not bypass Handoff, ExecutionIntent, Bind, approval, policy, or other downstream governance boundaries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a80887301148326b9bb3812579e829c)