### PR TITLE
feat(promotion): add guarded promotion eligibility packet v1

### DIFF
--- a/docs/en/architecture/guarded-promotion-eligibility-packet-v1.md
+++ b/docs/en/architecture/guarded-promotion-eligibility-packet-v1.md
@@ -1,0 +1,42 @@
+# Canonical Guarded Promotion Eligibility Packet v1
+
+## Purpose and boundary
+
+The packet freezes one exact `CanonicalDecisionHandoff`, its independently
+trusted validation context, the caller-supplied evaluation time, and the exact
+`READY_FOR_GUARDED_PROMOTION` validator result into a content-addressed local
+artifact. Verification reconstructs the context, reruns the handoff validator,
+and checks every digest and reviewer-facing summary.
+
+This is a pre-execution integrity artifact, not a new authority source:
+
+- `READY_FOR_GUARDED_PROMOTION` **is not** an `ExecutionIntent`.
+- A verified packet **is not** execution authorization or permission to Bind.
+- `semantic_match` **is not** Authority Evidence.
+- Replay evidence **is not** Human Approval.
+- Packet verification **is not** a Bind receipt or an external effect.
+
+Semantic divergence is reported exactly. A false `semantic_match` and nonempty
+`fields_changed` remain valid packet content when the independent handoff
+validator returns READY; packet integrity does not imply semantic agreement.
+
+## Sequence
+
+1. Canonical Decision Artifact (CDA)
+2. Trust Link
+3. Replay Source and Replay Evidence
+4. Replay Handoff Binding
+5. `CanonicalDecisionHandoff` validation
+6. Canonical Guarded Promotion Eligibility Packet v1
+7. **STOP**
+
+ExecutionIntent formation is intentionally deferred. The builder and verifier
+perform no API auto-wiring, filesystem or network access, provider calls,
+adapter calls, subprocesses, Bind invocation, or external effects.
+
+## Content addressing
+
+The format is `canonical-guarded-promotion-eligibility-packet/v1`; identifiers
+are `gpe:v1:sha256:<64 lowercase hexadecimal characters>`. Separate domains bind
+the source handoff, trusted context, validation result, and packet. The packet
+hash excludes only its own `eligibility_id` and `eligibility_hash` fields.

--- a/schemas/guarded-promotion-eligibility-packet-v1.schema.json
+++ b/schemas/guarded-promotion-eligibility-packet-v1.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://veritas-os.org/schemas/guarded-promotion-eligibility-packet-v1.schema.json",
+  "title": "Canonical Guarded Promotion Eligibility Packet v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["format_version", "eligibility_id", "eligibility_hash", "validation_mechanism", "handoff_validator_version", "issued_at", "evaluated_at", "validation_status", "ready_for_guarded_promotion", "fail_closed", "source_handoff", "source_handoff_hash", "trusted_validation_context", "trusted_validation_context_hash", "validation_result", "validation_result_hash", "verified_provenance_paths", "source_decision_identity", "candidate_identity", "evidence_lineage", "replay_summary", "scope_limitations"],
+  "properties": {
+    "format_version": {"const": "canonical-guarded-promotion-eligibility-packet/v1"},
+    "eligibility_id": {"type": "string", "pattern": "^gpe:v1:sha256:[0-9a-f]{64}$"},
+    "eligibility_hash": {"$ref": "#/$defs/digest"},
+    "validation_mechanism": {"const": "validate_canonical_decision_handoff/v1"},
+    "handoff_validator_version": {"type": "string", "minLength": 1},
+    "issued_at": {"type": "string", "format": "date-time"},
+    "evaluated_at": {"type": "string", "format": "date-time"},
+    "validation_status": {"const": "READY_FOR_GUARDED_PROMOTION"},
+    "ready_for_guarded_promotion": {"const": true},
+    "fail_closed": {"const": false},
+    "source_handoff": {"type": "object"},
+    "source_handoff_hash": {"$ref": "#/$defs/digest"},
+    "trusted_validation_context": {"type": "object"},
+    "trusted_validation_context_hash": {"$ref": "#/$defs/digest"},
+    "validation_result": {"type": "object"},
+    "validation_result_hash": {"$ref": "#/$defs/digest"},
+    "verified_provenance_paths": {"type": "array", "items": {"type": "string"}},
+    "source_decision_identity": {"$ref": "#/$defs/sourceIdentity"},
+    "candidate_identity": {"type": "object"},
+    "evidence_lineage": {"type": "object"},
+    "replay_summary": {"type": "object"},
+    "scope_limitations": {"type": "array", "minItems": 8, "uniqueItems": true, "items": {"type": "string"}}
+  },
+  "$defs": {
+    "digest": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "sourceIdentity": {
+      "type": "object", "additionalProperties": false,
+      "required": ["request_id", "canonical_decision_id", "canonical_decision_hash", "canonical_decision_ts"],
+      "properties": {
+        "request_id": {"type": "string", "minLength": 1},
+        "canonical_decision_id": {"type": "string", "minLength": 1},
+        "canonical_decision_hash": {"type": "string", "minLength": 1},
+        "canonical_decision_ts": {"type": "string", "format": "date-time"}
+      }
+    }
+  }
+}

--- a/schemas/guarded-promotion-eligibility-packet-v1.schema.json
+++ b/schemas/guarded-promotion-eligibility-packet-v1.schema.json
@@ -4,41 +4,614 @@
   "title": "Canonical Guarded Promotion Eligibility Packet v1",
   "type": "object",
   "additionalProperties": false,
