### PR TITLE
feat(execution): add canonical execution intent formation v1

### DIFF
--- a/docs/en/architecture/canonical-execution-intent-formation-v1.md
+++ b/docs/en/architecture/canonical-execution-intent-formation-v1.md
@@ -1,0 +1,71 @@
+# Canonical ExecutionIntent Formation v1
+
+## Purpose and boundary
+
+Canonical ExecutionIntent Formation v1 is a deterministic, local library
+boundary between a verified ExecutionIntent Formation Readiness Packet and a
+new `ExecutionIntent`. It records one narrow claim: **this exact verified
+Readiness Packet was used to deterministically form this exact ExecutionIntent
+artifact**.
+
+A Readiness Packet is not an `ExecutionIntent`. Conversely, an ExecutionIntent
+being formed is not execution authorization and is not Bind authorization. A
+valid ExecutionIntent hash is not a TrustLog write. `semantic_match` is not
+Authority Evidence or Human Approval. A verified ExecutionIntent is not an
+adapter invocation, operation commit, or external effect.
+
+The builder takes every actor, target, action, policy, expected-state,
+approval-context, and evidence-reference value solely from the mapping in the
+verified Readiness Packet. It performs no lookup and creates no authority or
+approval evidence. Missing or incoherent source data fails closed in readiness
+verification rather than being inferred or fabricated.
+
+## Auditable sequence
+
+1. Canonical Decision Artifact (CDA)
+2. Trust Link
+3. Replay Source and Replay Evidence
+4. Replay Handoff Binding
+5. `CanonicalDecisionHandoff` validation
+6. Canonical Guarded Promotion Eligibility Packet v1
+7. Canonical ExecutionIntent Formation Readiness Packet v1
+8. Canonical ExecutionIntent Formation Packet v1
+9. **STOP**
+
+Bind preflight, TrustLog lineage/write, Bind invocation, adapter activity, and
+any API or CLI wiring are intentionally deferred to future explicit PRs. The
+formation module creates no `BindReceipt` and has no filesystem, network,
+provider, subprocess, adapter, or external-system capability.
+
+## Deterministic integrity
+
+The packet format is `canonical-execution-intent-formation/v1`. Its identifier
+is `eif:v1:sha256:<64 lowercase hexadecimal characters>`; its packet hash
+preimage excludes only `formation_id` and `formation_hash`. The full Readiness
+Packet is embedded so the verifier can rerun readiness verification rather
+than trusting a compact summary.
+
+The ExecutionIntent identifier is
+`ei:v1:sha256:<64 lowercase hexadecimal characters>`. It is derived before
+instantiation from the readiness identity/hash, mapping digest, complete
+source mapping, and ExecutionIntent contract version. No random/default ID
+factory or current clock is used. The existing `hash_execution_intent`
+contract remains the sole source of `execution_intent_hash` semantics.
+
+The independent verifier reconstructs the ExecutionIntent, verifies every
+field against the source mapping and field-mapping proof, recomputes both
+content-addressed identities, and requires exact preservation of source
+decision identity, candidate identity, evidence lineage, required-field
+presence, and replay summary.
+
+## Replay semantics and non-claims
+
+Both `semantic_match: true` and `semantic_match: false` remain source facts.
+The formation step preserves `fields_changed` and does not transform semantic
+agreement or divergence into a refusal, authority, approval, Bind permission,
+or execution permission. Any operation-specific replay-equivalence policy must
+be introduced at a separately reviewed boundary.
+
+This artifact makes no production, customer, regulatory, or certification
+claim. Human review remains required for future Bind/admissibility and
+TrustLog behavior changes.

