### PR TITLE
feat(handoff): bind canonical replay evidence to replay lineage v1

### DIFF
--- a/docs/en/architecture/canonical-decision-to-bind-handoff-v1.md
+++ b/docs/en/architecture/canonical-decision-to-bind-handoff-v1.md
@@ -2,18 +2,18 @@
 
 ## Status and scope
 
-`CanonicalDecisionHandoff` is a **FUTURE**, reviewable, provenance-aware
+`CanonicalDecisionHandoff` is a reviewable, provenance-aware
 envelope between decision-side evidence and a possible guarded
 `DecisionCandidate` promotion. It is not an `ExecutionIntent`, `BindReceipt`,
-command, Authority Evidence, or permission to execute. This specification and
-its synthetic fixtures do not implement a validator or production bridge.
+command, Authority Evidence, or permission to execute. A deterministic runtime
+validator now implements this validation boundary and stops after classification.
 
-The current `/v1/decide` response exposes `request_id`, but does not expose a
-canonical `decision_id`, `decision_hash`, or `decision_ts`. Those values remain
-`UNAVAILABLE`/`UNRESOLVED`; `request_id`, an HTTP response hash, arrival time,
-TrustLog retrieval time, CI time, and current time are not substitutes.
+VERITAS now defines Canonical Decision Artifact v1, Canonical Decision Trust
+Link v1, and Canonical Replay Source/Evidence v1. An HTTP response hash, arrival
+time, TrustLog retrieval time, CI time, and current time are not substitutes
+for their canonical fields.
 
-The future canonical source for those values is a **verified**
+The canonical source for those values is a **verified**
 [`CanonicalDecisionArtifact v1`](canonical-decision-artifact-v1.md). Its
 allowed mapping is `artifact.request_id` to `source_decision.request_id`,
 `artifact.decision_id` to `source_decision.canonical_decision_id`,
@@ -21,15 +21,16 @@ allowed mapping is `artifact.request_id` to `source_decision.request_id`,
 `artifact.decision_ts` to `source_decision.canonical_decision_ts`. Merely
 copying these four strings is insufficient for READY: provenance must bind the
 source artifact reference and hash, verification mechanism, and successful