-  "required": ["format_version", "eligibility_id", "eligibility_hash", "validation_mechanism", "handoff_validator_version", "issued_at", "evaluated_at", "validation_status", "ready_for_guarded_promotion", "fail_closed", "source_handoff", "source_handoff_hash", "trusted_validation_context", "trusted_validation_context_hash", "validation_result", "validation_result_hash", "verified_provenance_paths", "source_decision_identity", "candidate_identity", "evidence_lineage", "replay_summary", "scope_limitations"],
+  "required": [
+    "format_version",
+    "eligibility_id",
+    "eligibility_hash",
+    "validation_mechanism",
+    "handoff_validator_version",
+    "issued_at",
+    "evaluated_at",
+    "validation_status",
+    "ready_for_guarded_promotion",
+    "fail_closed",
+    "source_handoff",
+    "source_handoff_hash",
+    "trusted_validation_context",
+    "trusted_validation_context_hash",
+    "validation_result",
+    "validation_result_hash",
+    "verified_provenance_paths",
+    "source_decision_identity",
+    "candidate_identity",
+    "evidence_lineage",
+    "replay_summary",
+    "scope_limitations"
+  ],
   "properties": {
-    "format_version": {"const": "canonical-guarded-promotion-eligibility-packet/v1"},
-    "eligibility_id": {"type": "string", "pattern": "^gpe:v1:sha256:[0-9a-f]{64}$"},
-    "eligibility_hash": {"$ref": "#/$defs/digest"},
-    "validation_mechanism": {"const": "validate_canonical_decision_handoff/v1"},
-    "handoff_validator_version": {"type": "string", "minLength": 1},
-    "issued_at": {"type": "string", "format": "date-time"},
-    "evaluated_at": {"type": "string", "format": "date-time"},
-    "validation_status": {"const": "READY_FOR_GUARDED_PROMOTION"},
-    "ready_for_guarded_promotion": {"const": true},
-    "fail_closed": {"const": false},
-    "source_handoff": {"type": "object"},
-    "source_handoff_hash": {"$ref": "#/$defs/digest"},
-    "trusted_validation_context": {"type": "object"},
-    "trusted_validation_context_hash": {"$ref": "#/$defs/digest"},
-    "validation_result": {"type": "object"},
-    "validation_result_hash": {"$ref": "#/$defs/digest"},
-    "verified_provenance_paths": {"type": "array", "items": {"type": "string"}},
-    "source_decision_identity": {"$ref": "#/$defs/sourceIdentity"},
-    "candidate_identity": {"type": "object"},
-    "evidence_lineage": {"type": "object"},
-    "replay_summary": {"type": "object"},
-    "scope_limitations": {"type": "array", "minItems": 8, "uniqueItems": true, "items": {"type": "string"}}
+    "format_version": {
+      "const": "canonical-guarded-promotion-eligibility-packet/v1"
+    },
+    "eligibility_id": {
+      "type": "string",
+      "pattern": "^gpe:v1:sha256:[0-9a-f]{64}$"
+    },
+    "eligibility_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "validation_mechanism": {
+      "const": "validate_canonical_decision_handoff/v1"
+    },
+    "handoff_validator_version": {
+      "type": "string"
+    },
+    "issued_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "evaluated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "validation_status": {
+      "const": "READY_FOR_GUARDED_PROMOTION"
+    },
+    "ready_for_guarded_promotion": {
+      "const": true
+    },
+    "fail_closed": {
+      "const": false
+    },
+    "source_handoff": {
+      "type": "object"
+    },
+    "source_handoff_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "trusted_validation_context": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "value_assertions",
+        "candidate_hash_binding",
+        "authority_requirement_binding"
+      ],
+      "properties": {
+        "value_assertions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/valueAssertion"
+          }
+        },
+        "candidate_hash_binding": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/candidateBinding"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "authority_requirement_binding": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/authorityBinding"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "trusted_validation_context_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "validation_result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "reason_codes",
+        "structure_valid",
+        "declared_status",
+        "declared_status_matches",
+        "declared_reason_codes",
+        "declared_reason_codes_match",
+        "verified_provenance_paths",
+        "validation_version",
+        "ready_for_guarded_promotion",
+        "fail_closed",
+        "requires_review"
+      ],
+      "properties": {
+        "status": {
+          "const": "READY_FOR_GUARDED_PROMOTION"
+        },
+        "reason_codes": {
+          "const": []
+        },
+        "structure_valid": {
+          "const": true
+        },
+        "declared_status": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "declared_status_matches": {
+          "type": "boolean"
+        },
+        "declared_reason_codes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "declared_reason_codes_match": {
+          "type": "boolean"
+        },
+        "verified_provenance_paths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "validation_version": {
+          "type": "string"
+        },
+        "ready_for_guarded_promotion": {
+          "const": true
+        },
+        "fail_closed": {
+          "const": false
+        },
+        "requires_review": {
+          "const": false
+        }
+      }
+    },
+    "validation_result_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "verified_provenance_paths": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "source_decision_identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "request_id",
+        "canonical_decision_id",
+        "canonical_decision_hash",
+        "canonical_decision_ts"
+      ],
+      "properties": {
+        "request_id": {
+          "type": "string"
+        },
+        "canonical_decision_id": {
+          "type": "string"
+        },
+        "canonical_decision_hash": {
+          "type": "string"
+        },
+        "canonical_decision_ts": {
+          "type": "string"
+        }
+      }
+    },
+    "candidate_identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "candidate_id",
+        "candidate_hash",
+        "actor_identity",
+        "target_system",
+        "target_resource",
+        "action_contract_id",
+        "action_contract_version"
+      ],
+      "properties": {
+        "candidate_id": {
+          "type": "string"
+        },
+        "candidate_hash": {
+          "type": "string"
+        },
+        "actor_identity": {
+          "type": "string"
+        },
+        "target_system": {
+          "type": "string"
+        },
+        "target_resource": {
+          "type": "string"
+        },
+        "action_contract_id": {
+          "type": "string"
+        },
+        "action_contract_version": {
+          "type": "string"
+        }
+      }
+    },
+    "evidence_lineage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "trustlog_artifact_ref",
+        "trustlog_chain_hash",
+        "replay_artifact_ref",
+        "replay_artifact_hash",
+        "authority_evidence_ref",
+        "authority_evidence_hash",
+        "human_approval_receipt_ref",
+        "human_approval_receipt_hash",
+        "policy_snapshot_id",
+        "policy_version",
+        "policy_semantic_digest",
+        "expected_state_fingerprint",
+        "expected_state_source_ref"
+      ],
+      "properties": {
+        "trustlog_artifact_ref": {
+          "type": "string"
+        },
+        "trustlog_chain_hash": {
+          "type": "string"
+        },
+        "replay_artifact_ref": {
+          "type": "string"
+        },
+        "replay_artifact_hash": {
+          "type": "string"
+        },
+        "authority_evidence_ref": {
+          "type": "string"
+        },
+        "authority_evidence_hash": {
+          "type": "string"
+        },
+        "human_approval_receipt_ref": {
+          "type": "string"
+        },
+        "human_approval_receipt_hash": {
+          "type": "string"
+        },
+        "policy_snapshot_id": {
+          "type": "string"
+        },
+        "policy_version": {
+          "type": "string"
+        },
+        "policy_semantic_digest": {
+          "type": "string"
+        },
+        "expected_state_fingerprint": {
+          "type": "string"
+        },
+        "expected_state_source_ref": {
+          "type": "string"
+        }
+      }
+    },
+    "replay_summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "original_decision_id",
+        "replay_decision_id",
+        "original_request_id",
+        "replay_request_id",
+        "semantic_profile",
+        "semantic_match",
+        "fields_changed",
+        "severity",
+        "divergence_level"
+      ],
+      "properties": {
+        "original_decision_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "replay_decision_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "original_request_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "replay_request_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "semantic_profile": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "semantic_match": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "fields_changed": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "severity": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "divergence_level": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "scope_limitations": {
+      "type": "array",
+      "prefixItems": [
+        {
+          "const": "NOT_EXECUTION_AUTHORITY"
+        },
+        {
+          "const": "NOT_EXECUTION_INTENT"
+        },
+        {
+          "const": "NOT_BIND_AUTHORIZATION"
+        },
+        {
+          "const": "NOT_BIND_RECEIPT"
+        },
+        {
+          "const": "NOT_EXTERNAL_EFFECT"
+        },
+        {
+          "const": "NOT_AUTHORITY_EVIDENCE"
+        },
+        {
+          "const": "NOT_HUMAN_APPROVAL"
+        },
+        {
+          "const": "NOT_TRUSTLOG_SUBSTITUTE"
+        }
+      ],
+      "items": false,
+      "minItems": 8,
+      "maxItems": 8
+    }
   },
   "$defs": {
-    "digest": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
-    "sourceIdentity": {
-      "type": "object", "additionalProperties": false,
-      "required": ["request_id", "canonical_decision_id", "canonical_decision_hash", "canonical_decision_ts"],
+    "valueAssertion": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "field_path",
+        "value_digest",
+        "verification_mechanism",
+        "source_artifact_ref",
+        "source_hash",
+        "verified_at",
+        "claims"
+      ],
       "properties": {
-        "request_id": {"type": "string", "minLength": 1},
-        "canonical_decision_id": {"type": "string", "minLength": 1},
-        "canonical_decision_hash": {"type": "string", "minLength": 1},
-        "canonical_decision_ts": {"type": "string", "format": "date-time"}
+        "field_path": {
+          "type": "string"
+        },
+        "value_digest": {
+          "type": "string"
+        },
+        "verification_mechanism": {
+          "type": "string"
+        },
+        "source_artifact_ref": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "source_hash": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "verified_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "claims": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "candidateBinding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "candidate_value_digest",
+        "asserted_candidate_hash",
+        "candidate_hash_profile",
+        "verification_mechanism",
+        "claim",
+        "source_artifact_ref",
+        "source_hash",
+        "verified_at"
+      ],
+      "properties": {
+        "candidate_value_digest": {
+          "type": "string"
+        },
+        "asserted_candidate_hash": {
+          "type": "string"
+        },
+        "candidate_hash_profile": {
+          "type": "string"
+        },
+        "verification_mechanism": {
+          "type": "string"
+        },
+        "claim": {
+          "type": "string"
+        },
+        "source_artifact_ref": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "source_hash": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "verified_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "authorityBinding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "authority_requirement_value_digest",
+        "authority_evidence_value_digest",
+        "verification_mechanism",
+        "claim",
+        "source_artifact_ref",
+        "source_hash",
+        "verified_at"
+      ],
+      "properties": {
+        "authority_requirement_value_digest": {
+          "type": "string"
+        },
+        "authority_evidence_value_digest": {
+          "type": "string"
+        },
+        "verification_mechanism": {
+          "type": "string"
+        },
+        "claim": {
+          "type": "string"
+        },
+        "source_artifact_ref": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "source_hash": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "verified_at": {
+          "type": "string",
+          "format": "date-time"
+        }
       }
     }
   }