--- a/schemas/canonical-execution-intent-formation-v1.schema.json
+++ b/schemas/canonical-execution-intent-formation-v1.schema.json
@@ -1,0 +1,1929 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://veritas-os.org/schemas/canonical-execution-intent-formation-v1.schema.json",
+  "title": "Canonical ExecutionIntent Formation Packet v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "format_version",
+    "formation_id",
+    "formation_hash",
+    "formation_mechanism",
+    "formed_at",
+    "source_readiness",
+    "source_readiness_hash",
+    "source_readiness_packet",
+    "source_eligibility_hash",
+    "source_handoff_hash",
+    "trusted_validation_context_hash",
+    "validation_result_hash",
+    "mapping_value_digest",
+    "execution_intent_contract_version",
+    "execution_intent",
+    "execution_intent_id",
+    "execution_intent_hash",
+    "source_to_execution_intent_mapping",
+    "field_mapping_proof",
+    "required_field_presence",
+    "source_decision_identity",
+    "candidate_identity",
+    "evidence_lineage",
+    "replay_summary",
+    "scope_limitations"
+  ],
+  "properties": {
+    "format_version": {
+      "const": "canonical-execution-intent-formation/v1"
+    },
+    "formation_id": {
+      "type": "string",
+      "pattern": "^eif:v1:sha256:[0-9a-f]{64}$"
+    },
+    "formation_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "formation_mechanism": {
+      "const": "build_execution_intent_from_readiness/v1"
+    },
+    "formed_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "source_readiness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "readiness_id",
+        "readiness_hash",
+        "format_version",
+        "checked_at",
+        "formation_status",
+        "ready_for_execution_intent_formation"
+      ],
+      "properties": {
+        "readiness_id": {
+          "type": "string",
+          "pattern": "^eifr:v1:sha256:[0-9a-f]{64}$"
+        },
+        "readiness_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "format_version": {
+          "const": "canonical-execution-intent-formation-readiness/v1"
+        },
+        "checked_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "formation_status": {
+          "const": "READY_FOR_EXECUTION_INTENT_FORMATION"
+        },
+        "ready_for_execution_intent_formation": {
+          "const": true
+        }
+      }
+    },
+    "source_readiness_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "source_readiness_packet": {
+      "$ref": "#/$defs/readiness"
+    },
+    "source_eligibility_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "source_handoff_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "trusted_validation_context_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "validation_result_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "mapping_value_digest": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "execution_intent_contract_version": {
+      "const": "execution-intent-contract/v1"
+    },
+    "execution_intent": {
+      "$ref": "#/$defs/execution_intent"
+    },
+    "execution_intent_id": {
+      "type": "string",
+      "pattern": "^ei:v1:sha256:[0-9a-f]{64}$"
+    },
+    "execution_intent_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "source_to_execution_intent_mapping": {
+      "$ref": "#/$defs/mapping"
+    },
+    "field_mapping_proof": {
+      "$ref": "#/$defs/mapping"
+    },
+    "required_field_presence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "execution_intent_id",
+        "decision_id",
+        "request_id",
+        "policy_snapshot_id",
+        "actor_identity",
+        "target_system",
+        "target_resource",
+        "intended_action",
+        "evidence_refs",
+        "decision_hash",
+        "decision_ts",
+        "ttl_seconds",
+        "expected_state_fingerprint",
+        "approval_context",
+        "policy_lineage"
+      ],
+      "properties": {
+        "execution_intent_id": {
+          "const": "intentionally_deferred"
+        },
+        "decision_id": {
+          "const": "mapped"
+        },
+        "request_id": {
+          "const": "mapped"
+        },
+        "policy_snapshot_id": {
+          "const": "mapped"
+        },
+        "actor_identity": {
+          "const": "mapped"
+        },
+        "target_system": {
+          "const": "mapped"
+        },
+        "target_resource": {
+          "const": "mapped"
+        },
+        "intended_action": {
+          "const": "mapped"
+        },
+        "evidence_refs": {
+          "const": "mapped"
+        },
+        "decision_hash": {
+          "const": "mapped"
+        },
+        "decision_ts": {
+          "const": "mapped"
+        },
+        "ttl_seconds": {
+          "const": "intentionally_deferred"
+        },
+        "expected_state_fingerprint": {
+          "const": "mapped"
+        },
+        "approval_context": {
+          "const": "mapped"
+        },
+        "policy_lineage": {
+          "const": "mapped"
+        }
+      }
+    },
+    "source_decision_identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "request_id",
+        "canonical_decision_id",
+        "canonical_decision_hash",
+        "canonical_decision_ts"
+      ],
+      "properties": {
+        "request_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "canonical_decision_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "canonical_decision_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "canonical_decision_ts": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "candidate_identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "candidate_id",
+        "candidate_hash",
+        "actor_identity",
+        "target_system",
+        "target_resource",
+        "action_contract_id",
+        "action_contract_version"
+      ],
+      "properties": {
+        "candidate_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "candidate_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "actor_identity": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_system": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_resource": {
+          "type": "string",
+          "minLength": 1
+        },
+        "action_contract_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "action_contract_version": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "evidence_lineage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "trustlog_artifact_ref",
+        "trustlog_chain_hash",
+        "replay_artifact_ref",
+        "replay_artifact_hash",
+        "authority_evidence_ref",
+        "authority_evidence_hash",
+        "human_approval_receipt_ref",
+        "human_approval_receipt_hash",
+        "policy_snapshot_id",
+        "policy_version",
+        "policy_semantic_digest",
+        "expected_state_fingerprint",
+        "expected_state_source_ref"
+      ],
+      "properties": {
+        "trustlog_artifact_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "trustlog_chain_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "replay_artifact_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "replay_artifact_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "authority_evidence_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "authority_evidence_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "human_approval_receipt_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "human_approval_receipt_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_snapshot_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_semantic_digest": {
+          "type": "string",
+          "minLength": 1
+        },
+        "expected_state_fingerprint": {
+          "type": "string",
+          "minLength": 1
+        },
+        "expected_state_source_ref": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "replay_summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "original_decision_id",
+        "replay_decision_id",
+        "original_request_id",
+        "replay_request_id",
+        "semantic_profile",
+        "semantic_match",
+        "fields_changed",
+        "severity",
+        "divergence_level"
+      ],
+      "properties": {
+        "original_decision_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "replay_decision_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "original_request_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "replay_request_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "semantic_profile": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "semantic_match": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "fields_changed": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "severity": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "divergence_level": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "scope_limitations": {
+      "type": "array",
+      "prefixItems": [
+        {
+          "const": "NOT_EXECUTION_AUTHORITY"
+        },
+        {
+          "const": "NOT_BIND_AUTHORIZATION"
+        },
+        {
+          "const": "NOT_BIND_RECEIPT"
+        },
+        {
+          "const": "NOT_BIND_INVOCATION"
+        },
+        {
+          "const": "NOT_EXTERNAL_EFFECT"
+        },
+        {
+          "const": "NOT_ADAPTER_INVOCATION"
+        },
+        {
+          "const": "NOT_OPERATION_COMMIT"
+        },
+        {
+          "const": "NOT_TRUSTLOG_WRITE"
+        },
+        {
+          "const": "NOT_AUTHORITY_EVIDENCE"
+        },
+        {
+          "const": "NOT_HUMAN_APPROVAL"
+        }
+      ],
+      "items": false,
+      "minItems": 10,
+      "maxItems": 10
+    }
+  },
+  "$defs": {
+    "readiness": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://veritas-os.org/schemas/execution-intent-formation-readiness-v1.schema.json",
+      "title": "Canonical ExecutionIntent Formation Readiness Packet v1",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "format_version",
+        "readiness_id",
+        "readiness_hash",
+        "verification_mechanism",
+        "checked_at",
+        "source_eligibility",
+        "source_eligibility_hash",
+        "source_eligibility_packet",
+        "source_handoff_hash",
+        "trusted_validation_context_hash",
+        "validation_result_hash",
+        "formation_status",
+        "ready_for_execution_intent_formation",
+        "fail_closed",
+        "execution_intent_contract_version",
+        "execution_intent_required_fields",
+        "source_to_execution_intent_mapping",
+        "mapping_value_digest",
+        "required_field_presence",
+        "source_decision_identity",
+        "candidate_identity",
+        "evidence_lineage",
+        "replay_summary",
+        "scope_limitations"
+      ],
+      "properties": {
+        "format_version": {
+          "const": "canonical-execution-intent-formation-readiness/v1"
+        },
+        "readiness_id": {
+          "type": "string",
+          "pattern": "^eifr:v1:sha256:[0-9a-f]{64}$"
+        },
+        "readiness_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "verification_mechanism": {
+          "const": "verify_guarded_promotion_eligibility_packet/v1"
+        },
+        "checked_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "source_eligibility": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "eligibility_id",
+            "eligibility_hash",
+            "format_version",
+            "validation_mechanism",
+            "handoff_validator_version",
+            "issued_at",
+            "evaluated_at"
+          ],
+          "properties": {
+            "eligibility_id": {
+              "type": "string",
+              "pattern": "^gpe:v1:sha256:[0-9a-f]{64}$"
+            },
+            "eligibility_hash": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "format_version": {
+              "const": "canonical-guarded-promotion-eligibility-packet/v1"
+            },
+            "validation_mechanism": {
+              "const": "validate_canonical_decision_handoff/v1"
+            },
+            "handoff_validator_version": {
+              "type": "string",
+              "minLength": 1
+            },
+            "issued_at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "evaluated_at": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "source_eligibility_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_eligibility_packet": {
+          "$ref": "#/$defs/eligibility"
+        },
+        "source_handoff_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "trusted_validation_context_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "validation_result_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "formation_status": {
+          "const": "READY_FOR_EXECUTION_INTENT_FORMATION"
+        },
+        "ready_for_execution_intent_formation": {
+          "const": true
+        },
+        "fail_closed": {
+          "const": false
+        },
+        "execution_intent_contract_version": {
+          "const": "execution-intent-contract/v1"
+        },
+        "execution_intent_required_fields": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "const": "execution_intent_id"
+            },
+            {
+              "const": "decision_id"
+            },
+            {
+              "const": "request_id"
+            },
+            {
+              "const": "policy_snapshot_id"
+            },
+            {
+              "const": "actor_identity"
+            },
+            {
+              "const": "target_system"
+            },
+            {
+              "const": "target_resource"
+            },
+            {
+              "const": "intended_action"
+            },
+            {
+              "const": "evidence_refs"
+            },
+            {
+              "const": "decision_hash"
+            },
+            {
+              "const": "decision_ts"
+            },
+            {
+              "const": "ttl_seconds"
+            },
+            {
+              "const": "expected_state_fingerprint"
+            },
+            {
+              "const": "approval_context"
+            },
+            {
+              "const": "policy_lineage"
+            }
+          ],
+          "items": false,
+          "minItems": 15,
+          "maxItems": 15
+        },
+        "source_to_execution_intent_mapping": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "decision_id",
+            "request_id",
+            "policy_snapshot_id",
+            "actor_identity",
+            "target_system",
+            "target_resource",
+            "intended_action",
+            "evidence_refs",
+            "decision_hash",
+            "decision_ts",
+            "ttl_seconds",
+            "expected_state_fingerprint",
+            "approval_context",
+            "policy_lineage"
+          ],
+          "properties": {
+            "decision_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "request_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_snapshot_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "actor_identity": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target_system": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target_resource": {
+              "type": "string",
+              "minLength": 1
+            },
+            "intended_action": {
+              "type": "string",
+              "minLength": 1
+            },
+            "evidence_refs": {
+              "type": "array",
+              "minItems": 5,
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "decision_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "decision_ts": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "ttl_seconds": {
+              "type": "null"
+            },
+            "expected_state_fingerprint": {
+              "type": "string",
+              "minLength": 1
+            },
+            "approval_context": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "human_approval_receipt_ref",
+                "human_approval_receipt_hash"
+              ],
+              "properties": {
+                "human_approval_receipt_ref": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "human_approval_receipt_hash": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            },
+            "policy_lineage": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "policy_snapshot_id",
+                "policy_version",
+                "policy_semantic_digest"
+              ],
+              "properties": {
+                "policy_snapshot_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "policy_version": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "policy_semantic_digest": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            }
+          }
+        },
+        "mapping_value_digest": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "required_field_presence": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "execution_intent_id",
+            "decision_id",
+            "request_id",
+            "policy_snapshot_id",
+            "actor_identity",
+            "target_system",
+            "target_resource",
+            "intended_action",
+            "evidence_refs",
+            "decision_hash",
+            "decision_ts",
+            "ttl_seconds",
+            "expected_state_fingerprint",
+            "approval_context",
+            "policy_lineage"
+          ],
+          "properties": {
+            "execution_intent_id": {
+              "const": "intentionally_deferred"
+            },
+            "decision_id": {
+              "const": "mapped"
+            },
+            "request_id": {
+              "const": "mapped"
+            },
+            "policy_snapshot_id": {
+              "const": "mapped"
+            },
+            "actor_identity": {
+              "const": "mapped"
+            },
+            "target_system": {
+              "const": "mapped"
+            },
+            "target_resource": {
+              "const": "mapped"
+            },
+            "intended_action": {
+              "const": "mapped"
+            },
+            "evidence_refs": {
+              "const": "mapped"
+            },
+            "decision_hash": {
+              "const": "mapped"
+            },
+            "decision_ts": {
+              "const": "mapped"
+            },
+            "ttl_seconds": {
+              "const": "intentionally_deferred"
+            },
+            "expected_state_fingerprint": {
+              "const": "mapped"
+            },
+            "approval_context": {
+              "const": "mapped"
+            },
+            "policy_lineage": {
+              "const": "mapped"
+            }
+          }
+        },
+        "source_decision_identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "request_id",
+            "canonical_decision_id",
+            "canonical_decision_hash",
+            "canonical_decision_ts"
+          ],
+          "properties": {
+            "request_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "canonical_decision_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "canonical_decision_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "canonical_decision_ts": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "candidate_identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "candidate_id",
+            "candidate_hash",
+            "actor_identity",
+            "target_system",
+            "target_resource",
+            "action_contract_id",
+            "action_contract_version"
+          ],
+          "properties": {
+            "candidate_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "candidate_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "actor_identity": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target_system": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target_resource": {
+              "type": "string",
+              "minLength": 1
+            },
+            "action_contract_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "action_contract_version": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "evidence_lineage": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "trustlog_artifact_ref",
+            "trustlog_chain_hash",
+            "replay_artifact_ref",
+            "replay_artifact_hash",
+            "authority_evidence_ref",
+            "authority_evidence_hash",
+            "human_approval_receipt_ref",
+            "human_approval_receipt_hash",
+            "policy_snapshot_id",
+            "policy_version",
+            "policy_semantic_digest",
+            "expected_state_fingerprint",
+            "expected_state_source_ref"
+          ],
+          "properties": {
+            "trustlog_artifact_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "trustlog_chain_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "replay_artifact_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "replay_artifact_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "authority_evidence_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "authority_evidence_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "human_approval_receipt_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "human_approval_receipt_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_snapshot_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_version": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_semantic_digest": {
+              "type": "string",
+              "minLength": 1
+            },
+            "expected_state_fingerprint": {
+              "type": "string",
+              "minLength": 1
+            },
+            "expected_state_source_ref": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "replay_summary": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "original_decision_id",
+            "replay_decision_id",
+            "original_request_id",
+            "replay_request_id",
+            "semantic_profile",
+            "semantic_match",
+            "fields_changed",
+            "severity",
+            "divergence_level"
+          ],
+          "properties": {
+            "original_decision_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "replay_decision_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "original_request_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "replay_request_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "semantic_profile": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "semantic_match": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "fields_changed": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "severity": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "divergence_level": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        "scope_limitations": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "const": "NOT_EXECUTION_INTENT"
+            },
+            {
+              "const": "NOT_EXECUTION_AUTHORITY"
+            },
+            {
+              "const": "NOT_BIND_AUTHORIZATION"
+            },
+            {
+              "const": "NOT_BIND_RECEIPT"
+            },
+            {
+              "const": "NOT_EXTERNAL_EFFECT"
+            },
+            {
+              "const": "NOT_ADAPTER_INVOCATION"
+            },
+            {
+              "const": "NOT_OPERATION_COMMIT"
+            },
+            {
+              "const": "NOT_TRUSTLOG_WRITE"
+            }
+          ],
+          "items": false,
+          "minItems": 8,
+          "maxItems": 8
+        }
+      },
+      "$defs": {
+        "eligibility": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "$id": "https://veritas-os.org/schemas/guarded-promotion-eligibility-packet-v1.schema.json",
+          "title": "Canonical Guarded Promotion Eligibility Packet v1",
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "format_version",
+            "eligibility_id",
+            "eligibility_hash",
+            "validation_mechanism",
+            "handoff_validator_version",
+            "issued_at",
+            "evaluated_at",
+            "validation_status",
+            "ready_for_guarded_promotion",
+            "fail_closed",
+            "source_handoff",
+            "source_handoff_hash",
+            "trusted_validation_context",
+            "trusted_validation_context_hash",
+            "validation_result",
+            "validation_result_hash",
+            "verified_provenance_paths",
+            "source_decision_identity",
+            "candidate_identity",
+            "evidence_lineage",
+            "replay_summary",
+            "scope_limitations"
+          ],
+          "properties": {
+            "format_version": {
+              "const": "canonical-guarded-promotion-eligibility-packet/v1"
+            },
+            "eligibility_id": {
+              "type": "string",
+              "pattern": "^gpe:v1:sha256:[0-9a-f]{64}$"
+            },
+            "eligibility_hash": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "validation_mechanism": {
+              "const": "validate_canonical_decision_handoff/v1"
+            },
+            "handoff_validator_version": {
+              "type": "string"
+            },
+            "issued_at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "evaluated_at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "validation_status": {
+              "const": "READY_FOR_GUARDED_PROMOTION"
+            },
+            "ready_for_guarded_promotion": {
+              "const": true
+            },
+            "fail_closed": {
+              "const": false
+            },
+            "source_handoff": {
+              "type": "object"
+            },
+            "source_handoff_hash": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "trusted_validation_context": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "value_assertions",
+                "candidate_hash_binding",
+                "authority_requirement_binding"
+              ],
+              "properties": {
+                "value_assertions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/$defs/valueAssertion"
+                  }
+                },
+                "candidate_hash_binding": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/$defs/candidateBinding"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "authority_requirement_binding": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/$defs/authorityBinding"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              }
+            },
+            "trusted_validation_context_hash": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "validation_result": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "status",
+                "reason_codes",
+                "structure_valid",
+                "declared_status",
+                "declared_status_matches",
+                "declared_reason_codes",
+                "declared_reason_codes_match",
+                "verified_provenance_paths",
+                "validation_version",
+                "ready_for_guarded_promotion",
+                "fail_closed",
+                "requires_review"
+              ],
+              "properties": {
+                "status": {
+                  "const": "READY_FOR_GUARDED_PROMOTION"
+                },
+                "reason_codes": {
+                  "const": []
+                },
+                "structure_valid": {
+                  "const": true
+                },
+                "declared_status": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "declared_status_matches": {
+                  "type": "boolean"
+                },
+                "declared_reason_codes": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "declared_reason_codes_match": {
+                  "type": "boolean"
+                },
+                "verified_provenance_paths": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "validation_version": {
+                  "type": "string"
+                },
+                "ready_for_guarded_promotion": {
+                  "const": true
+                },
+                "fail_closed": {
+                  "const": false
+                },
+                "requires_review": {
+                  "const": false
+                }
+              }
+            },
+            "validation_result_hash": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "verified_provenance_paths": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "source_decision_identity": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "request_id",
+                "canonical_decision_id",
+                "canonical_decision_hash",
+                "canonical_decision_ts"
+              ],
+              "properties": {
+                "request_id": {
+                  "type": "string"
+                },
+                "canonical_decision_id": {
+                  "type": "string"
+                },
+                "canonical_decision_hash": {
+                  "type": "string"
+                },
+                "canonical_decision_ts": {
+                  "type": "string"
+                }
+              }
+            },
+            "candidate_identity": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "candidate_id",
+                "candidate_hash",
+                "actor_identity",
+                "target_system",
+                "target_resource",
+                "action_contract_id",
+                "action_contract_version"
+              ],
+              "properties": {
+                "candidate_id": {
+                  "type": "string"
+                },
+                "candidate_hash": {
+                  "type": "string"
+                },
+                "actor_identity": {
+                  "type": "string"
+                },
+                "target_system": {
+                  "type": "string"
+                },
+                "target_resource": {
+                  "type": "string"
+                },
+                "action_contract_id": {
+                  "type": "string"
+                },
+                "action_contract_version": {
+                  "type": "string"
+                }
+              }
+            },
+            "evidence_lineage": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "trustlog_artifact_ref",
+                "trustlog_chain_hash",
+                "replay_artifact_ref",
+                "replay_artifact_hash",
+                "authority_evidence_ref",
+                "authority_evidence_hash",
+                "human_approval_receipt_ref",
+                "human_approval_receipt_hash",
+                "policy_snapshot_id",
+                "policy_version",
+                "policy_semantic_digest",
+                "expected_state_fingerprint",
+                "expected_state_source_ref"
+              ],
+              "properties": {
+                "trustlog_artifact_ref": {
+                  "type": "string"
+                },
+                "trustlog_chain_hash": {
+                  "type": "string"
+                },
+                "replay_artifact_ref": {
+                  "type": "string"
+                },
+                "replay_artifact_hash": {
+                  "type": "string"
+                },
+                "authority_evidence_ref": {
+                  "type": "string"
+                },
+                "authority_evidence_hash": {
+                  "type": "string"
+                },
+                "human_approval_receipt_ref": {
+                  "type": "string"
+                },
+                "human_approval_receipt_hash": {
+                  "type": "string"
+                },
+                "policy_snapshot_id": {
+                  "type": "string"
+                },
+                "policy_version": {
+                  "type": "string"
+                },
+                "policy_semantic_digest": {
+                  "type": "string"
+                },
+                "expected_state_fingerprint": {
+                  "type": "string"
+                },
+                "expected_state_source_ref": {
+                  "type": "string"
+                }
+              }
+            },
+            "replay_summary": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "original_decision_id",
+                "replay_decision_id",
+                "original_request_id",
+                "replay_request_id",
+                "semantic_profile",
+                "semantic_match",
+                "fields_changed",
+                "severity",
+                "divergence_level"
+              ],
+              "properties": {
+                "original_decision_id": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "replay_decision_id": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "original_request_id": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "replay_request_id": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "semantic_profile": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "semantic_match": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "fields_changed": {
+                  "anyOf": [
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "severity": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "divergence_level": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              }
+            },
+            "scope_limitations": {
+              "type": "array",
+              "prefixItems": [
+                {
+                  "const": "NOT_EXECUTION_AUTHORITY"
+                },
+                {
+                  "const": "NOT_EXECUTION_INTENT"
+                },
+                {
+                  "const": "NOT_BIND_AUTHORIZATION"
+                },
+                {
+                  "const": "NOT_BIND_RECEIPT"
+                },
+                {
+                  "const": "NOT_EXTERNAL_EFFECT"
+                },
+                {
+                  "const": "NOT_AUTHORITY_EVIDENCE"
+                },
+                {
+                  "const": "NOT_HUMAN_APPROVAL"
+                },
+                {
+                  "const": "NOT_TRUSTLOG_SUBSTITUTE"
+                }
+              ],
+              "items": false,
+              "minItems": 8,
+              "maxItems": 8
+            }
+          },
+          "$defs": {
+            "valueAssertion": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "field_path",
+                "value_digest",
+                "verification_mechanism",
+                "source_artifact_ref",
+                "source_hash",
+                "verified_at",
+                "claims"
+              ],
+              "properties": {
+                "field_path": {
+                  "type": "string"
+                },
+                "value_digest": {
+                  "type": "string"
+                },
+                "verification_mechanism": {
+                  "type": "string"
+                },
+                "source_artifact_ref": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "source_hash": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "verified_at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "claims": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "candidateBinding": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "candidate_value_digest",
+                "asserted_candidate_hash",
+                "candidate_hash_profile",
+                "verification_mechanism",
+                "claim",
+                "source_artifact_ref",
+                "source_hash",
+                "verified_at"
+              ],
+              "properties": {
+                "candidate_value_digest": {
+                  "type": "string"
+                },
+                "asserted_candidate_hash": {
+                  "type": "string"
+                },
+                "candidate_hash_profile": {
+                  "type": "string"
+                },
+                "verification_mechanism": {
+                  "type": "string"
+                },
+                "claim": {
+                  "type": "string"
+                },
+                "source_artifact_ref": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "source_hash": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "verified_at": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              }
+            },
+            "authorityBinding": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "authority_requirement_value_digest",
+                "authority_evidence_value_digest",
+                "verification_mechanism",
+                "claim",
+                "source_artifact_ref",
+                "source_hash",
+                "verified_at"
+              ],
+              "properties": {
+                "authority_requirement_value_digest": {
+                  "type": "string"
+                },
+                "authority_evidence_value_digest": {
+                  "type": "string"
+                },
+                "verification_mechanism": {
+                  "type": "string"
+                },
+                "claim": {
+                  "type": "string"
+                },
+                "source_artifact_ref": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "source_hash": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "verified_at": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "mapping": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "decision_id",
+        "request_id",
+        "policy_snapshot_id",
+        "actor_identity",
+        "target_system",
+        "target_resource",
+        "intended_action",
+        "evidence_refs",
+        "decision_hash",
+        "decision_ts",
+        "ttl_seconds",
+        "expected_state_fingerprint",
+        "approval_context",
+        "policy_lineage"
+      ],
+      "properties": {
+        "decision_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "request_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_snapshot_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "actor_identity": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_system": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_resource": {
+          "type": "string",
+          "minLength": 1
+        },
+        "intended_action": {
+          "type": "string",
+          "minLength": 1
+        },
+        "evidence_refs": {
+          "type": "array",
+          "minItems": 5,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "decision_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "decision_ts": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "ttl_seconds": {
+          "type": "null"
+        },
+        "expected_state_fingerprint": {
+          "type": "string",
+          "minLength": 1
+        },
+        "approval_context": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "human_approval_receipt_ref",
+            "human_approval_receipt_hash"
+          ],
+          "properties": {
+            "human_approval_receipt_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "human_approval_receipt_hash": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "policy_lineage": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "policy_snapshot_id",
+            "policy_version",
+            "policy_semantic_digest"
+          ],
+          "properties": {
+            "policy_snapshot_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_version": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_semantic_digest": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    },
+    "execution_intent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "execution_intent_id",
+        "decision_id",
+        "request_id",
+        "policy_snapshot_id",
+        "actor_identity",
+        "target_system",
+        "target_resource",
+        "intended_action",
+        "evidence_refs",
+        "decision_hash",
+        "decision_ts",
+        "ttl_seconds",
+        "expected_state_fingerprint",
+        "approval_context",
+        "policy_lineage"
+      ],
+      "properties": {
+        "execution_intent_id": {
+          "type": "string",
+          "pattern": "^ei:v1:sha256:[0-9a-f]{64}$"
+        },
+        "decision_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "request_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_snapshot_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "actor_identity": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_system": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_resource": {
+          "type": "string",
+          "minLength": 1
+        },
+        "intended_action": {
+          "type": "string",
+          "minLength": 1
+        },
+        "evidence_refs": {
+          "type": "array",
+          "minItems": 5,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "decision_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "decision_ts": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "ttl_seconds": {
+          "type": "null"
+        },
+        "expected_state_fingerprint": {
+          "type": "string",
+          "minLength": 1
+        },
+        "approval_context": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "human_approval_receipt_ref",
+            "human_approval_receipt_hash"
+          ],
+          "properties": {
+            "human_approval_receipt_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "human_approval_receipt_hash": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "policy_lineage": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "policy_snapshot_id",
+            "policy_version",
+            "policy_semantic_digest"
+          ],
+          "properties": {
+            "policy_snapshot_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_version": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_semantic_digest": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/veritas_os/policy/canonical_execution_intent_formation.py
+++ b/veritas_os/policy/canonical_execution_intent_formation.py
@@ -1,0 +1,364 @@
+"""Deterministically form an ExecutionIntent without crossing the Bind boundary.
+
+The artifact produced here proves only that an exact, verified readiness packet
+was mapped into an exact ``ExecutionIntent``.  This module deliberately has no
+I/O, TrustLog, adapter, authorization, or Bind capability.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from veritas_os.policy.bind_artifacts import (
+    ExecutionIntent,
+    canonical_execution_intent_json,
+    hash_execution_intent,
+)
+from veritas_os.policy.execution_intent_formation_readiness import (
+    CanonicalExecutionIntentFormationReadinessPacket,
+    ExecutionIntentFormationReadinessError,
+    verify_execution_intent_formation_readiness_packet,
+)
+
+FORMAT_VERSION = "canonical-execution-intent-formation/v1"
+FORMATION_MECHANISM = "build_execution_intent_from_readiness/v1"
+EXECUTION_INTENT_ID_DOMAIN = (
+    "veritas.execution-intent-formation.execution-intent-id/v1"
+)
+FIELD_MAPPING_DOMAIN = "veritas.execution-intent-formation.field-mapping/v1"
+PACKET_DOMAIN = "veritas.execution-intent-formation.packet/v1"
+EXECUTION_INTENT_FIELDS = (
+    "decision_id",
+    "request_id",
+    "policy_snapshot_id",
+    "actor_identity",
+    "target_system",
+    "target_resource",
+    "intended_action",
+    "evidence_refs",
+    "decision_hash",
+    "decision_ts",
+    "ttl_seconds",
+    "expected_state_fingerprint",
+    "approval_context",
+    "policy_lineage",
+)
+SCOPE_LIMITATIONS = (
+    "NOT_EXECUTION_AUTHORITY",
+    "NOT_BIND_AUTHORIZATION",
+    "NOT_BIND_RECEIPT",
+    "NOT_BIND_INVOCATION",
+    "NOT_EXTERNAL_EFFECT",
+    "NOT_ADAPTER_INVOCATION",
+    "NOT_OPERATION_COMMIT",
+    "NOT_TRUSTLOG_WRITE",
+    "NOT_AUTHORITY_EVIDENCE",
+    "NOT_HUMAN_APPROVAL",
+)
+
+
+class CanonicalExecutionIntentFormationError(ValueError):
+    """Stable fail-closed formation construction or verification refusal."""
+
+
+class CanonicalExecutionIntentFormationPacket(BaseModel):
+    """Strict immutable binding between readiness and a formed intent."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    format_version: Literal["canonical-execution-intent-formation/v1"]
+    formation_id: str = Field(pattern=r"^eif:v1:sha256:[0-9a-f]{64}$")
+    formation_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    formation_mechanism: Literal["build_execution_intent_from_readiness/v1"]
+    formed_at: str
+    source_readiness: dict[str, Any]
+    source_readiness_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    source_readiness_packet: dict[str, Any]
+    source_eligibility_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    source_handoff_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    trusted_validation_context_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    validation_result_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    mapping_value_digest: str = Field(pattern=r"^[0-9a-f]{64}$")
+    execution_intent_contract_version: str
+    execution_intent: dict[str, Any]
+    execution_intent_id: str = Field(pattern=r"^ei:v1:sha256:[0-9a-f]{64}$")
+    execution_intent_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    source_to_execution_intent_mapping: dict[str, Any]
+    field_mapping_proof: dict[str, Any]
+    required_field_presence: dict[str, str]
+    source_decision_identity: dict[str, Any]
+    candidate_identity: dict[str, Any]
+    evidence_lineage: dict[str, Any]
+    replay_summary: dict[str, Any]
+    scope_limitations: tuple[str, ...]
+
+
+def _json_value(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        value = value.model_dump(mode="python")
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        if value != value or value in (float("inf"), float("-inf")):
+            raise CanonicalExecutionIntentFormationError("EIF_PACKET_INVALID")
+        return value
+    if isinstance(value, datetime):
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise CanonicalExecutionIntentFormationError("EIF_FORMED_AT_INVALID")
+        return value.isoformat()
+    if isinstance(value, (list, tuple)):
+        return [_json_value(item) for item in value]
+    if isinstance(value, dict):
+        if not all(isinstance(key, str) for key in value):
+            raise CanonicalExecutionIntentFormationError("EIF_PACKET_INVALID")
+        return {key: _json_value(item) for key, item in value.items()}
+    raise CanonicalExecutionIntentFormationError("EIF_PACKET_INVALID")
+
+
+def _digest(domain: str, value: Any) -> str:
+    payload = json.dumps(
+        {"domain": domain, "value": _json_value(value)},
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _packet_hash(raw: dict[str, Any]) -> str:
+    preimage = {
+        key: value
+        for key, value in raw.items()
+        if key not in {"formation_id", "formation_hash"}
+    }
+    return _digest(PACKET_DOMAIN, preimage)
+
+
+def _aware_iso(value: Any) -> datetime:
+    try:
+        parsed = value if isinstance(value, datetime) else datetime.fromisoformat(value)
+    except (TypeError, ValueError) as exc:
+        raise CanonicalExecutionIntentFormationError(
+            "EIF_FORMED_AT_INVALID"
+        ) from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise CanonicalExecutionIntentFormationError("EIF_FORMED_AT_INVALID")
+    return parsed
+
+
+def _verified_readiness(
+    value: Any,
+) -> CanonicalExecutionIntentFormationReadinessPacket:
+    try:
+        readiness = verify_execution_intent_formation_readiness_packet(value)
+    except (ExecutionIntentFormationReadinessError, TypeError, ValueError) as exc:
+        raise CanonicalExecutionIntentFormationError("EIF_READINESS_INVALID") from exc
+    if not (
+        readiness.formation_status == "READY_FOR_EXECUTION_INTENT_FORMATION"
+        and readiness.ready_for_execution_intent_formation is True
+        and readiness.fail_closed is False
+    ):
+        raise CanonicalExecutionIntentFormationError("EIF_READINESS_INVALID")
+    return readiness
+
+
+def _execution_intent_id(readiness: Any) -> str:
+    value = {
+        "source_readiness_id": readiness.readiness_id,
+        "source_readiness_hash": readiness.readiness_hash,
+        "mapping_value_digest": readiness.mapping_value_digest,
+        "source_to_execution_intent_mapping": (
+            readiness.source_to_execution_intent_mapping
+        ),
+        "execution_intent_contract_version": (
+            readiness.execution_intent_contract_version
+        ),
+    }
+    return f"ei:v1:sha256:{_digest(EXECUTION_INTENT_ID_DOMAIN, value)}"
+
+
+def _intent(intent_id: str, mapping: dict[str, Any]) -> ExecutionIntent:
+    if set(mapping) != set(EXECUTION_INTENT_FIELDS):
+        raise CanonicalExecutionIntentFormationError("EIF_MAPPING_MISMATCH")
+    try:
+        return ExecutionIntent(execution_intent_id=intent_id, **mapping)
+    except (TypeError, ValueError) as exc:
+        raise CanonicalExecutionIntentFormationError(
+            "EIF_EXECUTION_INTENT_FIELD_MISMATCH"
+        ) from exc
+
+
+def build_canonical_execution_intent_formation_packet(
+    readiness_packet: Any,
+    formed_at: datetime,
+) -> CanonicalExecutionIntentFormationPacket:
+    """Form an intent solely from a verified readiness packet.
+
+    Args:
+        readiness_packet: Full canonical formation-readiness artifact.
+        formed_at: Caller-supplied timezone-aware formation time.
+
+    Returns:
+        A content-addressed packet containing the deterministic intent.
+    """
+    formed = _aware_iso(formed_at)
+    readiness = _verified_readiness(_json_value(readiness_packet))
+    checked = _aware_iso(readiness.checked_at)
+    if formed < checked:
+        raise CanonicalExecutionIntentFormationError(
+            "EIF_FORMED_BEFORE_READINESS_CHECKED"
+        )
+    source_packet = readiness.model_dump(mode="json")
+    intent_id = _execution_intent_id(readiness)
+    intent = _intent(intent_id, readiness.source_to_execution_intent_mapping)
+    intent_json = intent.to_dict()
+    raw = {
+        "format_version": FORMAT_VERSION,
+        "formation_mechanism": FORMATION_MECHANISM,
+        "formed_at": formed.isoformat(),
+        "source_readiness": {
+            key: source_packet[key]
+            for key in (
+                "readiness_id",
+                "readiness_hash",
+                "format_version",
+                "checked_at",
+                "formation_status",
+                "ready_for_execution_intent_formation",
+            )
+        },
+        "source_readiness_hash": readiness.readiness_hash,
+        "source_readiness_packet": source_packet,
+        "source_eligibility_hash": readiness.source_eligibility_hash,
+        "source_handoff_hash": readiness.source_handoff_hash,
+        "trusted_validation_context_hash": readiness.trusted_validation_context_hash,
+        "validation_result_hash": readiness.validation_result_hash,
+        "mapping_value_digest": readiness.mapping_value_digest,
+        "execution_intent_contract_version": (
+            readiness.execution_intent_contract_version
+        ),
+        "execution_intent": intent_json,
+        "execution_intent_id": intent_id,
+        "execution_intent_hash": hash_execution_intent(intent),
+        "source_to_execution_intent_mapping": (
+            readiness.source_to_execution_intent_mapping
+        ),
+        "field_mapping_proof": {
+            key: intent_json[key] for key in EXECUTION_INTENT_FIELDS
+        },
+        "required_field_presence": readiness.required_field_presence,
+        "source_decision_identity": readiness.source_decision_identity,
+        "candidate_identity": readiness.candidate_identity,
+        "evidence_lineage": readiness.evidence_lineage,
+        "replay_summary": readiness.replay_summary,
+        "scope_limitations": SCOPE_LIMITATIONS,
+    }
+    digest = _packet_hash(raw)
+    raw.update(formation_hash=digest, formation_id=f"eif:v1:sha256:{digest}")
+    return verify_canonical_execution_intent_formation_packet(raw)
+
+
+def verify_canonical_execution_intent_formation_packet(
+    packet: Any,
+) -> CanonicalExecutionIntentFormationPacket:
+    """Independently revalidate every source, mapping, and hash binding."""
+    try:
+        raw_input = (
+            packet.model_dump(mode="json")
+            if isinstance(packet, BaseModel)
+            else _json_value(packet)
+        )
+        candidate = CanonicalExecutionIntentFormationPacket.model_validate(raw_input)
+    except (ValidationError, CanonicalExecutionIntentFormationError, TypeError) as exc:
+        raise CanonicalExecutionIntentFormationError("EIF_PACKET_INVALID") from exc
+    raw = candidate.model_dump(mode="json")
+    readiness = _verified_readiness(candidate.source_readiness_packet)
+    formed = _aware_iso(candidate.formed_at)
+    if formed < _aware_iso(readiness.checked_at):
+        raise CanonicalExecutionIntentFormationError(
+            "EIF_FORMED_BEFORE_READINESS_CHECKED"
+        )
+    source_packet = readiness.model_dump(mode="json")
+    summary_keys = {
+        "readiness_id",
+        "readiness_hash",
+        "format_version",
+        "checked_at",
+        "formation_status",
+        "ready_for_execution_intent_formation",
+    }
+    expected_summary = {key: source_packet[key] for key in summary_keys}
+    if candidate.source_readiness != expected_summary:
+        raise CanonicalExecutionIntentFormationError("EIF_READINESS_INVALID")
+    bindings = (
+        (candidate.source_readiness_hash, readiness.readiness_hash),
+        (candidate.source_eligibility_hash, readiness.source_eligibility_hash),
+        (candidate.source_handoff_hash, readiness.source_handoff_hash),
+        (
+            candidate.trusted_validation_context_hash,
+            readiness.trusted_validation_context_hash,
+        ),
+        (candidate.validation_result_hash, readiness.validation_result_hash),
+        (candidate.mapping_value_digest, readiness.mapping_value_digest),
+        (
+            candidate.execution_intent_contract_version,
+            readiness.execution_intent_contract_version,
+        ),
+    )
+    if any(actual != expected for actual, expected in bindings):
+        raise CanonicalExecutionIntentFormationError("EIF_MAPPING_MISMATCH")
+    mapping = readiness.source_to_execution_intent_mapping
+    if candidate.source_to_execution_intent_mapping != mapping:
+        raise CanonicalExecutionIntentFormationError("EIF_MAPPING_MISMATCH")
+    intent_id = _execution_intent_id(readiness)
+    if candidate.execution_intent_id != intent_id:
+        raise CanonicalExecutionIntentFormationError(
+            "EIF_EXECUTION_INTENT_ID_MISMATCH"
+        )
+    expected_intent = _intent(intent_id, mapping)
+    expected_json = expected_intent.to_dict()
+    if candidate.execution_intent != expected_json:
+        raise CanonicalExecutionIntentFormationError(
+            "EIF_EXECUTION_INTENT_FIELD_MISMATCH"
+        )
+    reconstructed = _intent(intent_id, {
+        key: candidate.execution_intent[key] for key in EXECUTION_INTENT_FIELDS
+    })
+    if reconstructed.to_dict() != candidate.execution_intent:
+        raise CanonicalExecutionIntentFormationError(
+            "EIF_EXECUTION_INTENT_FIELD_MISMATCH"
+        )
+    if candidate.execution_intent_hash != hash_execution_intent(reconstructed):
+        raise CanonicalExecutionIntentFormationError(
+            "EIF_EXECUTION_INTENT_HASH_MISMATCH"
+        )
+    # Exercise and bind the existing canonical serialization contract as well.
+    canonical_execution_intent_json(reconstructed)
+    proof = {key: expected_json[key] for key in EXECUTION_INTENT_FIELDS}
+    if candidate.field_mapping_proof != proof:
+        raise CanonicalExecutionIntentFormationError(
+            "EIF_FIELD_MAPPING_PROOF_MISMATCH"
+        )
+    preserved = (
+        (candidate.required_field_presence, readiness.required_field_presence),
+        (candidate.source_decision_identity, readiness.source_decision_identity),
+        (candidate.candidate_identity, readiness.candidate_identity),
+        (candidate.evidence_lineage, readiness.evidence_lineage),
+        (candidate.replay_summary, readiness.replay_summary),
+    )
+    if any(actual != expected for actual, expected in preserved):
+        raise CanonicalExecutionIntentFormationError("EIF_MAPPING_MISMATCH")
+    if candidate.scope_limitations != SCOPE_LIMITATIONS:
+        raise CanonicalExecutionIntentFormationError("EIF_SCOPE_LIMITATIONS_MISSING")
+    digest = _packet_hash(raw)
+    if candidate.formation_hash != digest:
+        raise CanonicalExecutionIntentFormationError("EIF_FORMATION_HASH_MISMATCH")
+    if candidate.formation_id != f"eif:v1:sha256:{digest}":
+        raise CanonicalExecutionIntentFormationError("EIF_FORMATION_ID_MISMATCH")
+    return candidate

--- a/veritas_os/tests/test_canonical_execution_intent_formation.py
+++ b/veritas_os/tests/test_canonical_execution_intent_formation.py
@@ -1,0 +1,311 @@
+"""Security tests for Canonical ExecutionIntent Formation v1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from copy import deepcopy
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator, FormatChecker
+
+from veritas_os.policy.bind_artifacts import ExecutionIntent, hash_execution_intent
+from veritas_os.policy.canonical_execution_intent_formation import (
+    EXECUTION_INTENT_FIELDS,
+    EXECUTION_INTENT_ID_DOMAIN,
+    FIELD_MAPPING_DOMAIN,
+    PACKET_DOMAIN,
+    SCOPE_LIMITATIONS,
+    CanonicalExecutionIntentFormationError,
+    CanonicalExecutionIntentFormationPacket,
+    _digest,
+    _packet_hash,
+    build_canonical_execution_intent_formation_packet,
+    verify_canonical_execution_intent_formation_packet,
+)
+from veritas_os.policy.execution_intent_formation_readiness import (
+    build_execution_intent_formation_readiness_packet,
+)
+from veritas_os.tests.test_execution_intent_formation_readiness import (
+    NOW,
+    _canonical_replay_eligibility,
+    _eligibility,
+)
+
+FORMED_AT = NOW + timedelta(seconds=1)
+MODULE = Path("veritas_os/policy/canonical_execution_intent_formation.py")
+SCHEMA = Path("schemas/canonical-execution-intent-formation-v1.schema.json")
+
+
+def _readiness(*, semantic_match: bool | None = None):
+    eligibility = (
+        _eligibility()
+        if semantic_match is None
+        else _canonical_replay_eligibility(
+            semantic_match=semantic_match,
+            fields_changed=[] if semantic_match else ["outcome.status"],
+        )
+    )
+    return build_execution_intent_formation_readiness_packet(eligibility, NOW)
+
+
+def _packet(*, semantic_match: bool | None = None):
+    return build_canonical_execution_intent_formation_packet(
+        _readiness(semantic_match=semantic_match), FORMED_AT
+    )
+
+
+def _resign(raw: dict) -> dict:
+    raw["formation_hash"] = _packet_hash(raw)
+    raw["formation_id"] = f"eif:v1:sha256:{raw['formation_hash']}"
+    return raw
+
+
+def test_build_verify_mapping_content_addressing_and_no_effects(monkeypatch) -> None:
+    import veritas_os.policy.canonical_execution_intent_formation as module
+
+    readiness = _readiness()
+    actual = module.verify_execution_intent_formation_readiness_packet
+    calls = []
+
+    def recording_verifier(value):
+        calls.append(value)
+        return actual(value)
+
+    monkeypatch.setattr(
+        module, "verify_execution_intent_formation_readiness_packet", recording_verifier
+    )
+    packet = module.build_canonical_execution_intent_formation_packet(
+        readiness, FORMED_AT
+    )
+    assert len(calls) == 2  # builder verification, then final verifier verification
+    assert module.verify_canonical_execution_intent_formation_packet(packet) == packet
+    assert len(calls) == 3
+    assert packet.formation_id == f"eif:v1:sha256:{packet.formation_hash}"
+    assert packet.formation_hash == _packet_hash(packet.model_dump(mode="json"))
+    assert packet.execution_intent_id.startswith("ei:v1:sha256:")
+    assert packet.execution_intent["execution_intent_id"] == packet.execution_intent_id
+    mapping = readiness.source_to_execution_intent_mapping
+    assert packet.execution_intent == {
+        "execution_intent_id": packet.execution_intent_id,
+        **mapping,
+    }
+    assert packet.field_mapping_proof == mapping
+    intent = ExecutionIntent(
+        execution_intent_id=packet.execution_intent_id, **mapping
+    )
+    assert packet.execution_intent_hash == hash_execution_intent(intent)
+    assert packet.required_field_presence == readiness.required_field_presence
+    assert packet.source_decision_identity == readiness.source_decision_identity
+    assert packet.candidate_identity == readiness.candidate_identity
+    assert packet.evidence_lineage == readiness.evidence_lineage
+    assert packet.replay_summary == readiness.replay_summary
+    assert packet.scope_limitations == SCOPE_LIMITATIONS
+    assert not hasattr(packet, "bind_receipt")
+    assert not hasattr(packet, "trustlog_entry")
+
+
+@pytest.mark.parametrize("semantic_match", [True, False])
+def test_semantic_match_is_preserved_not_gated(semantic_match: bool) -> None:
+    packet = _packet(semantic_match=semantic_match)
+    assert packet.replay_summary["semantic_match"] is semantic_match
+    assert packet.replay_summary["fields_changed"] == (
+        [] if semantic_match else ["outcome.status"]
+    )
+    assert verify_canonical_execution_intent_formation_packet(packet) == packet
+
+
+def test_deterministic_execution_intent_id() -> None:
+    readiness = _readiness()
+    first = build_canonical_execution_intent_formation_packet(readiness, FORMED_AT)
+    second = build_canonical_execution_intent_formation_packet(readiness, FORMED_AT)
+    value = {
+        "source_readiness_id": readiness.readiness_id,
+        "source_readiness_hash": readiness.readiness_hash,
+        "mapping_value_digest": readiness.mapping_value_digest,
+        "source_to_execution_intent_mapping": (
+            readiness.source_to_execution_intent_mapping
+        ),
+        "execution_intent_contract_version": (
+            readiness.execution_intent_contract_version
+        ),
+    }
+    assert first == second
+    assert first.execution_intent_id == (
+        f"ei:v1:sha256:{_digest(EXECUTION_INTENT_ID_DOMAIN, value)}"
+    )
+
+
+def test_invalid_readiness_and_formation_time_refuse() -> None:
+    invalid = _readiness().model_dump(mode="json")
+    invalid["readiness_hash"] = "0" * 64
+    with pytest.raises(CanonicalExecutionIntentFormationError, match="EIF_READINESS_INVALID"):
+        build_canonical_execution_intent_formation_packet(invalid, FORMED_AT)
+    invalid = _readiness().model_dump(mode="json")
+    invalid["readiness_id"] = "eifr:v1:sha256:" + "0" * 64
+    with pytest.raises(CanonicalExecutionIntentFormationError, match="EIF_READINESS_INVALID"):
+        build_canonical_execution_intent_formation_packet(invalid, FORMED_AT)
+    with pytest.raises(
+        CanonicalExecutionIntentFormationError, match="EIF_FORMED_AT_INVALID"
+    ):
+        build_canonical_execution_intent_formation_packet(
+            _readiness(), FORMED_AT.replace(tzinfo=None)
+        )
+    with pytest.raises(
+        CanonicalExecutionIntentFormationError,
+        match="EIF_FORMED_BEFORE_READINESS_CHECKED",
+    ):
+        build_canonical_execution_intent_formation_packet(
+            _readiness(), NOW - timedelta(seconds=1)
+        )
+
+
+@pytest.mark.parametrize("field", EXECUTION_INTENT_FIELDS)
+def test_missing_mapping_fields_refuse(field: str) -> None:
+    readiness = _readiness().model_dump(mode="json")
+    del readiness["source_to_execution_intent_mapping"][field]
+    with pytest.raises(CanonicalExecutionIntentFormationError, match="EIF_READINESS_INVALID"):
+        build_canonical_execution_intent_formation_packet(readiness, FORMED_AT)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        ("formation_id",),
+        ("formation_hash",),
+        ("formed_at",),
+        ("source_readiness", "checked_at"),
+        ("source_readiness_hash",),
+        ("source_readiness_packet", "readiness_hash"),
+        ("source_eligibility_hash",),
+        ("source_handoff_hash",),
+        ("trusted_validation_context_hash",),
+        ("validation_result_hash",),
+        ("mapping_value_digest",),
+        ("execution_intent", "decision_id"),
+        ("execution_intent_id",),
+        ("execution_intent_hash",),
+        ("source_to_execution_intent_mapping", "decision_id"),
+        ("field_mapping_proof", "decision_id"),
+        ("source_decision_identity", "request_id"),
+        ("candidate_identity", "actor_identity"),
+        ("evidence_lineage", "policy_snapshot_id"),
+        ("replay_summary", "semantic_match"),
+        ("replay_summary", "fields_changed"),
+        ("scope_limitations",),
+    ],
+)
+def test_single_field_tampering_refuses(path: tuple[str, ...]) -> None:
+    raw = _packet(semantic_match=True).model_dump(mode="json")
+    target = raw
+    for key in path[:-1]:
+        target = target[key]
+    key = path[-1]
+    if key == "formation_id":
+        target[key] = "eif:v1:sha256:" + "0" * 64
+    elif key in {
+        "formation_hash", "source_readiness_hash", "source_eligibility_hash",
+        "source_handoff_hash", "trusted_validation_context_hash",
+        "validation_result_hash", "mapping_value_digest", "execution_intent_hash",
+    }:
+        target[key] = "0" * 64
+    elif key == "execution_intent_id":
+        target[key] = "ei:v1:sha256:" + "0" * 64
+    elif key == "formed_at":
+        target[key] = (FORMED_AT + timedelta(seconds=1)).isoformat()
+    elif key == "readiness_hash":
+        target[key] = "0" * 64
+    elif key == "semantic_match":
+        target[key] = False
+    elif key == "fields_changed":
+        target[key] = ["outcome.status"]
+    elif key == "scope_limitations":
+        target[key] = target[key][:-1]
+    else:
+        target[key] = "tampered"
+    with pytest.raises(CanonicalExecutionIntentFormationError):
+        verify_canonical_execution_intent_formation_packet(raw)
+
+
+@pytest.mark.parametrize(
+    "updates",
+    [
+        {"format_version": "wrong"},
+        {"formation_hash": "0" * 64},
+        {"execution_intent_id": "ei:v1:sha256:" + "0" * 64},
+        {"execution_intent": {}},
+        {"source_to_execution_intent_mapping": {}},
+        {"replay_summary": {}},
+    ],
+)
+@pytest.mark.parametrize("method", ["copy", "construct"])
+def test_typed_instance_bypass_refuses(updates: dict, method: str) -> None:
+    packet = _packet()
+    bypass = (
+        packet.model_copy(update=updates)
+        if method == "copy"
+        else CanonicalExecutionIntentFormationPacket.model_construct(
+            **{**packet.model_dump(mode="python"), **updates}
+        )
+    )
+    with pytest.raises(CanonicalExecutionIntentFormationError):
+        verify_canonical_execution_intent_formation_packet(bypass)
+
+
+def test_schema_accepts_valid_and_rejects_invalid_packet() -> None:
+    schema = json.loads(SCHEMA.read_text())
+    validator = Draft202012Validator(schema, format_checker=FormatChecker())
+    valid = _packet().model_dump(mode="json")
+    validator.validate(valid)
+    invalid = deepcopy(valid)
+    invalid["execution_intent"]["unexpected"] = True
+    assert list(validator.iter_errors(invalid))
+    invalid = deepcopy(valid)
+    invalid["scope_limitations"] = invalid["scope_limitations"][:-1]
+    assert list(validator.iter_errors(invalid))
+
+
+def test_static_import_and_side_effect_boundary() -> None:
+    source = MODULE.read_text()
+    tree = ast.parse(source)
+    forbidden = {
+        "BindReceipt", "hash_bind_receipt", "build_execution_intent_trustlog_entry",
+        "execute_bind_boundary", "execute_bind_adjudication", "WebhookBindAdapter",
+        "ReferenceBindAdapter", "requests", "httpx", "subprocess", "uuid4",
+    }
+    imported = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.Import, ast.ImportFrom))
+        for alias in node.names
+    }
+    assert imported.isdisjoint(forbidden)
+    calls = [node.func for node in ast.walk(tree) if isinstance(node, ast.Call)]
+    assert not any(
+        isinstance(call, ast.Attribute)
+        and isinstance(call.value, ast.Name)
+        and call.value.id == "datetime"
+        and call.attr == "now"
+        for call in calls
+    )
+    intent_calls = [
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "ExecutionIntent"
+    ]
+    assert intent_calls
+    assert all(
+        any(keyword.arg == "execution_intent_id" for keyword in call.keywords)
+        for call in intent_calls
+    )
+    function_names = {
+        node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    }
+    assert function_names.isdisjoint(
+        {"bind", "execute", "commit", "dispatch", "send", "webhook",
+         "adapter_call", "write_trustlog"}
+    )
+    assert FIELD_MAPPING_DOMAIN != PACKET_DOMAIN


### PR DESCRIPTION
### Motivation

- Deterministically form an `ExecutionIntent` from a verified ExecutionIntent Formation Readiness Packet while preserving the security boundary that forbids Bind, TrustLog writes, adapters, network, filesystem, or other external effects.
- Provide a content-addressed, strictly canonical formation artifact that proves which exact verified readiness packet produced an exact ExecutionIntent and that is independently verifiable.
- Prevent nondeterministic IDs and implicit side-effects by deriving `execution_intent_id` deterministically and instantiating `ExecutionIntent` with explicit fields only.

### Description

- Add `veritas_os/policy/canonical_execution_intent_formation.py` implementing `CanonicalExecutionIntentFormationPacket`, deterministic `execution_intent_id` derivation, `build_canonical_execution_intent_formation_packet`, and `verify_canonical_execution_intent_formation_packet` with strict JSON normalization, canonical hashing, and fail-closed error codes.
- The builder verifies the source ExecutionIntent Formation Readiness Packet, forms an `ExecutionIntent` only from the verified readiness mapping, computes `execution_intent_hash` with the existing `hash_execution_intent(...)`, and returns only a content-addressed formation packet.
- The verifier independently re-verifies the embedded Readiness Packet, recomputes the deterministic `execution_intent_id`, reconstructs the `ExecutionIntent`, recomputes `execution_intent_hash`, and checks the exact field mapping proof and preserved source/replay summaries.
- Add closed JSON Schema `schemas/canonical-execution-intent-formation-v1.schema.json` (Draft 2020-12) describing the formation packet shape and pinning required fields and scope limitations.
- Add focused tests `veritas_os/tests/test_canonical_execution_intent_formation.py` covering success path, deterministic ID/hash assertions, tamper/refusal cases, `model_copy`/`model_construct` bypass checks, semantic match true/false preservation, schema validation, and static import/side-effect boundary checks.
- Add docs `docs/en/architecture/canonical-execution-intent-formation-v1.md` clarifying that formation != authorization and explicitly noting no Bind/BindReceipt/TrustLog/write/invocation occurs in this PR.

### Security / non-claims

- Formed `ExecutionIntent` does not authorize execution.
- Formed `ExecutionIntent` does not invoke Bind.
- Formed `ExecutionIntent` does not create a `BindReceipt`.
- Formed `ExecutionIntent` does not write TrustLog.
- Formed `ExecutionIntent` does not call adapters, webhooks, providers, network, filesystem, subprocess, or external systems.
- Formed `ExecutionIntent` does not satisfy Authority Evidence or Human Approval.
- Formed `ExecutionIntent` does not turn replay `semantic_match` into execution authorization.

### Testing / validation

Current head: `99e429d8d3cc5552e5ba5e174807f50a852363a4`
Base: `115b55b14adc56504fedc3e38718cb85e18b45ab`

- GitHub CI run #5056 passed for the current head.
- Python 3.11 full test job: success.
- Python 3.12 full test job: success.
- PostgreSQL parity/contention job: success.
- Slow tests job: success.
- Governance smoke job: success.
- Governance backend fast job: success.
- Lint job, including Ruff, security scans, responsibility-boundary checks, and schema/policy consistency checks: success.
- Dependency audit job: success.
- Future dependency compatibility job: success.
- Frontend lint/test/e2e jobs: success.
- Companion workflows passed for the current head: Security Gates, CodeQL, Runtime Proof Evidence, Runtime Pickle Guard, and Reviewer Evidence Packet Validation.

No production fail-closed rule was weakened. The implementation uses a deterministic `ei:v1:sha256:<hash>` `execution_intent_id`; no `uuid4()` default ID is used by the formation module. No `BindReceipt`, Bind invocation, TrustLog write, adapter call, API auto-wiring, or external effect was introduced. Replay `semantic_match` true/false is preserved exactly and is not converted into Authority Evidence, Human Approval, Bind authorization, or execution authority.

### Final invariant

Canonical ExecutionIntent Formation v1 now deterministically forms an
ExecutionIntent from a verified ExecutionIntent Formation Readiness Packet and
binds that formation into a content-addressed, independently verifiable
artifact. It does not write TrustLog, does not create a BindReceipt, does not
invoke Bind, does not authorize execution, and does not convert replay
semantic_match into Authority Evidence, Human Approval, or execution authority.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a81d724efc883269a7700441bbc1f6b)