### PR TITLE
feat(bind): add execution intent pre-bind validation v1

### DIFF
--- a/docs/en/architecture/execution-intent-pre-bind-validation-v1.md
+++ b/docs/en/architecture/execution-intent-pre-bind-validation-v1.md
@@ -1,0 +1,68 @@
+# Canonical ExecutionIntent Pre-Bind Validation v1
+
+## Purpose and boundary
+
+Canonical ExecutionIntent Pre-Bind Validation v1 is a deterministic, local,
+side-effect-free library boundary between a verified Canonical ExecutionIntent
+Formation Packet and any future Bind boundary. It makes one narrow claim:
+**this exact ExecutionIntent, from this exact independently verified Formation
+Packet, satisfies deterministic local structural and lineage checks**.
+
+An ExecutionIntent being formed is not execution authorization. Pre-bind
+validation is neither Bind authorization nor Bind invocation. Verifying the
+ExecutionIntent hash is not a TrustLog write. Replay `semantic_match` is not
+Authority Evidence or Human Approval. A verified pre-bind packet is not an
+external effect, operation commit, live-state check, or runtime-risk acceptance.
+
+The validator reconstructs the existing ExecutionIntent without assigning a
+new ID, recomputes its existing canonical hash, and requires exact equality of
+the source mapping, field-mapping proof, required-field presence, source and
+candidate identities, evidence lineage, and replay summary. It performs no
+policy, authority, approval, expected-state, or live-state lookup and fabricates
+none of those facts.
+
+## Auditable sequence
+
+1. Canonical Decision Artifact (CDA)
+2. Trust Link
+3. Replay Source and Replay Evidence
+4. Replay Handoff Binding
+5. `CanonicalDecisionHandoff` validation
+6. Canonical Guarded Promotion Eligibility Packet v1
+7. Canonical ExecutionIntent Formation Readiness Packet v1
+8. Canonical ExecutionIntent Formation Packet v1
+9. Canonical ExecutionIntent Pre-Bind Validation Packet v1
+10. **STOP**
+
+Bind preflight, Bind adjudication, TrustLog write, `BindReceipt` creation,
+adapter invocation, and API/CLI auto-wiring are intentionally deferred to
+future explicit PRs.
+
+## Deterministic integrity
+
+The packet format is
+`canonical-execution-intent-pre-bind-validation/v1`. Its content-addressed ID
+is `eipbv:v1:sha256:<64 lowercase hexadecimal characters>`. The packet-hash
+preimage excludes only `pre_bind_validation_id` and
+`pre_bind_validation_hash`, under the
+`veritas.execution-intent-pre-bind-validation.packet/v1` domain. Local checks
+use the separate
+`veritas.execution-intent-pre-bind-validation.local-checks/v1` domain.
+
+The complete verified Formation Packet is embedded, not replaced by its compact
+summary. Both builder and verifier run the Formation Packet verifier. The
+verifier then reconstructs the ExecutionIntent, requires its `to_dict()` to be
+exact, and recomputes `hash_execution_intent` without changing existing
+ExecutionIntent hash semantics.
+
+## Replay semantics and non-claims
+
+Both `semantic_match: true` and `semantic_match: false`, including the exact
+`fields_changed`, are preserved. Semantic agreement or divergence is not
+converted into authorization, approval, authority, refusal, Bind permission,
+or execution permission. Any operation-specific replay-equivalence gate needs
+a separately reviewed future boundary.
+
+This artifact makes no production, customer, regulatory, or certification
+claim. Human approval remains required for future Bind/admissibility,
+TrustLog, and public-claim changes.

