### PR TITLE
feat(promotion): add execution-intent formation readiness v1

### DIFF
--- a/docs/en/architecture/execution-intent-formation-readiness-v1.md
+++ b/docs/en/architecture/execution-intent-formation-readiness-v1.md
@@ -1,0 +1,57 @@
+# ExecutionIntent Formation Readiness v1
+
+## Purpose and safety boundary
+
+The Canonical ExecutionIntent Formation Readiness Packet verifies that one
+exact, content-addressed Guarded Promotion Eligibility Packet contains the
+minimum deterministic source values needed by a **future** explicit
+ExecutionIntent formation step. The builder verifies the embedded eligibility
+packet; the readiness verifier independently verifies it again and recomputes
+the complete mapping.
+
+This artifact is deliberately narrower than promotion or execution:
+
+- an Eligibility Packet is **not** an `ExecutionIntent`;
+- formation readiness is **not** execution authorization;
+- formation readiness is **not** Bind authorization;
+- `semantic_match` is **not** Authority Evidence or Human Approval; and
+- verified readiness is **not** an adapter call or external effect.
+
+The packet maps only values already present in the verified eligibility
+artifact. It does not infer or create actor identity, target, action, policy,
+approval, authority, or expected state. `execution_intent_id` and `ttl_seconds`
+are explicitly deferred. No `ExecutionIntent`, ExecutionIntent hash,
+ExecutionIntent TrustLog entry, or `BindReceipt` is created, and Bind is never
+invoked.
+
+## Auditable sequence
+
+1. Canonical Decision Artifact (CDA)
+2. Trust Link
+3. Replay Source and Replay Evidence
+4. Replay Handoff Binding
+5. `CanonicalDecisionHandoff` validation
+6. Canonical Guarded Promotion Eligibility Packet v1
+7. Canonical ExecutionIntent Formation Readiness Packet v1
+8. **STOP**
+
+Actual ExecutionIntent formation is intentionally deferred to a future,
+explicitly reviewed PR. This module is a local library boundary and is not
+automatically wired into API routes or pipeline stages.
+
+## Integrity and semantic divergence
+
+The format version is
+`canonical-execution-intent-formation-readiness/v1`. Its identifier is
+`eifr:v1:sha256:<64 lowercase hexadecimal characters>`. The packet hash
+excludes only `readiness_id` and `readiness_hash`.
+
+Separate domain strings protect the mapping, required-field contract, and
+packet. The full Eligibility Packet is embedded as exact JSON, while compact
+reviewer-facing identity and lineage summaries must exactly match it.
+
+A verified Eligibility Packet may preserve `semantic_match: false` and its
+exact `fields_changed`. Formation readiness does not hide or reverse that
+divergence and does not turn semantic agreement or divergence into authority,
+approval, execution permission, or a refusal policy. Any future
+operation-specific replay-equivalence gate requires a separate change.