-verification status. This is a future producer/consumer contract only; the v1
-runtime validator continues to accept an already formed handoff plus trusted
-validation context and does not yet depend on artifact production.
+verification status. The validator accepts an already formed handoff plus
+trusted validation context; it does not infer or automatically produce one.
+Verified replay evidence can now be adapted into `replay_lineage` through
+[`Canonical Replay Handoff Binding v1`](canonical-replay-handoff-binding-v1.md).
 
 ```mermaid
 flowchart TD
   A[LLM / Agent - EXISTING] -->|untrusted proposal| B[DecisionCandidate - EXISTING]
   B -->|structured validation| C[Decision governance - EXISTING]
-  C -->|separately verified TrustLog + replay| D[CanonicalDecisionHandoff - FUTURE]
+  C -->|separately verified TrustLog + replay| D[CanonicalDecisionHandoff validator]
   D -->|provenance, authority, approval, policy, state checks| E[Guarded promotion - FUTURE]
   E --> F[ExecutionIntent - EXISTING artifact]
   F -->|STILL NOT EXECUTION| G[Bind Boundary - EXISTING]

--- a/docs/en/architecture/canonical-replay-handoff-binding-v1.md
+++ b/docs/en/architecture/canonical-replay-handoff-binding-v1.md
@@ -1,0 +1,41 @@
+# Canonical Replay Handoff Binding v1
+
+## Boundary
+
+This local, deterministic adapter converts a verified Canonical Replay
+Source/Evidence v1 pair into an exact `replay_lineage` value and a
+`TrustedValueAssertion`. It calls `verify_canonical_replay_evidence` first. It
+performs no I/O and does not form a candidate, promote a handoff, create an
+`ExecutionIntent`, invoke Bind, or authorize an external effect.
+
+The identities remain separate. Handoff `source_decision` is the original CDA;
+`replay_lineage.request_id` is the original request ID required by the Handoff
+lineage invariant, while `replay_request_id` is the distinct replay request.
+Likewise, `original_decision_id` identifies the original CDA and
+`replay_decision_id` identifies the distinct replay CDA. Both pairs must differ.
+
+## Exact evidence representation
+
+`replay_lineage.verified=true` means only that Replay Evidence and Replay Source
+linkage passed the v1 integrity verifier. It does not mean `semantic_match` is
+true. Authentic divergence remains visible as `semantic_match=false` with its
+exact changed fields, severity, and divergence level.
+
+The assertion binds exact lineage JSON using the Handoff assertion-value digest.
+Its artifact reference/hash are Replay Evidence `evidence_id`/`evidence_hash`,
+and its mechanism is `verify_canonical_replay_evidence/v1`. Replay Source,
+Replay Evidence, original/replay CDA, TrustLog, candidate, and assertion-value
+hashes remain separate cryptographic domains.
+
+## Security non-claims
+
+Original CDA is not Replay CDA. Evidence verification is not semantic match.
+Semantic match is not Authority Evidence or Human Approval. Replay lineage is
+not TrustLog lineage, and a replay CDA Trust receipt is not source-decision
+TrustLog proof. `READY_FOR_GUARDED_PROMOTION` is neither an `ExecutionIntent`
+nor Bind authorization or execution authority.
+
+Replay evidence never fabricates actor, target, action, authority, approval,
+policy lineage, or expected state. An untrusted lineage declaring
+`verified=true` cannot become ready without its independent exact-value
+assertion.

--- a/schemas/canonical-replay-handoff-lineage-v1.schema.json
+++ b/schemas/canonical-replay-handoff-lineage-v1.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://veritas-os.example/schemas/canonical-replay-handoff-lineage-v1.schema.json",
+  "title": "Canonical Replay Handoff Lineage v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "format_version", "request_id", "verified", "verification_mechanism",
+    "artifact_type", "artifact_ref", "artifact_hash", "replay_source_id",
+    "replay_source_hash", "original_decision_id", "original_decision_hash",
+    "original_decision_ts", "replay_request_id", "replay_decision_id",
+    "replay_decision_hash", "replay_decision_ts", "semantic_profile",
+    "original_semantic_hash", "replay_semantic_hash", "semantic_match",
+    "fields_changed", "severity", "divergence_level",
+    "replay_trust_receipt_present"
+  ],
+  "properties": {
+    "format_version": {"const": "canonical-replay-handoff-lineage/v1"},
+    "request_id": {"type": "string", "minLength": 1},
+    "verified": {"const": true},
+    "verification_mechanism": {"const": "verify_canonical_replay_evidence/v1"},
+    "artifact_type": {"const": "canonical-replay-evidence/v1"},
+    "artifact_ref": {"type": "string", "pattern": "^cre:v1:sha256:[0-9a-f]{64}$"},
+    "artifact_hash": {"$ref": "#/$defs/digest"},
+    "replay_source_id": {"type": "string", "pattern": "^crs:v1:sha256:[0-9a-f]{64}$"},
+    "replay_source_hash": {"$ref": "#/$defs/digest"},
+    "original_decision_id": {"$ref": "#/$defs/cdaId"},
+    "original_decision_hash": {"$ref": "#/$defs/digest"},
+    "original_decision_ts": {"type": "string", "format": "date-time"},
+    "replay_request_id": {"type": "string", "minLength": 1},
+    "replay_decision_id": {"$ref": "#/$defs/cdaId"},
+    "replay_decision_hash": {"$ref": "#/$defs/digest"},
+    "replay_decision_ts": {"type": "string", "format": "date-time"},
+    "semantic_profile": {"const": "veritas.replay-semantic/v1"},
+    "original_semantic_hash": {"$ref": "#/$defs/digest"},
+    "replay_semantic_hash": {"$ref": "#/$defs/digest"},
+    "semantic_match": {"type": "boolean"},
+    "fields_changed": {"type": "array", "items": {"type": "string"}},
+    "severity": {"enum": ["info", "warning", "critical"]},
+    "divergence_level": {"enum": ["no_divergence", "acceptable_divergence", "critical_divergence"]},
+    "replay_trust_receipt_present": {"type": "boolean"}
+  },
+  "$defs": {
+    "digest": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "cdaId": {"type": "string", "pattern": "^cda:v1:sha256:[0-9a-f]{64}$"}
+  }
+}

--- a/tests/spec/test_decision_to_bind_handoff_spec.py
+++ b/tests/spec/test_decision_to_bind_handoff_spec.py
@@ -315,22 +315,27 @@ def test_target_context_mismatch_has_a_distinct_canonical_reason_code() -> None:
     assert target_context_reason in specification
 
 
-def test_future_canonical_decision_artifact_mapping_is_non_operational() -> None:
-    """Pin the future verified artifact source without changing readiness."""
+def test_current_canonical_decision_artifact_and_handoff_boundary() -> None:
+    """Pin current artifact identity and the non-producing validator boundary."""
     specification = Path(
         "docs/en/architecture/canonical-decision-to-bind-handoff-v1.md"
     ).read_text(encoding="utf-8")
 
-    assert "CanonicalDecisionArtifact v1" in specification
+    assert "Canonical Decision Artifact v1" in specification
+    assert "CanonicalDecisionHandoff validator" in specification
     for field_name in (
         "canonical_decision_id",
         "canonical_decision_hash",
         "canonical_decision_ts",
     ):
         assert field_name in specification
-    assert "runtime validator continues to accept an already formed handoff" in (
-        specification
-    )
+    assert "accepts an already formed handoff" in specification
+    assert "trusted validation context" in specification
+    assert "does not infer or automatically produce one" in specification
+    ready_section = specification.split("`READY_FOR_GUARDED_PROMOTION`", 1)[1]
+    assert "does not authorize execution" in ready_section
+    assert "bypass Bind" in ready_section
+    assert "ExecutionIntent" in specification
 
 
 def test_action_substitution_invalidates_authority_and_approval_bindings() -> None:

--- a/veritas_os/policy/canonical_decision_handoff.py
+++ b/veritas_os/policy/canonical_decision_handoff.py
@@ -341,6 +341,23 @@ def validate_canonical_decision_handoff(
         )
     if request_ids[0] != request_ids[1] or request_ids[0] != request_ids[2]:
         invalid.append(reason.HANDOFF_REQUEST_LINEAGE_MISMATCH)
+    if replay.get("format_version") == (
+        "canonical-replay-handoff-lineage/v1"
+    ):
+        source_binding = (
+            replay.get("request_id") == source.get("request_id")
+            and replay.get("original_decision_id")
+            == source.get("canonical_decision_id")
+            and replay.get("original_decision_hash")
+            == source.get("canonical_decision_hash")
+            and replay.get("original_decision_ts")
+            == source.get("canonical_decision_ts")
+            and replay.get("replay_request_id") != source.get("request_id")
+            and replay.get("replay_decision_id")
+            != source.get("canonical_decision_id")
+        )
+        if not source_binding:
+            invalid.append(reason.HANDOFF_SOURCE_ARTIFACT_MISMATCH)
     trustlog_verified = trustlog.get("verified")
     replay_verified = replay.get("verified")
     if type(trustlog_verified) is not bool or type(replay_verified) is not bool:

--- a/veritas_os/policy/canonical_replay_handoff_binding.py
+++ b/veritas_os/policy/canonical_replay_handoff_binding.py
@@ -1,0 +1,194 @@
+"""Bind verified replay evidence to handoff lineage without authority.
+
+This adapter is deterministic and side-effect free.  It verifies replay
+artifacts, represents their exact committed values, and produces only a local
+handoff assertion; it does not form a candidate, promote, or execute anything.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from veritas_os.policy.canonical_decision_handoff import (
+    TrustedValueAssertion,
+    canonical_handoff_assertion_value_digest,
+)
+from veritas_os.replay.canonical_replay import (
+    CanonicalReplayError,
+    CanonicalReplayEvidence,
+    CanonicalReplaySource,
+    verify_canonical_replay_evidence,
+    verify_canonical_replay_source,
+)
+
+LINEAGE_VERSION = "canonical-replay-handoff-lineage/v1"
+VERIFICATION_MECHANISM = "verify_canonical_replay_evidence/v1"
+EVIDENCE_VERIFIED_CLAIM = "CANONICAL_REPLAY_EVIDENCE_VERIFIED"
+ORIGINAL_DECISION_BOUND_CLAIM = (
+    "CANONICAL_REPLAY_EVIDENCE_BINDS_ORIGINAL_DECISION"
+)
+_DIGEST_PATTERN = r"^[0-9a-f]{64}$"
+
+
+class CanonicalReplayHandoffBindingError(ValueError):
+    """Fail-closed replay-to-handoff binding refusal."""
+
+
+class CanonicalReplayHandoffLineage(BaseModel):
+    """Exact handoff representation of verified Canonical Replay Evidence."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    format_version: Literal["canonical-replay-handoff-lineage/v1"]
+    request_id: str
+    verified: Literal[True]
+    verification_mechanism: Literal["verify_canonical_replay_evidence/v1"]
+    artifact_type: Literal["canonical-replay-evidence/v1"]
+    artifact_ref: str
+    artifact_hash: str = Field(pattern=_DIGEST_PATTERN)
+    replay_source_id: str
+    replay_source_hash: str = Field(pattern=_DIGEST_PATTERN)
+    original_decision_id: str
+    original_decision_hash: str = Field(pattern=_DIGEST_PATTERN)
+    original_decision_ts: str
+    replay_request_id: str
+    replay_decision_id: str
+    replay_decision_hash: str = Field(pattern=_DIGEST_PATTERN)
+    replay_decision_ts: str
+    semantic_profile: Literal["veritas.replay-semantic/v1"]
+    original_semantic_hash: str = Field(pattern=_DIGEST_PATTERN)
+    replay_semantic_hash: str = Field(pattern=_DIGEST_PATTERN)
+    semantic_match: bool
+    fields_changed: list[str]
+    severity: Literal["info", "warning", "critical"]
+    divergence_level: Literal[
+        "no_divergence", "acceptable_divergence", "critical_divergence"
+    ]
+    replay_trust_receipt_present: bool
+
+
+@dataclass(frozen=True)
+class CanonicalReplayHandoffBinding:
+    """Immutable lineage and its independently usable trusted assertion."""
+
+    replay_lineage: CanonicalReplayHandoffLineage
+    trusted_assertion: TrustedValueAssertion
+
+
+def _lineage(evidence: CanonicalReplayEvidence) -> CanonicalReplayHandoffLineage:
+    replay_cda = evidence.replay_cda
+    return CanonicalReplayHandoffLineage(
+        format_version=LINEAGE_VERSION,
+        request_id=evidence.original_request_id,
+        verified=True,
+        verification_mechanism=VERIFICATION_MECHANISM,
+        artifact_type=evidence.format_version,
+        artifact_ref=evidence.evidence_id,
+        artifact_hash=evidence.evidence_hash,
+        replay_source_id=evidence.replay_source_id,
+        replay_source_hash=evidence.replay_source_hash,
+        original_decision_id=evidence.original_decision_id,
+        original_decision_hash=evidence.original_decision_hash,
+        original_decision_ts=evidence.original_decision_ts,
+        replay_request_id=evidence.replay_request_id,
+        replay_decision_id=replay_cda.decision_id,
+        replay_decision_hash=replay_cda.decision_hash,
+        replay_decision_ts=replay_cda.decision_ts,
+        semantic_profile=evidence.semantic_profile,
+        original_semantic_hash=evidence.original_semantic_hash,
+        replay_semantic_hash=evidence.replay_semantic_hash,
+        semantic_match=evidence.semantic_match,
+        fields_changed=evidence.fields_changed,
+        severity=evidence.severity,
+        divergence_level=evidence.divergence_level,
+        replay_trust_receipt_present=evidence.replay_cda_trust_receipt is not None,
+    )
+
+
+def _aware(value: Any) -> bool:
+    return isinstance(value, datetime) and value.tzinfo is not None
+
+
+def build_canonical_replay_handoff_binding(
+    source: CanonicalReplaySource,
+    evidence: CanonicalReplayEvidence,
+    *,
+    verified_at: datetime,
+) -> CanonicalReplayHandoffBinding:
+    """Build lineage only after full replay evidence verification.
+
+    Args:
+        source: Canonical replay source for the original decision.
+        evidence: Evidence for a distinct replay decision.
+        verified_at: Explicit timezone-aware verification time.
+
+    Raises:
+        CanonicalReplayHandoffBindingError: If time or identity separation is
+            invalid. Replay verifier failures propagate as CanonicalReplayError.
+    """
+    if not _aware(verified_at):
+        raise CanonicalReplayHandoffBindingError("VERIFIED_AT_INVALID")
+    verified = verify_canonical_replay_evidence(source, evidence)
+    lineage = _lineage(verified)
+    if (
+        lineage.replay_request_id == lineage.request_id
+        or lineage.replay_decision_id == lineage.original_decision_id
+    ):
+        raise CanonicalReplayHandoffBindingError("REPLAY_IDENTITY_REUSED")
+    value = lineage.model_dump(mode="json")
+    assertion = TrustedValueAssertion(
+        field_path="replay_lineage",
+        value_digest=canonical_handoff_assertion_value_digest(value),
+        source_artifact_ref=verified.evidence_id,
+        source_hash=verified.evidence_hash,
+        verification_mechanism=VERIFICATION_MECHANISM,
+        verified_at=verified_at,
+        claims=(EVIDENCE_VERIFIED_CLAIM, ORIGINAL_DECISION_BOUND_CLAIM),
+    )
+    return CanonicalReplayHandoffBinding(lineage, assertion)
+
+
+def verify_canonical_replay_handoff_binding(
+    source: Any,
+    evidence: Any,
+    replay_lineage: Any,
+    trusted_assertion: Any,
+) -> CanonicalReplayHandoffBinding:
+    """Independently revalidate artifacts, exact lineage, and assertion."""
+    try:
+        verified_source = verify_canonical_replay_source(source)
+        verified_evidence = verify_canonical_replay_evidence(
+            verified_source, evidence
+        )
+        raw_lineage = (
+            replay_lineage.model_dump(mode="json")
+            if isinstance(replay_lineage, BaseModel)
+            else replay_lineage
+        )
+        candidate = CanonicalReplayHandoffLineage.model_validate(raw_lineage)
+    except (CanonicalReplayError, ValidationError, TypeError) as exc:
+        raise CanonicalReplayHandoffBindingError("REPLAY_BINDING_INVALID") from exc
+    expected = _lineage(verified_evidence)
+    if candidate != expected:
+        raise CanonicalReplayHandoffBindingError("REPLAY_LINEAGE_MISMATCH")
+    if not isinstance(trusted_assertion, TrustedValueAssertion):
+        raise CanonicalReplayHandoffBindingError("REPLAY_ASSERTION_INVALID")
+    assertion = trusted_assertion
+    value = candidate.model_dump(mode="json")
+    if (
+        assertion.field_path != "replay_lineage"
+        or assertion.value_digest
+        != canonical_handoff_assertion_value_digest(value)
+        or assertion.source_artifact_ref != verified_evidence.evidence_id
+        or assertion.source_hash != verified_evidence.evidence_hash
+        or assertion.verification_mechanism != VERIFICATION_MECHANISM
+        or not _aware(assertion.verified_at)
+        or assertion.claims
+        != (EVIDENCE_VERIFIED_CLAIM, ORIGINAL_DECISION_BOUND_CLAIM)
+    ):
+        raise CanonicalReplayHandoffBindingError("REPLAY_ASSERTION_MISMATCH")
+    return CanonicalReplayHandoffBinding(candidate, assertion)

--- a/veritas_os/tests/test_canonical_decision_handoff.py
+++ b/veritas_os/tests/test_canonical_decision_handoff.py
@@ -29,6 +29,9 @@ from veritas_os.policy.canonical_decision_handoff import (
 
 VECTOR_DIR = Path("docs/en/architecture/test-vectors/decision-to-bind-handoff-v1")
 EVALUATED_AT = datetime(2030, 1, 1, 0, 0, 2, tzinfo=timezone.utc)
+REPLAY_INTEGRATION_EVALUATED_AT = datetime(
+    2031, 2, 3, 4, 6, tzinfo=timezone.utc
+)
 
 
 def _vectors() -> list[dict[str, object]]:
@@ -134,8 +137,18 @@ def test_real_replay_binding_reaches_ready_but_cannot_self_certify() -> None:
         _artifacts,
     )
 
-    source, _, binding = _artifacts(verified_at=EVALUATED_AT)
+    source, _, binding = _artifacts(
+        verified_at=REPLAY_INTEGRATION_EVALUATED_AT
+    )
     handoff = deepcopy(_vectors()[0]["input"])
+    handoff["created_at"] = "2031-02-03T04:05:07Z"
+    handoff["expires_at"] = "2031-02-03T04:10:07Z"
+    handoff["authority_evidence"]["expires_at"] = "2031-03-01T00:00:00Z"
+    handoff["human_approval_evidence"]["expires_at"] = (
+        "2031-03-01T00:00:00Z"
+    )
+    handoff["policy_lineage"]["expires_at"] = "2031-03-01T00:00:00Z"
+    handoff["expected_state"]["observed_at"] = "2031-02-03T04:05:30Z"
     original = source.original_cda
     source_values = {
         "request_id": original.request_id,
@@ -157,6 +170,13 @@ def test_real_replay_binding_reaches_ready_but_cannot_self_certify() -> None:
             record["value"] = handoff["replay_lineage"]
             record["source_artifact_ref"] = binding.trusted_assertion.source_artifact_ref
             record["source_hash"] = binding.trusted_assertion.source_hash
+        elif path in {
+            "authority_evidence",
+            "human_approval_evidence",
+            "policy_lineage",
+            "expected_state",
+        }:
+            record["value"] = handoff[path]
     synthetic = _complete_context(handoff)
     assertions = tuple(
         binding.trusted_assertion
@@ -166,7 +186,9 @@ def test_real_replay_binding_reaches_ready_but_cannot_self_certify() -> None:
     )
     context = replace(synthetic, value_assertions=assertions)
 
-    ready = validate_canonical_decision_handoff(handoff, context, EVALUATED_AT)
+    ready = validate_canonical_decision_handoff(
+        handoff, context, REPLAY_INTEGRATION_EVALUATED_AT
+    )
     assert ready.status is CanonicalDecisionHandoffStatus.READY_FOR_GUARDED_PROMOTION
     assert ready.ready_for_guarded_promotion is True
     assert ready.fail_closed is False
@@ -178,7 +200,7 @@ def test_real_replay_binding_reaches_ready_but_cannot_self_certify() -> None:
         ),
     )
     refused = validate_canonical_decision_handoff(
-        handoff, without_assertion, EVALUATED_AT
+        handoff, without_assertion, REPLAY_INTEGRATION_EVALUATED_AT
     )
     assert refused.status is CanonicalDecisionHandoffStatus.INCOMPLETE
     assert refused.ready_for_guarded_promotion is False

--- a/veritas_os/tests/test_canonical_decision_handoff.py
+++ b/veritas_os/tests/test_canonical_decision_handoff.py
@@ -128,6 +128,111 @@ def test_ready_requires_independent_context_and_is_deterministic_and_immutable()
     assert handoff == before
 
 
+def test_real_replay_binding_reaches_ready_but_cannot_self_certify() -> None:
+    """Plug verified replay lineage into READY without creating authority."""
+    from veritas_os.tests.test_canonical_replay_handoff_binding import (
+        _artifacts,
+    )
+
+    source, _, binding = _artifacts(verified_at=EVALUATED_AT)
+    handoff = deepcopy(_vectors()[0]["input"])
+    original = source.original_cda
+    source_values = {
+        "request_id": original.request_id,
+        "canonical_decision_id": original.decision_id,
+        "canonical_decision_hash": original.decision_hash,
+        "canonical_decision_ts": original.decision_ts,
+    }
+    handoff["source_decision"].update(source_values)
+    handoff["decision_lineage"]["decision_id"] = original.decision_id
+    handoff["trustlog_lineage"]["request_id"] = original.request_id
+    handoff["replay_lineage"] = binding.replay_lineage.model_dump(mode="json")
+    for record in handoff["provenance"]:
+        path = record["field_path"]
+        if path.startswith("source_decision."):
+            record["value"] = source_values[path.rsplit(".", 1)[1]]
+        elif path == "trustlog_lineage":
+            record["value"] = handoff["trustlog_lineage"]
+        elif path == "replay_lineage":
+            record["value"] = handoff["replay_lineage"]
+            record["source_artifact_ref"] = binding.trusted_assertion.source_artifact_ref
+            record["source_hash"] = binding.trusted_assertion.source_hash
+    synthetic = _complete_context(handoff)
+    assertions = tuple(
+        binding.trusted_assertion
+        if assertion.field_path == "replay_lineage"
+        else assertion
+        for assertion in synthetic.value_assertions
+    )
+    context = replace(synthetic, value_assertions=assertions)
+
+    ready = validate_canonical_decision_handoff(handoff, context, EVALUATED_AT)
+    assert ready.status is CanonicalDecisionHandoffStatus.READY_FOR_GUARDED_PROMOTION
+    assert ready.ready_for_guarded_promotion is True
+    assert ready.fail_closed is False
+
+    without_assertion = replace(
+        context,
+        value_assertions=tuple(
+            item for item in assertions if item.field_path != "replay_lineage"
+        ),
+    )
+    refused = validate_canonical_decision_handoff(
+        handoff, without_assertion, EVALUATED_AT
+    )
+    assert refused.status is CanonicalDecisionHandoffStatus.INCOMPLETE
+    assert refused.ready_for_guarded_promotion is False
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "original_decision_id",
+        "original_decision_hash",
+        "original_decision_ts",
+        "replay_request_id",
+        "replay_decision_id",
+    ],
+)
+def test_v1_replay_lineage_cross_decision_substitution_is_invalid(
+    field: str,
+) -> None:
+    """Apply strict source binding only to the new replay lineage version."""
+    handoff = deepcopy(_vectors()[0]["input"])
+    handoff["replay_lineage"].update(
+        {
+            "format_version": "canonical-replay-handoff-lineage/v1",
+            "original_decision_id": handoff["source_decision"][
+                "canonical_decision_id"
+            ],
+            "original_decision_hash": handoff["source_decision"][
+                "canonical_decision_hash"
+            ],
+            "original_decision_ts": handoff["source_decision"][
+                "canonical_decision_ts"
+            ],
+            "replay_request_id": "distinct-replay-request",
+            "replay_decision_id": "distinct-replay-decision",
+        }
+    )
+    if field == "replay_request_id":
+        handoff["replay_lineage"][field] = handoff["source_decision"]["request_id"]
+    elif field == "replay_decision_id":
+        handoff["replay_lineage"][field] = handoff["source_decision"][
+            "canonical_decision_id"
+        ]
+    else:
+        handoff["replay_lineage"][field] = "substituted"
+
+    result = validate_canonical_decision_handoff(
+        handoff, CanonicalDecisionHandoffValidationContext(), EVALUATED_AT
+    )
+    assert result.status is CanonicalDecisionHandoffStatus.INVALID
+    assert CanonicalDecisionHandoffReasonCode.HANDOFF_SOURCE_ARTIFACT_MISMATCH in (
+        result.reason_codes
+    )
+
+
 @pytest.mark.parametrize(
     ("mutation", "reason"),
     [

--- a/veritas_os/tests/test_canonical_replay_handoff_binding.py
+++ b/veritas_os/tests/test_canonical_replay_handoff_binding.py
@@ -40,16 +40,20 @@ def _payload(request_id: str, *, divergent: bool = False) -> dict:
     vector = json.loads(VECTOR.read_text(encoding="utf-8"))
     projection = dict(vector["source_projection"])
     projection["request_id"] = request_id
-    if divergent:
-        projection["decision"] = "REJECT"
     response = DecideResponse.model_validate(projection)
     cda = build_canonical_decision_artifact(
         response, decision_ts="2031-02-03T04:05:06.123456Z"
     )
     payload = response.model_dump(mode="json")
+    if divergent:
+        payload["decision"] = {"output": "REJECT", "answer": None}
     payload["canonical_decision_artifact"] = cda.model_dump(mode="json")
     payload["deterministic_replay"] = {
-        "final_output": response.model_dump(mode="json"),
+        "final_output": {
+            key: value
+            for key, value in payload.items()
+            if key != "canonical_decision_artifact"
+        },
         "seed": 7,
         "temperature": 0,
     }
@@ -92,7 +96,9 @@ def test_authentic_semantic_divergence_remains_visible_and_verifiable() -> None:
     source, evidence, binding = _artifacts(divergent=True)
 
     assert binding.replay_lineage.semantic_match is False
-    assert binding.replay_lineage.fields_changed
+    assert binding.replay_lineage.fields_changed == ["decision"]
+    assert binding.replay_lineage.severity == "critical"
+    assert binding.replay_lineage.divergence_level == "critical_divergence"
     assert verify_canonical_replay_handoff_binding(
         source, evidence, binding.replay_lineage, binding.trusted_assertion
     ) == binding

--- a/veritas_os/tests/test_canonical_replay_handoff_binding.py
+++ b/veritas_os/tests/test_canonical_replay_handoff_binding.py
@@ -1,0 +1,229 @@
+"""Security tests for Canonical Replay Evidence handoff binding v1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator, ValidationError
+
+from veritas_os.api.schemas import DecideResponse
+from veritas_os.governance.canonical_decision_artifact import (
+    build_canonical_decision_artifact,
+)
+from veritas_os.policy.canonical_decision_handoff import TrustedValueAssertion
+from veritas_os.policy.canonical_replay_handoff_binding import (
+    CanonicalReplayHandoffBindingError,
+    CanonicalReplayHandoffLineage,
+    build_canonical_replay_handoff_binding,
+    verify_canonical_replay_handoff_binding,
+)
+from veritas_os.replay.canonical_replay import (
+    CanonicalReplayError,
+    ReplayControls,
+    build_replay_evidence,
+    build_replay_source,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+VECTOR = ROOT / (
+    "docs/en/architecture/test-vectors/canonical-decision-artifact-v1/"
+    "vector-01.json"
+)
+VERIFIED_AT = datetime(2031, 2, 3, 4, 6, tzinfo=timezone.utc)
+
+
+def _payload(request_id: str, *, divergent: bool = False) -> dict:
+    vector = json.loads(VECTOR.read_text(encoding="utf-8"))
+    projection = dict(vector["source_projection"])
+    projection["request_id"] = request_id
+    if divergent:
+        projection["decision"] = "REJECT"
+    response = DecideResponse.model_validate(projection)
+    cda = build_canonical_decision_artifact(
+        response, decision_ts="2031-02-03T04:05:06.123456Z"
+    )
+    payload = response.model_dump(mode="json")
+    payload["canonical_decision_artifact"] = cda.model_dump(mode="json")
+    payload["deterministic_replay"] = {
+        "final_output": response.model_dump(mode="json"),
+        "seed": 7,
+        "temperature": 0,
+    }
+    return payload
+
+
+def _artifacts(*, divergent: bool = False, verified_at: datetime = VERIFIED_AT):
+    source = build_replay_source(_payload("original-request"))
+    evidence = build_replay_evidence(
+        source,
+        _payload("distinct-replay-request", divergent=divergent),
+        ReplayControls(
+            strict=True, mock_external_apis=True, seed=7, temperature=0
+        ),
+    )
+    binding = build_canonical_replay_handoff_binding(
+        source, evidence, verified_at=verified_at
+    )
+    return source, evidence, binding
+
+
+def test_semantic_match_preserves_distinct_original_and_replay_identities() -> None:
+    source, evidence, binding = _artifacts()
+    lineage = binding.replay_lineage
+
+    assert lineage.semantic_match is True
+    assert lineage.fields_changed == []
+    assert lineage.request_id == evidence.original_request_id
+    assert lineage.replay_request_id == evidence.replay_request_id
+    assert lineage.request_id != lineage.replay_request_id
+    assert lineage.original_decision_id == source.original_cda.decision_id
+    assert lineage.replay_decision_id == evidence.replay_cda.decision_id
+    assert lineage.original_decision_id != lineage.replay_decision_id
+    assert verify_canonical_replay_handoff_binding(
+        source, evidence, lineage, binding.trusted_assertion
+    ) == binding
+
+
+def test_authentic_semantic_divergence_remains_visible_and_verifiable() -> None:
+    source, evidence, binding = _artifacts(divergent=True)
+
+    assert binding.replay_lineage.semantic_match is False
+    assert binding.replay_lineage.fields_changed
+    assert verify_canonical_replay_handoff_binding(
+        source, evidence, binding.replay_lineage, binding.trusted_assertion
+    ) == binding
+
+
+def test_assertion_maps_exact_lineage_to_evidence_identity() -> None:
+    _, evidence, binding = _artifacts()
+    assertion = binding.trusted_assertion
+
+    assert assertion.field_path == "replay_lineage"
+    assert assertion.source_artifact_ref == evidence.evidence_id
+    assert assertion.source_hash == evidence.evidence_hash
+    assert assertion.verification_mechanism == (
+        "verify_canonical_replay_evidence/v1"
+    )
+    assert assertion.verified_at == VERIFIED_AT
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("format_version", "forged"),
+        ("artifact_ref", "cre:v1:sha256:" + "f" * 64),
+        ("artifact_hash", "f" * 64),
+        ("original_decision_id", "cda:v1:sha256:" + "f" * 64),
+        ("replay_decision_id", "cda:v1:sha256:" + "f" * 64),
+        ("semantic_match", False),
+        ("original_semantic_hash", "f" * 64),
+        ("replay_semantic_hash", "f" * 64),
+        ("fields_changed", ["decision"]),
+        ("severity", "critical"),
+        ("divergence_level", "critical_divergence"),
+        ("replay_request_id", "original-request"),
+    ],
+)
+def test_lineage_model_copy_tampering_is_rejected(field: str, value: object) -> None:
+    source, evidence, binding = _artifacts()
+    tampered = binding.replay_lineage.model_copy(update={field: value})
+
+    with pytest.raises(CanonicalReplayHandoffBindingError):
+        verify_canonical_replay_handoff_binding(
+            source, evidence, tampered, binding.trusted_assertion
+        )
+
+
+def test_lineage_model_construct_bypass_is_rejected() -> None:
+    source, evidence, binding = _artifacts()
+    raw = binding.replay_lineage.model_dump(mode="json")
+    raw["format_version"] = "forged"
+    tampered = CanonicalReplayHandoffLineage.model_construct(**raw)
+
+    with pytest.raises(CanonicalReplayHandoffBindingError):
+        verify_canonical_replay_handoff_binding(
+            source, evidence, tampered, binding.trusted_assertion
+        )
+
+
+def test_source_and_evidence_substitution_are_rejected() -> None:
+    source_a, evidence_a, binding_a = _artifacts()
+    source_b = build_replay_source(_payload("other-original"))
+    evidence_b = build_replay_evidence(
+        source_b,
+        _payload("other-replay"),
+        ReplayControls(
+            strict=True, mock_external_apis=True, seed=7, temperature=0
+        ),
+    )
+
+    for source, evidence in ((source_b, evidence_a), (source_a, evidence_b)):
+        with pytest.raises(
+            (CanonicalReplayError, CanonicalReplayHandoffBindingError)
+        ):
+            verify_canonical_replay_handoff_binding(
+                source,
+                evidence,
+                binding_a.replay_lineage,
+                binding_a.trusted_assertion,
+            )
+
+
+def test_assertion_substitution_and_naive_clock_are_rejected() -> None:
+    source, evidence, binding = _artifacts()
+    forged = TrustedValueAssertion(
+        **{
+            **binding.trusted_assertion.__dict__,
+            "source_hash": "f" * 64,
+        }
+    )
+    with pytest.raises(CanonicalReplayHandoffBindingError):
+        verify_canonical_replay_handoff_binding(
+            source, evidence, binding.replay_lineage, forged
+        )
+    with pytest.raises(CanonicalReplayHandoffBindingError):
+        build_canonical_replay_handoff_binding(
+            source, evidence, verified_at=datetime(2031, 1, 1)
+        )
+
+
+def test_closed_schema_accepts_binding_and_rejects_extra_or_bad_id() -> None:
+    _, _, binding = _artifacts()
+    schema = json.loads(
+        (ROOT / "schemas/canonical-replay-handoff-lineage-v1.schema.json")
+        .read_text(encoding="utf-8")
+    )
+    validator = Draft202012Validator(schema)
+    value = binding.replay_lineage.model_dump(mode="json")
+    validator.validate(value)
+    with pytest.raises(ValidationError):
+        validator.validate({**value, "authorized": True})
+    with pytest.raises(ValidationError):
+        validator.validate({**value, "artifact_ref": "not-content-addressed"})
+
+
+def test_module_import_boundary_has_no_candidate_execution_or_bind() -> None:
+    path = Path("veritas_os/policy/canonical_replay_handoff_binding.py")
+    source = path.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    imported = {
+        node.module or ""
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom)
+    }
+    assert not any(
+        token in source
+        for token in (
+            "DecisionCandidate",
+            "ExecutionIntent",
+            "BindReceipt",
+            "WebhookBindAdapter",
+            "build_decision_candidate",
+            "hash_decision_candidate",
+        )
+    )
+    assert not imported & {"requests", "httpx", "subprocess", "socket"}


### PR DESCRIPTION
### Motivation

- Connect the verified Canonical Replay Evidence v1 verifier (PR #2108) into the existing CanonicalDecisionHandoff v1 trust boundary by producing an exact, independently verifiable `replay_lineage` value and a TrustedValueAssertion without creating execution authority.
- Preserve strict identity separation between original CDA and replay CDA and keep evidence verification distinct from semantic agreement, authority, human approval, and TrustLog lineage.
- Harden the handoff validator to conditionally cross-bind the new strict `replay_lineage` shape while retaining all existing fail-closed semantics and reason codes.
- Security warning: this change tightens a governance-sensitive validation boundary and requires human maintainer review before merge.

### Description

- Add a deterministic, side-effect-free adapter `veritas_os/policy/canonical_replay_handoff_binding.py` that exposes `build_canonical_replay_handoff_binding(...)` and `verify_canonical_replay_handoff_binding(...)`, reconstructs an exact frozen `CanonicalReplayHandoffLineage` from re-verified `CanonicalReplaySource` + `CanonicalReplayEvidence`, and produces a `TrustedValueAssertion` binding the exact JSON lineage value to the evidence artifact id/hash and verifier string `verify_canonical_replay_evidence/v1`.
- Add closed JSON Schema `schemas/canonical-replay-handoff-lineage-v1.schema.json` (2020-12) that pins exact format_version, verification mechanism, artifact forms and lowercase 64-char SHA-256 patterns and forbids additional properties.
- Harden `veritas_os/policy/canonical_decision_handoff.py` so that when `replay_lineage.format_version == "canonical-replay-handoff-lineage/v1"` the validator additionally enforces: `replay_lineage.request_id == source_decision.request_id`, original decision id/hash/ts equality to `source_decision` fields, and ensures `replay_request_id`/`replay_decision_id` remain distinct from the source decision identity (on mismatch use existing `HANDOFF_SOURCE_ARTIFACT_MISMATCH`).
- Add comprehensive adversarial and integration tests in `veritas_os/tests/test_canonical_replay_handoff_binding.py` and update `veritas_os/tests/test_canonical_decision_handoff.py` to exercise real binding integration (model_copy/model_construct bypasses, artifact substitution, semantic divergence, assertion checks, clock-awareness, and import-boundary assertions).
- Documentation updates: update `docs/en/architecture/canonical-decision-to-bind-handoff-v1.md` and add `docs/en/architecture/canonical-replay-handoff-binding-v1.md` describing scope, non-claims, and the safe adapter boundary.
- Non-goals preserved: no DecisionCandidate formation, no ExecutionIntent creation, no Bind invocation, no network/filesystem/subprocess/provider I/O from the new adapter.

### Security / Non-claims

- Verified Canonical Replay Evidence does **not** authorize execution.
- `semantic_match == true` does **not** satisfy Authority Evidence, Human Approval, TrustLog lineage, guarded promotion, ExecutionIntent, Bind authorization, or execution authority.
- Replay Trust receipts remain scoped to the replay CDA and do **not** satisfy the original/source decision TrustLog proof.
- `READY_FOR_GUARDED_PROMOTION` remains a validator state only; this PR does not create, promote, bind, or execute anything.

### Testing / Validation

Final PR head:

- `692d0e3c57c0bf53b15fa194a335357fcb6af90f`

GitHub Actions for the final head:

- CI #5048: **SUCCESS**
- Python 3.11 full suite: **SUCCESS**
- Python 3.12 full suite: **SUCCESS**
  - `9887 passed`
  - `24 skipped`
  - coverage `88.84%`
- PostgreSQL / contention jobs: **SUCCESS**
- slow tests: **SUCCESS**
- governance backend fast: **SUCCESS**
- governance smoke: **SUCCESS**
- lint: **SUCCESS**
- dependency audit: **SUCCESS**
- future dependency compatibility: **SUCCESS**
- frontend checks: **SUCCESS**
- Security Gates #3938: **SUCCESS**
- CodeQL #4096: **SUCCESS**
- Runtime Proof Evidence #82: **SUCCESS**
- Runtime Pickle Guard #2033: **SUCCESS**
- Reviewer Evidence Packet Validation #932: **SUCCESS**

Additional local/static validation reported by Codex:

- `ruff check` on changed Python files: passed
- `python -m py_compile` on changed production Python files: passed
- `git diff --check`: passed

Final compatibility fixes were test/fixture and documentation-coherence fixes only:

- kept the Handoff validator fail-closed rule for future CDA timestamps;
- fixed the semantic-divergence fixture to mutate a real `veritas.replay-semantic/v1` field;
- updated the historical future-only documentation test to assert the current runtime boundary;
- did not weaken production security invariants.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a812649dbcc8326ba88571424b2bb09)