--- a/schemas/execution-intent-pre-bind-validation-v1.schema.json
+++ b/schemas/execution-intent-pre-bind-validation-v1.schema.json
@@ -1,0 +1,2464 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://veritas-os.org/schemas/execution-intent-pre-bind-validation-v1.schema.json",
+  "title": "Canonical ExecutionIntent Pre-Bind Validation Packet v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "format_version",
+    "pre_bind_validation_id",
+    "pre_bind_validation_hash",
+    "validation_mechanism",
+    "checked_at",
+    "source_formation",
+    "source_formation_hash",
+    "source_formation_packet",
+    "source_readiness_hash",
+    "source_eligibility_hash",
+    "source_handoff_hash",
+    "trusted_validation_context_hash",
+    "validation_result_hash",
+    "mapping_value_digest",
+    "execution_intent_contract_version",
+    "execution_intent",
+    "execution_intent_id",
+    "execution_intent_hash",
+    "source_to_execution_intent_mapping",
+    "field_mapping_proof",
+    "required_field_presence",
+    "source_decision_identity",
+    "candidate_identity",
+    "evidence_lineage",
+    "replay_summary",
+    "pre_bind_status",
+    "ready_for_bind_preflight",
+    "fail_closed",
+    "local_validation_checks",
+    "scope_limitations"
+  ],
+  "properties": {
+    "format_version": {
+      "const": "canonical-execution-intent-pre-bind-validation/v1"
+    },
+    "pre_bind_validation_id": {
+      "type": "string",
+      "pattern": "^eipbv:v1:sha256:[0-9a-f]{64}$"
+    },
+    "pre_bind_validation_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "validation_mechanism": {
+      "const": "validate_execution_intent_before_bind/v1"
+    },
+    "checked_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "source_formation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "formation_id",
+        "formation_hash",
+        "format_version",
+        "formation_mechanism",
+        "formed_at",
+        "execution_intent_id",
+        "execution_intent_hash"
+      ],
+      "properties": {
+        "formation_id": {
+          "type": "string",
+          "pattern": "^eif:v1:sha256:[0-9a-f]{64}$"
+        },
+        "formation_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "format_version": {
+          "const": "canonical-execution-intent-formation/v1"
+        },
+        "formation_mechanism": {
+          "const": "build_execution_intent_from_readiness/v1"
+        },
+        "formed_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "execution_intent_id": {
+          "type": "string",
+          "pattern": "^ei:v1:sha256:[0-9a-f]{64}$"
+        },
+        "execution_intent_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        }
+      }
+    },
+    "source_formation_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "source_formation_packet": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://veritas-os.org/schemas/canonical-execution-intent-formation-v1.schema.json",
+      "title": "Canonical ExecutionIntent Formation Packet v1",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "format_version",
+        "formation_id",
+        "formation_hash",
+        "formation_mechanism",
+        "formed_at",
+        "source_readiness",
+        "source_readiness_hash",
+        "source_readiness_packet",
+        "source_eligibility_hash",
+        "source_handoff_hash",
+        "trusted_validation_context_hash",
+        "validation_result_hash",
+        "mapping_value_digest",
+        "execution_intent_contract_version",
+        "execution_intent",
+        "execution_intent_id",
+        "execution_intent_hash",
+        "source_to_execution_intent_mapping",
+        "field_mapping_proof",
+        "required_field_presence",
+        "source_decision_identity",
+        "candidate_identity",
+        "evidence_lineage",
+        "replay_summary",
+        "scope_limitations"
+      ],
+      "properties": {
+        "format_version": {
+          "const": "canonical-execution-intent-formation/v1"
+        },
+        "formation_id": {
+          "type": "string",
+          "pattern": "^eif:v1:sha256:[0-9a-f]{64}$"
+        },
+        "formation_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "formation_mechanism": {
+          "const": "build_execution_intent_from_readiness/v1"
+        },
+        "formed_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "source_readiness": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "readiness_id",
+            "readiness_hash",
+            "format_version",
+            "checked_at",
+            "formation_status",
+            "ready_for_execution_intent_formation"
+          ],
+          "properties": {
+            "readiness_id": {
+              "type": "string",
+              "pattern": "^eifr:v1:sha256:[0-9a-f]{64}$"
+            },
+            "readiness_hash": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "format_version": {
+              "const": "canonical-execution-intent-formation-readiness/v1"
+            },
+            "checked_at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "formation_status": {
+              "const": "READY_FOR_EXECUTION_INTENT_FORMATION"
+            },
+            "ready_for_execution_intent_formation": {
+              "const": true
+            }
+          }
+        },
+        "source_readiness_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_readiness_packet": {
+          "$ref": "#/$defs/readiness"
+        },
+        "source_eligibility_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_handoff_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "trusted_validation_context_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "validation_result_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "mapping_value_digest": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "execution_intent_contract_version": {
+          "const": "execution-intent-contract/v1"
+        },
+        "execution_intent": {
+          "$ref": "#/$defs/execution_intent"
+        },
+        "execution_intent_id": {
+          "type": "string",
+          "pattern": "^ei:v1:sha256:[0-9a-f]{64}$"
+        },
+        "execution_intent_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_to_execution_intent_mapping": {
+          "$ref": "#/$defs/mapping"
+        },
+        "field_mapping_proof": {
+          "$ref": "#/$defs/mapping"
+        },
+        "required_field_presence": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "execution_intent_id",
+            "decision_id",
+            "request_id",
+            "policy_snapshot_id",
+            "actor_identity",
+            "target_system",
+            "target_resource",
+            "intended_action",
+            "evidence_refs",
+            "decision_hash",
+            "decision_ts",
+            "ttl_seconds",
+            "expected_state_fingerprint",
+            "approval_context",
+            "policy_lineage"
+          ],
+          "properties": {
+            "execution_intent_id": {
+              "const": "intentionally_deferred"
+            },
+            "decision_id": {
+              "const": "mapped"
+            },
+            "request_id": {
+              "const": "mapped"
+            },
+            "policy_snapshot_id": {
+              "const": "mapped"
+            },
+            "actor_identity": {
+              "const": "mapped"
+            },
+            "target_system": {
+              "const": "mapped"
+            },
+            "target_resource": {
+              "const": "mapped"
+            },
+            "intended_action": {
+              "const": "mapped"
+            },
+            "evidence_refs": {
+              "const": "mapped"
+            },
+            "decision_hash": {
+              "const": "mapped"
+            },
+            "decision_ts": {
+              "const": "mapped"
+            },
+            "ttl_seconds": {
+              "const": "intentionally_deferred"
+            },
+            "expected_state_fingerprint": {
+              "const": "mapped"
+            },
+            "approval_context": {
+              "const": "mapped"
+            },
+            "policy_lineage": {
+              "const": "mapped"
+            }
+          }
+        },
+        "source_decision_identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "request_id",
+            "canonical_decision_id",
+            "canonical_decision_hash",
+            "canonical_decision_ts"
+          ],
+          "properties": {
+            "request_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "canonical_decision_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "canonical_decision_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "canonical_decision_ts": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "candidate_identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "candidate_id",
+            "candidate_hash",
+            "actor_identity",
+            "target_system",
+            "target_resource",
+            "action_contract_id",
+            "action_contract_version"
+          ],
+          "properties": {
+            "candidate_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "candidate_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "actor_identity": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target_system": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target_resource": {
+              "type": "string",
+              "minLength": 1
+            },
+            "action_contract_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "action_contract_version": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "evidence_lineage": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "trustlog_artifact_ref",
+            "trustlog_chain_hash",
+            "replay_artifact_ref",
+            "replay_artifact_hash",
+            "authority_evidence_ref",
+            "authority_evidence_hash",
+            "human_approval_receipt_ref",
+            "human_approval_receipt_hash",
+            "policy_snapshot_id",
+            "policy_version",
+            "policy_semantic_digest",
+            "expected_state_fingerprint",
+            "expected_state_source_ref"
+          ],
+          "properties": {
+            "trustlog_artifact_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "trustlog_chain_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "replay_artifact_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "replay_artifact_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "authority_evidence_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "authority_evidence_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "human_approval_receipt_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "human_approval_receipt_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_snapshot_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_version": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_semantic_digest": {
+              "type": "string",
+              "minLength": 1
+            },
+            "expected_state_fingerprint": {
+              "type": "string",
+              "minLength": 1
+            },
+            "expected_state_source_ref": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "replay_summary": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "original_decision_id",
+            "replay_decision_id",
+            "original_request_id",
+            "replay_request_id",
+            "semantic_profile",
+            "semantic_match",
+            "fields_changed",
+            "severity",
+            "divergence_level"
+          ],
+          "properties": {
+            "original_decision_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "replay_decision_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "original_request_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "replay_request_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "semantic_profile": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "semantic_match": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "fields_changed": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "severity": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "divergence_level": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        "scope_limitations": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "const": "NOT_EXECUTION_AUTHORITY"
+            },
+            {
+              "const": "NOT_BIND_AUTHORIZATION"
+            },
+            {
+              "const": "NOT_BIND_RECEIPT"
+            },
+            {
+              "const": "NOT_BIND_INVOCATION"
+            },
+            {
+              "const": "NOT_EXTERNAL_EFFECT"
+            },
+            {
+              "const": "NOT_ADAPTER_INVOCATION"
+            },
+            {
+              "const": "NOT_OPERATION_COMMIT"
+            },
+            {
+              "const": "NOT_TRUSTLOG_WRITE"
+            },
+            {
+              "const": "NOT_AUTHORITY_EVIDENCE"
+            },
+            {
+              "const": "NOT_HUMAN_APPROVAL"
+            }
+          ],
+          "items": false,
+          "minItems": 10,
+          "maxItems": 10
+        }
+      },
+      "$defs": {
+        "readiness": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "$id": "https://veritas-os.org/schemas/execution-intent-formation-readiness-v1.schema.json",
+          "title": "Canonical ExecutionIntent Formation Readiness Packet v1",
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "format_version",
+            "readiness_id",
+            "readiness_hash",
+            "verification_mechanism",
+            "checked_at",
+            "source_eligibility",
+            "source_eligibility_hash",
+            "source_eligibility_packet",
+            "source_handoff_hash",
+            "trusted_validation_context_hash",
+            "validation_result_hash",
+            "formation_status",
+            "ready_for_execution_intent_formation",
+            "fail_closed",
+            "execution_intent_contract_version",
+            "execution_intent_required_fields",
+            "source_to_execution_intent_mapping",
+            "mapping_value_digest",
+            "required_field_presence",
+            "source_decision_identity",
+            "candidate_identity",
+            "evidence_lineage",
+            "replay_summary",
+            "scope_limitations"
+          ],
+          "properties": {
+            "format_version": {
+              "const": "canonical-execution-intent-formation-readiness/v1"
+            },
+            "readiness_id": {
+              "type": "string",
+              "pattern": "^eifr:v1:sha256:[0-9a-f]{64}$"
+            },
+            "readiness_hash": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "verification_mechanism": {
+              "const": "verify_guarded_promotion_eligibility_packet/v1"
+            },
+            "checked_at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "source_eligibility": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "eligibility_id",
+                "eligibility_hash",
+                "format_version",
+                "validation_mechanism",
+                "handoff_validator_version",
+                "issued_at",
+                "evaluated_at"
+              ],
+              "properties": {
+                "eligibility_id": {
+                  "type": "string",
+                  "pattern": "^gpe:v1:sha256:[0-9a-f]{64}$"
+                },
+                "eligibility_hash": {
+                  "type": "string",
+                  "pattern": "^[0-9a-f]{64}$"
+                },
+                "format_version": {
+                  "const": "canonical-guarded-promotion-eligibility-packet/v1"
+                },
+                "validation_mechanism": {
+                  "const": "validate_canonical_decision_handoff/v1"
+                },
+                "handoff_validator_version": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "issued_at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "evaluated_at": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              }
+            },
+            "source_eligibility_hash": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "source_eligibility_packet": {
+              "$ref": "#/$defs/eligibility"
+            },
+            "source_handoff_hash": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "trusted_validation_context_hash": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "validation_result_hash": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "formation_status": {
+              "const": "READY_FOR_EXECUTION_INTENT_FORMATION"
+            },
+            "ready_for_execution_intent_formation": {
+              "const": true
+            },
+            "fail_closed": {
+              "const": false
+            },
+            "execution_intent_contract_version": {
+              "const": "execution-intent-contract/v1"
+            },
+            "execution_intent_required_fields": {
+              "type": "array",
+              "prefixItems": [
+                {
+                  "const": "execution_intent_id"
+                },
+                {
+                  "const": "decision_id"
+                },
+                {
+                  "const": "request_id"
+                },
+                {
+                  "const": "policy_snapshot_id"
+                },
+                {
+                  "const": "actor_identity"
+                },
+                {
+                  "const": "target_system"
+                },
+                {
+                  "const": "target_resource"
+                },
+                {
+                  "const": "intended_action"
+                },
+                {
+                  "const": "evidence_refs"
+                },
+                {
+                  "const": "decision_hash"
+                },
+                {
+                  "const": "decision_ts"
+                },
+                {
+                  "const": "ttl_seconds"
+                },
+                {
+                  "const": "expected_state_fingerprint"
+                },
+                {
+                  "const": "approval_context"
+                },
+                {
+                  "const": "policy_lineage"
+                }
+              ],
+              "items": false,
+              "minItems": 15,
+              "maxItems": 15
+            },
+            "source_to_execution_intent_mapping": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "decision_id",
+                "request_id",
+                "policy_snapshot_id",
+                "actor_identity",
+                "target_system",
+                "target_resource",
+                "intended_action",
+                "evidence_refs",
+                "decision_hash",
+                "decision_ts",
+                "ttl_seconds",
+                "expected_state_fingerprint",
+                "approval_context",
+                "policy_lineage"
+              ],
+              "properties": {
+                "decision_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "request_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "policy_snapshot_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "actor_identity": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "target_system": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "target_resource": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "intended_action": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "evidence_refs": {
+                  "type": "array",
+                  "minItems": 5,
+                  "items": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "decision_hash": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "decision_ts": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "ttl_seconds": {
+                  "type": "null"
+                },
+                "expected_state_fingerprint": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "approval_context": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "human_approval_receipt_ref",
+                    "human_approval_receipt_hash"
+                  ],
+                  "properties": {
+                    "human_approval_receipt_ref": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "human_approval_receipt_hash": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
+                },
+                "policy_lineage": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "policy_snapshot_id",
+                    "policy_version",
+                    "policy_semantic_digest"
+                  ],
+                  "properties": {
+                    "policy_snapshot_id": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "policy_version": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "policy_semantic_digest": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
+                }
+              }
+            },
+            "mapping_value_digest": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "required_field_presence": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "execution_intent_id",
+                "decision_id",
+                "request_id",
+                "policy_snapshot_id",
+                "actor_identity",
+                "target_system",
+                "target_resource",
+                "intended_action",
+                "evidence_refs",
+                "decision_hash",
+                "decision_ts",
+                "ttl_seconds",
+                "expected_state_fingerprint",
+                "approval_context",
+                "policy_lineage"
+              ],
+              "properties": {
+                "execution_intent_id": {
+                  "const": "intentionally_deferred"
+                },
+                "decision_id": {
+                  "const": "mapped"
+                },
+                "request_id": {
+                  "const": "mapped"
+                },
+                "policy_snapshot_id": {
+                  "const": "mapped"
+                },
+                "actor_identity": {
+                  "const": "mapped"
+                },
+                "target_system": {
+                  "const": "mapped"
+                },
+                "target_resource": {
+                  "const": "mapped"
+                },
+                "intended_action": {
+                  "const": "mapped"
+                },
+                "evidence_refs": {
+                  "const": "mapped"
+                },
+                "decision_hash": {
+                  "const": "mapped"
+                },
+                "decision_ts": {
+                  "const": "mapped"
+                },
+                "ttl_seconds": {
+                  "const": "intentionally_deferred"
+                },
+                "expected_state_fingerprint": {
+                  "const": "mapped"
+                },
+                "approval_context": {
+                  "const": "mapped"
+                },
+                "policy_lineage": {
+                  "const": "mapped"
+                }
+              }
+            },
+            "source_decision_identity": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "request_id",
+                "canonical_decision_id",
+                "canonical_decision_hash",
+                "canonical_decision_ts"
+              ],
+              "properties": {
+                "request_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "canonical_decision_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "canonical_decision_hash": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "canonical_decision_ts": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              }
+            },
+            "candidate_identity": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "candidate_id",
+                "candidate_hash",
+                "actor_identity",
+                "target_system",
+                "target_resource",
+                "action_contract_id",
+                "action_contract_version"
+              ],
+              "properties": {
+                "candidate_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "candidate_hash": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "actor_identity": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "target_system": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "target_resource": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "action_contract_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "action_contract_version": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            },
+            "evidence_lineage": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "trustlog_artifact_ref",
+                "trustlog_chain_hash",
+                "replay_artifact_ref",
+                "replay_artifact_hash",
+                "authority_evidence_ref",
+                "authority_evidence_hash",
+                "human_approval_receipt_ref",
+                "human_approval_receipt_hash",
+                "policy_snapshot_id",
+                "policy_version",
+                "policy_semantic_digest",
+                "expected_state_fingerprint",
+                "expected_state_source_ref"
+              ],
+              "properties": {
+                "trustlog_artifact_ref": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "trustlog_chain_hash": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "replay_artifact_ref": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "replay_artifact_hash": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "authority_evidence_ref": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "authority_evidence_hash": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "human_approval_receipt_ref": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "human_approval_receipt_hash": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "policy_snapshot_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "policy_version": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "policy_semantic_digest": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "expected_state_fingerprint": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "expected_state_source_ref": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            },
+            "replay_summary": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "original_decision_id",
+                "replay_decision_id",
+                "original_request_id",
+                "replay_request_id",
+                "semantic_profile",
+                "semantic_match",
+                "fields_changed",
+                "severity",
+                "divergence_level"
+              ],
+              "properties": {
+                "original_decision_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "replay_decision_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "original_request_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "replay_request_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "semantic_profile": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "semantic_match": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "fields_changed": {
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "severity": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "divergence_level": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              }
+            },
+            "scope_limitations": {
+              "type": "array",
+              "prefixItems": [
+                {
+                  "const": "NOT_EXECUTION_INTENT"
+                },
+                {
+                  "const": "NOT_EXECUTION_AUTHORITY"
+                },
+                {
+                  "const": "NOT_BIND_AUTHORIZATION"
+                },
+                {
+                  "const": "NOT_BIND_RECEIPT"
+                },
+                {
+                  "const": "NOT_EXTERNAL_EFFECT"
+                },
+                {
+                  "const": "NOT_ADAPTER_INVOCATION"
+                },
+                {
+                  "const": "NOT_OPERATION_COMMIT"
+                },
+                {
+                  "const": "NOT_TRUSTLOG_WRITE"
+                }
+              ],
+              "items": false,
+              "minItems": 8,
+              "maxItems": 8
+            }
+          },
+          "$defs": {
+            "eligibility": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "https://veritas-os.org/schemas/guarded-promotion-eligibility-packet-v1.schema.json",
+              "title": "Canonical Guarded Promotion Eligibility Packet v1",
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "format_version",
+                "eligibility_id",
+                "eligibility_hash",
+                "validation_mechanism",
+                "handoff_validator_version",
+                "issued_at",
+                "evaluated_at",
+                "validation_status",
+                "ready_for_guarded_promotion",
+                "fail_closed",
+                "source_handoff",
+                "source_handoff_hash",
+                "trusted_validation_context",
+                "trusted_validation_context_hash",
+                "validation_result",
+                "validation_result_hash",
+                "verified_provenance_paths",
+                "source_decision_identity",
+                "candidate_identity",
+                "evidence_lineage",
+                "replay_summary",
+                "scope_limitations"
+              ],
+              "properties": {
+                "format_version": {
+                  "const": "canonical-guarded-promotion-eligibility-packet/v1"
+                },
+                "eligibility_id": {
+                  "type": "string",
+                  "pattern": "^gpe:v1:sha256:[0-9a-f]{64}$"
+                },
+                "eligibility_hash": {
+                  "type": "string",
+                  "pattern": "^[0-9a-f]{64}$"
+                },
+                "validation_mechanism": {
+                  "const": "validate_canonical_decision_handoff/v1"
+                },
+                "handoff_validator_version": {
+                  "type": "string"
+                },
+                "issued_at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "evaluated_at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "validation_status": {
+                  "const": "READY_FOR_GUARDED_PROMOTION"
+                },
+                "ready_for_guarded_promotion": {
+                  "const": true
+                },
+                "fail_closed": {
+                  "const": false
+                },
+                "source_handoff": {
+                  "type": "object"
+                },
+                "source_handoff_hash": {
+                  "type": "string",
+                  "pattern": "^[0-9a-f]{64}$"
+                },
+                "trusted_validation_context": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "value_assertions",
+                    "candidate_hash_binding",
+                    "authority_requirement_binding"
+                  ],
+                  "properties": {
+                    "value_assertions": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/$defs/valueAssertion"
+                      }
+                    },
+                    "candidate_hash_binding": {
+                      "anyOf": [
+                        {
+                          "$ref": "#/$defs/candidateBinding"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "authority_requirement_binding": {
+                      "anyOf": [
+                        {
+                          "$ref": "#/$defs/authorityBinding"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  }
+                },
+                "trusted_validation_context_hash": {
+                  "type": "string",
+                  "pattern": "^[0-9a-f]{64}$"
+                },
+                "validation_result": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "status",
+                    "reason_codes",
+                    "structure_valid",
+                    "declared_status",
+                    "declared_status_matches",
+                    "declared_reason_codes",
+                    "declared_reason_codes_match",
+                    "verified_provenance_paths",
+                    "validation_version",
+                    "ready_for_guarded_promotion",
+                    "fail_closed",
+                    "requires_review"
+                  ],
+                  "properties": {
+                    "status": {
+                      "const": "READY_FOR_GUARDED_PROMOTION"
+                    },
+                    "reason_codes": {
+                      "const": []
+                    },
+                    "structure_valid": {
+                      "const": true
+                    },
+                    "declared_status": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "declared_status_matches": {
+                      "type": "boolean"
+                    },
+                    "declared_reason_codes": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "declared_reason_codes_match": {
+                      "type": "boolean"
+                    },
+                    "verified_provenance_paths": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "validation_version": {
+                      "type": "string"
+                    },
+                    "ready_for_guarded_promotion": {
+                      "const": true
+                    },
+                    "fail_closed": {
+                      "const": false
+                    },
+                    "requires_review": {
+                      "const": false
+                    }
+                  }
+                },
+                "validation_result_hash": {
+                  "type": "string",
+                  "pattern": "^[0-9a-f]{64}$"
+                },
+                "verified_provenance_paths": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "source_decision_identity": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "request_id",
+                    "canonical_decision_id",
+                    "canonical_decision_hash",
+                    "canonical_decision_ts"
+                  ],
+                  "properties": {
+                    "request_id": {
+                      "type": "string"
+                    },
+                    "canonical_decision_id": {
+                      "type": "string"
+                    },
+                    "canonical_decision_hash": {
+                      "type": "string"
+                    },
+                    "canonical_decision_ts": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "candidate_identity": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "candidate_id",
+                    "candidate_hash",
+                    "actor_identity",
+                    "target_system",
+                    "target_resource",
+                    "action_contract_id",
+                    "action_contract_version"
+                  ],
+                  "properties": {
+                    "candidate_id": {
+                      "type": "string"
+                    },
+                    "candidate_hash": {
+                      "type": "string"
+                    },
+                    "actor_identity": {
+                      "type": "string"
+                    },
+                    "target_system": {
+                      "type": "string"
+                    },
+                    "target_resource": {
+                      "type": "string"
+                    },
+                    "action_contract_id": {
+                      "type": "string"
+                    },
+                    "action_contract_version": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "evidence_lineage": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "trustlog_artifact_ref",
+                    "trustlog_chain_hash",
+                    "replay_artifact_ref",
+                    "replay_artifact_hash",
+                    "authority_evidence_ref",
+                    "authority_evidence_hash",
+                    "human_approval_receipt_ref",
+                    "human_approval_receipt_hash",
+                    "policy_snapshot_id",
+                    "policy_version",
+                    "policy_semantic_digest",
+                    "expected_state_fingerprint",
+                    "expected_state_source_ref"
+                  ],
+                  "properties": {
+                    "trustlog_artifact_ref": {
+                      "type": "string"
+                    },
+                    "trustlog_chain_hash": {
+                      "type": "string"
+                    },
+                    "replay_artifact_ref": {
+                      "type": "string"
+                    },
+                    "replay_artifact_hash": {
+                      "type": "string"
+                    },
+                    "authority_evidence_ref": {
+                      "type": "string"
+                    },
+                    "authority_evidence_hash": {
+                      "type": "string"
+                    },
+                    "human_approval_receipt_ref": {
+                      "type": "string"
+                    },
+                    "human_approval_receipt_hash": {
+                      "type": "string"
+                    },
+                    "policy_snapshot_id": {
+                      "type": "string"
+                    },
+                    "policy_version": {
+                      "type": "string"
+                    },
+                    "policy_semantic_digest": {
+                      "type": "string"
+                    },
+                    "expected_state_fingerprint": {
+                      "type": "string"
+                    },
+                    "expected_state_source_ref": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "replay_summary": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "original_decision_id",
+                    "replay_decision_id",
+                    "original_request_id",
+                    "replay_request_id",
+                    "semantic_profile",
+                    "semantic_match",
+                    "fields_changed",
+                    "severity",
+                    "divergence_level"
+                  ],
+                  "properties": {
+                    "original_decision_id": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "replay_decision_id": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "original_request_id": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "replay_request_id": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "semantic_profile": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "semantic_match": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "fields_changed": {
+                      "anyOf": [
+                        {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "severity": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "divergence_level": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  }
+                },
+                "scope_limitations": {
+                  "type": "array",
+                  "prefixItems": [
+                    {
+                      "const": "NOT_EXECUTION_AUTHORITY"
+                    },
+                    {
+                      "const": "NOT_EXECUTION_INTENT"
+                    },
+                    {
+                      "const": "NOT_BIND_AUTHORIZATION"
+                    },
+                    {
+                      "const": "NOT_BIND_RECEIPT"
+                    },
+                    {
+                      "const": "NOT_EXTERNAL_EFFECT"
+                    },
+                    {
+                      "const": "NOT_AUTHORITY_EVIDENCE"
+                    },
+                    {
+                      "const": "NOT_HUMAN_APPROVAL"
+                    },
+                    {
+                      "const": "NOT_TRUSTLOG_SUBSTITUTE"
+                    }
+                  ],
+                  "items": false,
+                  "minItems": 8,
+                  "maxItems": 8
+                }
+              },
+              "$defs": {
+                "valueAssertion": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "field_path",
+                    "value_digest",
+                    "verification_mechanism",
+                    "source_artifact_ref",
+                    "source_hash",
+                    "verified_at",
+                    "claims"
+                  ],
+                  "properties": {
+                    "field_path": {
+                      "type": "string"
+                    },
+                    "value_digest": {
+                      "type": "string"
+                    },
+                    "verification_mechanism": {
+                      "type": "string"
+                    },
+                    "source_artifact_ref": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "source_hash": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "verified_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "claims": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "candidateBinding": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "candidate_value_digest",
+                    "asserted_candidate_hash",
+                    "candidate_hash_profile",
+                    "verification_mechanism",
+                    "claim",
+                    "source_artifact_ref",
+                    "source_hash",
+                    "verified_at"
+                  ],
+                  "properties": {
+                    "candidate_value_digest": {
+                      "type": "string"
+                    },
+                    "asserted_candidate_hash": {
+                      "type": "string"
+                    },
+                    "candidate_hash_profile": {
+                      "type": "string"
+                    },
+                    "verification_mechanism": {
+                      "type": "string"
+                    },
+                    "claim": {
+                      "type": "string"
+                    },
+                    "source_artifact_ref": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "source_hash": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "verified_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  }
+                },
+                "authorityBinding": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "authority_requirement_value_digest",
+                    "authority_evidence_value_digest",
+                    "verification_mechanism",
+                    "claim",
+                    "source_artifact_ref",
+                    "source_hash",
+                    "verified_at"
+                  ],
+                  "properties": {
+                    "authority_requirement_value_digest": {
+                      "type": "string"
+                    },
+                    "authority_evidence_value_digest": {
+                      "type": "string"
+                    },
+                    "verification_mechanism": {
+                      "type": "string"
+                    },
+                    "claim": {
+                      "type": "string"
+                    },
+                    "source_artifact_ref": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "source_hash": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "verified_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "mapping": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "decision_id",
+            "request_id",
+            "policy_snapshot_id",
+            "actor_identity",
+            "target_system",
+            "target_resource",
+            "intended_action",
+            "evidence_refs",
+            "decision_hash",
+            "decision_ts",
+            "ttl_seconds",
+            "expected_state_fingerprint",
+            "approval_context",
+            "policy_lineage"
+          ],
+          "properties": {
+            "decision_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "request_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_snapshot_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "actor_identity": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target_system": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target_resource": {
+              "type": "string",
+              "minLength": 1
+            },
+            "intended_action": {
+              "type": "string",
+              "minLength": 1
+            },
+            "evidence_refs": {
+              "type": "array",
+              "minItems": 5,
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "decision_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "decision_ts": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "ttl_seconds": {
+              "type": "null"
+            },
+            "expected_state_fingerprint": {
+              "type": "string",
+              "minLength": 1
+            },
+            "approval_context": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "human_approval_receipt_ref",
+                "human_approval_receipt_hash"
+              ],
+              "properties": {
+                "human_approval_receipt_ref": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "human_approval_receipt_hash": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            },
+            "policy_lineage": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "policy_snapshot_id",
+                "policy_version",
+                "policy_semantic_digest"
+              ],
+              "properties": {
+                "policy_snapshot_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "policy_version": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "policy_semantic_digest": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            }
+          }
+        },
+        "execution_intent": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "execution_intent_id",
+            "decision_id",
+            "request_id",
+            "policy_snapshot_id",
+            "actor_identity",
+            "target_system",
+            "target_resource",
+            "intended_action",
+            "evidence_refs",
+            "decision_hash",
+            "decision_ts",
+            "ttl_seconds",
+            "expected_state_fingerprint",
+            "approval_context",
+            "policy_lineage"
+          ],
+          "properties": {
+            "execution_intent_id": {
+              "type": "string",
+              "pattern": "^ei:v1:sha256:[0-9a-f]{64}$"
+            },
+            "decision_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "request_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_snapshot_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "actor_identity": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target_system": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target_resource": {
+              "type": "string",
+              "minLength": 1
+            },
+            "intended_action": {
+              "type": "string",
+              "minLength": 1
+            },
+            "evidence_refs": {
+              "type": "array",
+              "minItems": 5,
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "decision_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "decision_ts": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "ttl_seconds": {
+              "type": "null"
+            },
+            "expected_state_fingerprint": {
+              "type": "string",
+              "minLength": 1
+            },
+            "approval_context": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "human_approval_receipt_ref",
+                "human_approval_receipt_hash"
+              ],
+              "properties": {
+                "human_approval_receipt_ref": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "human_approval_receipt_hash": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            },
+            "policy_lineage": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "policy_snapshot_id",
+                "policy_version",
+                "policy_semantic_digest"
+              ],
+              "properties": {
+                "policy_snapshot_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "policy_version": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "policy_semantic_digest": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "source_readiness_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "source_eligibility_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "source_handoff_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "trusted_validation_context_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "validation_result_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "mapping_value_digest": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "execution_intent_contract_version": {
+      "const": "execution-intent-contract/v1"
+    },
+    "execution_intent": {
+      "$ref": "#/$defs/execution_intent"
+    },
+    "execution_intent_id": {
+      "type": "string",
+      "pattern": "^ei:v1:sha256:[0-9a-f]{64}$"
+    },
+    "execution_intent_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "source_to_execution_intent_mapping": {
+      "$ref": "#/$defs/mapping"
+    },
+    "field_mapping_proof": {
+      "$ref": "#/$defs/mapping"
+    },
+    "required_field_presence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "execution_intent_id",
+        "decision_id",
+        "request_id",
+        "policy_snapshot_id",
+        "actor_identity",
+        "target_system",
+        "target_resource",
+        "intended_action",
+        "evidence_refs",
+        "decision_hash",
+        "decision_ts",
+        "ttl_seconds",
+        "expected_state_fingerprint",
+        "approval_context",
+        "policy_lineage"
+      ],
+      "properties": {
+        "execution_intent_id": {
+          "const": "intentionally_deferred"
+        },
+        "decision_id": {
+          "const": "mapped"
+        },
+        "request_id": {
+          "const": "mapped"
+        },
+        "policy_snapshot_id": {
+          "const": "mapped"
+        },
+        "actor_identity": {
+          "const": "mapped"
+        },
+        "target_system": {
+          "const": "mapped"
+        },
+        "target_resource": {
+          "const": "mapped"
+        },
+        "intended_action": {
+          "const": "mapped"
+        },
+        "evidence_refs": {
+          "const": "mapped"
+        },
+        "decision_hash": {
+          "const": "mapped"
+        },
+        "decision_ts": {
+          "const": "mapped"
+        },
+        "ttl_seconds": {
+          "const": "intentionally_deferred"
+        },
+        "expected_state_fingerprint": {
+          "const": "mapped"
+        },
+        "approval_context": {
+          "const": "mapped"
+        },
+        "policy_lineage": {
+          "const": "mapped"
+        }
+      }
+    },
+    "source_decision_identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "request_id",
+        "canonical_decision_id",
+        "canonical_decision_hash",
+        "canonical_decision_ts"
+      ],
+      "properties": {
+        "request_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "canonical_decision_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "canonical_decision_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "canonical_decision_ts": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "candidate_identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "candidate_id",
+        "candidate_hash",
+        "actor_identity",
+        "target_system",
+        "target_resource",
+        "action_contract_id",
+        "action_contract_version"
+      ],
+      "properties": {
+        "candidate_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "candidate_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "actor_identity": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_system": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_resource": {
+          "type": "string",
+          "minLength": 1
+        },
+        "action_contract_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "action_contract_version": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "evidence_lineage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "trustlog_artifact_ref",
+        "trustlog_chain_hash",
+        "replay_artifact_ref",
+        "replay_artifact_hash",
+        "authority_evidence_ref",
+        "authority_evidence_hash",
+        "human_approval_receipt_ref",
+        "human_approval_receipt_hash",
+        "policy_snapshot_id",
+        "policy_version",
+        "policy_semantic_digest",
+        "expected_state_fingerprint",
+        "expected_state_source_ref"
+      ],
+      "properties": {
+        "trustlog_artifact_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "trustlog_chain_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "replay_artifact_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "replay_artifact_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "authority_evidence_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "authority_evidence_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "human_approval_receipt_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "human_approval_receipt_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_snapshot_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_semantic_digest": {
+          "type": "string",
+          "minLength": 1
+        },
+        "expected_state_fingerprint": {
+          "type": "string",
+          "minLength": 1
+        },
+        "expected_state_source_ref": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "replay_summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "original_decision_id",
+        "replay_decision_id",
+        "original_request_id",
+        "replay_request_id",
+        "semantic_profile",
+        "semantic_match",
+        "fields_changed",
+        "severity",
+        "divergence_level"
+      ],
+      "properties": {
+        "original_decision_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "replay_decision_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "original_request_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "replay_request_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "semantic_profile": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "semantic_match": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "fields_changed": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "severity": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "divergence_level": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "pre_bind_status": {
+      "const": "READY_FOR_BIND_PREFLIGHT"
+    },
+    "ready_for_bind_preflight": {
+      "const": true
+    },
+    "fail_closed": {
+      "const": false
+    },
+    "local_validation_checks": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "formation_verified",
+        "execution_intent_hash_verified",
+        "execution_intent_id_verified",
+        "field_mapping_verified",
+        "required_field_presence_verified",
+        "evidence_refs_non_empty",
+        "decision_timestamp_timezone_aware",
+        "checked_after_formation",
+        "no_bind_invocation",
+        "no_trustlog_write"
+      ],
+      "properties": {
+        "formation_verified": {
+          "const": true
+        },
+        "execution_intent_hash_verified": {
+          "const": true
+        },
+        "execution_intent_id_verified": {
+          "const": true
+        },
+        "field_mapping_verified": {
+          "const": true
+        },
+        "required_field_presence_verified": {
+          "const": true
+        },
+        "evidence_refs_non_empty": {
+          "const": true
+        },
+        "decision_timestamp_timezone_aware": {
+          "const": true
+        },
+        "checked_after_formation": {
+          "const": true
+        },
+        "no_bind_invocation": {
+          "const": true
+        },
+        "no_trustlog_write": {
+          "const": true
+        }
+      }
+    },
+    "scope_limitations": {
+      "type": "array",
+      "prefixItems": [
+        {
+          "const": "NOT_EXECUTION_AUTHORITY"
+        },
+        {
+          "const": "NOT_BIND_AUTHORIZATION"
+        },
+        {
+          "const": "NOT_BIND_RECEIPT"
+        },
+        {
+          "const": "NOT_BIND_INVOCATION"
+        },
+        {
+          "const": "NOT_ADAPTER_INVOCATION"
+        },
+        {
+          "const": "NOT_EXTERNAL_EFFECT"
+        },
+        {
+          "const": "NOT_OPERATION_COMMIT"
+        },
+        {
+          "const": "NOT_TRUSTLOG_WRITE"
+        },
+        {
+          "const": "NOT_LIVE_STATE_CHECK"
+        },
+        {
+          "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+        },
+        {
+          "const": "NOT_AUTHORITY_EVIDENCE"
+        },
+        {
+          "const": "NOT_HUMAN_APPROVAL"
+        }
+      ],
+      "items": false,
+      "minItems": 12,
+      "maxItems": 12
+    }
+  }
+}