--- a/schemas/execution-intent-formation-readiness-v1.schema.json
+++ b/schemas/execution-intent-formation-readiness-v1.schema.json
@@ -1,0 +1,1234 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://veritas-os.org/schemas/execution-intent-formation-readiness-v1.schema.json",
+  "title": "Canonical ExecutionIntent Formation Readiness Packet v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "format_version",
+    "readiness_id",
+    "readiness_hash",
+    "verification_mechanism",
+    "checked_at",
+    "source_eligibility",
+    "source_eligibility_hash",
+    "source_eligibility_packet",
+    "source_handoff_hash",
+    "trusted_validation_context_hash",
+    "validation_result_hash",
+    "formation_status",
+    "ready_for_execution_intent_formation",
+    "fail_closed",
+    "execution_intent_contract_version",
+    "execution_intent_required_fields",
+    "source_to_execution_intent_mapping",
+    "mapping_value_digest",
+    "required_field_presence",
+    "source_decision_identity",
+    "candidate_identity",
+    "evidence_lineage",
+    "replay_summary",
+    "scope_limitations"
+  ],
+  "properties": {
+    "format_version": {
+      "const": "canonical-execution-intent-formation-readiness/v1"
+    },
+    "readiness_id": {
+      "type": "string",
+      "pattern": "^eifr:v1:sha256:[0-9a-f]{64}$"
+    },
+    "readiness_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "verification_mechanism": {
+      "const": "verify_guarded_promotion_eligibility_packet/v1"
+    },
+    "checked_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "source_eligibility": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "eligibility_id",
+        "eligibility_hash",
+        "format_version",
+        "validation_mechanism",
+        "handoff_validator_version",
+        "issued_at",
+        "evaluated_at"
+      ],
+      "properties": {
+        "eligibility_id": {
+          "type": "string",
+          "pattern": "^gpe:v1:sha256:[0-9a-f]{64}$"
+        },
+        "eligibility_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "format_version": {
+          "const": "canonical-guarded-promotion-eligibility-packet/v1"
+        },
+        "validation_mechanism": {
+          "const": "validate_canonical_decision_handoff/v1"
+        },
+        "handoff_validator_version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "issued_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "evaluated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "source_eligibility_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "source_eligibility_packet": {
+      "$ref": "#/$defs/eligibility"
+    },
+    "source_handoff_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "trusted_validation_context_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "validation_result_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "formation_status": {
+      "const": "READY_FOR_EXECUTION_INTENT_FORMATION"
+    },
+    "ready_for_execution_intent_formation": {
+      "const": true
+    },
+    "fail_closed": {
+      "const": false
+    },
+    "execution_intent_contract_version": {
+      "const": "execution-intent-contract/v1"
+    },
+    "execution_intent_required_fields": {
+      "type": "array",
+      "prefixItems": [
+        {
+          "const": "execution_intent_id"
+        },
+        {
+          "const": "decision_id"
+        },
+        {
+          "const": "request_id"
+        },
+        {
+          "const": "policy_snapshot_id"
+        },
+        {
+          "const": "actor_identity"
+        },
+        {
+          "const": "target_system"
+        },
+        {
+          "const": "target_resource"
+        },
+        {
+          "const": "intended_action"
+        },
+        {
+          "const": "evidence_refs"
+        },
+        {
+          "const": "decision_hash"
+        },
+        {
+          "const": "decision_ts"
+        },
+        {
+          "const": "ttl_seconds"
+        },
+        {
+          "const": "expected_state_fingerprint"
+        },
+        {
+          "const": "approval_context"
+        },
+        {
+          "const": "policy_lineage"
+        }
+      ],
+      "items": false,
+      "minItems": 15,
+      "maxItems": 15
+    },
+    "source_to_execution_intent_mapping": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "decision_id",
+        "request_id",
+        "policy_snapshot_id",
+        "actor_identity",
+        "target_system",
+        "target_resource",
+        "intended_action",
+        "evidence_refs",
+        "decision_hash",
+        "decision_ts",
+        "ttl_seconds",
+        "expected_state_fingerprint",
+        "approval_context",
+        "policy_lineage"
+      ],
+      "properties": {
+        "decision_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "request_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_snapshot_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "actor_identity": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_system": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_resource": {
+          "type": "string",
+          "minLength": 1
+        },
+        "intended_action": {
+          "type": "string",
+          "minLength": 1
+        },
+        "evidence_refs": {
+          "type": "array",
+          "minItems": 5,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "decision_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "decision_ts": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "ttl_seconds": {
+          "type": "null"
+        },
+        "expected_state_fingerprint": {
+          "type": "string",
+          "minLength": 1
+        },
+        "approval_context": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "human_approval_receipt_ref",
+            "human_approval_receipt_hash"
+          ],
+          "properties": {
+            "human_approval_receipt_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "human_approval_receipt_hash": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "policy_lineage": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "policy_snapshot_id",
+            "policy_version",
+            "policy_semantic_digest"
+          ],
+          "properties": {
+            "policy_snapshot_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_version": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_semantic_digest": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    },
+    "mapping_value_digest": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "required_field_presence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "execution_intent_id",
+        "decision_id",
+        "request_id",
+        "policy_snapshot_id",
+        "actor_identity",
+        "target_system",
+        "target_resource",
+        "intended_action",
+        "evidence_refs",
+        "decision_hash",
+        "decision_ts",
+        "ttl_seconds",
+        "expected_state_fingerprint",
+        "approval_context",
+        "policy_lineage"
+      ],
+      "properties": {
+        "execution_intent_id": {
+          "const": "intentionally_deferred"
+        },
+        "decision_id": {
+          "const": "mapped"
+        },
+        "request_id": {
+          "const": "mapped"
+        },
+        "policy_snapshot_id": {
+          "const": "mapped"
+        },
+        "actor_identity": {
+          "const": "mapped"
+        },
+        "target_system": {
+          "const": "mapped"
+        },
+        "target_resource": {
+          "const": "mapped"
+        },
+        "intended_action": {
+          "const": "mapped"
+        },
+        "evidence_refs": {
+          "const": "mapped"
+        },
+        "decision_hash": {
+          "const": "mapped"
+        },
+        "decision_ts": {
+          "const": "mapped"
+        },
+        "ttl_seconds": {
+          "const": "intentionally_deferred"
+        },
+        "expected_state_fingerprint": {
+          "const": "mapped"
+        },
+        "approval_context": {
+          "const": "mapped"
+        },
+        "policy_lineage": {
+          "const": "mapped"
+        }
+      }
+    },
+    "source_decision_identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "request_id",
+        "canonical_decision_id",
+        "canonical_decision_hash",
+        "canonical_decision_ts"
+      ],
+      "properties": {
+        "request_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "canonical_decision_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "canonical_decision_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "canonical_decision_ts": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "candidate_identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "candidate_id",
+        "candidate_hash",
+        "actor_identity",
+        "target_system",
+        "target_resource",
+        "action_contract_id",
+        "action_contract_version"
+      ],
+      "properties": {
+        "candidate_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "candidate_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "actor_identity": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_system": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_resource": {
+          "type": "string",
+          "minLength": 1
+        },
+        "action_contract_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "action_contract_version": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "evidence_lineage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "trustlog_artifact_ref",
+        "trustlog_chain_hash",
+        "replay_artifact_ref",
+        "replay_artifact_hash",
+        "authority_evidence_ref",
+        "authority_evidence_hash",
+        "human_approval_receipt_ref",
+        "human_approval_receipt_hash",
+        "policy_snapshot_id",
+        "policy_version",
+        "policy_semantic_digest",
+        "expected_state_fingerprint",
+        "expected_state_source_ref"
+      ],
+      "properties": {
+        "trustlog_artifact_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "trustlog_chain_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "replay_artifact_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "replay_artifact_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "authority_evidence_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "authority_evidence_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "human_approval_receipt_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "human_approval_receipt_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_snapshot_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_semantic_digest": {
+          "type": "string",
+          "minLength": 1
+        },
+        "expected_state_fingerprint": {
+          "type": "string",
+          "minLength": 1
+        },
+        "expected_state_source_ref": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "replay_summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "original_decision_id",
+        "replay_decision_id",
+        "original_request_id",
+        "replay_request_id",
+        "semantic_profile",
+        "semantic_match",
+        "fields_changed",
+        "severity",
+        "divergence_level"
+      ],
+      "properties": {
+        "original_decision_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "replay_decision_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "original_request_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "replay_request_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "semantic_profile": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "semantic_match": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "fields_changed": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "severity": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "divergence_level": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "scope_limitations": {
+      "type": "array",
+      "prefixItems": [
+        {
+          "const": "NOT_EXECUTION_INTENT"
+        },
+        {
+          "const": "NOT_EXECUTION_AUTHORITY"
+        },
+        {
+          "const": "NOT_BIND_AUTHORIZATION"
+        },
+        {
+          "const": "NOT_BIND_RECEIPT"
+        },
+        {
+          "const": "NOT_EXTERNAL_EFFECT"
+        },
+        {
+          "const": "NOT_ADAPTER_INVOCATION"
+        },
+        {
+          "const": "NOT_OPERATION_COMMIT"
+        },
+        {
+          "const": "NOT_TRUSTLOG_WRITE"
+        }
+      ],
+      "items": false,
+      "minItems": 8,
+      "maxItems": 8
+    }
+  },
+  "$defs": {
+    "eligibility": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://veritas-os.org/schemas/guarded-promotion-eligibility-packet-v1.schema.json",
+      "title": "Canonical Guarded Promotion Eligibility Packet v1",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "format_version",
+        "eligibility_id",
+        "eligibility_hash",
+        "validation_mechanism",
+        "handoff_validator_version",
+        "issued_at",
+        "evaluated_at",
+        "validation_status",
+        "ready_for_guarded_promotion",
+        "fail_closed",
+        "source_handoff",
+        "source_handoff_hash",
+        "trusted_validation_context",
+        "trusted_validation_context_hash",
+        "validation_result",
+        "validation_result_hash",
+        "verified_provenance_paths",
+        "source_decision_identity",
+        "candidate_identity",
+        "evidence_lineage",
+        "replay_summary",
+        "scope_limitations"
+      ],
+      "properties": {
+        "format_version": {
+          "const": "canonical-guarded-promotion-eligibility-packet/v1"
+        },
+        "eligibility_id": {
+          "type": "string",
+          "pattern": "^gpe:v1:sha256:[0-9a-f]{64}$"
+        },
+        "eligibility_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "validation_mechanism": {
+          "const": "validate_canonical_decision_handoff/v1"
+        },
+        "handoff_validator_version": {
+          "type": "string"
+        },
+        "issued_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "evaluated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "validation_status": {
+          "const": "READY_FOR_GUARDED_PROMOTION"
+        },
+        "ready_for_guarded_promotion": {
+          "const": true
+        },
+        "fail_closed": {
+          "const": false
+        },
+        "source_handoff": {
+          "type": "object"
+        },
+        "source_handoff_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "trusted_validation_context": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "value_assertions",
+            "candidate_hash_binding",
+            "authority_requirement_binding"
+          ],
+          "properties": {
+            "value_assertions": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/valueAssertion"
+              }
+            },
+            "candidate_hash_binding": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/candidateBinding"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "authority_requirement_binding": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/authorityBinding"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        },
+        "trusted_validation_context_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "validation_result": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "status",
+            "reason_codes",
+            "structure_valid",
+            "declared_status",
+            "declared_status_matches",
+            "declared_reason_codes",
+            "declared_reason_codes_match",
+            "verified_provenance_paths",
+            "validation_version",
+            "ready_for_guarded_promotion",
+            "fail_closed",
+            "requires_review"
+          ],
+          "properties": {
+            "status": {
+              "const": "READY_FOR_GUARDED_PROMOTION"
+            },
+            "reason_codes": {
+              "const": []
+            },
+            "structure_valid": {
+              "const": true
+            },
+            "declared_status": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "declared_status_matches": {
+              "type": "boolean"
+            },
+            "declared_reason_codes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "declared_reason_codes_match": {
+              "type": "boolean"
+            },
+            "verified_provenance_paths": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "validation_version": {
+              "type": "string"
+            },
+            "ready_for_guarded_promotion": {
+              "const": true
+            },
+            "fail_closed": {
+              "const": false
+            },
+            "requires_review": {
+              "const": false
+            }
+          }
+        },
+        "validation_result_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "verified_provenance_paths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source_decision_identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "request_id",
+            "canonical_decision_id",
+            "canonical_decision_hash",
+            "canonical_decision_ts"
+          ],
+          "properties": {
+            "request_id": {
+              "type": "string"
+            },
+            "canonical_decision_id": {
+              "type": "string"
+            },
+            "canonical_decision_hash": {
+              "type": "string"
+            },
+            "canonical_decision_ts": {
+              "type": "string"
+            }
+          }
+        },
+        "candidate_identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "candidate_id",
+            "candidate_hash",
+            "actor_identity",
+            "target_system",
+            "target_resource",
+            "action_contract_id",
+            "action_contract_version"
+          ],
+          "properties": {
+            "candidate_id": {
+              "type": "string"
+            },
+            "candidate_hash": {
+              "type": "string"
+            },
+            "actor_identity": {
+              "type": "string"
+            },
+            "target_system": {
+              "type": "string"
+            },
+            "target_resource": {
+              "type": "string"
+            },
+            "action_contract_id": {
+              "type": "string"
+            },
+            "action_contract_version": {
+              "type": "string"
+            }
+          }
+        },
+        "evidence_lineage": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "trustlog_artifact_ref",
+            "trustlog_chain_hash",
+            "replay_artifact_ref",
+            "replay_artifact_hash",
+            "authority_evidence_ref",
+            "authority_evidence_hash",
+            "human_approval_receipt_ref",
+            "human_approval_receipt_hash",
+            "policy_snapshot_id",
+            "policy_version",
+            "policy_semantic_digest",
+            "expected_state_fingerprint",
+            "expected_state_source_ref"
+          ],
+          "properties": {
+            "trustlog_artifact_ref": {
+              "type": "string"
+            },
+            "trustlog_chain_hash": {
+              "type": "string"
+            },
+            "replay_artifact_ref": {
+              "type": "string"
+            },
+            "replay_artifact_hash": {
+              "type": "string"
+            },
+            "authority_evidence_ref": {
+              "type": "string"
+            },
+            "authority_evidence_hash": {
+              "type": "string"
+            },
+            "human_approval_receipt_ref": {
+              "type": "string"
+            },
+            "human_approval_receipt_hash": {
+              "type": "string"
+            },
+            "policy_snapshot_id": {
+              "type": "string"
+            },
+            "policy_version": {
+              "type": "string"
+            },
+            "policy_semantic_digest": {
+              "type": "string"
+            },
+            "expected_state_fingerprint": {
+              "type": "string"
+            },
+            "expected_state_source_ref": {
+              "type": "string"
+            }
+          }
+        },
+        "replay_summary": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "original_decision_id",
+            "replay_decision_id",
+            "original_request_id",
+            "replay_request_id",
+            "semantic_profile",
+            "semantic_match",
+            "fields_changed",
+            "severity",
+            "divergence_level"
+          ],
+          "properties": {
+            "original_decision_id": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "replay_decision_id": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "original_request_id": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "replay_request_id": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "semantic_profile": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "semantic_match": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "fields_changed": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "severity": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "divergence_level": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        },
+        "scope_limitations": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "const": "NOT_EXECUTION_AUTHORITY"
+            },
+            {
+              "const": "NOT_EXECUTION_INTENT"
+            },
+            {
+              "const": "NOT_BIND_AUTHORIZATION"
+            },
+            {
+              "const": "NOT_BIND_RECEIPT"
+            },
+            {
+              "const": "NOT_EXTERNAL_EFFECT"
+            },
+            {
+              "const": "NOT_AUTHORITY_EVIDENCE"
+            },
+            {
+              "const": "NOT_HUMAN_APPROVAL"
+            },
+            {
+              "const": "NOT_TRUSTLOG_SUBSTITUTE"
+            }
+          ],
+          "items": false,
+          "minItems": 8,
+          "maxItems": 8
+        }
+      },
+      "$defs": {
+        "valueAssertion": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "field_path",
+            "value_digest",
+            "verification_mechanism",
+            "source_artifact_ref",
+            "source_hash",
+            "verified_at",
+            "claims"
+          ],
+          "properties": {
+            "field_path": {
+              "type": "string"
+            },
+            "value_digest": {
+              "type": "string"
+            },
+            "verification_mechanism": {
+              "type": "string"
+            },
+            "source_artifact_ref": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "source_hash": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "verified_at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "claims": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "candidateBinding": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "candidate_value_digest",
+            "asserted_candidate_hash",
+            "candidate_hash_profile",
+            "verification_mechanism",
+            "claim",
+            "source_artifact_ref",
+            "source_hash",
+            "verified_at"
+          ],
+          "properties": {
+            "candidate_value_digest": {
+              "type": "string"
+            },
+            "asserted_candidate_hash": {
+              "type": "string"
+            },
+            "candidate_hash_profile": {
+              "type": "string"
+            },
+            "verification_mechanism": {
+              "type": "string"
+            },
+            "claim": {
+              "type": "string"
+            },
+            "source_artifact_ref": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "source_hash": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "verified_at": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "authorityBinding": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "authority_requirement_value_digest",
+            "authority_evidence_value_digest",
+            "verification_mechanism",
+            "claim",
+            "source_artifact_ref",
+            "source_hash",
+            "verified_at"
+          ],
+          "properties": {
+            "authority_requirement_value_digest": {
+              "type": "string"
+            },
+            "authority_evidence_value_digest": {
+              "type": "string"
+            },
+            "verification_mechanism": {
+              "type": "string"
+            },
+            "claim": {
+              "type": "string"
+            },
+            "source_artifact_ref": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "source_hash": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "verified_at": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/veritas_os/policy/execution_intent_formation_readiness.py
+++ b/veritas_os/policy/execution_intent_formation_readiness.py
@@ -1,0 +1,407 @@
+"""Verify deterministic source readiness for future ExecutionIntent formation.
+
+This local boundary only maps an already verified guarded-promotion eligibility
+packet.  It deliberately creates no execution artifact, authority, receipt,
+TrustLog entry, adapter invocation, or external effect.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from veritas_os.policy.guarded_promotion_eligibility import (
+    CanonicalGuardedPromotionEligibilityPacket,
+    GuardedPromotionEligibilityError,
+    verify_guarded_promotion_eligibility_packet,
+)
+
+FORMAT_VERSION = "canonical-execution-intent-formation-readiness/v1"
+VERIFICATION_MECHANISM = "verify_guarded_promotion_eligibility_packet/v1"
+EXECUTION_INTENT_CONTRACT_VERSION = "execution-intent-contract/v1"
+MAPPING_DOMAIN = "veritas.execution-intent-formation-readiness.mapping/v1"
+REQUIRED_FIELDS_DOMAIN = (
+    "veritas.execution-intent-formation-readiness.required-fields/v1"
+)
+PACKET_DOMAIN = "veritas.execution-intent-formation-readiness.packet/v1"
+EXECUTION_INTENT_REQUIRED_FIELDS = (
+    "execution_intent_id",
+    "decision_id",
+    "request_id",
+    "policy_snapshot_id",
+    "actor_identity",
+    "target_system",
+    "target_resource",
+    "intended_action",
+    "evidence_refs",
+    "decision_hash",
+    "decision_ts",
+    "ttl_seconds",
+    "expected_state_fingerprint",
+    "approval_context",
+    "policy_lineage",
+)
+REQUIRED_FIELD_PRESENCE = {
+    field: (
+        "intentionally_deferred"
+        if field in {"execution_intent_id", "ttl_seconds"}
+        else "mapped"
+    )
+    for field in EXECUTION_INTENT_REQUIRED_FIELDS
+}
+SCOPE_LIMITATIONS = (
+    "NOT_EXECUTION_INTENT",
+    "NOT_EXECUTION_AUTHORITY",
+    "NOT_BIND_AUTHORIZATION",
+    "NOT_BIND_RECEIPT",
+    "NOT_EXTERNAL_EFFECT",
+    "NOT_ADAPTER_INVOCATION",
+    "NOT_OPERATION_COMMIT",
+    "NOT_TRUSTLOG_WRITE",
+)
+
+
+class ExecutionIntentFormationReadinessError(ValueError):
+    """Stable fail-closed readiness construction or verification refusal."""
+
+
+class CanonicalExecutionIntentFormationReadinessPacket(BaseModel):
+    """Strict immutable audit packet proving formation-source readiness only."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    format_version: Literal["canonical-execution-intent-formation-readiness/v1"]
+    readiness_id: str = Field(pattern=r"^eifr:v1:sha256:[0-9a-f]{64}$")
+    readiness_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    verification_mechanism: Literal["verify_guarded_promotion_eligibility_packet/v1"]
+    checked_at: str
+    source_eligibility: dict[str, Any]
+    source_eligibility_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    source_eligibility_packet: dict[str, Any]
+    source_handoff_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    trusted_validation_context_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    validation_result_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    formation_status: Literal["READY_FOR_EXECUTION_INTENT_FORMATION"]
+    ready_for_execution_intent_formation: Literal[True]
+    fail_closed: Literal[False]
+    execution_intent_contract_version: Literal["execution-intent-contract/v1"]
+    execution_intent_required_fields: tuple[str, ...]
+    source_to_execution_intent_mapping: dict[str, Any]
+    mapping_value_digest: str = Field(pattern=r"^[0-9a-f]{64}$")
+    required_field_presence: dict[str, str]
+    source_decision_identity: dict[str, Any]
+    candidate_identity: dict[str, Any]
+    evidence_lineage: dict[str, Any]
+    replay_summary: dict[str, Any]
+    scope_limitations: tuple[str, ...]
+
+
+def _json_value(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        value = value.model_dump(mode="python")
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        if value != value or value in (float("inf"), float("-inf")):
+            raise ExecutionIntentFormationReadinessError("EIFR_PACKET_INVALID")
+        return value
+    if isinstance(value, datetime):
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ExecutionIntentFormationReadinessError("EIFR_CHECKED_AT_INVALID")
+        return value.isoformat()
+    if isinstance(value, (list, tuple)):
+        return [_json_value(item) for item in value]
+    if isinstance(value, dict):
+        if not all(isinstance(key, str) for key in value):
+            raise ExecutionIntentFormationReadinessError("EIFR_PACKET_INVALID")
+        return {key: _json_value(item) for key, item in value.items()}
+    raise ExecutionIntentFormationReadinessError("EIFR_PACKET_INVALID")
+
+
+def _digest(domain: str, value: Any) -> str:
+    encoded = json.dumps(
+        {"domain": domain, "value": _json_value(value)},
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _packet_hash(raw: dict[str, Any]) -> str:
+    return _digest(
+        PACKET_DOMAIN,
+        {
+            key: value
+            for key, value in raw.items()
+            if key not in {"readiness_id", "readiness_hash"}
+        },
+    )
+
+
+def _aware_iso(value: Any, code: str) -> datetime:
+    try:
+        parsed = value if isinstance(value, datetime) else datetime.fromisoformat(value)
+    except (TypeError, ValueError) as exc:
+        raise ExecutionIntentFormationReadinessError(code) from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ExecutionIntentFormationReadinessError(code)
+    return parsed
+
+
+def _require_source_fields(
+    eligibility: CanonicalGuardedPromotionEligibilityPacket,
+) -> None:
+    paths = {
+        "source_decision_identity": (
+            "request_id",
+            "canonical_decision_id",
+            "canonical_decision_hash",
+            "canonical_decision_ts",
+        ),
+        "candidate_identity": (
+            "actor_identity",
+            "target_system",
+            "target_resource",
+            "action_contract_id",
+            "action_contract_version",
+        ),
+        "evidence_lineage": (
+            "trustlog_artifact_ref",
+            "trustlog_chain_hash",
+            "replay_artifact_ref",
+            "replay_artifact_hash",
+            "authority_evidence_ref",
+            "authority_evidence_hash",
+            "human_approval_receipt_ref",
+            "human_approval_receipt_hash",
+            "policy_snapshot_id",
+            "policy_version",
+            "policy_semantic_digest",
+            "expected_state_fingerprint",
+            "expected_state_source_ref",
+        ),
+    }
+    for section, fields in paths.items():
+        values = getattr(eligibility, section)
+        if any(
+            not isinstance(values.get(field), str) or not values[field].strip()
+            for field in fields
+        ):
+            raise ExecutionIntentFormationReadinessError("EIFR_SOURCE_FIELD_MISSING")
+    _aware_iso(
+        eligibility.source_decision_identity["canonical_decision_ts"],
+        "EIFR_SOURCE_FIELD_MISSING",
+    )
+    replay = eligibility.replay_summary
+    if replay.get("original_request_id") is not None and (
+        replay.get("original_request_id") == replay.get("replay_request_id")
+        or replay.get("original_decision_id") == replay.get("replay_decision_id")
+    ):
+        raise ExecutionIntentFormationReadinessError("EIFR_REPLAY_IDENTITY_COLLAPSED")
+
+
+def _mapping(
+    eligibility: CanonicalGuardedPromotionEligibilityPacket,
+) -> dict[str, Any]:
+    source = eligibility.source_decision_identity
+    candidate = eligibility.candidate_identity
+    evidence = eligibility.evidence_lineage
+    return {
+        "decision_id": source["canonical_decision_id"],
+        "request_id": source["request_id"],
+        "policy_snapshot_id": evidence["policy_snapshot_id"],
+        "actor_identity": candidate["actor_identity"],
+        "target_system": candidate["target_system"],
+        "target_resource": candidate["target_resource"],
+        "intended_action": candidate["action_contract_id"],
+        "evidence_refs": [
+            evidence["trustlog_artifact_ref"],
+            evidence["replay_artifact_ref"],
+            evidence["authority_evidence_ref"],
+            evidence["human_approval_receipt_ref"],
+            evidence["expected_state_source_ref"],
+        ],
+        "decision_hash": source["canonical_decision_hash"],
+        "decision_ts": source["canonical_decision_ts"],
+        "ttl_seconds": None,
+        "expected_state_fingerprint": evidence["expected_state_fingerprint"],
+        "approval_context": {
+            "human_approval_receipt_ref": evidence["human_approval_receipt_ref"],
+            "human_approval_receipt_hash": evidence["human_approval_receipt_hash"],
+        },
+        "policy_lineage": {
+            "policy_snapshot_id": evidence["policy_snapshot_id"],
+            "policy_version": evidence["policy_version"],
+            "policy_semantic_digest": evidence["policy_semantic_digest"],
+        },
+    }
+
+
+def _verify_eligibility(value: Any) -> CanonicalGuardedPromotionEligibilityPacket:
+    try:
+        eligibility = verify_guarded_promotion_eligibility_packet(value)
+    except (GuardedPromotionEligibilityError, TypeError, ValueError) as exc:
+        raise ExecutionIntentFormationReadinessError(
+            "EIFR_ELIGIBILITY_INVALID"
+        ) from exc
+    if not (
+        eligibility.validation_status == "READY_FOR_GUARDED_PROMOTION"
+        and eligibility.ready_for_guarded_promotion is True
+        and eligibility.fail_closed is False
+    ):
+        raise ExecutionIntentFormationReadinessError("EIFR_ELIGIBILITY_INVALID")
+    _require_source_fields(eligibility)
+    return eligibility
+
+
+def build_execution_intent_formation_readiness_packet(
+    eligibility_packet: Any,
+    checked_at: datetime,
+) -> CanonicalExecutionIntentFormationReadinessPacket:
+    """Build readiness after verifying all mapped source values.
+
+    Args:
+        eligibility_packet: Full guarded-promotion eligibility artifact.
+        checked_at: Caller-supplied timezone-aware check time.
+
+    Returns:
+        A verified immutable readiness packet, never an execution artifact.
+    """
+    checked = _aware_iso(checked_at, "EIFR_CHECKED_AT_INVALID")
+    eligibility = _verify_eligibility(_json_value(eligibility_packet))
+    issued = _aware_iso(eligibility.issued_at, "EIFR_ELIGIBILITY_INVALID")
+    if checked < issued:
+        raise ExecutionIntentFormationReadinessError(
+            "EIFR_CHECKED_BEFORE_ELIGIBILITY_ISSUED"
+        )
+    source_packet = eligibility.model_dump(mode="json")
+    mapping = _mapping(eligibility)
+    summary = {
+        key: source_packet[key]
+        for key in (
+            "eligibility_id",
+            "eligibility_hash",
+            "format_version",
+            "validation_mechanism",
+            "handoff_validator_version",
+            "issued_at",
+            "evaluated_at",
+        )
+    }
+    raw = {
+        "format_version": FORMAT_VERSION,
+        "verification_mechanism": VERIFICATION_MECHANISM,
+        "checked_at": checked.isoformat(),
+        "source_eligibility": summary,
+        "source_eligibility_hash": eligibility.eligibility_hash,
+        "source_eligibility_packet": source_packet,
+        "source_handoff_hash": eligibility.source_handoff_hash,
+        "trusted_validation_context_hash": eligibility.trusted_validation_context_hash,
+        "validation_result_hash": eligibility.validation_result_hash,
+        "formation_status": "READY_FOR_EXECUTION_INTENT_FORMATION",
+        "ready_for_execution_intent_formation": True,
+        "fail_closed": False,
+        "execution_intent_contract_version": EXECUTION_INTENT_CONTRACT_VERSION,
+        "execution_intent_required_fields": EXECUTION_INTENT_REQUIRED_FIELDS,
+        "source_to_execution_intent_mapping": mapping,
+        "mapping_value_digest": _digest(MAPPING_DOMAIN, mapping),
+        "required_field_presence": REQUIRED_FIELD_PRESENCE,
+        "source_decision_identity": eligibility.source_decision_identity,
+        "candidate_identity": eligibility.candidate_identity,
+        "evidence_lineage": eligibility.evidence_lineage,
+        "replay_summary": eligibility.replay_summary,
+        "scope_limitations": SCOPE_LIMITATIONS,
+    }
+    digest = _packet_hash(raw)
+    raw.update(
+        readiness_hash=digest,
+        readiness_id=f"eifr:v1:sha256:{digest}",
+    )
+    return verify_execution_intent_formation_readiness_packet(raw)
+
+
+def verify_execution_intent_formation_readiness_packet(
+    packet: Any,
+) -> CanonicalExecutionIntentFormationReadinessPacket:
+    """Revalidate and independently recompute every readiness binding."""
+    try:
+        raw = (
+            packet.model_dump(mode="json")
+            if isinstance(packet, BaseModel)
+            else _json_value(packet)
+        )
+        candidate = CanonicalExecutionIntentFormationReadinessPacket.model_validate(raw)
+    except (ValidationError, ExecutionIntentFormationReadinessError, TypeError) as exc:
+        raise ExecutionIntentFormationReadinessError("EIFR_PACKET_INVALID") from exc
+    raw = candidate.model_dump(mode="json")
+    eligibility = _verify_eligibility(candidate.source_eligibility_packet)
+    checked = _aware_iso(candidate.checked_at, "EIFR_CHECKED_AT_INVALID")
+    issued = _aware_iso(eligibility.issued_at, "EIFR_ELIGIBILITY_INVALID")
+    if checked < issued:
+        raise ExecutionIntentFormationReadinessError(
+            "EIFR_CHECKED_BEFORE_ELIGIBILITY_ISSUED"
+        )
+    source_packet = eligibility.model_dump(mode="json")
+    summary = {
+        key: source_packet[key]
+        for key in candidate.source_eligibility
+        if key in source_packet
+    }
+    expected_summary_keys = {
+        "eligibility_id",
+        "eligibility_hash",
+        "format_version",
+        "validation_mechanism",
+        "handoff_validator_version",
+        "issued_at",
+        "evaluated_at",
+    }
+    if set(candidate.source_eligibility) != expected_summary_keys or (
+        candidate.source_eligibility != summary
+    ):
+        raise ExecutionIntentFormationReadinessError("EIFR_ELIGIBILITY_INVALID")
+    bindings = (
+        (candidate.source_eligibility_hash, eligibility.eligibility_hash),
+        (candidate.source_handoff_hash, eligibility.source_handoff_hash),
+        (
+            candidate.trusted_validation_context_hash,
+            eligibility.trusted_validation_context_hash,
+        ),
+        (candidate.validation_result_hash, eligibility.validation_result_hash),
+    )
+    if any(actual != expected for actual, expected in bindings):
+        raise ExecutionIntentFormationReadinessError("EIFR_ELIGIBILITY_INVALID")
+    expected_mapping = _mapping(eligibility)
+    if candidate.source_to_execution_intent_mapping != expected_mapping:
+        raise ExecutionIntentFormationReadinessError("EIFR_MAPPING_MISMATCH")
+    if candidate.mapping_value_digest != _digest(MAPPING_DOMAIN, expected_mapping):
+        raise ExecutionIntentFormationReadinessError("EIFR_MAPPING_DIGEST_MISMATCH")
+    if (
+        candidate.execution_intent_required_fields != EXECUTION_INTENT_REQUIRED_FIELDS
+        or candidate.required_field_presence != REQUIRED_FIELD_PRESENCE
+        or _digest(REQUIRED_FIELDS_DOMAIN, candidate.required_field_presence)
+        != _digest(REQUIRED_FIELDS_DOMAIN, REQUIRED_FIELD_PRESENCE)
+    ):
+        raise ExecutionIntentFormationReadinessError("EIFR_REQUIRED_FIELD_MISMATCH")
+    summaries = (
+        (candidate.source_decision_identity, eligibility.source_decision_identity),
+        (candidate.candidate_identity, eligibility.candidate_identity),
+        (candidate.evidence_lineage, eligibility.evidence_lineage),
+        (candidate.replay_summary, eligibility.replay_summary),
+    )
+    if any(actual != expected for actual, expected in summaries):
+        raise ExecutionIntentFormationReadinessError("EIFR_MAPPING_MISMATCH")
+    if candidate.scope_limitations != SCOPE_LIMITATIONS:
+        raise ExecutionIntentFormationReadinessError("EIFR_SCOPE_LIMITATIONS_MISSING")
+    digest = _packet_hash(raw)
+    if candidate.readiness_hash != digest:
+        raise ExecutionIntentFormationReadinessError("EIFR_PACKET_HASH_MISMATCH")
+    if candidate.readiness_id != f"eifr:v1:sha256:{digest}":
+        raise ExecutionIntentFormationReadinessError("EIFR_PACKET_ID_MISMATCH")
+    return candidate

--- a/veritas_os/tests/test_execution_intent_formation_readiness.py
+++ b/veritas_os/tests/test_execution_intent_formation_readiness.py
@@ -36,27 +36,40 @@ VECTOR = Path(
 NOW = datetime(2030, 1, 1, 0, 0, 3, tzinfo=timezone.utc)
 
 
-def _eligibility(*, semantic_match: bool = True):
+def _eligibility():
     handoff = json.loads(VECTOR.read_text())["input"]
-    if not semantic_match:
-        handoff["replay_lineage"].update(
-            semantic_match=False, fields_changed=["outcome.status"]
-        )
-        replay_record = next(
-            item
-            for item in handoff["provenance"]
-            if item["field_path"] == "replay_lineage"
-        )
-        replay_record["value"] = deepcopy(handoff["replay_lineage"])
     return build_guarded_promotion_eligibility_packet(
         handoff, _complete_context(handoff), NOW, NOW
     )
 
 
-def _packet(*, semantic_match: bool = True):
-    return build_execution_intent_formation_readiness_packet(
-        _eligibility(semantic_match=semantic_match), NOW
+def _canonical_replay_eligibility(*, semantic_match: bool, fields_changed: list[str]):
+    """Build eligibility with explicit, distinct canonical replay identities."""
+    handoff = json.loads(VECTOR.read_text())["input"]
+    handoff["replay_lineage"].update(
+        original_request_id="original-request-001",
+        replay_request_id="replay-request-001",
+        original_decision_id="cda:v1:sha256:" + "a" * 64,
+        replay_decision_id="cda:v1:sha256:" + "b" * 64,
+        semantic_profile="veritas.replay-semantic/v1",
+        semantic_match=semantic_match,
+        fields_changed=fields_changed,
+        severity="info" if semantic_match else "warning",
+        divergence_level=(
+            "no_divergence" if semantic_match else "acceptable_divergence"
+        ),
     )
+    replay_record = next(
+        item for item in handoff["provenance"] if item["field_path"] == "replay_lineage"
+    )
+    replay_record["value"] = deepcopy(handoff["replay_lineage"])
+    return build_guarded_promotion_eligibility_packet(
+        handoff, _complete_context(handoff), NOW, NOW
+    )
+
+
+def _packet():
+    return build_execution_intent_formation_readiness_packet(_eligibility(), NOW)
 
 
 def _resign(raw: dict) -> dict:
@@ -129,6 +142,21 @@ def test_source_summaries_and_replay_identity_are_preserved() -> None:
     assert packet.candidate_identity == eligibility.candidate_identity
     assert packet.evidence_lineage == eligibility.evidence_lineage
     assert packet.replay_summary == eligibility.replay_summary
+    original_request_id = packet.replay_summary.get("original_request_id")
+    replay_request_id = packet.replay_summary.get("replay_request_id")
+    if original_request_id is not None and replay_request_id is not None:
+        assert original_request_id != replay_request_id
+    original_decision_id = packet.replay_summary.get("original_decision_id")
+    replay_decision_id = packet.replay_summary.get("replay_decision_id")
+    if original_decision_id is not None and replay_decision_id is not None:
+        assert original_decision_id != replay_decision_id
+
+
+def test_explicit_canonical_replay_identities_are_preserved() -> None:
+    eligibility = _canonical_replay_eligibility(semantic_match=True, fields_changed=[])
+    packet = build_execution_intent_formation_readiness_packet(eligibility, NOW)
+    assert packet.replay_summary["original_request_id"] == "original-request-001"
+    assert packet.replay_summary["replay_request_id"] == "replay-request-001"
     assert (
         packet.replay_summary["original_request_id"]
         != packet.replay_summary["replay_request_id"]
@@ -137,14 +165,30 @@ def test_source_summaries_and_replay_identity_are_preserved() -> None:
         packet.replay_summary["original_decision_id"]
         != packet.replay_summary["replay_decision_id"]
     )
+    assert packet.replay_summary["semantic_match"] is True
+    assert packet.replay_summary["fields_changed"] == []
 
 
-def test_semantic_match_true_and_false_are_preserved_not_gated() -> None:
-    assert _packet().replay_summary["semantic_match"] is True
-    divergent = _packet(semantic_match=False)
-    assert divergent.replay_summary["semantic_match"] is False
-    assert divergent.replay_summary["fields_changed"] == ["outcome.status"]
-    assert verify_execution_intent_formation_readiness_packet(divergent)
+@pytest.mark.parametrize(
+    "semantic_match,fields_changed",
+    [(True, []), (False, ["outcome.status"])],
+)
+def test_semantic_match_is_preserved_not_gated(
+    semantic_match: bool, fields_changed: list[str]
+) -> None:
+    eligibility = _canonical_replay_eligibility(
+        semantic_match=semantic_match, fields_changed=fields_changed
+    )
+    packet = build_execution_intent_formation_readiness_packet(eligibility, NOW)
+    assert packet.replay_summary["semantic_match"] is semantic_match
+    assert packet.replay_summary["fields_changed"] == fields_changed
+    assert verify_execution_intent_formation_readiness_packet(packet) == packet
+
+
+def test_legacy_absent_semantic_match_is_preserved() -> None:
+    packet = _packet()
+    assert packet.replay_summary["semantic_match"] is None
+    assert verify_execution_intent_formation_readiness_packet(packet) == packet
 
 
 def test_invalid_eligibility_and_checked_at_are_refused() -> None:

--- a/veritas_os/tests/test_execution_intent_formation_readiness.py
+++ b/veritas_os/tests/test_execution_intent_formation_readiness.py
@@ -1,0 +1,322 @@
+"""Security tests for ExecutionIntent Formation Readiness v1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from copy import deepcopy
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator, FormatChecker
+
+from veritas_os.policy.execution_intent_formation_readiness import (
+    EXECUTION_INTENT_REQUIRED_FIELDS,
+    MAPPING_DOMAIN,
+    REQUIRED_FIELD_PRESENCE,
+    SCOPE_LIMITATIONS,
+    CanonicalExecutionIntentFormationReadinessPacket,
+    ExecutionIntentFormationReadinessError,
+    _digest,
+    _packet_hash,
+    build_execution_intent_formation_readiness_packet,
+    verify_execution_intent_formation_readiness_packet,
+)
+from veritas_os.policy.guarded_promotion_eligibility import (
+    PACKET_DOMAIN as ELIGIBILITY_PACKET_DOMAIN,
+    _digest as eligibility_digest,
+    build_guarded_promotion_eligibility_packet,
+)
+from veritas_os.tests.test_canonical_decision_handoff import _complete_context
+
+VECTOR = Path(
+    "docs/en/architecture/test-vectors/decision-to-bind-handoff-v1/vector-01.json"
+)
+NOW = datetime(2030, 1, 1, 0, 0, 3, tzinfo=timezone.utc)
+
+
+def _eligibility(*, semantic_match: bool = True):
+    handoff = json.loads(VECTOR.read_text())["input"]
+    if not semantic_match:
+        handoff["replay_lineage"].update(
+            semantic_match=False, fields_changed=["outcome.status"]
+        )
+        replay_record = next(
+            item
+            for item in handoff["provenance"]
+            if item["field_path"] == "replay_lineage"
+        )
+        replay_record["value"] = deepcopy(handoff["replay_lineage"])
+    return build_guarded_promotion_eligibility_packet(
+        handoff, _complete_context(handoff), NOW, NOW
+    )
+
+
+def _packet(*, semantic_match: bool = True):
+    return build_execution_intent_formation_readiness_packet(
+        _eligibility(semantic_match=semantic_match), NOW
+    )
+
+
+def _resign(raw: dict) -> dict:
+    raw["readiness_hash"] = _packet_hash(raw)
+    raw["readiness_id"] = f"eifr:v1:sha256:{raw['readiness_hash']}"
+    return raw
+
+
+def _resign_eligibility(raw: dict) -> dict:
+    preimage = {
+        key: value
+        for key, value in raw.items()
+        if key not in {"eligibility_id", "eligibility_hash"}
+    }
+    raw["eligibility_hash"] = eligibility_digest(ELIGIBILITY_PACKET_DOMAIN, preimage)
+    raw["eligibility_id"] = f"gpe:v1:sha256:{raw['eligibility_hash']}"
+    return raw
+
+
+def test_build_verify_mapping_and_content_addressing() -> None:
+    eligibility = _eligibility()
+    packet = build_execution_intent_formation_readiness_packet(eligibility, NOW)
+    assert verify_execution_intent_formation_readiness_packet(packet) == packet
+    assert packet.readiness_id == f"eifr:v1:sha256:{packet.readiness_hash}"
+    assert packet.readiness_hash == _packet_hash(packet.model_dump(mode="json"))
+    evidence = eligibility.evidence_lineage
+    assert packet.source_to_execution_intent_mapping == {
+        "decision_id": eligibility.source_decision_identity["canonical_decision_id"],
+        "request_id": eligibility.source_decision_identity["request_id"],
+        "policy_snapshot_id": evidence["policy_snapshot_id"],
+        "actor_identity": eligibility.candidate_identity["actor_identity"],
+        "target_system": eligibility.candidate_identity["target_system"],
+        "target_resource": eligibility.candidate_identity["target_resource"],
+        "intended_action": eligibility.candidate_identity["action_contract_id"],
+        "evidence_refs": [
+            evidence["trustlog_artifact_ref"],
+            evidence["replay_artifact_ref"],
+            evidence["authority_evidence_ref"],
+            evidence["human_approval_receipt_ref"],
+            evidence["expected_state_source_ref"],
+        ],
+        "decision_hash": eligibility.source_decision_identity[
+            "canonical_decision_hash"
+        ],
+        "decision_ts": eligibility.source_decision_identity["canonical_decision_ts"],
+        "ttl_seconds": None,
+        "expected_state_fingerprint": evidence["expected_state_fingerprint"],
+        "approval_context": {
+            "human_approval_receipt_ref": evidence["human_approval_receipt_ref"],
+            "human_approval_receipt_hash": evidence["human_approval_receipt_hash"],
+        },
+        "policy_lineage": {
+            "policy_snapshot_id": evidence["policy_snapshot_id"],
+            "policy_version": evidence["policy_version"],
+            "policy_semantic_digest": evidence["policy_semantic_digest"],
+        },
+    }
+    assert packet.mapping_value_digest == _digest(
+        MAPPING_DOMAIN, packet.source_to_execution_intent_mapping
+    )
+    assert packet.execution_intent_required_fields == (EXECUTION_INTENT_REQUIRED_FIELDS)
+    assert packet.required_field_presence == REQUIRED_FIELD_PRESENCE
+    assert packet.scope_limitations == SCOPE_LIMITATIONS
+
+
+def test_source_summaries_and_replay_identity_are_preserved() -> None:
+    eligibility = _eligibility()
+    packet = _packet()
+    assert packet.source_decision_identity == eligibility.source_decision_identity
+    assert packet.candidate_identity == eligibility.candidate_identity
+    assert packet.evidence_lineage == eligibility.evidence_lineage
+    assert packet.replay_summary == eligibility.replay_summary
+    assert (
+        packet.replay_summary["original_request_id"]
+        != packet.replay_summary["replay_request_id"]
+    )
+    assert (
+        packet.replay_summary["original_decision_id"]
+        != packet.replay_summary["replay_decision_id"]
+    )
+
+
+def test_semantic_match_true_and_false_are_preserved_not_gated() -> None:
+    assert _packet().replay_summary["semantic_match"] is True
+    divergent = _packet(semantic_match=False)
+    assert divergent.replay_summary["semantic_match"] is False
+    assert divergent.replay_summary["fields_changed"] == ["outcome.status"]
+    assert verify_execution_intent_formation_readiness_packet(divergent)
+
+
+def test_invalid_eligibility_and_checked_at_are_refused() -> None:
+    invalid = _eligibility().model_dump(mode="json")
+    invalid["eligibility_hash"] = "0" * 64
+    with pytest.raises(
+        ExecutionIntentFormationReadinessError, match="EIFR_ELIGIBILITY_INVALID"
+    ):
+        build_execution_intent_formation_readiness_packet(invalid, NOW)
+    with pytest.raises(
+        ExecutionIntentFormationReadinessError, match="EIFR_CHECKED_AT_INVALID"
+    ):
+        build_execution_intent_formation_readiness_packet(
+            _eligibility(), NOW.replace(tzinfo=None)
+        )
+    with pytest.raises(
+        ExecutionIntentFormationReadinessError,
+        match="EIFR_CHECKED_BEFORE_ELIGIBILITY_ISSUED",
+    ):
+        build_execution_intent_formation_readiness_packet(
+            _eligibility(), NOW - timedelta(seconds=1)
+        )
+
+
+@pytest.mark.parametrize(
+    "section,field,value",
+    [
+        ("source_decision_identity", "request_id", ""),
+        ("source_decision_identity", "canonical_decision_id", ""),
+        ("source_decision_identity", "canonical_decision_hash", ""),
+        ("source_decision_identity", "canonical_decision_ts", "malformed"),
+        ("candidate_identity", "actor_identity", ""),
+        ("candidate_identity", "target_system", ""),
+        ("candidate_identity", "target_resource", ""),
+        ("candidate_identity", "action_contract_id", ""),
+        ("evidence_lineage", "trustlog_artifact_ref", ""),
+        ("evidence_lineage", "replay_artifact_ref", ""),
+        ("evidence_lineage", "authority_evidence_ref", ""),
+        ("evidence_lineage", "human_approval_receipt_ref", ""),
+        ("evidence_lineage", "policy_snapshot_id", ""),
+        ("evidence_lineage", "expected_state_fingerprint", ""),
+    ],
+)
+def test_missing_or_malformed_source_fields_fail_closed(
+    section: str, field: str, value: str
+) -> None:
+    raw = _eligibility().model_dump(mode="json")
+    raw[section][field] = value
+    with pytest.raises(
+        ExecutionIntentFormationReadinessError, match="EIFR_ELIGIBILITY_INVALID"
+    ):
+        build_execution_intent_formation_readiness_packet(_resign_eligibility(raw), NOW)
+
+
+def test_eligibility_verifier_runs_in_builder_and_verifier(monkeypatch) -> None:
+    import veritas_os.policy.execution_intent_formation_readiness as module
+
+    actual = module.verify_guarded_promotion_eligibility_packet
+    calls = []
+
+    def recording_verifier(value):
+        calls.append(value)
+        return actual(value)
+
+    monkeypatch.setattr(
+        module, "verify_guarded_promotion_eligibility_packet", recording_verifier
+    )
+    packet = module.build_execution_intent_formation_readiness_packet(
+        _eligibility(), NOW
+    )
+    builder_calls = len(calls)
+    module.verify_execution_intent_formation_readiness_packet(packet)
+    assert builder_calls >= 2
+    assert len(calls) == builder_calls + 1
+
+
+@pytest.mark.parametrize(
+    "path,value",
+    [
+        (("readiness_id",), "eifr:v1:sha256:" + "0" * 64),
+        (("readiness_hash",), "0" * 64),
+        (("checked_at",), "2031-01-01T00:00:00+00:00"),
+        (("source_eligibility", "eligibility_hash"), "0" * 64),
+        (("source_eligibility_hash",), "0" * 64),
+        (("source_eligibility_packet", "eligibility_hash"), "0" * 64),
+        (("source_handoff_hash",), "0" * 64),
+        (("trusted_validation_context_hash",), "0" * 64),
+        (("validation_result_hash",), "0" * 64),
+        (("source_to_execution_intent_mapping", "decision_id"), "changed"),
+        (("mapping_value_digest",), "0" * 64),
+        (("required_field_presence", "decision_id"), "deferred"),
+        (("source_decision_identity", "request_id"), "changed"),
+        (("candidate_identity", "actor_identity"), "changed"),
+        (("evidence_lineage", "trustlog_artifact_ref"), "changed"),
+        (("replay_summary", "semantic_match"), False),
+        (("replay_summary", "fields_changed"), ["changed"]),
+        (("scope_limitations",), ["NOT_EXECUTION_INTENT"]),
+    ],
+)
+def test_each_tamper_and_model_copy_bypass_is_refused(path, value) -> None:
+    packet = _packet()
+    raw = packet.model_dump(mode="json")
+    target = raw
+    for component in path[:-1]:
+        target = target[component]
+    target[path[-1]] = value
+    bypass = packet.model_copy(update={path[0]: raw[path[0]]})
+    with pytest.raises(ExecutionIntentFormationReadinessError):
+        verify_execution_intent_formation_readiness_packet(bypass)
+
+
+def test_semantic_tamper_is_refused_even_with_recomputed_packet_hash() -> None:
+    raw = _packet().model_dump(mode="json")
+    raw["source_to_execution_intent_mapping"]["decision_id"] = "changed"
+    with pytest.raises(
+        ExecutionIntentFormationReadinessError, match="EIFR_MAPPING_MISMATCH"
+    ):
+        verify_execution_intent_formation_readiness_packet(_resign(raw))
+
+
+def test_construct_bypass_and_strict_json_refusals() -> None:
+    packet = _packet()
+    bypass = CanonicalExecutionIntentFormationReadinessPacket.model_construct(
+        **(packet.model_dump(mode="python") | {"format_version": "bad"})
+    )
+    with pytest.raises(ExecutionIntentFormationReadinessError):
+        verify_execution_intent_formation_readiness_packet(bypass)
+    for value in (float("nan"), float("inf"), object(), {1: "bad"}, {"x"}):
+        raw = packet.model_dump(mode="json")
+        raw["source_eligibility"] = value
+        with pytest.raises(ExecutionIntentFormationReadinessError):
+            verify_execution_intent_formation_readiness_packet(raw)
+
+
+def test_static_boundary_and_no_execution_artifact() -> None:
+    source = Path(
+        "veritas_os/policy/execution_intent_formation_readiness.py"
+    ).read_text()
+    imported = {
+        alias.name
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, (ast.Import, ast.ImportFrom))
+        for alias in node.names
+    }
+    forbidden = {
+        "ExecutionIntent",
+        "BindReceipt",
+        "hash_execution_intent",
+        "build_execution_intent_trustlog_entry",
+        "execute_bind_boundary",
+        "execute_bind_adjudication",
+        "WebhookBindAdapter",
+        "ReferenceBindAdapter",
+        "requests",
+        "httpx",
+        "subprocess",
+    }
+    assert imported.isdisjoint(forbidden)
+    raw = _packet().model_dump(mode="json")
+    assert "execution_intent_id" not in raw
+    assert "bind_receipt_id" not in raw
+    assert raw["required_field_presence"]["execution_intent_id"] == (
+        "intentionally_deferred"
+    )
+
+
+def test_closed_schema_accepts_valid_and_rejects_nested_extra() -> None:
+    schema = json.loads(
+        Path("schemas/execution-intent-formation-readiness-v1.schema.json").read_text()
+    )
+    validator = Draft202012Validator(schema, format_checker=FormatChecker())
+    raw = _packet().model_dump(mode="json")
+    validator.validate(raw)
+    raw["source_to_execution_intent_mapping"]["ignored"] = True
+    assert list(validator.iter_errors(raw))


### PR DESCRIPTION
### Motivation

- Introduce a deterministic, side-effect-free boundary that proves a verified Guarded Promotion Eligibility Packet contains the exact deterministic source fields required for a future ExecutionIntent formation step without creating any execution artifacts or invoking Bind.
- Provide an auditable, content-addressed readiness packet to separate formation-readiness from execution authorization and prevent accidental escalation of authority.
- Preserve existing fail-closed semantics and replay/eligibility verification while enabling a future, explicit ExecutionIntent formation step.

### Description

- Adds a new local policy module `veritas_os/policy/execution_intent_formation_readiness.py` implementing `CanonicalExecutionIntentFormationReadinessPacket`, `build_execution_intent_formation_readiness_packet(...)`, and `verify_execution_intent_formation_readiness_packet(...)`, with strict JSON normalization, domain-separated hashing, required-field presence contract, and stable error codes.
- The builder and verifier both call `verify_guarded_promotion_eligibility_packet(...)` to independently revalidate the embedded Eligibility Packet and then compute/verify the exact `source_to_execution_intent_mapping` and its `mapping_value_digest`.
- The readiness packet embeds the full source Eligibility Packet and exposes compact summary bindings for `source_handoff_hash`, `trusted_validation_context_hash`, and `validation_result_hash`.
- The implementation preserves legacy/absent replay summary fields as `None`, while explicit canonical replay lineage fixtures preserve distinct original/replay identities and `semantic_match` values exactly.
- Adds a closed JSON Schema `schemas/execution-intent-formation-readiness-v1.schema.json` (2020-12) and documentation `docs/en/architecture/execution-intent-formation-readiness-v1.md` explaining the safety boundary and non-claims.
- Adds focused tests `veritas_os/tests/test_execution_intent_formation_readiness.py` covering success path, tamper/refusal cases, model-bypass protections, semantic match true/false/None preservation, static import-boundary checks, and schema validation behavior.

### Security / non-claims

- Readiness does not authorize execution.
- Readiness does not create an `ExecutionIntent`.
- Readiness does not compute an ExecutionIntent hash.
- Readiness does not create an ExecutionIntent TrustLog entry.
- Readiness does not create a `BindReceipt`.
- Readiness does not invoke Bind.
- Readiness does not call adapters, webhooks, providers, network, filesystem, subprocess, or external systems.
- Readiness does not satisfy Authority Evidence or Human Approval.
- Readiness does not turn replay `semantic_match` into execution authorization.

### Testing / validation

Current head: `65ded9bb64eec4af2c22afc702b09996d8ec6067`
Base: `39910c09dbdb62c29ae02c8c4ceb78661389626c`

- GitHub CI run #5054 passed for the current head.
- Python 3.11 full test job: success.
- Python 3.12 full test job: success.
- PostgreSQL parity/contention job: success.
- Slow tests job: success.
- Governance smoke job: success.
- Governance backend fast job: success.
- Lint job, including Ruff, security scans, responsibility-boundary checks, and schema/policy consistency checks: success.
- Dependency audit job: success.
- Future dependency compatibility job: success.
- Frontend lint/test/e2e jobs: success.
- Companion workflows passed for the current head: Security Gates, CodeQL, Runtime Proof Evidence, Runtime Pickle Guard, and Reviewer Evidence Packet Validation.
- The earlier py3.11/py3.12 failures were fixed test-side only by preserving legacy absent replay fields as `None` and adding explicit canonical replay fixtures for distinct original/replay identities and `semantic_match=True/False` preservation.

No production fail-closed rule was weakened. No replay identity is fabricated. `semantic_match` true/false/None is preserved exactly and is not converted into Authority Evidence, Human Approval, Bind authorization, or execution authority. No `ExecutionIntent`, ExecutionIntent hash, ExecutionIntent TrustLog entry, `BindReceipt`, Bind invocation, adapter call, API auto-wiring, or external effect was introduced.

### Final invariant

ExecutionIntent Formation Readiness v1 now verifies that a content-addressed
Guarded Promotion Eligibility Packet contains the deterministic source fields
required for a future ExecutionIntent formation step. It does not create an
ExecutionIntent, does not compute an ExecutionIntent hash, does not write
TrustLog, does not create a BindReceipt, does not invoke Bind, does not
authorize execution, and does not convert replay semantic_match into Authority
Evidence, Human Approval, or execution authority.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a81cb271fd08326a0d34c747c36883c)