--- a/veritas_os/policy/guarded_promotion_eligibility.py
+++ b/veritas_os/policy/guarded_promotion_eligibility.py
@@ -125,7 +125,50 @@ def _aware_iso(value: datetime, code: str) -> str:
 def _context_from_json(
     raw: dict[str, Any],
 ) -> CanonicalDecisionHandoffValidationContext:
+    """Reconstruct only the complete, closed v1 trusted-context shape."""
+    context_keys = {
+        "value_assertions",
+        "candidate_hash_binding",
+        "authority_requirement_binding",
+    }
+    value_assertion_keys = {
+        "field_path",
+        "value_digest",
+        "source_artifact_ref",
+        "source_hash",
+        "verification_mechanism",
+        "verified_at",
+        "claims",
+    }
+    candidate_binding_keys = {
+        "candidate_value_digest",
+        "asserted_candidate_hash",
+        "candidate_hash_profile",
+        "source_artifact_ref",
+        "source_hash",
+        "verification_mechanism",
+        "verified_at",
+        "claim",
+    }
+    authority_binding_keys = {
+        "authority_requirement_value_digest",
+        "authority_evidence_value_digest",
+        "source_artifact_ref",
+        "source_hash",
+        "verification_mechanism",
+        "verified_at",
+        "claim",
+    }
     try:
+        if not isinstance(raw, dict) or set(raw) != context_keys:
+            raise ValueError("trusted context keys differ")
+        if not isinstance(raw["value_assertions"], list):
+            raise TypeError("value_assertions is not an array")
+        if any(
+            not isinstance(item, dict) or set(item) != value_assertion_keys
+            for item in raw["value_assertions"]
+        ):
+            raise ValueError("value assertion keys differ")
         assertions = tuple(
             TrustedValueAssertion(
                 **{
@@ -138,7 +181,11 @@ def _context_from_json(
         )
         candidate = raw.get("candidate_hash_binding")
         authority = raw.get("authority_requirement_binding")
-        if candidate:
+        if candidate is not None:
+            if not isinstance(candidate, dict) or set(candidate) != (
+                candidate_binding_keys
+            ):
+                raise ValueError("candidate binding keys differ")
             candidate = CandidateHashBindingAssertion(
                 **{
                     **candidate,
@@ -147,7 +194,11 @@ def _context_from_json(
                     ),
                 }
             )
-        if authority:
+        if authority is not None:
+            if not isinstance(authority, dict) or set(authority) != (
+                authority_binding_keys
+            ):
+                raise ValueError("authority binding keys differ")
             authority = AuthorityEvidenceRequirementBindingAssertion(
                 **{
                     **authority,
@@ -161,7 +212,7 @@ def _context_from_json(
         )
         _json_value(context)
         return context
-    except (KeyError, TypeError, ValueError) as exc:
+    except (AttributeError, KeyError, TypeError, ValueError) as exc:
         raise GuardedPromotionEligibilityError(
             "GPE_CONTEXT_RECONSTRUCTION_FAILED"
         ) from exc
@@ -227,6 +278,8 @@ def build_guarded_promotion_eligibility_packet(
     """Build a packet only after independently rerunning the handoff validator."""
     evaluated = _aware_iso(evaluated_at, "GPE_EVALUATED_AT_INVALID")
     issued = _aware_iso(issued_at, "GPE_ISSUED_AT_INVALID")
+    if issued_at < evaluated_at:
+        raise GuardedPromotionEligibilityError("GPE_ISSUED_BEFORE_EVALUATED")
     source = _json_value(handoff)
     context = _json_value(trusted_context)
     result = validate_canonical_decision_handoff(source, trusted_context, evaluated_at)
@@ -300,6 +353,10 @@ def verify_guarded_promotion_eligibility_packet(
         if actual != expected:
             raise GuardedPromotionEligibilityError(code)
     context = _context_from_json(candidate.trusted_validation_context)
+    if _json_value(context) != candidate.trusted_validation_context:
+        raise GuardedPromotionEligibilityError(
+            "GPE_TRUSTED_CONTEXT_ROUNDTRIP_MISMATCH"
+        )
     try:
         evaluated = datetime.fromisoformat(candidate.evaluated_at)
         issued = datetime.fromisoformat(candidate.issued_at)
@@ -307,9 +364,16 @@ def verify_guarded_promotion_eligibility_packet(
         _aware_iso(issued, "GPE_ISSUED_AT_INVALID")
     except ValueError as exc:
         raise GuardedPromotionEligibilityError("GPE_TIMESTAMP_INVALID") from exc
-    result = validate_canonical_decision_handoff(
-        candidate.source_handoff, context, evaluated
-    )
+    if issued < evaluated:
+        raise GuardedPromotionEligibilityError("GPE_ISSUED_BEFORE_EVALUATED")
+    try:
+        result = validate_canonical_decision_handoff(
+            candidate.source_handoff, context, evaluated
+        )
+    except (AttributeError, KeyError, TypeError, ValueError) as exc:
+        raise GuardedPromotionEligibilityError(
+            "GPE_VALIDATION_RERUN_FAILED"
+        ) from exc
     if result.status is not CanonicalDecisionHandoffStatus.READY_FOR_GUARDED_PROMOTION:
         raise GuardedPromotionEligibilityError("GPE_HANDOFF_NOT_READY")
     if _json_value(result.to_dict()) != candidate.validation_result:

--- a/veritas_os/policy/guarded_promotion_eligibility.py
+++ b/veritas_os/policy/guarded_promotion_eligibility.py
@@ -1,0 +1,334 @@
+"""Content-addressed, pre-execution guarded-promotion eligibility packets.
+
+This module is deliberately local and side-effect free.  A verified packet is
+only evidence that the handoff validator returned READY for the captured input;
+it is neither execution authority nor permission to invoke Bind.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from veritas_os.policy.canonical_decision_handoff import (
+    AuthorityEvidenceRequirementBindingAssertion,
+    CandidateHashBindingAssertion,
+    CanonicalDecisionHandoffStatus,
+    CanonicalDecisionHandoffValidationContext,
+    TrustedValueAssertion,
+    validate_canonical_decision_handoff,
+)
+
+FORMAT_VERSION = "canonical-guarded-promotion-eligibility-packet/v1"
+VALIDATION_MECHANISM = "validate_canonical_decision_handoff/v1"
+SOURCE_HANDOFF_DOMAIN = "veritas.guarded-promotion-eligibility.source-handoff/v1"
+TRUSTED_CONTEXT_DOMAIN = "veritas.guarded-promotion-eligibility.trusted-context/v1"
+VALIDATION_RESULT_DOMAIN = "veritas.guarded-promotion-eligibility.validation-result/v1"
+PACKET_DOMAIN = "veritas.guarded-promotion-eligibility.packet/v1"
+SCOPE_LIMITATIONS = (
+    "NOT_EXECUTION_AUTHORITY",
+    "NOT_EXECUTION_INTENT",
+    "NOT_BIND_AUTHORIZATION",
+    "NOT_BIND_RECEIPT",
+    "NOT_EXTERNAL_EFFECT",
+    "NOT_AUTHORITY_EVIDENCE",
+    "NOT_HUMAN_APPROVAL",
+    "NOT_TRUSTLOG_SUBSTITUTE",
+)
+
+
+class GuardedPromotionEligibilityError(ValueError):
+    """Stable, fail-closed packet construction or verification refusal."""
+
+
+class CanonicalGuardedPromotionEligibilityPacket(BaseModel):
+    """Strict immutable snapshot of one READY handoff validation."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    format_version: Literal[
+        "canonical-guarded-promotion-eligibility-packet/v1"
+    ]
+    eligibility_id: str = Field(pattern=r"^gpe:v1:sha256:[0-9a-f]{64}$")
+    eligibility_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    validation_mechanism: Literal["validate_canonical_decision_handoff/v1"]
+    handoff_validator_version: str
+    issued_at: str
+    evaluated_at: str
+    validation_status: Literal["READY_FOR_GUARDED_PROMOTION"]
+    ready_for_guarded_promotion: Literal[True]
+    fail_closed: Literal[False]
+    source_handoff: dict[str, Any]
+    source_handoff_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    trusted_validation_context: dict[str, Any]
+    trusted_validation_context_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    validation_result: dict[str, Any]
+    validation_result_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    verified_provenance_paths: tuple[str, ...]
+    source_decision_identity: dict[str, Any]
+    candidate_identity: dict[str, Any]
+    evidence_lineage: dict[str, Any]
+    replay_summary: dict[str, Any]
+    scope_limitations: tuple[str, ...]
+
+
+def _json_value(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        value = value.model_dump(mode="python")
+    elif hasattr(value, "__dataclass_fields__"):
+        value = asdict(value)
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        if value != value or value in (float("inf"), float("-inf")):
+            raise GuardedPromotionEligibilityError("GPE_JSON_VALUE_INVALID")
+        return value
+    if isinstance(value, datetime):
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise GuardedPromotionEligibilityError("GPE_TIMESTAMP_INVALID")
+        return value.isoformat()
+    if isinstance(value, (list, tuple)):
+        return [_json_value(item) for item in value]
+    if isinstance(value, dict):
+        if not all(isinstance(key, str) for key in value):
+            raise GuardedPromotionEligibilityError("GPE_JSON_VALUE_INVALID")
+        return {key: _json_value(item) for key, item in value.items()}
+    raise GuardedPromotionEligibilityError("GPE_JSON_VALUE_INVALID")
+
+
+def _digest(domain: str, value: Any) -> str:
+    raw = json.dumps(
+        {"domain": domain, "value": _json_value(value)},
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _aware_iso(value: datetime, code: str) -> str:
+    if (
+        not isinstance(value, datetime)
+        or value.tzinfo is None
+        or value.utcoffset() is None
+    ):
+        raise GuardedPromotionEligibilityError(code)
+    return value.isoformat()
+
+
+def _context_from_json(
+    raw: dict[str, Any],
+) -> CanonicalDecisionHandoffValidationContext:
+    try:
+        assertions = tuple(
+            TrustedValueAssertion(
+                **{
+                    **item,
+                    "verified_at": datetime.fromisoformat(item["verified_at"]),
+                    "claims": tuple(item.get("claims", ())),
+                },
+            )
+            for item in raw["value_assertions"]
+        )
+        candidate = raw.get("candidate_hash_binding")
+        authority = raw.get("authority_requirement_binding")
+        if candidate:
+            candidate = CandidateHashBindingAssertion(
+                **{
+                    **candidate,
+                    "verified_at": datetime.fromisoformat(
+                        candidate["verified_at"]
+                    ),
+                }
+            )
+        if authority:
+            authority = AuthorityEvidenceRequirementBindingAssertion(
+                **{
+                    **authority,
+                    "verified_at": datetime.fromisoformat(
+                        authority["verified_at"]
+                    ),
+                }
+            )
+        context = CanonicalDecisionHandoffValidationContext(
+            assertions, candidate, authority
+        )
+        _json_value(context)
+        return context
+    except (KeyError, TypeError, ValueError) as exc:
+        raise GuardedPromotionEligibilityError(
+            "GPE_CONTEXT_RECONSTRUCTION_FAILED"
+        ) from exc
+
+
+def _identities(handoff: dict[str, Any]) -> tuple[dict[str, Any], ...]:
+    source = handoff["source_decision"]
+    candidate = handoff["candidate"]
+    action = candidate["canonical_action"]
+    trust = handoff["trustlog_lineage"]
+    replay = handoff["replay_lineage"]
+    authority = handoff["authority_evidence"]
+    approval = handoff["human_approval_evidence"]
+    policy = handoff["policy_lineage"]
+    state = handoff["expected_state"]
+    source_identity = {key: source[key] for key in (
+        "request_id", "canonical_decision_id", "canonical_decision_hash",
+        "canonical_decision_ts")}
+    candidate_identity = {
+        "candidate_id": candidate["candidate_id"],
+        "candidate_hash": handoff["candidate_hash"],
+        "actor_identity": candidate["actor_identity"],
+        "target_system": candidate["target_system"],
+        "target_resource": candidate["target_resource"],
+        "action_contract_id": action["contract_id"],
+        "action_contract_version": action["version"],
+    }
+    evidence = {
+        "trustlog_artifact_ref": trust["artifact_ref"],
+        "trustlog_chain_hash": trust["chain_hash"],
+        "replay_artifact_ref": replay["artifact_ref"],
+        "replay_artifact_hash": replay["artifact_hash"],
+        "authority_evidence_ref": authority["evidence_ref"],
+        "authority_evidence_hash": authority["evidence_hash"],
+        "human_approval_receipt_ref": approval["receipt_ref"],
+        "human_approval_receipt_hash": approval["receipt_hash"],
+        "policy_snapshot_id": policy["snapshot_id"],
+        "policy_version": policy["version"],
+        "policy_semantic_digest": policy["semantic_digest"],
+        "expected_state_fingerprint": state["fingerprint"],
+        "expected_state_source_ref": state["source_ref"],
+    }
+    replay_summary = {key: replay.get(key) for key in (
+        "original_decision_id", "replay_decision_id", "original_request_id",
+        "replay_request_id", "semantic_profile", "semantic_match",
+        "fields_changed", "severity", "divergence_level")}
+    return source_identity, candidate_identity, evidence, replay_summary
+
+
+def _packet_hash(raw: dict[str, Any]) -> str:
+    return _digest(PACKET_DOMAIN, {
+        key: value for key, value in raw.items()
+        if key not in {"eligibility_id", "eligibility_hash"}
+    })
+
+
+def build_guarded_promotion_eligibility_packet(
+    handoff: Any,
+    trusted_context: CanonicalDecisionHandoffValidationContext,
+    evaluated_at: datetime,
+    issued_at: datetime,
+) -> CanonicalGuardedPromotionEligibilityPacket:
+    """Build a packet only after independently rerunning the handoff validator."""
+    evaluated = _aware_iso(evaluated_at, "GPE_EVALUATED_AT_INVALID")
+    issued = _aware_iso(issued_at, "GPE_ISSUED_AT_INVALID")
+    source = _json_value(handoff)
+    context = _json_value(trusted_context)
+    result = validate_canonical_decision_handoff(source, trusted_context, evaluated_at)
+    if not (
+        result.status is CanonicalDecisionHandoffStatus.READY_FOR_GUARDED_PROMOTION
+        and result.ready_for_guarded_promotion
+        and not result.fail_closed
+        and result.reason_codes == ()
+    ):
+        raise GuardedPromotionEligibilityError("GPE_HANDOFF_NOT_READY")
+    result_json = _json_value(result.to_dict())
+    source_id, candidate_id, evidence, replay = _identities(source)
+    raw = {
+        "format_version": FORMAT_VERSION,
+        "validation_mechanism": VALIDATION_MECHANISM,
+        "handoff_validator_version": result.validation_version,
+        "issued_at": issued, "evaluated_at": evaluated,
+        "validation_status": result.status.value,
+        "ready_for_guarded_promotion": True, "fail_closed": False,
+        "source_handoff": source,
+        "source_handoff_hash": _digest(SOURCE_HANDOFF_DOMAIN, source),
+        "trusted_validation_context": context,
+        "trusted_validation_context_hash": _digest(TRUSTED_CONTEXT_DOMAIN, context),
+        "validation_result": result_json,
+        "validation_result_hash": _digest(VALIDATION_RESULT_DOMAIN, result_json),
+        "verified_provenance_paths": result.verified_provenance_paths,
+        "source_decision_identity": source_id, "candidate_identity": candidate_id,
+        "evidence_lineage": evidence, "replay_summary": replay,
+        "scope_limitations": SCOPE_LIMITATIONS,
+    }
+    digest = _packet_hash(raw)
+    raw.update(eligibility_hash=digest, eligibility_id=f"gpe:v1:sha256:{digest}")
+    return verify_guarded_promotion_eligibility_packet(raw)
+
+
+def verify_guarded_promotion_eligibility_packet(
+    packet: Any,
+) -> CanonicalGuardedPromotionEligibilityPacket:
+    """Dump, revalidate, and independently recompute every packet binding."""
+    try:
+        raw = (
+            packet.model_dump(mode="json")
+            if isinstance(packet, BaseModel)
+            else _json_value(packet)
+        )
+        candidate = CanonicalGuardedPromotionEligibilityPacket.model_validate(raw)
+    except (ValidationError, GuardedPromotionEligibilityError, TypeError) as exc:
+        raise GuardedPromotionEligibilityError("GPE_PACKET_INVALID") from exc
+    raw = candidate.model_dump(mode="json")
+    checks = (
+        (
+            candidate.source_handoff_hash,
+            _digest(SOURCE_HANDOFF_DOMAIN, candidate.source_handoff),
+            "GPE_SOURCE_HANDOFF_HASH_MISMATCH",
+        ),
+        (
+            candidate.trusted_validation_context_hash,
+            _digest(
+                TRUSTED_CONTEXT_DOMAIN,
+                candidate.trusted_validation_context,
+            ),
+            "GPE_TRUSTED_CONTEXT_HASH_MISMATCH",
+        ),
+        (
+            candidate.validation_result_hash,
+            _digest(VALIDATION_RESULT_DOMAIN, candidate.validation_result),
+            "GPE_VALIDATION_RESULT_MISMATCH",
+        ),
+    )
+    for actual, expected, code in checks:
+        if actual != expected:
+            raise GuardedPromotionEligibilityError(code)
+    context = _context_from_json(candidate.trusted_validation_context)
+    try:
+        evaluated = datetime.fromisoformat(candidate.evaluated_at)
+        issued = datetime.fromisoformat(candidate.issued_at)
+        _aware_iso(evaluated, "GPE_EVALUATED_AT_INVALID")
+        _aware_iso(issued, "GPE_ISSUED_AT_INVALID")
+    except ValueError as exc:
+        raise GuardedPromotionEligibilityError("GPE_TIMESTAMP_INVALID") from exc
+    result = validate_canonical_decision_handoff(
+        candidate.source_handoff, context, evaluated
+    )
+    if result.status is not CanonicalDecisionHandoffStatus.READY_FOR_GUARDED_PROMOTION:
+        raise GuardedPromotionEligibilityError("GPE_HANDOFF_NOT_READY")
+    if _json_value(result.to_dict()) != candidate.validation_result:
+        raise GuardedPromotionEligibilityError("GPE_VALIDATION_RESULT_MISMATCH")
+    identities = _identities(candidate.source_handoff)
+    if identities != (candidate.source_decision_identity, candidate.candidate_identity,
+                      candidate.evidence_lineage, candidate.replay_summary):
+        raise GuardedPromotionEligibilityError("GPE_PACKET_SUMMARY_MISMATCH")
+    replay = candidate.replay_summary
+    if replay.get("original_request_id") is not None and (
+        replay["original_request_id"] == replay.get("replay_request_id")
+        or replay.get("original_decision_id") == replay.get("replay_decision_id")
+    ):
+        raise GuardedPromotionEligibilityError("GPE_REPLAY_IDENTITY_COLLAPSED")
+    if candidate.scope_limitations != SCOPE_LIMITATIONS:
+        raise GuardedPromotionEligibilityError("GPE_SCOPE_LIMITATIONS_MISSING")
+    digest = _packet_hash(raw)
+    if candidate.eligibility_hash != digest:
+        raise GuardedPromotionEligibilityError("GPE_PACKET_HASH_MISMATCH")
+    if candidate.eligibility_id != f"gpe:v1:sha256:{digest}":
+        raise GuardedPromotionEligibilityError("GPE_PACKET_ID_MISMATCH")
+    return candidate

--- a/veritas_os/tests/test_guarded_promotion_eligibility.py
+++ b/veritas_os/tests/test_guarded_promotion_eligibility.py
@@ -1,0 +1,137 @@
+"""Security and integrity tests for guarded-promotion eligibility packets."""
+
+from __future__ import annotations
+
+import ast
+import json
+from copy import deepcopy
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from veritas_os.policy.guarded_promotion_eligibility import (
+    GuardedPromotionEligibilityError,
+    build_guarded_promotion_eligibility_packet,
+    verify_guarded_promotion_eligibility_packet,
+)
+from veritas_os.tests.test_canonical_decision_handoff import _complete_context
+
+VECTOR = Path(
+    "docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-01.json"
+)
+NOW = datetime(2030, 1, 1, 0, 0, 2, tzinfo=timezone.utc)
+
+
+def _ready():
+    handoff = json.loads(VECTOR.read_text())["input"]
+    return handoff, _complete_context(handoff)
+
+
+def _packet():
+    handoff, context = _ready()
+    return build_guarded_promotion_eligibility_packet(handoff, context, NOW, NOW)
+
+
+def test_ready_packet_is_deterministic_verified_and_has_no_authority() -> None:
+    packet = _packet()
+    assert verify_guarded_promotion_eligibility_packet(packet) == packet
+    assert packet.validation_status == "READY_FOR_GUARDED_PROMOTION"
+    assert packet.ready_for_guarded_promotion is True
+    assert packet.fail_closed is False
+    expected_source = dict(packet.source_handoff["source_decision"])
+    expected_source.pop("gate_decision")
+    assert packet.source_decision_identity == expected_source
+    assert "NOT_EXECUTION_INTENT" in packet.scope_limitations
+    assert "NOT_BIND_RECEIPT" in packet.scope_limitations
+    assert _packet() == packet
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda h: h.__setitem__("authority_evidence", None),
+        lambda h: h.__setitem__("human_approval_evidence", None),
+        lambda h: h["trustlog_lineage"].__setitem__("verified", False),
+        lambda h: h["replay_lineage"].__setitem__("verified", False),
+        lambda h: h["target_context"].__setitem__("target_system", "other"),
+        lambda h: h.__setitem__("candidate_hash", "changed"),
+        lambda h: h["policy_lineage"].__setitem__("superseded", True),
+        lambda h: h["expected_state"].__setitem__(
+            "observed_at", "2020-01-01T00:00:00Z"
+        ),
+        lambda h: h.__setitem__("expires_at", "2029-01-01T00:00:00Z"),
+        lambda h: h["source_decision"].__setitem__(
+            "canonical_decision_ts", "2031-01-01T00:00:00Z"
+        ),
+    ],
+)
+def test_non_ready_handoff_is_refused(mutation) -> None:
+    handoff, _ = _ready()
+    mutation(handoff)
+    context = _complete_context(handoff)
+    with pytest.raises(GuardedPromotionEligibilityError, match="GPE_HANDOFF_NOT_READY"):
+        build_guarded_promotion_eligibility_packet(handoff, context, NOW, NOW)
+
+
+@pytest.mark.parametrize("which", ["evaluated", "issued"])
+def test_naive_times_are_refused(which: str) -> None:
+    handoff, context = _ready()
+    naive = NOW.replace(tzinfo=None)
+    with pytest.raises(GuardedPromotionEligibilityError, match="INVALID"):
+        build_guarded_promotion_eligibility_packet(
+            handoff, context, naive if which == "evaluated" else NOW,
+            naive if which == "issued" else NOW,
+        )
+
+
+@pytest.mark.parametrize(
+    "path,value",
+    [
+        (("eligibility_id",), "gpe:v1:sha256:" + "0" * 64),
+        (("eligibility_hash",), "0" * 64),
+        (("source_handoff_hash",), "0" * 64),
+        (("trusted_validation_context_hash",), "0" * 64),
+        (("validation_result_hash",), "0" * 64),
+        (("validation_result", "structure_valid"), False),
+        (("source_decision_identity", "request_id"), "substituted"),
+        (("candidate_identity", "candidate_id"), "substituted"),
+        (("evidence_lineage", "trustlog_artifact_ref"), "substituted"),
+        (("replay_summary", "semantic_match"), False),
+        (("scope_limitations",), ["NOT_EXECUTION_INTENT"]),
+    ],
+)
+def test_tamper_and_instance_bypass_are_refused(path, value) -> None:
+    packet = _packet()
+    raw = packet.model_dump(mode="json")
+    target = raw
+    for component in path[:-1]:
+        target = target[component]
+    target[path[-1]] = value
+    bypass = packet.model_copy(update={path[0]: raw[path[0]]})
+    with pytest.raises(GuardedPromotionEligibilityError):
+        verify_guarded_promotion_eligibility_packet(bypass)
+
+
+def test_construct_bypass_and_unsupported_json_are_refused() -> None:
+    packet = _packet()
+    bypass = type(packet).model_construct(
+        **(packet.model_dump(mode="python") | {"format_version": "bad"})
+    )
+    with pytest.raises(GuardedPromotionEligibilityError):
+        verify_guarded_promotion_eligibility_packet(bypass)
+    handoff, context = _ready()
+    handoff["bad"] = object()
+    with pytest.raises(GuardedPromotionEligibilityError):
+        build_guarded_promotion_eligibility_packet(handoff, context, NOW, NOW)
+
+
+def test_static_import_boundary() -> None:
+    source = Path("veritas_os/policy/guarded_promotion_eligibility.py").read_text()
+    imported = {alias.name for node in ast.walk(ast.parse(source))
+                if isinstance(node, (ast.Import, ast.ImportFrom))
+                for alias in node.names}
+    forbidden = {"ExecutionIntent", "BindReceipt", "execute_bind_boundary",
+                 "execute_bind_adjudication", "WebhookBindAdapter",
+                 "ReferenceBindAdapter", "requests", "httpx", "subprocess"}
+    assert imported.isdisjoint(forbidden)

--- a/veritas_os/tests/test_guarded_promotion_eligibility.py
+++ b/veritas_os/tests/test_guarded_promotion_eligibility.py
@@ -5,13 +5,17 @@ from __future__ import annotations
 import ast
 import json
 from copy import deepcopy
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
+from jsonschema import Draft202012Validator, FormatChecker
 
 from veritas_os.policy.guarded_promotion_eligibility import (
+    TRUSTED_CONTEXT_DOMAIN,
     GuardedPromotionEligibilityError,
+    _digest,
+    _packet_hash,
     build_guarded_promotion_eligibility_packet,
     verify_guarded_promotion_eligibility_packet,
 )
@@ -31,6 +35,17 @@ def _ready():
 def _packet():
     handoff, context = _ready()
     return build_guarded_promotion_eligibility_packet(handoff, context, NOW, NOW)
+
+
+def _resign(raw: dict, *, context_changed: bool = False) -> dict:
+    """Recompute test-only digests so a mutation reaches semantic checks."""
+    if context_changed:
+        raw["trusted_validation_context_hash"] = _digest(
+            TRUSTED_CONTEXT_DOMAIN, raw["trusted_validation_context"]
+        )
+    raw["eligibility_hash"] = _packet_hash(raw)
+    raw["eligibility_id"] = f"gpe:v1:sha256:{raw['eligibility_hash']}"
+    return raw
 
 
 def test_ready_packet_is_deterministic_verified_and_has_no_authority() -> None:
@@ -85,6 +100,85 @@ def test_naive_times_are_refused(which: str) -> None:
         )
 
 
+def test_packet_timeline_accepts_equal_and_later_issue_times() -> None:
+    handoff, context = _ready()
+    equal = build_guarded_promotion_eligibility_packet(
+        handoff, context, NOW, NOW
+    )
+    later = build_guarded_promotion_eligibility_packet(
+        handoff, context, NOW, NOW + timedelta(seconds=1)
+    )
+    assert verify_guarded_promotion_eligibility_packet(equal) == equal
+    assert verify_guarded_promotion_eligibility_packet(later) == later
+
+
+def test_packet_timeline_rejects_issue_before_evaluation() -> None:
+    handoff, context = _ready()
+    with pytest.raises(
+        GuardedPromotionEligibilityError,
+        match="GPE_ISSUED_BEFORE_EVALUATED",
+    ):
+        build_guarded_promotion_eligibility_packet(
+            handoff, context, NOW, NOW - timedelta(seconds=1)
+        )
+    raw = _packet().model_dump(mode="json")
+    raw["issued_at"] = (NOW - timedelta(seconds=1)).isoformat()
+    with pytest.raises(
+        GuardedPromotionEligibilityError,
+        match="GPE_ISSUED_BEFORE_EVALUATED",
+    ):
+        verify_guarded_promotion_eligibility_packet(_resign(raw))
+
+
+def test_semantic_divergence_is_preserved_and_is_not_a_gate() -> None:
+    handoff, _ = _ready()
+    handoff["replay_lineage"].update(
+        semantic_match=False,
+        fields_changed=["outcome.status"],
+    )
+    replay_record = next(
+        item
+        for item in handoff["provenance"]
+        if item["field_path"] == "replay_lineage"
+    )
+    replay_record["value"] = deepcopy(handoff["replay_lineage"])
+    packet = build_guarded_promotion_eligibility_packet(
+        handoff, _complete_context(handoff), NOW, NOW
+    )
+    assert packet.replay_summary["semantic_match"] is False
+    assert packet.replay_summary["fields_changed"] == ["outcome.status"]
+    assert verify_guarded_promotion_eligibility_packet(packet) == packet
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda c: c.__setitem__("ignored", "must-not-be-ignored"),
+        lambda c: c["value_assertions"][0].__setitem__("ignored", True),
+        lambda c: c["candidate_hash_binding"].__setitem__("ignored", True),
+        lambda c: c["authority_requirement_binding"].__setitem__(
+            "ignored", True
+        ),
+        lambda c: c.__setitem__("candidate_hash_binding", {}),
+        lambda c: c.__setitem__("authority_requirement_binding", {}),
+        lambda c: c["value_assertions"][0].__setitem__(
+            "verified_at", "malformed"
+        ),
+        lambda c: c["value_assertions"][0].pop("field_path"),
+    ],
+)
+def test_malformed_or_unused_trusted_context_is_rejected(mutation) -> None:
+    raw = _packet().model_dump(mode="json")
+    mutation(raw["trusted_validation_context"])
+    with pytest.raises(
+        GuardedPromotionEligibilityError,
+        match="GPE_CONTEXT_RECONSTRUCTION_FAILED",
+    ):
+        verify_guarded_promotion_eligibility_packet(
+            _resign(raw, context_changed=True)
+        )
+
+
 @pytest.mark.parametrize(
     "path,value",
     [
@@ -135,3 +229,16 @@ def test_static_import_boundary() -> None:
                  "execute_bind_adjudication", "WebhookBindAdapter",
                  "ReferenceBindAdapter", "requests", "httpx", "subprocess"}
     assert imported.isdisjoint(forbidden)
+
+
+def test_closed_schema_accepts_packet_and_rejects_nested_extra_fields() -> None:
+    schema = json.loads(
+        Path(
+            "schemas/guarded-promotion-eligibility-packet-v1.schema.json"
+        ).read_text()
+    )
+    validator = Draft202012Validator(schema, format_checker=FormatChecker())
+    raw = _packet().model_dump(mode="json")
+    validator.validate(raw)
+    raw["trusted_validation_context"]["ignored"] = True
+    assert list(validator.iter_errors(raw))


### PR DESCRIPTION
### Motivation
- Freeze a `READY_FOR_GUARDED_PROMOTION` `CanonicalDecisionHandoff` validation result into a local, content-addressed, side-effect-free eligibility packet prior to any `ExecutionIntent` formation.
- Provide an auditable artifact that preserves exact handoff/context/validator outputs and that cannot be used to authorize execution, invoke Bind, or fabricate approvals.
- Expose deterministic builder and verifier helpers so downstream code or a future API can request, validate, and display the packet without introducing side effects.

### Description
- Add a new local, side-effect-free module `veritas_os/policy/guarded_promotion_eligibility.py` implementing the strict Pydantic model `CanonicalGuardedPromotionEligibilityPacket`, the builder `build_guarded_promotion_eligibility_packet`, and the verifier `verify_guarded_promotion_eligibility_packet` with separate domain hashes (`veritas.guarded-promotion-eligibility.*`) and `format_version` `canonical-guarded-promotion-eligibility-packet/v1`.
- The builder reruns `validate_canonical_decision_handoff(...)` and only creates a packet when the exact handoff validates as `READY_FOR_GUARDED_PROMOTION` with no reason codes, `ready_for_guarded_promotion == true`, and `fail_closed == false`.
- The verifier revalidates the strict packet model, recomputes source handoff / trusted context / validation result / packet hashes, reconstructs the trusted context, reruns the Handoff validator, checks exact validation-result equality, verifies reviewer-facing identity/lineage summaries, enforces original/replay identity separation, and rejects tampering.
- Hardened trusted-context handling: the packet now requires a closed trusted validation context shape, rejects ignored/extra fields, verifies exact trusted-context round-trip equality, and wraps malformed reconstruction or validation rerun failures into stable `GuardedPromotionEligibilityError` failures.
- Enforce packet timeline integrity: `issued_at` and `evaluated_at` must be timezone-aware and `issued_at >= evaluated_at`.
- Add a closed JSON Schema `schemas/guarded-promotion-eligibility-packet-v1.schema.json` and an architecture doc `docs/en/architecture/guarded-promotion-eligibility-packet-v1.md` documenting non-claims, scope limitations, and the STOP boundary before `ExecutionIntent` or Bind.
- Add focused tests `veritas_os/tests/test_guarded_promotion_eligibility.py` covering success, non-READY refusals, tamper/instance-bypass rejections, strict trusted-context reconstruction, timeline checks, semantic divergence preservation, schema closure, and static import-boundary enforcement.

### Security / Non-claims
- A verified Guarded Promotion Eligibility Packet does **not** authorize execution.
- It does **not** create an `ExecutionIntent`.
- It does **not** create a `BindReceipt`.
- It does **not** invoke Bind, adapters, webhooks, providers, network, filesystem, subprocesses, or external systems.
- It does **not** satisfy Authority Evidence, Human Approval, TrustLog lineage, Replay lineage, Policy lineage, Expected State, Target Context, or Candidate Hash.
- `semantic_match == true` does **not** become execution authorization, and `semantic_match == false` is preserved as evidence content rather than converted into an execution gate in this PR.
- `READY_FOR_GUARDED_PROMOTION` remains a validator state only; this PR stops before promotion, ExecutionIntent formation, Bind authorization, or external effect.

### Testing / Validation

Final PR head:

- `b89247538b60f1f13d991464337d067315ce63ff`

GitHub Actions for the final head:

- CI #5051: **SUCCESS**
- Python 3.11 full suite: **SUCCESS**
- Python 3.12 full suite: **SUCCESS**
- PostgreSQL / contention jobs: **SUCCESS**
- slow tests: **SUCCESS**
- governance backend fast: **SUCCESS**
- governance smoke: **SUCCESS**
- lint: **SUCCESS**
- dependency audit: **SUCCESS**
- future dependency compatibility: **SUCCESS**
- frontend lint/test/e2e: **SUCCESS**
- Security Gates #3941: **SUCCESS**
- CodeQL #4099: **SUCCESS**
- Runtime Proof Evidence #88: **SUCCESS**
- Runtime Pickle Guard #2036: **SUCCESS**
- Reviewer Evidence Packet Validation #938: **SUCCESS**

Focused validation covered in the final implementation:

- READY Handoff builds and verifies a deterministic eligibility packet.
- Non-READY Handoffs refuse packet creation, including missing Authority Evidence, missing Human Approval, unverified TrustLog, unverified Replay lineage, target mismatch, candidate hash mismatch, stale policy/state, expired handoff, and future source-decision timestamp.
- Timezone-naive `evaluated_at` and `issued_at` are rejected.
- `issued_at == evaluated_at` and `issued_at > evaluated_at` are accepted; `issued_at < evaluated_at` is rejected.
- Strict trusted-context reconstruction rejects ignored or extra fields in `trusted_validation_context`, `TrustedValueAssertion`, `candidate_hash_binding`, and `authority_requirement_binding`.
- Semantic divergence is preserved: `semantic_match == false` with non-empty `fields_changed` can still produce a valid packet when the independent Handoff validator returns READY.
- Packet tamper and Pydantic instance-bypass tests reject changed ids, hashes, validation result, source decision summary, candidate summary, evidence lineage, replay summary, and scope limitations.
- The closed JSON Schema accepts a valid packet and rejects nested extra trusted-context fields.
- Static import-boundary test confirms the new module does not import `ExecutionIntent`, `BindReceipt`, bind execution helpers, webhook adapters, `requests`, `httpx`, or `subprocess`.

Final hardening commit notes:

- added exact trusted-context round-trip validation;
- wrapped malformed packet/context/validation rerun failures into stable fail-closed errors;
- enforced `issued_at >= evaluated_at`;
- tightened nested JSON Schema objects and exact scope limitations;
- added semantic-divergence preservation and schema-closure tests;
- did not weaken `CanonicalDecisionHandoff` semantics;
- did not create `ExecutionIntent`;
- did not create `BindReceipt`;
- did not invoke Bind;
- did not add API auto-wiring;
- did not turn replay `semantic_match` into execution authorization.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a817305a1708326adb8e58564be8446)