--- a/schemas/execution-intent-pre-bind-validation-v1.schema.json
+++ b/schemas/execution-intent-pre-bind-validation-v1.schema.json
@@ -101,9 +101,675 @@
       "pattern": "^[0-9a-f]{64}$"
     },
     "source_formation_packet": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "https://veritas-os.org/schemas/canonical-execution-intent-formation-v1.schema.json",
-      "title": "Canonical ExecutionIntent Formation Packet v1",
+      "$ref": "#/$defs/formation_packet"
+    },
+    "source_readiness_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "source_eligibility_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "source_handoff_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "trusted_validation_context_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "validation_result_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "mapping_value_digest": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "execution_intent_contract_version": {
+      "const": "execution-intent-contract/v1"
+    },
+    "execution_intent": {
+      "$ref": "#/$defs/execution_intent"
+    },
+    "execution_intent_id": {
+      "type": "string",
+      "pattern": "^ei:v1:sha256:[0-9a-f]{64}$"
+    },
+    "execution_intent_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "source_to_execution_intent_mapping": {
+      "$ref": "#/$defs/mapping"
+    },
+    "field_mapping_proof": {
+      "$ref": "#/$defs/mapping"
+    },
+    "required_field_presence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "execution_intent_id",
+        "decision_id",
+        "request_id",
+        "policy_snapshot_id",
+        "actor_identity",
+        "target_system",
+        "target_resource",
+        "intended_action",
+        "evidence_refs",
+        "decision_hash",
+        "decision_ts",
+        "ttl_seconds",
+        "expected_state_fingerprint",
+        "approval_context",
+        "policy_lineage"
+      ],
+      "properties": {
+        "execution_intent_id": {
+          "const": "intentionally_deferred"
+        },
+        "decision_id": {
+          "const": "mapped"
+        },
+        "request_id": {
+          "const": "mapped"
+        },
+        "policy_snapshot_id": {
+          "const": "mapped"
+        },
+        "actor_identity": {
+          "const": "mapped"
+        },
+        "target_system": {
+          "const": "mapped"
+        },
+        "target_resource": {
+          "const": "mapped"
+        },
+        "intended_action": {
+          "const": "mapped"
+        },
+        "evidence_refs": {
+          "const": "mapped"
+        },
+        "decision_hash": {
+          "const": "mapped"
+        },
+        "decision_ts": {
+          "const": "mapped"
+        },
+        "ttl_seconds": {
+          "const": "intentionally_deferred"
+        },
+        "expected_state_fingerprint": {
+          "const": "mapped"
+        },
+        "approval_context": {
+          "const": "mapped"
+        },
+        "policy_lineage": {
+          "const": "mapped"
+        }
+      }
+    },
+    "source_decision_identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "request_id",
+        "canonical_decision_id",
+        "canonical_decision_hash",
+        "canonical_decision_ts"
+      ],
+      "properties": {
+        "request_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "canonical_decision_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "canonical_decision_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "canonical_decision_ts": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "candidate_identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "candidate_id",
+        "candidate_hash",
+        "actor_identity",
+        "target_system",
+        "target_resource",
+        "action_contract_id",
+        "action_contract_version"
+      ],
+      "properties": {
+        "candidate_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "candidate_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "actor_identity": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_system": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_resource": {
+          "type": "string",
+          "minLength": 1
+        },
+        "action_contract_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "action_contract_version": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "evidence_lineage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "trustlog_artifact_ref",
+        "trustlog_chain_hash",
+        "replay_artifact_ref",
+        "replay_artifact_hash",
+        "authority_evidence_ref",
+        "authority_evidence_hash",
+        "human_approval_receipt_ref",
+        "human_approval_receipt_hash",
+        "policy_snapshot_id",
+        "policy_version",
+        "policy_semantic_digest",
+        "expected_state_fingerprint",
+        "expected_state_source_ref"
+      ],
+      "properties": {
+        "trustlog_artifact_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "trustlog_chain_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "replay_artifact_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "replay_artifact_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "authority_evidence_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "authority_evidence_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "human_approval_receipt_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "human_approval_receipt_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_snapshot_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_semantic_digest": {
+          "type": "string",
+          "minLength": 1
+        },
+        "expected_state_fingerprint": {
+          "type": "string",
+          "minLength": 1
+        },
+        "expected_state_source_ref": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "replay_summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "original_decision_id",
+        "replay_decision_id",
+        "original_request_id",
+        "replay_request_id",
+        "semantic_profile",
+        "semantic_match",
+        "fields_changed",
+        "severity",
+        "divergence_level"
+      ],
+      "properties": {
+        "original_decision_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "replay_decision_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "original_request_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "replay_request_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "semantic_profile": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "semantic_match": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "fields_changed": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "severity": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "divergence_level": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "pre_bind_status": {
+      "const": "READY_FOR_BIND_PREFLIGHT"
+    },
+    "ready_for_bind_preflight": {
+      "const": true
+    },
+    "fail_closed": {
+      "const": false
+    },
+    "local_validation_checks": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "formation_verified",
+        "execution_intent_hash_verified",
+        "execution_intent_id_verified",
+        "field_mapping_verified",
+        "required_field_presence_verified",
+        "evidence_refs_non_empty",
+        "decision_timestamp_timezone_aware",
+        "checked_after_formation",
+        "no_bind_invocation",
+        "no_trustlog_write"
+      ],
+      "properties": {
+        "formation_verified": {
+          "const": true
+        },
+        "execution_intent_hash_verified": {
+          "const": true
+        },
+        "execution_intent_id_verified": {
+          "const": true
+        },
+        "field_mapping_verified": {
+          "const": true
+        },
+        "required_field_presence_verified": {
+          "const": true
+        },
+        "evidence_refs_non_empty": {
+          "const": true
+        },
+        "decision_timestamp_timezone_aware": {
+          "const": true
+        },
+        "checked_after_formation": {
+          "const": true
+        },
+        "no_bind_invocation": {
+          "const": true
+        },
+        "no_trustlog_write": {
+          "const": true
+        }
+      }
+    },
+    "scope_limitations": {
+      "type": "array",
+      "prefixItems": [
+        {
+          "const": "NOT_EXECUTION_AUTHORITY"
+        },
+        {
+          "const": "NOT_BIND_AUTHORIZATION"
+        },
+        {
+          "const": "NOT_BIND_RECEIPT"
+        },
+        {
+          "const": "NOT_BIND_INVOCATION"
+        },
+        {
+          "const": "NOT_ADAPTER_INVOCATION"
+        },
+        {
+          "const": "NOT_EXTERNAL_EFFECT"
+        },
+        {
+          "const": "NOT_OPERATION_COMMIT"
+        },
+        {
+          "const": "NOT_TRUSTLOG_WRITE"
+        },
+        {
+          "const": "NOT_LIVE_STATE_CHECK"
+        },
+        {
+          "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+        },
+        {
+          "const": "NOT_AUTHORITY_EVIDENCE"
+        },
+        {
+          "const": "NOT_HUMAN_APPROVAL"
+        }
+      ],
+      "items": false,
+      "minItems": 12,
+      "maxItems": 12
+    }
+  },
+  "$defs": {
+    "execution_intent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "execution_intent_id",
+        "decision_id",
+        "request_id",
+        "policy_snapshot_id",
+        "actor_identity",
+        "target_system",
+        "target_resource",
+        "intended_action",
+        "evidence_refs",
+        "decision_hash",
+        "decision_ts",
+        "ttl_seconds",
+        "expected_state_fingerprint",
+        "approval_context",
+        "policy_lineage"
+      ],
+      "properties": {
+        "execution_intent_id": {
+          "type": "string",
+          "pattern": "^ei:v1:sha256:[0-9a-f]{64}$"
+        },
+        "decision_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "request_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_snapshot_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "actor_identity": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_system": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_resource": {
+          "type": "string",
+          "minLength": 1
+        },
+        "intended_action": {
+          "type": "string",
+          "minLength": 1
+        },
+        "evidence_refs": {
+          "type": "array",
+          "minItems": 5,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "decision_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "decision_ts": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "ttl_seconds": {
+          "type": "null"
+        },
+        "expected_state_fingerprint": {
+          "type": "string",
+          "minLength": 1
+        },
+        "approval_context": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "human_approval_receipt_ref",
+            "human_approval_receipt_hash"
+          ],
+          "properties": {
+            "human_approval_receipt_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "human_approval_receipt_hash": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "policy_lineage": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "policy_snapshot_id",
+            "policy_version",
+            "policy_semantic_digest"
+          ],
+          "properties": {
+            "policy_snapshot_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_version": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_semantic_digest": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    },
+    "mapping": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "decision_id",
+        "request_id",
+        "policy_snapshot_id",
+        "actor_identity",
+        "target_system",
+        "target_resource",
+        "intended_action",
+        "evidence_refs",
+        "decision_hash",
+        "decision_ts",
+        "ttl_seconds",
+        "expected_state_fingerprint",
+        "approval_context",
+        "policy_lineage"
+      ],
+      "properties": {
+        "decision_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "request_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_snapshot_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "actor_identity": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_system": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_resource": {
+          "type": "string",
+          "minLength": 1
+        },
+        "intended_action": {
+          "type": "string",
+          "minLength": 1
+        },
+        "evidence_refs": {
+          "type": "array",
+          "minItems": 5,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "decision_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "decision_ts": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "ttl_seconds": {
+          "type": "null"
+        },
+        "expected_state_fingerprint": {
+          "type": "string",
+          "minLength": 1
+        },
+        "approval_context": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "human_approval_receipt_ref",
+            "human_approval_receipt_hash"
+          ],
+          "properties": {
+            "human_approval_receipt_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "human_approval_receipt_hash": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "policy_lineage": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "policy_snapshot_id",
+            "policy_version",
+            "policy_semantic_digest"
+          ],
+          "properties": {
+            "policy_snapshot_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_version": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_semantic_digest": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    },
+    "formation_packet": {
       "type": "object",
       "additionalProperties": false,
       "required": [
@@ -558,1243 +1224,182 @@
           "minItems": 10,
           "maxItems": 10
         }
-      },
-      "$defs": {
-        "readiness": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "$id": "https://veritas-os.org/schemas/execution-intent-formation-readiness-v1.schema.json",
-          "title": "Canonical ExecutionIntent Formation Readiness Packet v1",
+      }
+    },
+    "readiness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "format_version",
+        "readiness_id",
+        "readiness_hash",
+        "verification_mechanism",
+        "checked_at",
+        "source_eligibility",
+        "source_eligibility_hash",
+        "source_eligibility_packet",
+        "source_handoff_hash",
+        "trusted_validation_context_hash",
+        "validation_result_hash",
+        "formation_status",
+        "ready_for_execution_intent_formation",
+        "fail_closed",
+        "execution_intent_contract_version",
+        "execution_intent_required_fields",
+        "source_to_execution_intent_mapping",
+        "mapping_value_digest",
+        "required_field_presence",
+        "source_decision_identity",
+        "candidate_identity",
+        "evidence_lineage",
+        "replay_summary",
+        "scope_limitations"
+      ],
+      "properties": {
+        "format_version": {
+          "const": "canonical-execution-intent-formation-readiness/v1"
+        },
+        "readiness_id": {
+          "type": "string",
+          "pattern": "^eifr:v1:sha256:[0-9a-f]{64}$"
+        },
+        "readiness_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "verification_mechanism": {
+          "const": "verify_guarded_promotion_eligibility_packet/v1"
+        },
+        "checked_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "source_eligibility": {
           "type": "object",
           "additionalProperties": false,
           "required": [
+            "eligibility_id",
+            "eligibility_hash",
             "format_version",
-            "readiness_id",
-            "readiness_hash",
-            "verification_mechanism",
-            "checked_at",
-            "source_eligibility",
-            "source_eligibility_hash",
-            "source_eligibility_packet",
-            "source_handoff_hash",
-            "trusted_validation_context_hash",
-            "validation_result_hash",
-            "formation_status",
-            "ready_for_execution_intent_formation",
-            "fail_closed",
-            "execution_intent_contract_version",
-            "execution_intent_required_fields",
-            "source_to_execution_intent_mapping",
-            "mapping_value_digest",
-            "required_field_presence",
-            "source_decision_identity",
-            "candidate_identity",
-            "evidence_lineage",
-            "replay_summary",
-            "scope_limitations"
+            "validation_mechanism",
+            "handoff_validator_version",
+            "issued_at",
+            "evaluated_at"
           ],
           "properties": {
-            "format_version": {
-              "const": "canonical-execution-intent-formation-readiness/v1"
-            },
-            "readiness_id": {
+            "eligibility_id": {
               "type": "string",
-              "pattern": "^eifr:v1:sha256:[0-9a-f]{64}$"
+              "pattern": "^gpe:v1:sha256:[0-9a-f]{64}$"
             },
-            "readiness_hash": {
+            "eligibility_hash": {
               "type": "string",
               "pattern": "^[0-9a-f]{64}$"
             },
-            "verification_mechanism": {
-              "const": "verify_guarded_promotion_eligibility_packet/v1"
+            "format_version": {
+              "const": "canonical-guarded-promotion-eligibility-packet/v1"
             },
-            "checked_at": {
+            "validation_mechanism": {
+              "const": "validate_canonical_decision_handoff/v1"
+            },
+            "handoff_validator_version": {
+              "type": "string",
+              "minLength": 1
+            },
+            "issued_at": {
               "type": "string",
               "format": "date-time"
             },
-            "source_eligibility": {
-              "type": "object",
-              "additionalProperties": false,
-              "required": [
-                "eligibility_id",
-                "eligibility_hash",
-                "format_version",
-                "validation_mechanism",
-                "handoff_validator_version",
-                "issued_at",
-                "evaluated_at"
-              ],
-              "properties": {
-                "eligibility_id": {
-                  "type": "string",
-                  "pattern": "^gpe:v1:sha256:[0-9a-f]{64}$"
-                },
-                "eligibility_hash": {
-                  "type": "string",
-                  "pattern": "^[0-9a-f]{64}$"
-                },
-                "format_version": {
-                  "const": "canonical-guarded-promotion-eligibility-packet/v1"
-                },
-                "validation_mechanism": {
-                  "const": "validate_canonical_decision_handoff/v1"
-                },
-                "handoff_validator_version": {
-                  "type": "string",
-                  "minLength": 1
-                },
-                "issued_at": {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                "evaluated_at": {
-                  "type": "string",
-                  "format": "date-time"
-                }
-              }
-            },
-            "source_eligibility_hash": {
+            "evaluated_at": {
               "type": "string",
-              "pattern": "^[0-9a-f]{64}$"
-            },
-            "source_eligibility_packet": {
-              "$ref": "#/$defs/eligibility"
-            },
-            "source_handoff_hash": {
-              "type": "string",
-              "pattern": "^[0-9a-f]{64}$"
-            },
-            "trusted_validation_context_hash": {
-              "type": "string",
-              "pattern": "^[0-9a-f]{64}$"
-            },
-            "validation_result_hash": {
-              "type": "string",
-              "pattern": "^[0-9a-f]{64}$"
-            },
-            "formation_status": {
-              "const": "READY_FOR_EXECUTION_INTENT_FORMATION"
-            },
-            "ready_for_execution_intent_formation": {
-              "const": true
-            },
-            "fail_closed": {
-              "const": false
-            },
-            "execution_intent_contract_version": {
-              "const": "execution-intent-contract/v1"
-            },
-            "execution_intent_required_fields": {
-              "type": "array",
-              "prefixItems": [
-                {
-                  "const": "execution_intent_id"
-                },
-                {
-                  "const": "decision_id"
-                },
-                {
-                  "const": "request_id"
-                },
-                {
-                  "const": "policy_snapshot_id"
-                },
-                {
-                  "const": "actor_identity"
-                },
-                {
-                  "const": "target_system"
-                },
-                {
-                  "const": "target_resource"
-                },
-                {
-                  "const": "intended_action"
-                },
-                {
-                  "const": "evidence_refs"
-                },
-                {
-                  "const": "decision_hash"
-                },
-                {
-                  "const": "decision_ts"
-                },
-                {
-                  "const": "ttl_seconds"
-                },
-                {
-                  "const": "expected_state_fingerprint"
-                },
-                {
-                  "const": "approval_context"
-                },
-                {
-                  "const": "policy_lineage"
-                }
-              ],
-              "items": false,
-              "minItems": 15,
-              "maxItems": 15
-            },
-            "source_to_execution_intent_mapping": {
-              "type": "object",
-              "additionalProperties": false,
-              "required": [
-                "decision_id",
-                "request_id",
-                "policy_snapshot_id",
-                "actor_identity",
-                "target_system",
-                "target_resource",
-                "intended_action",
-                "evidence_refs",
-                "decision_hash",
-                "decision_ts",
-                "ttl_seconds",
-                "expected_state_fingerprint",
-                "approval_context",
-                "policy_lineage"
-              ],
-              "properties": {
-                "decision_id": {
-                  "type": "string",
-                  "minLength": 1
-                },
-                "request_id": {
-                  "type": "string",
-                  "minLength": 1
-                },
-                "policy_snapshot_id": {
-                  "type": "string",
-                  "minLength": 1
-                },
-                "actor_identity": {
-                  "type": "string",
-                  "minLength": 1
-                },
-                "target_system": {
-                  "type": "string",
-                  "minLength": 1
-                },
-                "target_resource": {
-                  "type": "string",
-                  "minLength": 1
-                },
-                "intended_action": {
-                  "type": "string",
-                  "minLength": 1
-                },
-                "evidence_refs": {
-                  "type": "array",
-                  "minItems": 5,
-                  "items": {
-                    "type": "string",
-                    "minLength": 1
-                  }
-                },
-                "decision_hash": {
-                  "type": "string",
-                  "minLength": 1
-                },
-                "decision_ts": {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                "ttl_seconds": {
-                  "type": "null"
-                },
-                "expected_state_fingerprint": {
-                  "type": "string",
-                  "minLength": 1
-                },
-                "approval_context": {
-                  "type": "object",
-                  "additionalProperties": false,
-                  "required": [
-                    "human_approval_receipt_ref",
-                    "human_approval_receipt_hash"
-                  ],
-                  "properties": {
-                    "human_approval_receipt_ref": {
-                      "type": "string",
-                      "minLength": 1
-                    },
-                    "human_approval_receipt_hash": {
-                      "type": "string",
-                      "minLength": 1
-                    }
-                  }
-                },
-                "policy_lineage": {
-                  "type": "object",
-                  "additionalProperties": false,
-                  "required": [
-                    "policy_snapshot_id",
-                    "policy_version",
-                    "policy_semantic_digest"
-                  ],
-                  "properties": {
-                    "policy_snapshot_id": {
-                      "type": "string",
-                      "minLength": 1
-                    },
-                    "policy_version": {
-                      "type": "string",
-                      "minLength": 1
-                    },
-                    "policy_semantic_digest": {
-                      "type": "string",
-                      "minLength": 1
-                    }
-                  }
-                }
-              }
-            },
-            "mapping_value_digest": {
-              "type": "string",
-              "pattern": "^[0-9a-f]{64}$"
-            },
-            "required_field_presence": {
-              "type": "object",
-              "additionalProperties": false,
-              "required": [
-                "execution_intent_id",
-                "decision_id",
-                "request_id",
-                "policy_snapshot_id",
-                "actor_identity",
-                "target_system",
-                "target_resource",
-                "intended_action",
-                "evidence_refs",
-                "decision_hash",
-                "decision_ts",
-                "ttl_seconds",
-                "expected_state_fingerprint",
-                "approval_context",
-                "policy_lineage"
-              ],
-              "properties": {
-                "execution_intent_id": {
-                  "const": "intentionally_deferred"
-                },
-                "decision_id": {
-                  "const": "mapped"
-                },
-                "request_id": {
-                  "const": "mapped"
-                },
-                "policy_snapshot_id": {
-                  "const": "mapped"
-                },
-                "actor_identity": {
-                  "const": "mapped"
-                },
-                "target_system": {
-                  "const": "mapped"
-                },
-                "target_resource": {
-                  "const": "mapped"
-                },
-                "intended_action": {
-                  "const": "mapped"
-                },
-                "evidence_refs": {
-                  "const": "mapped"
-                },
-                "decision_hash": {
-                  "const": "mapped"
-                },
-                "decision_ts": {
-                  "const": "mapped"
-                },
-                "ttl_seconds": {
-                  "const": "intentionally_deferred"
-                },
-                "expected_state_fingerprint": {
-                  "const": "mapped"
-                },
-                "approval_context": {
-                  "const": "mapped"
-                },
-                "policy_lineage": {
-                  "const": "mapped"
-                }
-              }
-            },
-            "source_decision_identity": {
-              "type": "object",
-              "additionalProperties": false,
-              "required": [
-                "request_id",
-                "canonical_decision_id",
-                "canonical_decision_hash",
-                "canonical_decision_ts"
-              ],
-              "properties": {
-                "request_id": {
-                  "type": "string",
-                  "minLength": 1
-                },
-                "canonical_decision_id": {
-                  "type": "string",
-                  "minLength": 1
-                },
-                "canonical_decision_hash": {
-                  "type": "string",
-                  "minLength": 1
-                },
-                "canonical_decision_ts": {
-                  "type": "string",
-                  "format": "date-time"
-                }
-              }
-            },
-            "candidate_identity": {
-              "type": "object",
-              "additionalProperties": false,
-              "required": [
-                "candidate_id",
-                "candidate_hash",
-                "actor_identity",
-                "target_system",
-                "target_resource",
-                "action_contract_id",
-                "action_contract_version"
-              ],
-              "properties": {
-                "candidate_id": {
-                  "type": "string",
-                  "minLength": 1
-                },
-                "candidate_hash": {
-                  "type": "string",
-                  "minLength": 1
-                },
-                "actor_identity": {
-                  "type": "string",
-                  "minLength": 1
-                },
-                "target_system": {
-                  "type": "string",
-                  "minLength": 1
-                },
-                "target_resource": {
-                  "type": "string",
-                  "minLength": 1
-                },
-                "action_contract_id": {
-                  "type": "string",
-                  "minLength": 1
-                },
-                "action_contract_version": {
-                  "type": "string",
-                  "minLength": 1
-                }
-              }
-            },
-            "evidence_lineage": {
-              "type": "object",
-              "additionalProperties": false,
-              "required": [
-                "trustlog_artifact_ref",
-                "trustlog_chain_hash",
-                "replay_artifact_ref",
-                "replay_artifact_hash",
-                "authority_evidence_ref",
-                "authority_evidence_hash",
-                "human_approval_receipt_ref",
-                "human_approval_receipt_hash",
-                "policy_snapshot_id",
-                "policy_version",
-                "policy_semantic_digest",
-                "expected_state_fingerprint",
-                "expected_state_source_ref"
-              ],
-              "properties": {
-                "trustlog_artifact_ref": {
-                  "type": "string",
-                  "minLength": 1
-                },
-                "trustlog_chain_hash": {
-                  "type": "string",
-                  "minLength": 1
-                },
-                "replay_artifact_ref": {
-                  "type": "string",
-                  "minLength": 1
-                },
-                "replay_artifact_hash": {
-                  "type": "string",
-                  "minLength": 1
-                },
-                "authority_evidence_ref": {
-                  "type": "string",
-                  "minLength": 1
-                },
-                "authority_evidence_hash": {
-                  "type": "string",
-                  "minLength": 1
-                },
-                "human_approval_receipt_ref": {
-                  "type": "string",
-                  "minLength": 1
-                },
-                "human_approval_receipt_hash": {
-                  "type": "string",
-                  "minLength": 1
-                },
-                "policy_snapshot_id": {
-                  "type": "string",
-                  "minLength": 1
-                },
-                "policy_version": {
-                  "type": "string",
-                  "minLength": 1
-                },
-                "policy_semantic_digest": {
-                  "type": "string",
-                  "minLength": 1
-                },
-                "expected_state_fingerprint": {
-                  "type": "string",
-                  "minLength": 1
-                },
-                "expected_state_source_ref": {
-                  "type": "string",
-                  "minLength": 1
-                }
-              }
-            },
-            "replay_summary": {
-              "type": "object",
-              "additionalProperties": false,
-              "required": [
-                "original_decision_id",
-                "replay_decision_id",
-                "original_request_id",
-                "replay_request_id",
-                "semantic_profile",
-                "semantic_match",
-                "fields_changed",
-                "severity",
-                "divergence_level"
-              ],
-              "properties": {
-                "original_decision_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "replay_decision_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "original_request_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "replay_request_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "semantic_profile": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "semantic_match": {
-                  "type": [
-                    "boolean",
-                    "null"
-                  ]
-                },
-                "fields_changed": {
-                  "type": [
-                    "array",
-                    "null"
-                  ],
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "severity": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "divergence_level": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                }
-              }
-            },
-            "scope_limitations": {
-              "type": "array",
-              "prefixItems": [
-                {
-                  "const": "NOT_EXECUTION_INTENT"
-                },
-                {
-                  "const": "NOT_EXECUTION_AUTHORITY"
-                },
-                {
-                  "const": "NOT_BIND_AUTHORIZATION"
-                },
-                {
-                  "const": "NOT_BIND_RECEIPT"
-                },
-                {
-                  "const": "NOT_EXTERNAL_EFFECT"
-                },
-                {
-                  "const": "NOT_ADAPTER_INVOCATION"
-                },
-                {
-                  "const": "NOT_OPERATION_COMMIT"
-                },
-                {
-                  "const": "NOT_TRUSTLOG_WRITE"
-                }
-              ],
-              "items": false,
-              "minItems": 8,
-              "maxItems": 8
-            }
-          },
-          "$defs": {
-            "eligibility": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "$id": "https://veritas-os.org/schemas/guarded-promotion-eligibility-packet-v1.schema.json",
-              "title": "Canonical Guarded Promotion Eligibility Packet v1",
-              "type": "object",
-              "additionalProperties": false,
-              "required": [
-                "format_version",
-                "eligibility_id",
-                "eligibility_hash",
-                "validation_mechanism",
-                "handoff_validator_version",
-                "issued_at",
-                "evaluated_at",
-                "validation_status",
-                "ready_for_guarded_promotion",
-                "fail_closed",
-                "source_handoff",
-                "source_handoff_hash",
-                "trusted_validation_context",
-                "trusted_validation_context_hash",
-                "validation_result",
-                "validation_result_hash",
-                "verified_provenance_paths",
-                "source_decision_identity",
-                "candidate_identity",
-                "evidence_lineage",
-                "replay_summary",
-                "scope_limitations"
-              ],
-              "properties": {
-                "format_version": {
-                  "const": "canonical-guarded-promotion-eligibility-packet/v1"
-                },
-                "eligibility_id": {
-                  "type": "string",
-                  "pattern": "^gpe:v1:sha256:[0-9a-f]{64}$"
-                },
-                "eligibility_hash": {
-                  "type": "string",
-                  "pattern": "^[0-9a-f]{64}$"
-                },
-                "validation_mechanism": {
-                  "const": "validate_canonical_decision_handoff/v1"
-                },
-                "handoff_validator_version": {
-                  "type": "string"
-                },
-                "issued_at": {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                "evaluated_at": {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                "validation_status": {
-                  "const": "READY_FOR_GUARDED_PROMOTION"
-                },
-                "ready_for_guarded_promotion": {
-                  "const": true
-                },
-                "fail_closed": {
-                  "const": false
-                },
-                "source_handoff": {
-                  "type": "object"
-                },
-                "source_handoff_hash": {
-                  "type": "string",
-                  "pattern": "^[0-9a-f]{64}$"
-                },
-                "trusted_validation_context": {
-                  "type": "object",
-                  "additionalProperties": false,
-                  "required": [
-                    "value_assertions",
-                    "candidate_hash_binding",
-                    "authority_requirement_binding"
-                  ],
-                  "properties": {
-                    "value_assertions": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/$defs/valueAssertion"
-                      }
-                    },
-                    "candidate_hash_binding": {
-                      "anyOf": [
-                        {
-                          "$ref": "#/$defs/candidateBinding"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "authority_requirement_binding": {
-                      "anyOf": [
-                        {
-                          "$ref": "#/$defs/authorityBinding"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  }
-                },
-                "trusted_validation_context_hash": {
-                  "type": "string",
-                  "pattern": "^[0-9a-f]{64}$"
-                },
-                "validation_result": {
-                  "type": "object",
-                  "additionalProperties": false,
-                  "required": [
-                    "status",
-                    "reason_codes",
-                    "structure_valid",
-                    "declared_status",
-                    "declared_status_matches",
-                    "declared_reason_codes",
-                    "declared_reason_codes_match",
-                    "verified_provenance_paths",
-                    "validation_version",
-                    "ready_for_guarded_promotion",
-                    "fail_closed",
-                    "requires_review"
-                  ],
-                  "properties": {
-                    "status": {
-                      "const": "READY_FOR_GUARDED_PROMOTION"
-                    },
-                    "reason_codes": {
-                      "const": []
-                    },
-                    "structure_valid": {
-                      "const": true
-                    },
-                    "declared_status": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "declared_status_matches": {
-                      "type": "boolean"
-                    },
-                    "declared_reason_codes": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    },
-                    "declared_reason_codes_match": {
-                      "type": "boolean"
-                    },
-                    "verified_provenance_paths": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    },
-                    "validation_version": {
-                      "type": "string"
-                    },
-                    "ready_for_guarded_promotion": {
-                      "const": true
-                    },
-                    "fail_closed": {
-                      "const": false
-                    },
-                    "requires_review": {
-                      "const": false
-                    }
-                  }
-                },
-                "validation_result_hash": {
-                  "type": "string",
-                  "pattern": "^[0-9a-f]{64}$"
-                },
-                "verified_provenance_paths": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "source_decision_identity": {
-                  "type": "object",
-                  "additionalProperties": false,
-                  "required": [
-                    "request_id",
-                    "canonical_decision_id",
-                    "canonical_decision_hash",
-                    "canonical_decision_ts"
-                  ],
-                  "properties": {
-                    "request_id": {
-                      "type": "string"
-                    },
-                    "canonical_decision_id": {
-                      "type": "string"
-                    },
-                    "canonical_decision_hash": {
-                      "type": "string"
-                    },
-                    "canonical_decision_ts": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "candidate_identity": {
-                  "type": "object",
-                  "additionalProperties": false,
-                  "required": [
-                    "candidate_id",
-                    "candidate_hash",
-                    "actor_identity",
-                    "target_system",
-                    "target_resource",
-                    "action_contract_id",
-                    "action_contract_version"
-                  ],
-                  "properties": {
-                    "candidate_id": {
-                      "type": "string"
-                    },
-                    "candidate_hash": {
-                      "type": "string"
-                    },
-                    "actor_identity": {
-                      "type": "string"
-                    },
-                    "target_system": {
-                      "type": "string"
-                    },
-                    "target_resource": {
-                      "type": "string"
-                    },
-                    "action_contract_id": {
-                      "type": "string"
-                    },
-                    "action_contract_version": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "evidence_lineage": {
-                  "type": "object",
-                  "additionalProperties": false,
-                  "required": [
-                    "trustlog_artifact_ref",
-                    "trustlog_chain_hash",
-                    "replay_artifact_ref",
-                    "replay_artifact_hash",
-                    "authority_evidence_ref",
-                    "authority_evidence_hash",
-                    "human_approval_receipt_ref",
-                    "human_approval_receipt_hash",
-                    "policy_snapshot_id",
-                    "policy_version",
-                    "policy_semantic_digest",
-                    "expected_state_fingerprint",
-                    "expected_state_source_ref"
-                  ],
-                  "properties": {
-                    "trustlog_artifact_ref": {
-                      "type": "string"
-                    },
-                    "trustlog_chain_hash": {
-                      "type": "string"
-                    },
-                    "replay_artifact_ref": {
-                      "type": "string"
-                    },
-                    "replay_artifact_hash": {
-                      "type": "string"
-                    },
-                    "authority_evidence_ref": {
-                      "type": "string"
-                    },
-                    "authority_evidence_hash": {
-                      "type": "string"
-                    },
-                    "human_approval_receipt_ref": {
-                      "type": "string"
-                    },
-                    "human_approval_receipt_hash": {
-                      "type": "string"
-                    },
-                    "policy_snapshot_id": {
-                      "type": "string"
-                    },
-                    "policy_version": {
-                      "type": "string"
-                    },
-                    "policy_semantic_digest": {
-                      "type": "string"
-                    },
-                    "expected_state_fingerprint": {
-                      "type": "string"
-                    },
-                    "expected_state_source_ref": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "replay_summary": {
-                  "type": "object",
-                  "additionalProperties": false,
-                  "required": [
-                    "original_decision_id",
-                    "replay_decision_id",
-                    "original_request_id",
-                    "replay_request_id",
-                    "semantic_profile",
-                    "semantic_match",
-                    "fields_changed",
-                    "severity",
-                    "divergence_level"
-                  ],
-                  "properties": {
-                    "original_decision_id": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "replay_decision_id": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "original_request_id": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "replay_request_id": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "semantic_profile": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "semantic_match": {
-                      "anyOf": [
-                        {
-                          "type": "boolean"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "fields_changed": {
-                      "anyOf": [
-                        {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "severity": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "divergence_level": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  }
-                },
-                "scope_limitations": {
-                  "type": "array",
-                  "prefixItems": [
-                    {
-                      "const": "NOT_EXECUTION_AUTHORITY"
-                    },
-                    {
-                      "const": "NOT_EXECUTION_INTENT"
-                    },
-                    {
-                      "const": "NOT_BIND_AUTHORIZATION"
-                    },
-                    {
-                      "const": "NOT_BIND_RECEIPT"
-                    },
-                    {
-                      "const": "NOT_EXTERNAL_EFFECT"
-                    },
-                    {
-                      "const": "NOT_AUTHORITY_EVIDENCE"
-                    },
-                    {
-                      "const": "NOT_HUMAN_APPROVAL"
-                    },
-                    {
-                      "const": "NOT_TRUSTLOG_SUBSTITUTE"
-                    }
-                  ],
-                  "items": false,
-                  "minItems": 8,
-                  "maxItems": 8
-                }
-              },
-              "$defs": {
-                "valueAssertion": {
-                  "type": "object",
-                  "additionalProperties": false,
-                  "required": [
-                    "field_path",
-                    "value_digest",
-                    "verification_mechanism",
-                    "source_artifact_ref",
-                    "source_hash",
-                    "verified_at",
-                    "claims"
-                  ],
-                  "properties": {
-                    "field_path": {
-                      "type": "string"
-                    },
-                    "value_digest": {
-                      "type": "string"
-                    },
-                    "verification_mechanism": {
-                      "type": "string"
-                    },
-                    "source_artifact_ref": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "source_hash": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "verified_at": {
-                      "type": "string",
-                      "format": "date-time"
-                    },
-                    "claims": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                },
-                "candidateBinding": {
-                  "type": "object",
-                  "additionalProperties": false,
-                  "required": [
-                    "candidate_value_digest",
-                    "asserted_candidate_hash",
-                    "candidate_hash_profile",
-                    "verification_mechanism",
-                    "claim",
-                    "source_artifact_ref",
-                    "source_hash",
-                    "verified_at"
-                  ],
-                  "properties": {
-                    "candidate_value_digest": {
-                      "type": "string"
-                    },
-                    "asserted_candidate_hash": {
-                      "type": "string"
-                    },
-                    "candidate_hash_profile": {
-                      "type": "string"
-                    },
-                    "verification_mechanism": {
-                      "type": "string"
-                    },
-                    "claim": {
-                      "type": "string"
-                    },
-                    "source_artifact_ref": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "source_hash": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "verified_at": {
-                      "type": "string",
-                      "format": "date-time"
-                    }
-                  }
-                },
-                "authorityBinding": {
-                  "type": "object",
-                  "additionalProperties": false,
-                  "required": [
-                    "authority_requirement_value_digest",
-                    "authority_evidence_value_digest",
-                    "verification_mechanism",
-                    "claim",
-                    "source_artifact_ref",
-                    "source_hash",
-                    "verified_at"
-                  ],
-                  "properties": {
-                    "authority_requirement_value_digest": {
-                      "type": "string"
-                    },
-                    "authority_evidence_value_digest": {
-                      "type": "string"
-                    },
-                    "verification_mechanism": {
-                      "type": "string"
-                    },
-                    "claim": {
-                      "type": "string"
-                    },
-                    "source_artifact_ref": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "source_hash": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "verified_at": {
-                      "type": "string",
-                      "format": "date-time"
-                    }
-                  }
-                }
-              }
+              "format": "date-time"
             }
           }
         },
-        "mapping": {
+        "source_eligibility_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_eligibility_packet": {
+          "$ref": "#/$defs/eligibility"
+        },
+        "source_handoff_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "trusted_validation_context_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "validation_result_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "formation_status": {
+          "const": "READY_FOR_EXECUTION_INTENT_FORMATION"
+        },
+        "ready_for_execution_intent_formation": {
+          "const": true
+        },
+        "fail_closed": {
+          "const": false
+        },
+        "execution_intent_contract_version": {
+          "const": "execution-intent-contract/v1"
+        },
+        "execution_intent_required_fields": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "const": "execution_intent_id"
+            },
+            {
+              "const": "decision_id"
+            },
+            {
+              "const": "request_id"
+            },
+            {
+              "const": "policy_snapshot_id"
+            },
+            {
+              "const": "actor_identity"
+            },
+            {
+              "const": "target_system"
+            },
+            {
+              "const": "target_resource"
+            },
+            {
+              "const": "intended_action"
+            },
+            {
+              "const": "evidence_refs"
+            },
+            {
+              "const": "decision_hash"
+            },
+            {
+              "const": "decision_ts"
+            },
+            {
+              "const": "ttl_seconds"
+            },
+            {
+              "const": "expected_state_fingerprint"
+            },
+            {
+              "const": "approval_context"
+            },
+            {
+              "const": "policy_lineage"
+            }
+          ],
+          "items": false,
+          "minItems": 15,
+          "maxItems": 15
+        },
+        "source_to_execution_intent_mapping": {
           "type": "object",
           "additionalProperties": false,
           "required": [
@@ -1908,7 +1513,11 @@
             }
           }
         },
-        "execution_intent": {
+        "mapping_value_digest": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "required_field_presence": {
           "type": "object",
           "additionalProperties": false,
           "required": [
@@ -1930,18 +1539,98 @@
           ],
           "properties": {
             "execution_intent_id": {
-              "type": "string",
-              "pattern": "^ei:v1:sha256:[0-9a-f]{64}$"
+              "const": "intentionally_deferred"
             },
             "decision_id": {
-              "type": "string",
-              "minLength": 1
+              "const": "mapped"
             },
+            "request_id": {
+              "const": "mapped"
+            },
+            "policy_snapshot_id": {
+              "const": "mapped"
+            },
+            "actor_identity": {
+              "const": "mapped"
+            },
+            "target_system": {
+              "const": "mapped"
+            },
+            "target_resource": {
+              "const": "mapped"
+            },
+            "intended_action": {
+              "const": "mapped"
+            },
+            "evidence_refs": {
+              "const": "mapped"
+            },
+            "decision_hash": {
+              "const": "mapped"
+            },
+            "decision_ts": {
+              "const": "mapped"
+            },
+            "ttl_seconds": {
+              "const": "intentionally_deferred"
+            },
+            "expected_state_fingerprint": {
+              "const": "mapped"
+            },
+            "approval_context": {
+              "const": "mapped"
+            },
+            "policy_lineage": {
+              "const": "mapped"
+            }
+          }
+        },
+        "source_decision_identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "request_id",
+            "canonical_decision_id",
+            "canonical_decision_hash",
+            "canonical_decision_ts"
+          ],
+          "properties": {
             "request_id": {
               "type": "string",
               "minLength": 1
             },
-            "policy_snapshot_id": {
+            "canonical_decision_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "canonical_decision_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "canonical_decision_ts": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "candidate_identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "candidate_id",
+            "candidate_hash",
+            "actor_identity",
+            "target_system",
+            "target_resource",
+            "action_contract_id",
+            "action_contract_version"
+          ],
+          "properties": {
+            "candidate_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "candidate_hash": {
               "type": "string",
               "minLength": 1
             },
@@ -1957,508 +1646,809 @@
               "type": "string",
               "minLength": 1
             },
-            "intended_action": {
+            "action_contract_id": {
               "type": "string",
               "minLength": 1
             },
-            "evidence_refs": {
-              "type": "array",
-              "minItems": 5,
-              "items": {
-                "type": "string",
-                "minLength": 1
-              }
-            },
-            "decision_hash": {
+            "action_contract_version": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "evidence_lineage": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "trustlog_artifact_ref",
+            "trustlog_chain_hash",
+            "replay_artifact_ref",
+            "replay_artifact_hash",
+            "authority_evidence_ref",
+            "authority_evidence_hash",
+            "human_approval_receipt_ref",
+            "human_approval_receipt_hash",
+            "policy_snapshot_id",
+            "policy_version",
+            "policy_semantic_digest",
+            "expected_state_fingerprint",
+            "expected_state_source_ref"
+          ],
+          "properties": {
+            "trustlog_artifact_ref": {
               "type": "string",
               "minLength": 1
             },
-            "decision_ts": {
+            "trustlog_chain_hash": {
               "type": "string",
-              "format": "date-time"
+              "minLength": 1
             },
-            "ttl_seconds": {
-              "type": "null"
+            "replay_artifact_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "replay_artifact_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "authority_evidence_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "authority_evidence_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "human_approval_receipt_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "human_approval_receipt_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_snapshot_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_version": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_semantic_digest": {
+              "type": "string",
+              "minLength": 1
             },
             "expected_state_fingerprint": {
               "type": "string",
               "minLength": 1
             },
-            "approval_context": {
-              "type": "object",
-              "additionalProperties": false,
-              "required": [
-                "human_approval_receipt_ref",
-                "human_approval_receipt_hash"
+            "expected_state_source_ref": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "replay_summary": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "original_decision_id",
+            "replay_decision_id",
+            "original_request_id",
+            "replay_request_id",
+            "semantic_profile",
+            "semantic_match",
+            "fields_changed",
+            "severity",
+            "divergence_level"
+          ],
+          "properties": {
+            "original_decision_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "replay_decision_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "original_request_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "replay_request_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "semantic_profile": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "semantic_match": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "fields_changed": {
+              "type": [
+                "array",
+                "null"
               ],
-              "properties": {
-                "human_approval_receipt_ref": {
-                  "type": "string",
-                  "minLength": 1
-                },
-                "human_approval_receipt_hash": {
-                  "type": "string",
-                  "minLength": 1
-                }
+              "items": {
+                "type": "string"
               }
             },
-            "policy_lineage": {
-              "type": "object",
-              "additionalProperties": false,
-              "required": [
-                "policy_snapshot_id",
-                "policy_version",
-                "policy_semantic_digest"
-              ],
-              "properties": {
-                "policy_snapshot_id": {
-                  "type": "string",
-                  "minLength": 1
-                },
-                "policy_version": {
-                  "type": "string",
-                  "minLength": 1
-                },
-                "policy_semantic_digest": {
-                  "type": "string",
-                  "minLength": 1
-                }
-              }
+            "severity": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "divergence_level": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
+          }
+        },
+        "scope_limitations": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "const": "NOT_EXECUTION_INTENT"
+            },
+            {
+              "const": "NOT_EXECUTION_AUTHORITY"
+            },
+            {
+              "const": "NOT_BIND_AUTHORIZATION"
+            },
+            {
+              "const": "NOT_BIND_RECEIPT"
+            },
+            {
+              "const": "NOT_EXTERNAL_EFFECT"
+            },
+            {
+              "const": "NOT_ADAPTER_INVOCATION"
+            },
+            {
+              "const": "NOT_OPERATION_COMMIT"
+            },
+            {
+              "const": "NOT_TRUSTLOG_WRITE"
+            }
+          ],
+          "items": false,
+          "minItems": 8,
+          "maxItems": 8
+        }
+      }
+    },
+    "eligibility": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "format_version",
+        "eligibility_id",
+        "eligibility_hash",
+        "validation_mechanism",
+        "handoff_validator_version",
+        "issued_at",
+        "evaluated_at",
+        "validation_status",
+        "ready_for_guarded_promotion",
+        "fail_closed",
+        "source_handoff",
+        "source_handoff_hash",
+        "trusted_validation_context",
+        "trusted_validation_context_hash",
+        "validation_result",
+        "validation_result_hash",
+        "verified_provenance_paths",
+        "source_decision_identity",
+        "candidate_identity",
+        "evidence_lineage",
+        "replay_summary",
+        "scope_limitations"
+      ],
+      "properties": {
+        "format_version": {
+          "const": "canonical-guarded-promotion-eligibility-packet/v1"
+        },
+        "eligibility_id": {
+          "type": "string",
+          "pattern": "^gpe:v1:sha256:[0-9a-f]{64}$"
+        },
+        "eligibility_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "validation_mechanism": {
+          "const": "validate_canonical_decision_handoff/v1"
+        },
+        "handoff_validator_version": {
+          "type": "string"
+        },
+        "issued_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "evaluated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "validation_status": {
+          "const": "READY_FOR_GUARDED_PROMOTION"
+        },
+        "ready_for_guarded_promotion": {
+          "const": true
+        },
+        "fail_closed": {
+          "const": false
+        },
+        "source_handoff": {
+          "type": "object"
+        },
+        "source_handoff_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "trusted_validation_context": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "value_assertions",
+            "candidate_hash_binding",
+            "authority_requirement_binding"
+          ],
+          "properties": {
+            "value_assertions": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/valueAssertion"
+              }
+            },
+            "candidate_hash_binding": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/candidateBinding"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "authority_requirement_binding": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/authorityBinding"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        },
+        "trusted_validation_context_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "validation_result": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "status",
+            "reason_codes",
+            "structure_valid",
+            "declared_status",
+            "declared_status_matches",
+            "declared_reason_codes",
+            "declared_reason_codes_match",
+            "verified_provenance_paths",
+            "validation_version",
+            "ready_for_guarded_promotion",
+            "fail_closed",
+            "requires_review"
+          ],
+          "properties": {
+            "status": {
+              "const": "READY_FOR_GUARDED_PROMOTION"
+            },
+            "reason_codes": {
+              "const": []
+            },
+            "structure_valid": {
+              "const": true
+            },
+            "declared_status": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "declared_status_matches": {
+              "type": "boolean"
+            },
+            "declared_reason_codes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "declared_reason_codes_match": {
+              "type": "boolean"
+            },
+            "verified_provenance_paths": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "validation_version": {
+              "type": "string"
+            },
+            "ready_for_guarded_promotion": {
+              "const": true
+            },
+            "fail_closed": {
+              "const": false
+            },
+            "requires_review": {
+              "const": false
+            }
+          }
+        },
+        "validation_result_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "verified_provenance_paths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source_decision_identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "request_id",
+            "canonical_decision_id",
+            "canonical_decision_hash",
+            "canonical_decision_ts"
+          ],
+          "properties": {
+            "request_id": {
+              "type": "string"
+            },
+            "canonical_decision_id": {
+              "type": "string"
+            },
+            "canonical_decision_hash": {
+              "type": "string"
+            },
+            "canonical_decision_ts": {
+              "type": "string"
+            }
+          }
+        },
+        "candidate_identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "candidate_id",
+            "candidate_hash",
+            "actor_identity",
+            "target_system",
+            "target_resource",
+            "action_contract_id",
+            "action_contract_version"
+          ],
+          "properties": {
+            "candidate_id": {
+              "type": "string"
+            },
+            "candidate_hash": {
+              "type": "string"
+            },
+            "actor_identity": {
+              "type": "string"
+            },
+            "target_system": {
+              "type": "string"
+            },
+            "target_resource": {
+              "type": "string"
+            },
+            "action_contract_id": {
+              "type": "string"
+            },
+            "action_contract_version": {
+              "type": "string"
+            }
+          }
+        },
+        "evidence_lineage": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "trustlog_artifact_ref",
+            "trustlog_chain_hash",
+            "replay_artifact_ref",
+            "replay_artifact_hash",
+            "authority_evidence_ref",
+            "authority_evidence_hash",
+            "human_approval_receipt_ref",
+            "human_approval_receipt_hash",
+            "policy_snapshot_id",
+            "policy_version",
+            "policy_semantic_digest",
+            "expected_state_fingerprint",
+            "expected_state_source_ref"
+          ],
+          "properties": {
+            "trustlog_artifact_ref": {
+              "type": "string"
+            },
+            "trustlog_chain_hash": {
+              "type": "string"
+            },
+            "replay_artifact_ref": {
+              "type": "string"
+            },
+            "replay_artifact_hash": {
+              "type": "string"
+            },
+            "authority_evidence_ref": {
+              "type": "string"
+            },
+            "authority_evidence_hash": {
+              "type": "string"
+            },
+            "human_approval_receipt_ref": {
+              "type": "string"
+            },
+            "human_approval_receipt_hash": {
+              "type": "string"
+            },
+            "policy_snapshot_id": {
+              "type": "string"
+            },
+            "policy_version": {
+              "type": "string"
+            },
+            "policy_semantic_digest": {
+              "type": "string"
+            },
+            "expected_state_fingerprint": {
+              "type": "string"
+            },
+            "expected_state_source_ref": {
+              "type": "string"
+            }
+          }
+        },
+        "replay_summary": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "original_decision_id",
+            "replay_decision_id",
+            "original_request_id",
+            "replay_request_id",
+            "semantic_profile",
+            "semantic_match",
+            "fields_changed",
+            "severity",
+            "divergence_level"
+          ],
+          "properties": {
+            "original_decision_id": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "replay_decision_id": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "original_request_id": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "replay_request_id": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "semantic_profile": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "semantic_match": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "fields_changed": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "severity": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "divergence_level": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        },
+        "scope_limitations": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "const": "NOT_EXECUTION_AUTHORITY"
+            },
+            {
+              "const": "NOT_EXECUTION_INTENT"
+            },
+            {
+              "const": "NOT_BIND_AUTHORIZATION"
+            },
+            {
+              "const": "NOT_BIND_RECEIPT"
+            },
+            {
+              "const": "NOT_EXTERNAL_EFFECT"
+            },
+            {
+              "const": "NOT_AUTHORITY_EVIDENCE"
+            },
+            {
+              "const": "NOT_HUMAN_APPROVAL"
+            },
+            {
+              "const": "NOT_TRUSTLOG_SUBSTITUTE"
+            }
+          ],
+          "items": false,
+          "minItems": 8,
+          "maxItems": 8
+        }
+      }
+    },
+    "valueAssertion": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "field_path",
+        "value_digest",
+        "verification_mechanism",
+        "source_artifact_ref",
+        "source_hash",
+        "verified_at",
+        "claims"
+      ],
+      "properties": {
+        "field_path": {
+          "type": "string"
+        },
+        "value_digest": {
+          "type": "string"
+        },
+        "verification_mechanism": {
+          "type": "string"
+        },
+        "source_artifact_ref": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "source_hash": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "verified_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "claims": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
       }
     },
-    "source_readiness_hash": {
-      "type": "string",
-      "pattern": "^[0-9a-f]{64}$"
-    },
-    "source_eligibility_hash": {
-      "type": "string",
-      "pattern": "^[0-9a-f]{64}$"
-    },
-    "source_handoff_hash": {
-      "type": "string",
-      "pattern": "^[0-9a-f]{64}$"
-    },
-    "trusted_validation_context_hash": {
-      "type": "string",
-      "pattern": "^[0-9a-f]{64}$"
-    },
-    "validation_result_hash": {
-      "type": "string",
-      "pattern": "^[0-9a-f]{64}$"
-    },
-    "mapping_value_digest": {
-      "type": "string",
-      "pattern": "^[0-9a-f]{64}$"
-    },
-    "execution_intent_contract_version": {
-      "const": "execution-intent-contract/v1"
-    },
-    "execution_intent": {
-      "$ref": "#/$defs/execution_intent"
-    },
-    "execution_intent_id": {
-      "type": "string",
-      "pattern": "^ei:v1:sha256:[0-9a-f]{64}$"
-    },
-    "execution_intent_hash": {
-      "type": "string",
-      "pattern": "^[0-9a-f]{64}$"
-    },
-    "source_to_execution_intent_mapping": {
-      "$ref": "#/$defs/mapping"
-    },
-    "field_mapping_proof": {
-      "$ref": "#/$defs/mapping"
-    },
-    "required_field_presence": {
+    "candidateBinding": {
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "execution_intent_id",
-        "decision_id",
-        "request_id",
-        "policy_snapshot_id",
-        "actor_identity",
-        "target_system",
-        "target_resource",
-        "intended_action",
-        "evidence_refs",
-        "decision_hash",
-        "decision_ts",
-        "ttl_seconds",
-        "expected_state_fingerprint",
-        "approval_context",
-        "policy_lineage"
+        "candidate_value_digest",
+        "asserted_candidate_hash",
+        "candidate_hash_profile",
+        "verification_mechanism",
+        "claim",
+        "source_artifact_ref",
+        "source_hash",
+        "verified_at"
       ],
       "properties": {
-        "execution_intent_id": {
-          "const": "intentionally_deferred"
+        "candidate_value_digest": {
+          "type": "string"
         },
-        "decision_id": {
-          "const": "mapped"
+        "asserted_candidate_hash": {
+          "type": "string"
         },
-        "request_id": {
-          "const": "mapped"
+        "candidate_hash_profile": {
+          "type": "string"
         },
-        "policy_snapshot_id": {
-          "const": "mapped"
+        "verification_mechanism": {
+          "type": "string"
         },
-        "actor_identity": {
-          "const": "mapped"
+        "claim": {
+          "type": "string"
         },
-        "target_system": {
-          "const": "mapped"
+        "source_artifact_ref": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
-        "target_resource": {
-          "const": "mapped"
+        "source_hash": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
-        "intended_action": {
-          "const": "mapped"
-        },
-        "evidence_refs": {
-          "const": "mapped"
-        },
-        "decision_hash": {
-          "const": "mapped"
-        },
-        "decision_ts": {
-          "const": "mapped"
-        },
-        "ttl_seconds": {
-          "const": "intentionally_deferred"
-        },
-        "expected_state_fingerprint": {
-          "const": "mapped"
-        },
-        "approval_context": {
-          "const": "mapped"
-        },
-        "policy_lineage": {
-          "const": "mapped"
-        }
-      }
-    },
-    "source_decision_identity": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "request_id",
-        "canonical_decision_id",
-        "canonical_decision_hash",
-        "canonical_decision_ts"
-      ],
-      "properties": {
-        "request_id": {
-          "type": "string",
-          "minLength": 1
-        },
-        "canonical_decision_id": {
-          "type": "string",
-          "minLength": 1
-        },
-        "canonical_decision_hash": {
-          "type": "string",
-          "minLength": 1
-        },
-        "canonical_decision_ts": {
+        "verified_at": {
           "type": "string",
           "format": "date-time"
         }
       }
     },
-    "candidate_identity": {
+    "authorityBinding": {
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "candidate_id",
-        "candidate_hash",
-        "actor_identity",
-        "target_system",
-        "target_resource",
-        "action_contract_id",
-        "action_contract_version"
+        "authority_requirement_value_digest",
+        "authority_evidence_value_digest",
+        "verification_mechanism",
+        "claim",
+        "source_artifact_ref",
+        "source_hash",
+        "verified_at"
       ],
       "properties": {
-        "candidate_id": {
-          "type": "string",
-          "minLength": 1
+        "authority_requirement_value_digest": {
+          "type": "string"
         },
-        "candidate_hash": {
-          "type": "string",
-          "minLength": 1
+        "authority_evidence_value_digest": {
+          "type": "string"
         },
-        "actor_identity": {
-          "type": "string",
-          "minLength": 1
+        "verification_mechanism": {
+          "type": "string"
         },
-        "target_system": {
-          "type": "string",
-          "minLength": 1
+        "claim": {
+          "type": "string"
         },
-        "target_resource": {
-          "type": "string",
-          "minLength": 1
+        "source_artifact_ref": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
-        "action_contract_id": {
-          "type": "string",
-          "minLength": 1
+        "source_hash": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
-        "action_contract_version": {
+        "verified_at": {
           "type": "string",
-          "minLength": 1
+          "format": "date-time"
         }
       }
-    },
-    "evidence_lineage": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "trustlog_artifact_ref",
-        "trustlog_chain_hash",
-        "replay_artifact_ref",
-        "replay_artifact_hash",
-        "authority_evidence_ref",
-        "authority_evidence_hash",
-        "human_approval_receipt_ref",
-        "human_approval_receipt_hash",
-        "policy_snapshot_id",
-        "policy_version",
-        "policy_semantic_digest",
-        "expected_state_fingerprint",
-        "expected_state_source_ref"
-      ],
-      "properties": {
-        "trustlog_artifact_ref": {
-          "type": "string",
-          "minLength": 1
-        },
-        "trustlog_chain_hash": {
-          "type": "string",
-          "minLength": 1
-        },
-        "replay_artifact_ref": {
-          "type": "string",
-          "minLength": 1
-        },
-        "replay_artifact_hash": {
-          "type": "string",
-          "minLength": 1
-        },
-        "authority_evidence_ref": {
-          "type": "string",
-          "minLength": 1
-        },
-        "authority_evidence_hash": {
-          "type": "string",
-          "minLength": 1
-        },
-        "human_approval_receipt_ref": {
-          "type": "string",
-          "minLength": 1
-        },
-        "human_approval_receipt_hash": {
-          "type": "string",
-          "minLength": 1
-        },
-        "policy_snapshot_id": {
-          "type": "string",
-          "minLength": 1
-        },
-        "policy_version": {
-          "type": "string",
-          "minLength": 1
-        },
-        "policy_semantic_digest": {
-          "type": "string",
-          "minLength": 1
-        },
-        "expected_state_fingerprint": {
-          "type": "string",
-          "minLength": 1
-        },
-        "expected_state_source_ref": {
-          "type": "string",
-          "minLength": 1
-        }
-      }
-    },
-    "replay_summary": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "original_decision_id",
-        "replay_decision_id",
-        "original_request_id",
-        "replay_request_id",
-        "semantic_profile",
-        "semantic_match",
-        "fields_changed",
-        "severity",
-        "divergence_level"
-      ],
-      "properties": {
-        "original_decision_id": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "replay_decision_id": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "original_request_id": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "replay_request_id": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "semantic_profile": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "semantic_match": {
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "fields_changed": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
-        },
-        "severity": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "divergence_level": {
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      }
-    },
-    "pre_bind_status": {
-      "const": "READY_FOR_BIND_PREFLIGHT"
-    },
-    "ready_for_bind_preflight": {
-      "const": true
-    },
-    "fail_closed": {
-      "const": false
-    },
-    "local_validation_checks": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "formation_verified",
-        "execution_intent_hash_verified",
-        "execution_intent_id_verified",
-        "field_mapping_verified",
-        "required_field_presence_verified",
-        "evidence_refs_non_empty",
-        "decision_timestamp_timezone_aware",
-        "checked_after_formation",
-        "no_bind_invocation",
-        "no_trustlog_write"
-      ],
-      "properties": {
-        "formation_verified": {
-          "const": true
-        },
-        "execution_intent_hash_verified": {
-          "const": true
-        },
-        "execution_intent_id_verified": {
-          "const": true
-        },
-        "field_mapping_verified": {
-          "const": true
-        },
-        "required_field_presence_verified": {
-          "const": true
-        },
-        "evidence_refs_non_empty": {
-          "const": true
-        },
-        "decision_timestamp_timezone_aware": {
-          "const": true
-        },
-        "checked_after_formation": {
-          "const": true
-        },
-        "no_bind_invocation": {
-          "const": true
-        },
-        "no_trustlog_write": {
-          "const": true
-        }
-      }
-    },
-    "scope_limitations": {
-      "type": "array",
-      "prefixItems": [
-        {
-          "const": "NOT_EXECUTION_AUTHORITY"
-        },
-        {
-          "const": "NOT_BIND_AUTHORIZATION"
-        },
-        {
-          "const": "NOT_BIND_RECEIPT"
-        },
-        {
-          "const": "NOT_BIND_INVOCATION"
-        },
-        {
-          "const": "NOT_ADAPTER_INVOCATION"
-        },
-        {
-          "const": "NOT_EXTERNAL_EFFECT"
-        },
-        {
-          "const": "NOT_OPERATION_COMMIT"
-        },
-        {
-          "const": "NOT_TRUSTLOG_WRITE"
-        },
-        {
-          "const": "NOT_LIVE_STATE_CHECK"
-        },
-        {
-          "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
-        },
-        {
-          "const": "NOT_AUTHORITY_EVIDENCE"
-        },
-        {
-          "const": "NOT_HUMAN_APPROVAL"
-        }
-      ],
-      "items": false,
-      "minItems": 12,
-      "maxItems": 12
     }
   }
 }

--- a/veritas_os/policy/execution_intent_pre_bind_validation.py
+++ b/veritas_os/policy/execution_intent_pre_bind_validation.py
@@ -1,0 +1,417 @@
+"""Validate a formed ExecutionIntent without crossing the Bind boundary.
+
+This deterministic, local module binds an exact ExecutionIntent to an exact,
+independently verified Canonical ExecutionIntent Formation Packet.  It performs
+no authorization, I/O, adapter activity, TrustLog write, or Bind invocation.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from veritas_os.policy.bind_artifacts import (
+    ExecutionIntent,
+    canonical_execution_intent_json,
+    hash_execution_intent,
+)
+from veritas_os.policy.canonical_execution_intent_formation import (
+    EXECUTION_INTENT_FIELDS,
+    CanonicalExecutionIntentFormationError,
+    CanonicalExecutionIntentFormationPacket,
+    verify_canonical_execution_intent_formation_packet,
+)
+
+FORMAT_VERSION = "canonical-execution-intent-pre-bind-validation/v1"
+VALIDATION_MECHANISM = "validate_execution_intent_before_bind/v1"
+LOCAL_CHECKS_DOMAIN = (
+    "veritas.execution-intent-pre-bind-validation.local-checks/v1"
+)
+PACKET_DOMAIN = "veritas.execution-intent-pre-bind-validation.packet/v1"
+PRE_BIND_STATUS = "READY_FOR_BIND_PREFLIGHT"
+LOCAL_VALIDATION_CHECKS = {
+    "formation_verified": True,
+    "execution_intent_hash_verified": True,
+    "execution_intent_id_verified": True,
+    "field_mapping_verified": True,
+    "required_field_presence_verified": True,
+    "evidence_refs_non_empty": True,
+    "decision_timestamp_timezone_aware": True,
+    "checked_after_formation": True,
+    "no_bind_invocation": True,
+    "no_trustlog_write": True,
+}
+SCOPE_LIMITATIONS = (
+    "NOT_EXECUTION_AUTHORITY",
+    "NOT_BIND_AUTHORIZATION",
+    "NOT_BIND_RECEIPT",
+    "NOT_BIND_INVOCATION",
+    "NOT_ADAPTER_INVOCATION",
+    "NOT_EXTERNAL_EFFECT",
+    "NOT_OPERATION_COMMIT",
+    "NOT_TRUSTLOG_WRITE",
+    "NOT_LIVE_STATE_CHECK",
+    "NOT_RUNTIME_RISK_ACCEPTANCE",
+    "NOT_AUTHORITY_EVIDENCE",
+    "NOT_HUMAN_APPROVAL",
+)
+
+
+class ExecutionIntentPreBindValidationError(ValueError):
+    """Stable fail-closed pre-bind construction or verification refusal."""
+
+
+class CanonicalExecutionIntentPreBindValidationPacket(BaseModel):
+    """Strict immutable proof of deterministic local pre-bind checks only."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    format_version: Literal[
+        "canonical-execution-intent-pre-bind-validation/v1"
+    ]
+    pre_bind_validation_id: str = Field(
+        pattern=r"^eipbv:v1:sha256:[0-9a-f]{64}$"
+    )
+    pre_bind_validation_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    validation_mechanism: Literal["validate_execution_intent_before_bind/v1"]
+    checked_at: str
+    source_formation: dict[str, Any]
+    source_formation_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    source_formation_packet: dict[str, Any]
+    source_readiness_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    source_eligibility_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    source_handoff_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    trusted_validation_context_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    validation_result_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    mapping_value_digest: str = Field(pattern=r"^[0-9a-f]{64}$")
+    execution_intent_contract_version: str
+    execution_intent: dict[str, Any]
+    execution_intent_id: str = Field(pattern=r"^ei:v1:sha256:[0-9a-f]{64}$")
+    execution_intent_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    pre_bind_status: Literal["READY_FOR_BIND_PREFLIGHT"]
+    ready_for_bind_preflight: Literal[True]
+    fail_closed: Literal[False]
+    local_validation_checks: dict[str, bool]
+    source_to_execution_intent_mapping: dict[str, Any]
+    field_mapping_proof: dict[str, Any]
+    required_field_presence: dict[str, str]
+    source_decision_identity: dict[str, Any]
+    candidate_identity: dict[str, Any]
+    evidence_lineage: dict[str, Any]
+    replay_summary: dict[str, Any]
+    scope_limitations: tuple[str, ...]
+
+
+def _json_value(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        value = value.model_dump(mode="python")
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        if value != value or value in (float("inf"), float("-inf")):
+            raise ExecutionIntentPreBindValidationError("EIPBV_PACKET_INVALID")
+        return value
+    if isinstance(value, datetime):
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ExecutionIntentPreBindValidationError(
+                "EIPBV_CHECKED_AT_INVALID"
+            )
+        return value.isoformat()
+    if isinstance(value, (list, tuple)):
+        return [_json_value(item) for item in value]
+    if isinstance(value, dict):
+        if not all(isinstance(key, str) for key in value):
+            raise ExecutionIntentPreBindValidationError("EIPBV_PACKET_INVALID")
+        return {key: _json_value(item) for key, item in value.items()}
+    raise ExecutionIntentPreBindValidationError("EIPBV_PACKET_INVALID")
+
+
+def _aware_iso(value: Any, code: str) -> datetime:
+    try:
+        parsed = value if isinstance(value, datetime) else datetime.fromisoformat(value)
+    except (TypeError, ValueError) as exc:
+        raise ExecutionIntentPreBindValidationError(code) from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ExecutionIntentPreBindValidationError(code)
+    return parsed
+
+
+def _digest(domain: str, value: Any) -> str:
+    encoded = json.dumps(
+        {"domain": domain, "value": _json_value(value)},
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _packet_hash(raw: dict[str, Any]) -> str:
+    return _digest(
+        PACKET_DOMAIN,
+        {
+            key: value
+            for key, value in raw.items()
+            if key not in {
+                "pre_bind_validation_id",
+                "pre_bind_validation_hash",
+            }
+        },
+    )
+
+
+def _verified_formation(
+    value: Any,
+) -> CanonicalExecutionIntentFormationPacket:
+    try:
+        formation = verify_canonical_execution_intent_formation_packet(value)
+    except (CanonicalExecutionIntentFormationError, TypeError, ValueError) as exc:
+        raise ExecutionIntentPreBindValidationError(
+            "EIPBV_FORMATION_INVALID"
+        ) from exc
+    if formation.format_version != "canonical-execution-intent-formation/v1":
+        raise ExecutionIntentPreBindValidationError("EIPBV_FORMATION_INVALID")
+    return formation
+
+
+def _reconstruct_intent(raw: dict[str, Any]) -> ExecutionIntent:
+    expected = {"execution_intent_id", *EXECUTION_INTENT_FIELDS}
+    if set(raw) != expected:
+        raise ExecutionIntentPreBindValidationError(
+            "EIPBV_EXECUTION_INTENT_FIELD_MISMATCH"
+        )
+    required_strings = set(EXECUTION_INTENT_FIELDS) - {
+        "evidence_refs",
+        "ttl_seconds",
+        "approval_context",
+        "policy_lineage",
+    }
+    if any(
+        not isinstance(raw[field], str) or not raw[field].strip()
+        for field in required_strings
+    ):
+        raise ExecutionIntentPreBindValidationError(
+            "EIPBV_EXECUTION_INTENT_FIELD_MISMATCH"
+        )
+    refs = raw["evidence_refs"]
+    if not isinstance(refs, list) or not refs or any(
+        not isinstance(ref, str) or not ref.strip() for ref in refs
+    ):
+        raise ExecutionIntentPreBindValidationError(
+            "EIPBV_EVIDENCE_REFS_INVALID"
+        )
+    _aware_iso(raw["decision_ts"], "EIPBV_DECISION_TS_INVALID")
+    ttl = raw["ttl_seconds"]
+    if ttl is not None and (
+        isinstance(ttl, bool) or not isinstance(ttl, int) or ttl < 0
+    ):
+        raise ExecutionIntentPreBindValidationError("EIPBV_TTL_INVALID")
+    try:
+        intent = ExecutionIntent(**raw)
+    except (TypeError, ValueError) as exc:
+        raise ExecutionIntentPreBindValidationError(
+            "EIPBV_EXECUTION_INTENT_FIELD_MISMATCH"
+        ) from exc
+    if intent.to_dict() != raw:
+        raise ExecutionIntentPreBindValidationError(
+            "EIPBV_EXECUTION_INTENT_FIELD_MISMATCH"
+        )
+    canonical_execution_intent_json(intent)
+    return intent
+
+
+def build_execution_intent_pre_bind_validation_packet(
+    formation_packet: Any,
+    checked_at: datetime,
+) -> CanonicalExecutionIntentPreBindValidationPacket:
+    """Build a local validation packet from an independently verified formation.
+
+    Args:
+        formation_packet: Full Canonical ExecutionIntent Formation Packet.
+        checked_at: Caller-supplied timezone-aware validation time.
+
+    Returns:
+        A content-addressed packet that makes no authorization claim.
+    """
+    checked = _aware_iso(checked_at, "EIPBV_CHECKED_AT_INVALID")
+    formation = _verified_formation(_json_value(formation_packet))
+    formed = _aware_iso(formation.formed_at, "EIPBV_FORMATION_INVALID")
+    if checked < formed:
+        raise ExecutionIntentPreBindValidationError(
+            "EIPBV_CHECKED_BEFORE_FORMED"
+        )
+    source = formation.model_dump(mode="json")
+    raw = {
+        "format_version": FORMAT_VERSION,
+        "validation_mechanism": VALIDATION_MECHANISM,
+        "checked_at": checked.isoformat(),
+        "source_formation": {
+            key: source[key]
+            for key in (
+                "formation_id",
+                "formation_hash",
+                "format_version",
+                "formation_mechanism",
+                "formed_at",
+                "execution_intent_id",
+                "execution_intent_hash",
+            )
+        },
+        "source_formation_hash": formation.formation_hash,
+        "source_formation_packet": source,
+        "source_readiness_hash": formation.source_readiness_hash,
+        "source_eligibility_hash": formation.source_eligibility_hash,
+        "source_handoff_hash": formation.source_handoff_hash,
+        "trusted_validation_context_hash": (
+            formation.trusted_validation_context_hash
+        ),
+        "validation_result_hash": formation.validation_result_hash,
+        "mapping_value_digest": formation.mapping_value_digest,
+        "execution_intent_contract_version": (
+            formation.execution_intent_contract_version
+        ),
+        "execution_intent": formation.execution_intent,
+        "execution_intent_id": formation.execution_intent_id,
+        "execution_intent_hash": formation.execution_intent_hash,
+        "pre_bind_status": PRE_BIND_STATUS,
+        "ready_for_bind_preflight": True,
+        "fail_closed": False,
+        "local_validation_checks": LOCAL_VALIDATION_CHECKS,
+        "source_to_execution_intent_mapping": (
+            formation.source_to_execution_intent_mapping
+        ),
+        "field_mapping_proof": formation.field_mapping_proof,
+        "required_field_presence": formation.required_field_presence,
+        "source_decision_identity": formation.source_decision_identity,
+        "candidate_identity": formation.candidate_identity,
+        "evidence_lineage": formation.evidence_lineage,
+        "replay_summary": formation.replay_summary,
+        "scope_limitations": SCOPE_LIMITATIONS,
+    }
+    digest = _packet_hash(raw)
+    raw.update(
+        pre_bind_validation_hash=digest,
+        pre_bind_validation_id=f"eipbv:v1:sha256:{digest}",
+    )
+    return verify_execution_intent_pre_bind_validation_packet(raw)
+
+
+def verify_execution_intent_pre_bind_validation_packet(
+    packet: Any,
+) -> CanonicalExecutionIntentPreBindValidationPacket:
+    """Independently revalidate all formation, intent, and packet bindings."""
+    try:
+        raw_input = (
+            packet.model_dump(mode="json")
+            if isinstance(packet, BaseModel)
+            else _json_value(packet)
+        )
+        candidate = CanonicalExecutionIntentPreBindValidationPacket.model_validate(
+            raw_input
+        )
+    except (ValidationError, ExecutionIntentPreBindValidationError, TypeError) as exc:
+        raise ExecutionIntentPreBindValidationError("EIPBV_PACKET_INVALID") from exc
+    raw = candidate.model_dump(mode="json")
+    formation = _verified_formation(candidate.source_formation_packet)
+    checked = _aware_iso(candidate.checked_at, "EIPBV_CHECKED_AT_INVALID")
+    formed = _aware_iso(formation.formed_at, "EIPBV_FORMATION_INVALID")
+    if checked < formed:
+        raise ExecutionIntentPreBindValidationError(
+            "EIPBV_CHECKED_BEFORE_FORMED"
+        )
+    source = formation.model_dump(mode="json")
+    summary_keys = (
+        "formation_id",
+        "formation_hash",
+        "format_version",
+        "formation_mechanism",
+        "formed_at",
+        "execution_intent_id",
+        "execution_intent_hash",
+    )
+    if candidate.source_formation != {
+        key: source[key] for key in summary_keys
+    }:
+        raise ExecutionIntentPreBindValidationError("EIPBV_FORMATION_INVALID")
+    bindings = (
+        (candidate.source_formation_hash, formation.formation_hash),
+        (candidate.source_readiness_hash, formation.source_readiness_hash),
+        (candidate.source_eligibility_hash, formation.source_eligibility_hash),
+        (candidate.source_handoff_hash, formation.source_handoff_hash),
+        (
+            candidate.trusted_validation_context_hash,
+            formation.trusted_validation_context_hash,
+        ),
+        (candidate.validation_result_hash, formation.validation_result_hash),
+        (candidate.mapping_value_digest, formation.mapping_value_digest),
+        (
+            candidate.execution_intent_contract_version,
+            formation.execution_intent_contract_version,
+        ),
+    )
+    if any(actual != expected for actual, expected in bindings):
+        raise ExecutionIntentPreBindValidationError("EIPBV_MAPPING_MISMATCH")
+    intent = _reconstruct_intent(candidate.execution_intent)
+    if candidate.execution_intent != formation.execution_intent:
+        raise ExecutionIntentPreBindValidationError(
+            "EIPBV_EXECUTION_INTENT_FIELD_MISMATCH"
+        )
+    if candidate.execution_intent_id != intent.execution_intent_id or (
+        candidate.execution_intent_id != formation.execution_intent_id
+    ):
+        raise ExecutionIntentPreBindValidationError(
+            "EIPBV_EXECUTION_INTENT_ID_MISMATCH"
+        )
+    computed_intent_hash = hash_execution_intent(intent)
+    if candidate.execution_intent_hash != computed_intent_hash or (
+        candidate.execution_intent_hash != formation.execution_intent_hash
+    ):
+        raise ExecutionIntentPreBindValidationError(
+            "EIPBV_EXECUTION_INTENT_HASH_MISMATCH"
+        )
+    mapping = {
+        key: candidate.execution_intent[key] for key in EXECUTION_INTENT_FIELDS
+    }
+    if candidate.source_to_execution_intent_mapping != mapping or (
+        candidate.source_to_execution_intent_mapping
+        != formation.source_to_execution_intent_mapping
+    ):
+        raise ExecutionIntentPreBindValidationError("EIPBV_MAPPING_MISMATCH")
+    if candidate.field_mapping_proof != mapping or (
+        candidate.field_mapping_proof != formation.field_mapping_proof
+    ):
+        raise ExecutionIntentPreBindValidationError(
+            "EIPBV_FIELD_MAPPING_PROOF_MISMATCH"
+        )
+    preserved = (
+        (candidate.required_field_presence, formation.required_field_presence),
+        (candidate.source_decision_identity, formation.source_decision_identity),
+        (candidate.candidate_identity, formation.candidate_identity),
+        (candidate.evidence_lineage, formation.evidence_lineage),
+        (candidate.replay_summary, formation.replay_summary),
+    )
+    if any(actual != expected for actual, expected in preserved):
+        raise ExecutionIntentPreBindValidationError("EIPBV_MAPPING_MISMATCH")
+    if candidate.local_validation_checks != LOCAL_VALIDATION_CHECKS:
+        raise ExecutionIntentPreBindValidationError(
+            "EIPBV_LOCAL_CHECKS_MISMATCH"
+        )
+    # Bind the checks to their own domain without changing packet hash semantics.
+    _digest(LOCAL_CHECKS_DOMAIN, candidate.local_validation_checks)
+    if candidate.scope_limitations != SCOPE_LIMITATIONS:
+        raise ExecutionIntentPreBindValidationError(
+            "EIPBV_SCOPE_LIMITATIONS_MISSING"
+        )
+    digest = _packet_hash(raw)
+    if candidate.pre_bind_validation_hash != digest:
+        raise ExecutionIntentPreBindValidationError(
+            "EIPBV_PACKET_HASH_MISMATCH"
+        )
+    if candidate.pre_bind_validation_id != f"eipbv:v1:sha256:{digest}":
+        raise ExecutionIntentPreBindValidationError("EIPBV_PACKET_ID_MISMATCH")
+    return candidate

--- a/veritas_os/tests/test_execution_intent_pre_bind_validation.py
+++ b/veritas_os/tests/test_execution_intent_pre_bind_validation.py
@@ -1,0 +1,240 @@
+"""Security tests for Canonical ExecutionIntent Pre-Bind Validation v1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from copy import deepcopy
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator, FormatChecker
+
+from veritas_os.policy.bind_artifacts import ExecutionIntent, hash_execution_intent
+from veritas_os.policy.execution_intent_pre_bind_validation import (
+    LOCAL_CHECKS_DOMAIN,
+    LOCAL_VALIDATION_CHECKS,
+    PACKET_DOMAIN,
+    SCOPE_LIMITATIONS,
+    CanonicalExecutionIntentPreBindValidationPacket,
+    ExecutionIntentPreBindValidationError,
+    _packet_hash,
+    build_execution_intent_pre_bind_validation_packet,
+    verify_execution_intent_pre_bind_validation_packet,
+)
+from veritas_os.tests.test_canonical_execution_intent_formation import (
+    FORMED_AT,
+    _packet as formation_packet,
+)
+
+CHECKED_AT = FORMED_AT + timedelta(seconds=1)
+MODULE = Path("veritas_os/policy/execution_intent_pre_bind_validation.py")
+SCHEMA = Path("schemas/execution-intent-pre-bind-validation-v1.schema.json")
+
+
+def _packet(*, semantic_match: bool | None = None):
+    return build_execution_intent_pre_bind_validation_packet(
+        formation_packet(semantic_match=semantic_match), CHECKED_AT
+    )
+
+
+def test_build_verify_integrity_preservation_and_local_only(monkeypatch) -> None:
+    import veritas_os.policy.execution_intent_pre_bind_validation as module
+
+    formation = formation_packet()
+    actual = module.verify_canonical_execution_intent_formation_packet
+    calls = []
+
+    def recording_verifier(value):
+        calls.append(value)
+        return actual(value)
+
+    monkeypatch.setattr(
+        module, "verify_canonical_execution_intent_formation_packet", recording_verifier
+    )
+    packet = module.build_execution_intent_pre_bind_validation_packet(
+        formation, CHECKED_AT
+    )
+    assert len(calls) == 2
+    assert module.verify_execution_intent_pre_bind_validation_packet(packet) == packet
+    assert len(calls) == 3
+    assert packet.pre_bind_validation_id == (
+        f"eipbv:v1:sha256:{packet.pre_bind_validation_hash}"
+    )
+    assert packet.pre_bind_validation_hash == _packet_hash(
+        packet.model_dump(mode="json")
+    )
+    intent = ExecutionIntent(**packet.execution_intent)
+    assert intent.to_dict() == packet.execution_intent
+    assert packet.execution_intent_hash == hash_execution_intent(intent)
+    assert packet.execution_intent_id == formation.execution_intent_id
+    assert packet.source_to_execution_intent_mapping == (
+        formation.source_to_execution_intent_mapping
+    )
+    assert packet.field_mapping_proof == formation.field_mapping_proof
+    assert packet.local_validation_checks == LOCAL_VALIDATION_CHECKS
+    for field in (
+        "required_field_presence", "source_decision_identity", "candidate_identity",
+        "evidence_lineage", "replay_summary",
+    ):
+        assert getattr(packet, field) == getattr(formation, field)
+    assert packet.scope_limitations == SCOPE_LIMITATIONS
+    assert not hasattr(packet, "bind_receipt")
+    assert not hasattr(packet, "trustlog_entry")
+
+
+@pytest.mark.parametrize("semantic_match", [True, False])
+def test_semantic_match_is_preserved_not_gated(semantic_match: bool) -> None:
+    packet = _packet(semantic_match=semantic_match)
+    assert packet.replay_summary["semantic_match"] is semantic_match
+    assert packet.replay_summary["fields_changed"] == (
+        [] if semantic_match else ["outcome.status"]
+    )
+    assert verify_execution_intent_pre_bind_validation_packet(packet) == packet
+
+
+@pytest.mark.parametrize("field", [
+    "decision_id", "request_id", "policy_snapshot_id", "actor_identity",
+    "target_system", "target_resource", "intended_action", "decision_hash",
+])
+def test_missing_required_intent_field_refuses(field: str) -> None:
+    formation = formation_packet().model_dump(mode="json")
+    del formation["execution_intent"][field]
+    with pytest.raises(ExecutionIntentPreBindValidationError, match="EIPBV_FORMATION_INVALID"):
+        build_execution_intent_pre_bind_validation_packet(formation, CHECKED_AT)
+
+
+@pytest.mark.parametrize("mutation,code", [
+    (lambda raw: raw["execution_intent"].update(evidence_refs=[]), "EIPBV_FORMATION_INVALID"),
+    (lambda raw: raw["execution_intent"].update(evidence_refs=[1]), "EIPBV_FORMATION_INVALID"),
+    (lambda raw: raw["execution_intent"].update(decision_ts="invalid"), "EIPBV_FORMATION_INVALID"),
+    (lambda raw: raw["execution_intent"].update(ttl_seconds=-1), "EIPBV_FORMATION_INVALID"),
+])
+def test_invalid_formation_intent_refuses(mutation, code: str) -> None:
+    raw = formation_packet().model_dump(mode="json")
+    mutation(raw)
+    with pytest.raises(ExecutionIntentPreBindValidationError, match=code):
+        build_execution_intent_pre_bind_validation_packet(raw, CHECKED_AT)
+
+
+def test_invalid_formation_and_timeline_refuse() -> None:
+    for field in ("formation_hash", "formation_id"):
+        raw = formation_packet().model_dump(mode="json")
+        raw[field] = ("eif:v1:sha256:" if field.endswith("id") else "") + "0" * 64
+        with pytest.raises(ExecutionIntentPreBindValidationError, match="EIPBV_FORMATION_INVALID"):
+            build_execution_intent_pre_bind_validation_packet(raw, CHECKED_AT)
+    with pytest.raises(ExecutionIntentPreBindValidationError, match="EIPBV_CHECKED_AT_INVALID"):
+        build_execution_intent_pre_bind_validation_packet(
+            formation_packet(), CHECKED_AT.replace(tzinfo=None)
+        )
+    with pytest.raises(ExecutionIntentPreBindValidationError, match="EIPBV_CHECKED_BEFORE_FORMED"):
+        build_execution_intent_pre_bind_validation_packet(
+            formation_packet(), FORMED_AT - timedelta(seconds=1)
+        )
+
+
+@pytest.mark.parametrize("path", [
+    ("pre_bind_validation_id",), ("pre_bind_validation_hash",), ("checked_at",),
+    ("source_formation", "formed_at"), ("source_formation_hash",),
+    ("source_formation_packet", "formation_hash"), ("source_readiness_hash",),
+    ("source_eligibility_hash",), ("source_handoff_hash",),
+    ("trusted_validation_context_hash",), ("validation_result_hash",),
+    ("mapping_value_digest",), ("execution_intent", "decision_id"),
+    ("execution_intent_id",), ("execution_intent_hash",),
+    ("source_to_execution_intent_mapping", "decision_id"),
+    ("field_mapping_proof", "decision_id"),
+    ("local_validation_checks", "formation_verified"),
+    ("source_decision_identity", "request_id"),
+    ("candidate_identity", "actor_identity"),
+    ("evidence_lineage", "policy_snapshot_id"),
+    ("replay_summary", "semantic_match"), ("replay_summary", "fields_changed"),
+    ("scope_limitations",),
+])
+def test_single_field_tampering_refuses(path: tuple[str, ...]) -> None:
+    raw = _packet(semantic_match=True).model_dump(mode="json")
+    target = raw
+    for key in path[:-1]:
+        target = target[key]
+    key = path[-1]
+    if key.endswith("_id"):
+        target[key] = ("eipbv:v1:sha256:" if key.startswith("pre") else "ei:v1:sha256:") + "0" * 64
+    elif key.endswith("hash") or key.endswith("digest"):
+        target[key] = "0" * 64
+    elif key == "checked_at":
+        target[key] = (CHECKED_AT + timedelta(seconds=1)).isoformat()
+    elif key == "semantic_match":
+        target[key] = False
+    elif key == "fields_changed":
+        target[key] = ["outcome.status"]
+    elif key == "formation_verified":
+        target[key] = False
+    elif key == "scope_limitations":
+        target[key] = target[key][:-1]
+    else:
+        target[key] = "tampered"
+    with pytest.raises(ExecutionIntentPreBindValidationError):
+        verify_execution_intent_pre_bind_validation_packet(raw)
+
+
+@pytest.mark.parametrize("method", ["copy", "construct"])
+@pytest.mark.parametrize("updates", [
+    {"format_version": "wrong"}, {"pre_bind_validation_hash": "0" * 64},
+    {"execution_intent": {}}, {"source_to_execution_intent_mapping": {}},
+    {"local_validation_checks": {}}, {"replay_summary": {}},
+])
+def test_typed_instance_bypass_refuses(method: str, updates: dict) -> None:
+    packet = _packet()
+    bypass = (
+        packet.model_copy(update=updates)
+        if method == "copy"
+        else CanonicalExecutionIntentPreBindValidationPacket.model_construct(
+            **{**packet.model_dump(mode="python"), **updates}
+        )
+    )
+    with pytest.raises(ExecutionIntentPreBindValidationError):
+        verify_execution_intent_pre_bind_validation_packet(bypass)
+
+
+def test_schema_accepts_valid_and_rejects_invalid_packet() -> None:
+    validator = Draft202012Validator(
+        json.loads(SCHEMA.read_text()), format_checker=FormatChecker()
+    )
+    valid = _packet().model_dump(mode="json")
+    validator.validate(valid)
+    invalid = deepcopy(valid)
+    invalid["execution_intent"]["unexpected"] = True
+    assert list(validator.iter_errors(invalid))
+    invalid = deepcopy(valid)
+    invalid["scope_limitations"] = invalid["scope_limitations"][:-1]
+    assert list(validator.iter_errors(invalid))
+
+
+def test_static_import_and_side_effect_boundary() -> None:
+    source = MODULE.read_text()
+    tree = ast.parse(source)
+    forbidden = {
+        "BindReceipt", "hash_bind_receipt", "append_bind_receipt_trustlog",
+        "append_execution_intent_trustlog", "build_execution_intent_trustlog_entry",
+        "execute_bind_boundary", "execute_bind_adjudication", "BindBoundaryAdapter",
+        "ReferenceBindAdapter", "WebhookBindAdapter", "requests", "httpx",
+        "subprocess", "uuid4",
+    }
+    imported = {
+        alias.name for node in ast.walk(tree)
+        if isinstance(node, (ast.Import, ast.ImportFrom)) for alias in node.names
+    }
+    assert imported.isdisjoint(forbidden)
+    calls = [node.func for node in ast.walk(tree) if isinstance(node, ast.Call)]
+    assert not any(
+        isinstance(call, ast.Attribute) and isinstance(call.value, ast.Name)
+        and call.value.id == "datetime" and call.attr == "now" for call in calls
+    )
+    names = {node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)}
+    assert names.isdisjoint({
+        "bind", "execute", "commit", "dispatch", "send", "webhook",
+        "adapter_call", "write_trustlog", "append_trustlog",
+        "create_bind_receipt", "invoke_bind",
+    })
+    assert "bind_receipt_id" not in source
+    assert LOCAL_CHECKS_DOMAIN != PACKET_DOMAIN

--- a/veritas_os/tests/test_execution_intent_pre_bind_validation.py
+++ b/veritas_os/tests/test_execution_intent_pre_bind_validation.py
@@ -197,17 +197,49 @@ def test_typed_instance_bypass_refuses(method: str, updates: dict) -> None:
 
 
 def test_schema_accepts_valid_and_rejects_invalid_packet() -> None:
-    validator = Draft202012Validator(
-        json.loads(SCHEMA.read_text()), format_checker=FormatChecker()
-    )
+    schema = json.loads(SCHEMA.read_text())
+    Draft202012Validator.check_schema(schema)
+    validator = Draft202012Validator(schema, format_checker=FormatChecker())
     valid = _packet().model_dump(mode="json")
     validator.validate(valid)
-    invalid = deepcopy(valid)
-    invalid["execution_intent"]["unexpected"] = True
-    assert list(validator.iter_errors(invalid))
-    invalid = deepcopy(valid)
-    invalid["scope_limitations"] = invalid["scope_limitations"][:-1]
-    assert list(validator.iter_errors(invalid))
+    invalid_mutations = (
+        lambda packet: packet["execution_intent"].update(unexpected=True),
+        lambda packet: packet[
+            "source_to_execution_intent_mapping"
+        ].update(unexpected=True),
+        lambda packet: packet["source_formation_packet"][
+            "execution_intent"
+        ].update(unexpected=True),
+        lambda packet: packet["local_validation_checks"].update(
+            unexpected=True
+        ),
+        lambda packet: packet.update(
+            scope_limitations=packet["scope_limitations"][:-1]
+        ),
+    )
+    for mutate in invalid_mutations:
+        invalid = deepcopy(valid)
+        mutate(invalid)
+        assert list(validator.iter_errors(invalid))
+
+    refs: set[str] = set()
+
+    def collect_refs(value) -> None:
+        """Collect every local reference from the self-contained schema."""
+        if isinstance(value, dict):
+            if "$ref" in value:
+                refs.add(value["$ref"])
+            for nested in value.values():
+                collect_refs(nested)
+        elif isinstance(value, list):
+            for nested in value:
+                collect_refs(nested)
+
+    collect_refs(schema)
+    assert refs
+    for ref in refs:
+        assert ref.startswith("#/$defs/")
+        assert ref.removeprefix("#/$defs/") in schema["$defs"]
 
 
 def test_static_import_and_side_effect_boundary() -> None:


### PR DESCRIPTION
### Motivation

- Provide a deterministic, local, side-effect-free pre-bind validation step that proves a formed `ExecutionIntent` is exactly bound to its verified `CanonicalExecutionIntentFormationPacket` before any future Bind boundary.
- Preserve existing formation/readiness boundaries and avoid any Bind, adapter, TrustLog, network, filesystem, or external effects in this stage.

### Description

- Add a new module `veritas_os/policy/execution_intent_pre_bind_validation.py` implementing the strict immutable model `CanonicalExecutionIntentPreBindValidationPacket`, a builder `build_execution_intent_pre_bind_validation_packet`, and a verifier `verify_execution_intent_pre_bind_validation_packet` that revalidates the embedded Formation Packet and reconstructs the `ExecutionIntent` using existing `hash_execution_intent` semantics.
- Add a closed Draft 2020-12 JSON Schema `schemas/execution-intent-pre-bind-validation-v1.schema.json` and documentation `docs/en/architecture/execution-intent-pre-bind-validation-v1.md` describing boundaries, non-claims, and the audited sequence.
- Add focused unit tests `veritas_os/tests/test_execution_intent_pre_bind_validation.py` covering success paths, tamper/refusal cases, typed-instance bypasses, schema acceptance/rejection, and a static import/side-effect boundary test.
- Preserve fail-closed behavior and explicitly prohibit creation of `BindReceipt`, TrustLog writes, Bind invocation, adapter calls, live-state/authority/runtime checks, and any new IDs or clock-based generation within this module.

### Testing

- Ran `ruff check veritas_os/policy/execution_intent_pre_bind_validation.py veritas_os/tests/test_execution_intent_pre_bind_validation.py`, which passed.
- Ran `python -m py_compile veritas_os/policy/execution_intent_pre_bind_validation.py` (Python 3.12.13 environment), which passed.
- Ran `git diff --check` / staged-diff checks, which passed.
- Focused pytest `pytest -q veritas_os/tests/test_execution_intent_pre_bind_validation.py` was not executed to completion in this environment because required dependencies (notably `pydantic`) were not available and dependency fetches were blocked by the environment network constraints; therefore the suite was not run here and GitHub CI was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a81dfbe9e808326bc4bf9201065232c)