### PR TITLE
feat(bind): add canonical bind preflight adjudication v1

### DIFF
--- a/docs/en/architecture/canonical-bind-preflight-adjudication-v1.md
+++ b/docs/en/architecture/canonical-bind-preflight-adjudication-v1.md
@@ -1,0 +1,34 @@
+# Canonical Bind Preflight Adjudication v1
+
+Canonical Bind Preflight Adjudication is a deterministic, local, side-effect-free
+check of an exact verified ExecutionIntent Pre-Bind Validation Packet. Pre-Bind
+Validation and Bind Preflight Adjudication are distinct artifacts: the latter
+re-verifies and preserves the former and its ExecutionIntent, but makes no new
+claim about authority.
+
+A verified adjudication is **not** execution authorization, Bind authorization or
+invocation, a BindReceipt, an adapter call, an external effect, or an operation
+commit. Verifying the ExecutionIntent hash is not a TrustLog write. Replay
+`semantic_match` is preserved (including `false`) and is not Authority Evidence
+or Human Approval. No live state, runtime risk, authority, constraint,
+postcondition, or rollback check occurs.
+
+## Sequence and stop boundary
+
+1. CDA
+2. Trust Link
+3. Replay Source/Evidence
+4. Replay Handoff Binding
+5. CanonicalDecisionHandoff validation
+6. Guarded Promotion Eligibility Packet
+7. ExecutionIntent Formation Readiness Packet
+8. Canonical ExecutionIntent Formation Packet
+9. ExecutionIntent Pre-Bind Validation Packet
+10. Canonical Bind Preflight Adjudication Packet
+11. **STOP**
+
+Actual Bind adjudication, adapter activity, BindReceipt creation, TrustLog writes,
+and operation commit are intentionally deferred to future explicit changes. The
+packet only says that its exact verified source is structurally ready to enter a
+future Bind adjudication boundary. It is not a production, customer, or
+regulatory certification.

--- a/schemas/canonical-bind-preflight-adjudication-v1.schema.json
+++ b/schemas/canonical-bind-preflight-adjudication-v1.schema.json
@@ -1,0 +1,3087 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://veritas-os.org/schemas/canonical-bind-preflight-adjudication-v1.schema.json",
+  "title": "Canonical Bind Preflight Adjudication Packet v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "format_version",
+    "bind_preflight_adjudication_id",
+    "bind_preflight_adjudication_hash",
+    "adjudication_mechanism",
+    "adjudicated_at",
+    "source_pre_bind_validation",
+    "source_pre_bind_validation_hash",
+    "source_pre_bind_validation_packet",
+    "source_formation_hash",
+    "source_readiness_hash",
+    "source_eligibility_hash",
+    "source_handoff_hash",
+    "trusted_validation_context_hash",
+    "validation_result_hash",
+    "mapping_value_digest",
+    "execution_intent_contract_version",
+    "execution_intent",
+    "execution_intent_id",
+    "execution_intent_hash",
+    "source_to_execution_intent_mapping",
+    "field_mapping_proof",
+    "required_field_presence",
+    "source_decision_identity",
+    "candidate_identity",
+    "evidence_lineage",
+    "replay_summary",
+    "bind_preflight_status",
+    "ready_for_bind_adjudication",
+    "fail_closed",
+    "local_adjudication_checks",
+    "bind_entry_requirements",
+    "scope_limitations"
+  ],
+  "properties": {
+    "format_version": {
+      "const": "canonical-bind-preflight-adjudication/v1"
+    },
+    "bind_preflight_adjudication_id": {
+      "type": "string",
+      "pattern": "^bpa:v1:sha256:[0-9a-f]{64}$"
+    },
+    "bind_preflight_adjudication_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "adjudication_mechanism": {
+      "const": "adjudicate_bind_preflight_locally/v1"
+    },
+    "adjudicated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "source_pre_bind_validation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "pre_bind_validation_id",
+        "pre_bind_validation_hash",
+        "format_version",
+        "validation_mechanism",
+        "checked_at",
+        "execution_intent_id",
+        "execution_intent_hash",
+        "pre_bind_status",
+        "ready_for_bind_preflight"
+      ],
+      "properties": {
+        "pre_bind_validation_id": {
+          "type": "string",
+          "pattern": "^eipbv:v1:sha256:[0-9a-f]{64}$"
+        },
+        "pre_bind_validation_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "format_version": {
+          "const": "canonical-execution-intent-pre-bind-validation/v1"
+        },
+        "validation_mechanism": {
+          "const": "validate_execution_intent_before_bind/v1"
+        },
+        "checked_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "execution_intent_id": {
+          "type": "string",
+          "pattern": "^ei:v1:sha256:[0-9a-f]{64}$"
+        },
+        "execution_intent_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "pre_bind_status": {
+          "const": "READY_FOR_BIND_PREFLIGHT"
+        },
+        "ready_for_bind_preflight": {
+          "const": true
+        }
+      }
+    },
+    "source_pre_bind_validation_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "source_pre_bind_validation_packet": {
+      "$ref": "#/$defs/pre_bind_validation_packet"
+    },
+    "source_formation_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "source_readiness_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "source_eligibility_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "source_handoff_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "trusted_validation_context_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "validation_result_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "mapping_value_digest": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "execution_intent_contract_version": {
+      "const": "execution-intent-contract/v1"
+    },
+    "execution_intent": {
+      "$ref": "#/$defs/execution_intent"
+    },
+    "execution_intent_id": {
+      "type": "string",
+      "pattern": "^ei:v1:sha256:[0-9a-f]{64}$"
+    },
+    "execution_intent_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "source_to_execution_intent_mapping": {
+      "$ref": "#/$defs/mapping"
+    },
+    "field_mapping_proof": {
+      "$ref": "#/$defs/mapping"
+    },
+    "required_field_presence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "execution_intent_id",
+        "decision_id",
+        "request_id",
+        "policy_snapshot_id",
+        "actor_identity",
+        "target_system",
+        "target_resource",
+        "intended_action",
+        "evidence_refs",
+        "decision_hash",
+        "decision_ts",
+        "ttl_seconds",
+        "expected_state_fingerprint",
+        "approval_context",
+        "policy_lineage"
+      ],
+      "properties": {
+        "execution_intent_id": {
+          "const": "intentionally_deferred"
+        },
+        "decision_id": {
+          "const": "mapped"
+        },
+        "request_id": {
+          "const": "mapped"
+        },
+        "policy_snapshot_id": {
+          "const": "mapped"
+        },
+        "actor_identity": {
+          "const": "mapped"
+        },
+        "target_system": {
+          "const": "mapped"
+        },
+        "target_resource": {
+          "const": "mapped"
+        },
+        "intended_action": {
+          "const": "mapped"
+        },
+        "evidence_refs": {
+          "const": "mapped"
+        },
+        "decision_hash": {
+          "const": "mapped"
+        },
+        "decision_ts": {
+          "const": "mapped"
+        },
+        "ttl_seconds": {
+          "const": "intentionally_deferred"
+        },
+        "expected_state_fingerprint": {
+          "const": "mapped"
+        },
+        "approval_context": {
+          "const": "mapped"
+        },
+        "policy_lineage": {
+          "const": "mapped"
+        }
+      }
+    },
+    "source_decision_identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "request_id",
+        "canonical_decision_id",
+        "canonical_decision_hash",
+        "canonical_decision_ts"
+      ],
+      "properties": {
+        "request_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "canonical_decision_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "canonical_decision_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "canonical_decision_ts": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "candidate_identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "candidate_id",
+        "candidate_hash",
+        "actor_identity",
+        "target_system",
+        "target_resource",
+        "action_contract_id",
+        "action_contract_version"
+      ],
+      "properties": {
+        "candidate_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "candidate_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "actor_identity": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_system": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_resource": {
+          "type": "string",
+          "minLength": 1
+        },
+        "action_contract_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "action_contract_version": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "evidence_lineage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "trustlog_artifact_ref",
+        "trustlog_chain_hash",
+        "replay_artifact_ref",
+        "replay_artifact_hash",
+        "authority_evidence_ref",
+        "authority_evidence_hash",
+        "human_approval_receipt_ref",
+        "human_approval_receipt_hash",
+        "policy_snapshot_id",
+        "policy_version",
+        "policy_semantic_digest",
+        "expected_state_fingerprint",
+        "expected_state_source_ref"
+      ],
+      "properties": {
+        "trustlog_artifact_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "trustlog_chain_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "replay_artifact_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "replay_artifact_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "authority_evidence_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "authority_evidence_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "human_approval_receipt_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "human_approval_receipt_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_snapshot_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_semantic_digest": {
+          "type": "string",
+          "minLength": 1
+        },
+        "expected_state_fingerprint": {
+          "type": "string",
+          "minLength": 1
+        },
+        "expected_state_source_ref": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "replay_summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "original_decision_id",
+        "replay_decision_id",
+        "original_request_id",
+        "replay_request_id",
+        "semantic_profile",
+        "semantic_match",
+        "fields_changed",
+        "severity",
+        "divergence_level"
+      ],
+      "properties": {
+        "original_decision_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "replay_decision_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "original_request_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "replay_request_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "semantic_profile": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "semantic_match": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "fields_changed": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "severity": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "divergence_level": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "bind_preflight_status": {
+      "const": "READY_FOR_BIND_ADJUDICATION"
+    },
+    "ready_for_bind_adjudication": {
+      "const": true
+    },
+    "fail_closed": {
+      "const": false
+    },
+    "local_adjudication_checks": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "pre_bind_validation_verified",
+        "execution_intent_hash_verified",
+        "execution_intent_id_verified",
+        "source_formation_verified",
+        "field_mapping_verified",
+        "required_field_presence_verified",
+        "evidence_refs_non_empty",
+        "decision_timestamp_timezone_aware",
+        "adjudicated_after_pre_bind_validation",
+        "ttl_locally_well_formed",
+        "no_bind_invocation",
+        "no_adapter_invocation",
+        "no_bind_receipt_created",
+        "no_trustlog_write",
+        "no_live_state_check",
+        "no_runtime_risk_check"
+      ],
+      "properties": {
+        "pre_bind_validation_verified": {
+          "const": true
+        },
+        "execution_intent_hash_verified": {
+          "const": true
+        },
+        "execution_intent_id_verified": {
+          "const": true
+        },
+        "source_formation_verified": {
+          "const": true
+        },
+        "field_mapping_verified": {
+          "const": true
+        },
+        "required_field_presence_verified": {
+          "const": true
+        },
+        "evidence_refs_non_empty": {
+          "const": true
+        },
+        "decision_timestamp_timezone_aware": {
+          "const": true
+        },
+        "adjudicated_after_pre_bind_validation": {
+          "const": true
+        },
+        "ttl_locally_well_formed": {
+          "const": true
+        },
+        "no_bind_invocation": {
+          "const": true
+        },
+        "no_adapter_invocation": {
+          "const": true
+        },
+        "no_bind_receipt_created": {
+          "const": true
+        },
+        "no_trustlog_write": {
+          "const": true
+        },
+        "no_live_state_check": {
+          "const": true
+        },
+        "no_runtime_risk_check": {
+          "const": true
+        }
+      }
+    },
+    "bind_entry_requirements": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "adapter_required",
+        "adapter_snapshot_required",
+        "adapter_authority_revalidation_required",
+        "adapter_constraint_validation_required",
+        "runtime_risk_assessment_required",
+        "commit_boundary_evaluation_required",
+        "postcondition_verification_required",
+        "rollback_or_revert_path_required",
+        "bind_receipt_required",
+        "trustlog_policy_required"
+      ],
+      "properties": {
+        "adapter_required": {
+          "const": true
+        },
+        "adapter_snapshot_required": {
+          "const": true
+        },
+        "adapter_authority_revalidation_required": {
+          "const": true
+        },
+        "adapter_constraint_validation_required": {
+          "const": true
+        },
+        "runtime_risk_assessment_required": {
+          "const": true
+        },
+        "commit_boundary_evaluation_required": {
+          "const": true
+        },
+        "postcondition_verification_required": {
+          "const": true
+        },
+        "rollback_or_revert_path_required": {
+          "const": true
+        },
+        "bind_receipt_required": {
+          "const": true
+        },
+        "trustlog_policy_required": {
+          "const": true
+        }
+      }
+    },
+    "scope_limitations": {
+      "type": "array",
+      "prefixItems": [
+        {
+          "const": "NOT_EXECUTION_AUTHORITY"
+        },
+        {
+          "const": "NOT_BIND_AUTHORIZATION"
+        },
+        {
+          "const": "NOT_BIND_RECEIPT"
+        },
+        {
+          "const": "NOT_BIND_INVOCATION"
+        },
+        {
+          "const": "NOT_ADAPTER_INVOCATION"
+        },
+        {
+          "const": "NOT_EXTERNAL_EFFECT"
+        },
+        {
+          "const": "NOT_OPERATION_COMMIT"
+        },
+        {
+          "const": "NOT_TRUSTLOG_WRITE"
+        },
+        {
+          "const": "NOT_LIVE_STATE_CHECK"
+        },
+        {
+          "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+        },
+        {
+          "const": "NOT_AUTHORITY_REVALIDATION"
+        },
+        {
+          "const": "NOT_CONSTRAINT_REVALIDATION"
+        },
+        {
+          "const": "NOT_POSTCONDITION_VERIFICATION"
+        },
+        {
+          "const": "NOT_ROLLBACK_PROOF"
+        },
+        {
+          "const": "NOT_AUTHORITY_EVIDENCE"
+        },
+        {
+          "const": "NOT_HUMAN_APPROVAL"
+        }
+      ],
+      "items": false,
+      "minItems": 16,
+      "maxItems": 16
+    }
+  },
+  "$defs": {
+    "execution_intent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "execution_intent_id",
+        "decision_id",
+        "request_id",
+        "policy_snapshot_id",
+        "actor_identity",
+        "target_system",
+        "target_resource",
+        "intended_action",
+        "evidence_refs",
+        "decision_hash",
+        "decision_ts",
+        "ttl_seconds",
+        "expected_state_fingerprint",
+        "approval_context",
+        "policy_lineage"
+      ],
+      "properties": {
+        "execution_intent_id": {
+          "type": "string",
+          "pattern": "^ei:v1:sha256:[0-9a-f]{64}$"
+        },
+        "decision_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "request_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_snapshot_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "actor_identity": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_system": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_resource": {
+          "type": "string",
+          "minLength": 1
+        },
+        "intended_action": {
+          "type": "string",
+          "minLength": 1
+        },
+        "evidence_refs": {
+          "type": "array",
+          "minItems": 5,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "decision_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "decision_ts": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "ttl_seconds": {
+          "type": "null"
+        },
+        "expected_state_fingerprint": {
+          "type": "string",
+          "minLength": 1
+        },
+        "approval_context": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "human_approval_receipt_ref",
+            "human_approval_receipt_hash"
+          ],
+          "properties": {
+            "human_approval_receipt_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "human_approval_receipt_hash": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "policy_lineage": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "policy_snapshot_id",
+            "policy_version",
+            "policy_semantic_digest"
+          ],
+          "properties": {
+            "policy_snapshot_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_version": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_semantic_digest": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    },
+    "mapping": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "decision_id",
+        "request_id",
+        "policy_snapshot_id",
+        "actor_identity",
+        "target_system",
+        "target_resource",
+        "intended_action",
+        "evidence_refs",
+        "decision_hash",
+        "decision_ts",
+        "ttl_seconds",
+        "expected_state_fingerprint",
+        "approval_context",
+        "policy_lineage"
+      ],
+      "properties": {
+        "decision_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "request_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_snapshot_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "actor_identity": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_system": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_resource": {
+          "type": "string",
+          "minLength": 1
+        },
+        "intended_action": {
+          "type": "string",
+          "minLength": 1
+        },
+        "evidence_refs": {
+          "type": "array",
+          "minItems": 5,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "decision_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "decision_ts": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "ttl_seconds": {
+          "type": "null"
+        },
+        "expected_state_fingerprint": {
+          "type": "string",
+          "minLength": 1
+        },
+        "approval_context": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "human_approval_receipt_ref",
+            "human_approval_receipt_hash"
+          ],
+          "properties": {
+            "human_approval_receipt_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "human_approval_receipt_hash": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "policy_lineage": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "policy_snapshot_id",
+            "policy_version",
+            "policy_semantic_digest"
+          ],
+          "properties": {
+            "policy_snapshot_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_version": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_semantic_digest": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    },
+    "formation_packet": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "format_version",
+        "formation_id",
+        "formation_hash",
+        "formation_mechanism",
+        "formed_at",
+        "source_readiness",
+        "source_readiness_hash",
+        "source_readiness_packet",
+        "source_eligibility_hash",
+        "source_handoff_hash",
+        "trusted_validation_context_hash",
+        "validation_result_hash",
+        "mapping_value_digest",
+        "execution_intent_contract_version",
+        "execution_intent",
+        "execution_intent_id",
+        "execution_intent_hash",
+        "source_to_execution_intent_mapping",
+        "field_mapping_proof",
+        "required_field_presence",
+        "source_decision_identity",
+        "candidate_identity",
+        "evidence_lineage",
+        "replay_summary",
+        "scope_limitations"
+      ],
+      "properties": {
+        "format_version": {
+          "const": "canonical-execution-intent-formation/v1"
+        },
+        "formation_id": {
+          "type": "string",
+          "pattern": "^eif:v1:sha256:[0-9a-f]{64}$"
+        },
+        "formation_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "formation_mechanism": {
+          "const": "build_execution_intent_from_readiness/v1"
+        },
+        "formed_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "source_readiness": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "readiness_id",
+            "readiness_hash",
+            "format_version",
+            "checked_at",
+            "formation_status",
+            "ready_for_execution_intent_formation"
+          ],
+          "properties": {
+            "readiness_id": {
+              "type": "string",
+              "pattern": "^eifr:v1:sha256:[0-9a-f]{64}$"
+            },
+            "readiness_hash": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "format_version": {
+              "const": "canonical-execution-intent-formation-readiness/v1"
+            },
+            "checked_at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "formation_status": {
+              "const": "READY_FOR_EXECUTION_INTENT_FORMATION"
+            },
+            "ready_for_execution_intent_formation": {
+              "const": true
+            }
+          }
+        },
+        "source_readiness_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_readiness_packet": {
+          "$ref": "#/$defs/readiness"
+        },
+        "source_eligibility_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_handoff_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "trusted_validation_context_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "validation_result_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "mapping_value_digest": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "execution_intent_contract_version": {
+          "const": "execution-intent-contract/v1"
+        },
+        "execution_intent": {
+          "$ref": "#/$defs/execution_intent"
+        },
+        "execution_intent_id": {
+          "type": "string",
+          "pattern": "^ei:v1:sha256:[0-9a-f]{64}$"
+        },
+        "execution_intent_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_to_execution_intent_mapping": {
+          "$ref": "#/$defs/mapping"
+        },
+        "field_mapping_proof": {
+          "$ref": "#/$defs/mapping"
+        },
+        "required_field_presence": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "execution_intent_id",
+            "decision_id",
+            "request_id",
+            "policy_snapshot_id",
+            "actor_identity",
+            "target_system",
+            "target_resource",
+            "intended_action",
+            "evidence_refs",
+            "decision_hash",
+            "decision_ts",
+            "ttl_seconds",
+            "expected_state_fingerprint",
+            "approval_context",
+            "policy_lineage"
+          ],
+          "properties": {
+            "execution_intent_id": {
+              "const": "intentionally_deferred"
+            },
+            "decision_id": {
+              "const": "mapped"
+            },
+            "request_id": {
+              "const": "mapped"
+            },
+            "policy_snapshot_id": {
+              "const": "mapped"
+            },
+            "actor_identity": {
+              "const": "mapped"
+            },
+            "target_system": {
+              "const": "mapped"
+            },
+            "target_resource": {
+              "const": "mapped"
+            },
+            "intended_action": {
+              "const": "mapped"
+            },
+            "evidence_refs": {
+              "const": "mapped"
+            },
+            "decision_hash": {
+              "const": "mapped"
+            },
+            "decision_ts": {
+              "const": "mapped"
+            },
+            "ttl_seconds": {
+              "const": "intentionally_deferred"
+            },
+            "expected_state_fingerprint": {
+              "const": "mapped"
+            },
+            "approval_context": {
+              "const": "mapped"
+            },
+            "policy_lineage": {
+              "const": "mapped"
+            }
+          }
+        },
+        "source_decision_identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "request_id",
+            "canonical_decision_id",
+            "canonical_decision_hash",
+            "canonical_decision_ts"
+          ],
+          "properties": {
+            "request_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "canonical_decision_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "canonical_decision_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "canonical_decision_ts": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "candidate_identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "candidate_id",
+            "candidate_hash",
+            "actor_identity",
+            "target_system",
+            "target_resource",
+            "action_contract_id",
+            "action_contract_version"
+          ],
+          "properties": {
+            "candidate_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "candidate_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "actor_identity": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target_system": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target_resource": {
+              "type": "string",
+              "minLength": 1
+            },
+            "action_contract_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "action_contract_version": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "evidence_lineage": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "trustlog_artifact_ref",
+            "trustlog_chain_hash",
+            "replay_artifact_ref",
+            "replay_artifact_hash",
+            "authority_evidence_ref",
+            "authority_evidence_hash",
+            "human_approval_receipt_ref",
+            "human_approval_receipt_hash",
+            "policy_snapshot_id",
+            "policy_version",
+            "policy_semantic_digest",
+            "expected_state_fingerprint",
+            "expected_state_source_ref"
+          ],
+          "properties": {
+            "trustlog_artifact_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "trustlog_chain_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "replay_artifact_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "replay_artifact_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "authority_evidence_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "authority_evidence_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "human_approval_receipt_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "human_approval_receipt_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_snapshot_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_version": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_semantic_digest": {
+              "type": "string",
+              "minLength": 1
+            },
+            "expected_state_fingerprint": {
+              "type": "string",
+              "minLength": 1
+            },
+            "expected_state_source_ref": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "replay_summary": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "original_decision_id",
+            "replay_decision_id",
+            "original_request_id",
+            "replay_request_id",
+            "semantic_profile",
+            "semantic_match",
+            "fields_changed",
+            "severity",
+            "divergence_level"
+          ],
+          "properties": {
+            "original_decision_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "replay_decision_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "original_request_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "replay_request_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "semantic_profile": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "semantic_match": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "fields_changed": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "severity": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "divergence_level": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        "scope_limitations": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "const": "NOT_EXECUTION_AUTHORITY"
+            },
+            {
+              "const": "NOT_BIND_AUTHORIZATION"
+            },
+            {
+              "const": "NOT_BIND_RECEIPT"
+            },
+            {
+              "const": "NOT_BIND_INVOCATION"
+            },
+            {
+              "const": "NOT_EXTERNAL_EFFECT"
+            },
+            {
+              "const": "NOT_ADAPTER_INVOCATION"
+            },
+            {
+              "const": "NOT_OPERATION_COMMIT"
+            },
+            {
+              "const": "NOT_TRUSTLOG_WRITE"
+            },
+            {
+              "const": "NOT_AUTHORITY_EVIDENCE"
+            },
+            {
+              "const": "NOT_HUMAN_APPROVAL"
+            }
+          ],
+          "items": false,
+          "minItems": 10,
+          "maxItems": 10
+        }
+      }
+    },
+    "readiness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "format_version",
+        "readiness_id",
+        "readiness_hash",
+        "verification_mechanism",
+        "checked_at",
+        "source_eligibility",
+        "source_eligibility_hash",
+        "source_eligibility_packet",
+        "source_handoff_hash",
+        "trusted_validation_context_hash",
+        "validation_result_hash",
+        "formation_status",
+        "ready_for_execution_intent_formation",
+        "fail_closed",
+        "execution_intent_contract_version",
+        "execution_intent_required_fields",
+        "source_to_execution_intent_mapping",
+        "mapping_value_digest",
+        "required_field_presence",
+        "source_decision_identity",
+        "candidate_identity",
+        "evidence_lineage",
+        "replay_summary",
+        "scope_limitations"
+      ],
+      "properties": {
+        "format_version": {
+          "const": "canonical-execution-intent-formation-readiness/v1"
+        },
+        "readiness_id": {
+          "type": "string",
+          "pattern": "^eifr:v1:sha256:[0-9a-f]{64}$"
+        },
+        "readiness_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "verification_mechanism": {
+          "const": "verify_guarded_promotion_eligibility_packet/v1"
+        },
+        "checked_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "source_eligibility": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "eligibility_id",
+            "eligibility_hash",
+            "format_version",
+            "validation_mechanism",
+            "handoff_validator_version",
+            "issued_at",
+            "evaluated_at"
+          ],
+          "properties": {
+            "eligibility_id": {
+              "type": "string",
+              "pattern": "^gpe:v1:sha256:[0-9a-f]{64}$"
+            },
+            "eligibility_hash": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "format_version": {
+              "const": "canonical-guarded-promotion-eligibility-packet/v1"
+            },
+            "validation_mechanism": {
+              "const": "validate_canonical_decision_handoff/v1"
+            },
+            "handoff_validator_version": {
+              "type": "string",
+              "minLength": 1
+            },
+            "issued_at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "evaluated_at": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "source_eligibility_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_eligibility_packet": {
+          "$ref": "#/$defs/eligibility"
+        },
+        "source_handoff_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "trusted_validation_context_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "validation_result_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "formation_status": {
+          "const": "READY_FOR_EXECUTION_INTENT_FORMATION"
+        },
+        "ready_for_execution_intent_formation": {
+          "const": true
+        },
+        "fail_closed": {
+          "const": false
+        },
+        "execution_intent_contract_version": {
+          "const": "execution-intent-contract/v1"
+        },
+        "execution_intent_required_fields": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "const": "execution_intent_id"
+            },
+            {
+              "const": "decision_id"
+            },
+            {
+              "const": "request_id"
+            },
+            {
+              "const": "policy_snapshot_id"
+            },
+            {
+              "const": "actor_identity"
+            },
+            {
+              "const": "target_system"
+            },
+            {
+              "const": "target_resource"
+            },
+            {
+              "const": "intended_action"
+            },
+            {
+              "const": "evidence_refs"
+            },
+            {
+              "const": "decision_hash"
+            },
+            {
+              "const": "decision_ts"
+            },
+            {
+              "const": "ttl_seconds"
+            },
+            {
+              "const": "expected_state_fingerprint"
+            },
+            {
+              "const": "approval_context"
+            },
+            {
+              "const": "policy_lineage"
+            }
+          ],
+          "items": false,
+          "minItems": 15,
+          "maxItems": 15
+        },
+        "source_to_execution_intent_mapping": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "decision_id",
+            "request_id",
+            "policy_snapshot_id",
+            "actor_identity",
+            "target_system",
+            "target_resource",
+            "intended_action",
+            "evidence_refs",
+            "decision_hash",
+            "decision_ts",
+            "ttl_seconds",
+            "expected_state_fingerprint",
+            "approval_context",
+            "policy_lineage"
+          ],
+          "properties": {
+            "decision_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "request_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_snapshot_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "actor_identity": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target_system": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target_resource": {
+              "type": "string",
+              "minLength": 1
+            },
+            "intended_action": {
+              "type": "string",
+              "minLength": 1
+            },
+            "evidence_refs": {
+              "type": "array",
+              "minItems": 5,
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "decision_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "decision_ts": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "ttl_seconds": {
+              "type": "null"
+            },
+            "expected_state_fingerprint": {
+              "type": "string",
+              "minLength": 1
+            },
+            "approval_context": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "human_approval_receipt_ref",
+                "human_approval_receipt_hash"
+              ],
+              "properties": {
+                "human_approval_receipt_ref": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "human_approval_receipt_hash": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            },
+            "policy_lineage": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "policy_snapshot_id",
+                "policy_version",
+                "policy_semantic_digest"
+              ],
+              "properties": {
+                "policy_snapshot_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "policy_version": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "policy_semantic_digest": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            }
+          }
+        },
+        "mapping_value_digest": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "required_field_presence": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "execution_intent_id",
+            "decision_id",
+            "request_id",
+            "policy_snapshot_id",
+            "actor_identity",
+            "target_system",
+            "target_resource",
+            "intended_action",
+            "evidence_refs",
+            "decision_hash",
+            "decision_ts",
+            "ttl_seconds",
+            "expected_state_fingerprint",
+            "approval_context",
+            "policy_lineage"
+          ],
+          "properties": {
+            "execution_intent_id": {
+              "const": "intentionally_deferred"
+            },
+            "decision_id": {
+              "const": "mapped"
+            },
+            "request_id": {
+              "const": "mapped"
+            },
+            "policy_snapshot_id": {
+              "const": "mapped"
+            },
+            "actor_identity": {
+              "const": "mapped"
+            },
+            "target_system": {
+              "const": "mapped"
+            },
+            "target_resource": {
+              "const": "mapped"
+            },
+            "intended_action": {
+              "const": "mapped"
+            },
+            "evidence_refs": {
+              "const": "mapped"
+            },
+            "decision_hash": {
+              "const": "mapped"
+            },
+            "decision_ts": {
+              "const": "mapped"
+            },
+            "ttl_seconds": {
+              "const": "intentionally_deferred"
+            },
+            "expected_state_fingerprint": {
+              "const": "mapped"
+            },
+            "approval_context": {
+              "const": "mapped"
+            },
+            "policy_lineage": {
+              "const": "mapped"
+            }
+          }
+        },
+        "source_decision_identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "request_id",
+            "canonical_decision_id",
+            "canonical_decision_hash",
+            "canonical_decision_ts"
+          ],
+          "properties": {
+            "request_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "canonical_decision_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "canonical_decision_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "canonical_decision_ts": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "candidate_identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "candidate_id",
+            "candidate_hash",
+            "actor_identity",
+            "target_system",
+            "target_resource",
+            "action_contract_id",
+            "action_contract_version"
+          ],
+          "properties": {
+            "candidate_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "candidate_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "actor_identity": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target_system": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target_resource": {
+              "type": "string",
+              "minLength": 1
+            },
+            "action_contract_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "action_contract_version": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "evidence_lineage": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "trustlog_artifact_ref",
+            "trustlog_chain_hash",
+            "replay_artifact_ref",
+            "replay_artifact_hash",
+            "authority_evidence_ref",
+            "authority_evidence_hash",
+            "human_approval_receipt_ref",
+            "human_approval_receipt_hash",
+            "policy_snapshot_id",
+            "policy_version",
+            "policy_semantic_digest",
+            "expected_state_fingerprint",
+            "expected_state_source_ref"
+          ],
+          "properties": {
+            "trustlog_artifact_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "trustlog_chain_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "replay_artifact_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "replay_artifact_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "authority_evidence_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "authority_evidence_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "human_approval_receipt_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "human_approval_receipt_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_snapshot_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_version": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_semantic_digest": {
+              "type": "string",
+              "minLength": 1
+            },
+            "expected_state_fingerprint": {
+              "type": "string",
+              "minLength": 1
+            },
+            "expected_state_source_ref": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "replay_summary": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "original_decision_id",
+            "replay_decision_id",
+            "original_request_id",
+            "replay_request_id",
+            "semantic_profile",
+            "semantic_match",
+            "fields_changed",
+            "severity",
+            "divergence_level"
+          ],
+          "properties": {
+            "original_decision_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "replay_decision_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "original_request_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "replay_request_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "semantic_profile": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "semantic_match": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "fields_changed": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "severity": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "divergence_level": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        "scope_limitations": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "const": "NOT_EXECUTION_INTENT"
+            },
+            {
+              "const": "NOT_EXECUTION_AUTHORITY"
+            },
+            {
+              "const": "NOT_BIND_AUTHORIZATION"
+            },
+            {
+              "const": "NOT_BIND_RECEIPT"
+            },
+            {
+              "const": "NOT_EXTERNAL_EFFECT"
+            },
+            {
+              "const": "NOT_ADAPTER_INVOCATION"
+            },
+            {
+              "const": "NOT_OPERATION_COMMIT"
+            },
+            {
+              "const": "NOT_TRUSTLOG_WRITE"
+            }
+          ],
+          "items": false,
+          "minItems": 8,
+          "maxItems": 8
+        }
+      }
+    },
+    "eligibility": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "format_version",
+        "eligibility_id",
+        "eligibility_hash",
+        "validation_mechanism",
+        "handoff_validator_version",
+        "issued_at",
+        "evaluated_at",
+        "validation_status",
+        "ready_for_guarded_promotion",
+        "fail_closed",
+        "source_handoff",
+        "source_handoff_hash",
+        "trusted_validation_context",
+        "trusted_validation_context_hash",
+        "validation_result",
+        "validation_result_hash",
+        "verified_provenance_paths",
+        "source_decision_identity",
+        "candidate_identity",
+        "evidence_lineage",
+        "replay_summary",
+        "scope_limitations"
+      ],
+      "properties": {
+        "format_version": {
+          "const": "canonical-guarded-promotion-eligibility-packet/v1"
+        },
+        "eligibility_id": {
+          "type": "string",
+          "pattern": "^gpe:v1:sha256:[0-9a-f]{64}$"
+        },
+        "eligibility_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "validation_mechanism": {
+          "const": "validate_canonical_decision_handoff/v1"
+        },
+        "handoff_validator_version": {
+          "type": "string"
+        },
+        "issued_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "evaluated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "validation_status": {
+          "const": "READY_FOR_GUARDED_PROMOTION"
+        },
+        "ready_for_guarded_promotion": {
+          "const": true
+        },
+        "fail_closed": {
+          "const": false
+        },
+        "source_handoff": {
+          "type": "object"
+        },
+        "source_handoff_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "trusted_validation_context": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "value_assertions",
+            "candidate_hash_binding",
+            "authority_requirement_binding"
+          ],
+          "properties": {
+            "value_assertions": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/valueAssertion"
+              }
+            },
+            "candidate_hash_binding": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/candidateBinding"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "authority_requirement_binding": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/authorityBinding"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        },
+        "trusted_validation_context_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "validation_result": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "status",
+            "reason_codes",
+            "structure_valid",
+            "declared_status",
+            "declared_status_matches",
+            "declared_reason_codes",
+            "declared_reason_codes_match",
+            "verified_provenance_paths",
+            "validation_version",
+            "ready_for_guarded_promotion",
+            "fail_closed",
+            "requires_review"
+          ],
+          "properties": {
+            "status": {
+              "const": "READY_FOR_GUARDED_PROMOTION"
+            },
+            "reason_codes": {
+              "const": []
+            },
+            "structure_valid": {
+              "const": true
+            },
+            "declared_status": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "declared_status_matches": {
+              "type": "boolean"
+            },
+            "declared_reason_codes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "declared_reason_codes_match": {
+              "type": "boolean"
+            },
+            "verified_provenance_paths": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "validation_version": {
+              "type": "string"
+            },
+            "ready_for_guarded_promotion": {
+              "const": true
+            },
+            "fail_closed": {
+              "const": false
+            },
+            "requires_review": {
+              "const": false
+            }
+          }
+        },
+        "validation_result_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "verified_provenance_paths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source_decision_identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "request_id",
+            "canonical_decision_id",
+            "canonical_decision_hash",
+            "canonical_decision_ts"
+          ],
+          "properties": {
+            "request_id": {
+              "type": "string"
+            },
+            "canonical_decision_id": {
+              "type": "string"
+            },
+            "canonical_decision_hash": {
+              "type": "string"
+            },
+            "canonical_decision_ts": {
+              "type": "string"
+            }
+          }
+        },
+        "candidate_identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "candidate_id",
+            "candidate_hash",
+            "actor_identity",
+            "target_system",
+            "target_resource",
+            "action_contract_id",
+            "action_contract_version"
+          ],
+          "properties": {
+            "candidate_id": {
+              "type": "string"
+            },
+            "candidate_hash": {
+              "type": "string"
+            },
+            "actor_identity": {
+              "type": "string"
+            },
+            "target_system": {
+              "type": "string"
+            },
+            "target_resource": {
+              "type": "string"
+            },
+            "action_contract_id": {
+              "type": "string"
+            },
+            "action_contract_version": {
+              "type": "string"
+            }
+          }
+        },
+        "evidence_lineage": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "trustlog_artifact_ref",
+            "trustlog_chain_hash",
+            "replay_artifact_ref",
+            "replay_artifact_hash",
+            "authority_evidence_ref",
+            "authority_evidence_hash",
+            "human_approval_receipt_ref",
+            "human_approval_receipt_hash",
+            "policy_snapshot_id",
+            "policy_version",
+            "policy_semantic_digest",
+            "expected_state_fingerprint",
+            "expected_state_source_ref"
+          ],
+          "properties": {
+            "trustlog_artifact_ref": {
+              "type": "string"
+            },
+            "trustlog_chain_hash": {
+              "type": "string"
+            },
+            "replay_artifact_ref": {
+              "type": "string"
+            },
+            "replay_artifact_hash": {
+              "type": "string"
+            },
+            "authority_evidence_ref": {
+              "type": "string"
+            },
+            "authority_evidence_hash": {
+              "type": "string"
+            },
+            "human_approval_receipt_ref": {
+              "type": "string"
+            },
+            "human_approval_receipt_hash": {
+              "type": "string"
+            },
+            "policy_snapshot_id": {
+              "type": "string"
+            },
+            "policy_version": {
+              "type": "string"
+            },
+            "policy_semantic_digest": {
+              "type": "string"
+            },
+            "expected_state_fingerprint": {
+              "type": "string"
+            },
+            "expected_state_source_ref": {
+              "type": "string"
+            }
+          }
+        },
+        "replay_summary": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "original_decision_id",
+            "replay_decision_id",
+            "original_request_id",
+            "replay_request_id",
+            "semantic_profile",
+            "semantic_match",
+            "fields_changed",
+            "severity",
+            "divergence_level"
+          ],
+          "properties": {
+            "original_decision_id": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "replay_decision_id": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "original_request_id": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "replay_request_id": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "semantic_profile": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "semantic_match": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "fields_changed": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "severity": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "divergence_level": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        },
+        "scope_limitations": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "const": "NOT_EXECUTION_AUTHORITY"
+            },
+            {
+              "const": "NOT_EXECUTION_INTENT"
+            },
+            {
+              "const": "NOT_BIND_AUTHORIZATION"
+            },
+            {
+              "const": "NOT_BIND_RECEIPT"
+            },
+            {
+              "const": "NOT_EXTERNAL_EFFECT"
+            },
+            {
+              "const": "NOT_AUTHORITY_EVIDENCE"
+            },
+            {
+              "const": "NOT_HUMAN_APPROVAL"
+            },
+            {
+              "const": "NOT_TRUSTLOG_SUBSTITUTE"
+            }
+          ],
+          "items": false,
+          "minItems": 8,
+          "maxItems": 8
+        }
+      }
+    },
+    "valueAssertion": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "field_path",
+        "value_digest",
+        "verification_mechanism",
+        "source_artifact_ref",
+        "source_hash",
+        "verified_at",
+        "claims"
+      ],
+      "properties": {
+        "field_path": {
+          "type": "string"
+        },
+        "value_digest": {
+          "type": "string"
+        },
+        "verification_mechanism": {
+          "type": "string"
+        },
+        "source_artifact_ref": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "source_hash": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "verified_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "claims": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "candidateBinding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "candidate_value_digest",
+        "asserted_candidate_hash",
+        "candidate_hash_profile",
+        "verification_mechanism",
+        "claim",
+        "source_artifact_ref",
+        "source_hash",
+        "verified_at"
+      ],
+      "properties": {
+        "candidate_value_digest": {
+          "type": "string"
+        },
+        "asserted_candidate_hash": {
+          "type": "string"
+        },
+        "candidate_hash_profile": {
+          "type": "string"
+        },
+        "verification_mechanism": {
+          "type": "string"
+        },
+        "claim": {
+          "type": "string"
+        },
+        "source_artifact_ref": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "source_hash": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "verified_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "authorityBinding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "authority_requirement_value_digest",
+        "authority_evidence_value_digest",
+        "verification_mechanism",
+        "claim",
+        "source_artifact_ref",
+        "source_hash",
+        "verified_at"
+      ],
+      "properties": {
+        "authority_requirement_value_digest": {
+          "type": "string"
+        },
+        "authority_evidence_value_digest": {
+          "type": "string"
+        },
+        "verification_mechanism": {
+          "type": "string"
+        },
+        "claim": {
+          "type": "string"
+        },
+        "source_artifact_ref": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "source_hash": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "verified_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "pre_bind_validation_packet": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "format_version",
+        "pre_bind_validation_id",
+        "pre_bind_validation_hash",
+        "validation_mechanism",
+        "checked_at",
+        "source_formation",
+        "source_formation_hash",
+        "source_formation_packet",
+        "source_readiness_hash",
+        "source_eligibility_hash",
+        "source_handoff_hash",
+        "trusted_validation_context_hash",
+        "validation_result_hash",
+        "mapping_value_digest",
+        "execution_intent_contract_version",
+        "execution_intent",
+        "execution_intent_id",
+        "execution_intent_hash",
+        "source_to_execution_intent_mapping",
+        "field_mapping_proof",
+        "required_field_presence",
+        "source_decision_identity",
+        "candidate_identity",
+        "evidence_lineage",
+        "replay_summary",
+        "pre_bind_status",
+        "ready_for_bind_preflight",
+        "fail_closed",
+        "local_validation_checks",
+        "scope_limitations"
+      ],
+      "properties": {
+        "format_version": {
+          "const": "canonical-execution-intent-pre-bind-validation/v1"
+        },
+        "pre_bind_validation_id": {
+          "type": "string",
+          "pattern": "^eipbv:v1:sha256:[0-9a-f]{64}$"
+        },
+        "pre_bind_validation_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "validation_mechanism": {
+          "const": "validate_execution_intent_before_bind/v1"
+        },
+        "checked_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "source_formation": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "formation_id",
+            "formation_hash",
+            "format_version",
+            "formation_mechanism",
+            "formed_at",
+            "execution_intent_id",
+            "execution_intent_hash"
+          ],
+          "properties": {
+            "formation_id": {
+              "type": "string",
+              "pattern": "^eif:v1:sha256:[0-9a-f]{64}$"
+            },
+            "formation_hash": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "format_version": {
+              "const": "canonical-execution-intent-formation/v1"
+            },
+            "formation_mechanism": {
+              "const": "build_execution_intent_from_readiness/v1"
+            },
+            "formed_at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "execution_intent_id": {
+              "type": "string",
+              "pattern": "^ei:v1:sha256:[0-9a-f]{64}$"
+            },
+            "execution_intent_hash": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            }
+          }
+        },
+        "source_formation_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_formation_packet": {
+          "$ref": "#/$defs/formation_packet"
+        },
+        "source_readiness_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_eligibility_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_handoff_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "trusted_validation_context_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "validation_result_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "mapping_value_digest": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "execution_intent_contract_version": {
+          "const": "execution-intent-contract/v1"
+        },
+        "execution_intent": {
+          "$ref": "#/$defs/execution_intent"
+        },
+        "execution_intent_id": {
+          "type": "string",
+          "pattern": "^ei:v1:sha256:[0-9a-f]{64}$"
+        },
+        "execution_intent_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_to_execution_intent_mapping": {
+          "$ref": "#/$defs/mapping"
+        },
+        "field_mapping_proof": {
+          "$ref": "#/$defs/mapping"
+        },
+        "required_field_presence": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "execution_intent_id",
+            "decision_id",
+            "request_id",
+            "policy_snapshot_id",
+            "actor_identity",
+            "target_system",
+            "target_resource",
+            "intended_action",
+            "evidence_refs",
+            "decision_hash",
+            "decision_ts",
+            "ttl_seconds",
+            "expected_state_fingerprint",
+            "approval_context",
+            "policy_lineage"
+          ],
+          "properties": {
+            "execution_intent_id": {
+              "const": "intentionally_deferred"
+            },
+            "decision_id": {
+              "const": "mapped"
+            },
+            "request_id": {
+              "const": "mapped"
+            },
+            "policy_snapshot_id": {
+              "const": "mapped"
+            },
+            "actor_identity": {
+              "const": "mapped"
+            },
+            "target_system": {
+              "const": "mapped"
+            },
+            "target_resource": {
+              "const": "mapped"
+            },
+            "intended_action": {
+              "const": "mapped"
+            },
+            "evidence_refs": {
+              "const": "mapped"
+            },
+            "decision_hash": {
+              "const": "mapped"
+            },
+            "decision_ts": {
+              "const": "mapped"
+            },
+            "ttl_seconds": {
+              "const": "intentionally_deferred"
+            },
+            "expected_state_fingerprint": {
+              "const": "mapped"
+            },
+            "approval_context": {
+              "const": "mapped"
+            },
+            "policy_lineage": {
+              "const": "mapped"
+            }
+          }
+        },
+        "source_decision_identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "request_id",
+            "canonical_decision_id",
+            "canonical_decision_hash",
+            "canonical_decision_ts"
+          ],
+          "properties": {
+            "request_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "canonical_decision_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "canonical_decision_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "canonical_decision_ts": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "candidate_identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "candidate_id",
+            "candidate_hash",
+            "actor_identity",
+            "target_system",
+            "target_resource",
+            "action_contract_id",
+            "action_contract_version"
+          ],
+          "properties": {
+            "candidate_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "candidate_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "actor_identity": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target_system": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target_resource": {
+              "type": "string",
+              "minLength": 1
+            },
+            "action_contract_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "action_contract_version": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "evidence_lineage": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "trustlog_artifact_ref",
+            "trustlog_chain_hash",
+            "replay_artifact_ref",
+            "replay_artifact_hash",
+            "authority_evidence_ref",
+            "authority_evidence_hash",
+            "human_approval_receipt_ref",
+            "human_approval_receipt_hash",
+            "policy_snapshot_id",
+            "policy_version",
+            "policy_semantic_digest",
+            "expected_state_fingerprint",
+            "expected_state_source_ref"
+          ],
+          "properties": {
+            "trustlog_artifact_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "trustlog_chain_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "replay_artifact_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "replay_artifact_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "authority_evidence_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "authority_evidence_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "human_approval_receipt_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "human_approval_receipt_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_snapshot_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_version": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_semantic_digest": {
+              "type": "string",
+              "minLength": 1
+            },
+            "expected_state_fingerprint": {
+              "type": "string",
+              "minLength": 1
+            },
+            "expected_state_source_ref": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "replay_summary": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "original_decision_id",
+            "replay_decision_id",
+            "original_request_id",
+            "replay_request_id",
+            "semantic_profile",
+            "semantic_match",
+            "fields_changed",
+            "severity",
+            "divergence_level"
+          ],
+          "properties": {
+            "original_decision_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "replay_decision_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "original_request_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "replay_request_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "semantic_profile": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "semantic_match": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "fields_changed": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "severity": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "divergence_level": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        "pre_bind_status": {
+          "const": "READY_FOR_BIND_PREFLIGHT"
+        },
+        "ready_for_bind_preflight": {
+          "const": true
+        },
+        "fail_closed": {
+          "const": false
+        },
+        "local_validation_checks": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "formation_verified",
+            "execution_intent_hash_verified",
+            "execution_intent_id_verified",
+            "field_mapping_verified",
+            "required_field_presence_verified",
+            "evidence_refs_non_empty",
+            "decision_timestamp_timezone_aware",
+            "checked_after_formation",
+            "no_bind_invocation",
+            "no_trustlog_write"
+          ],
+          "properties": {
+            "formation_verified": {
+              "const": true
+            },
+            "execution_intent_hash_verified": {
+              "const": true
+            },
+            "execution_intent_id_verified": {
+              "const": true
+            },
+            "field_mapping_verified": {
+              "const": true
+            },
+            "required_field_presence_verified": {
+              "const": true
+            },
+            "evidence_refs_non_empty": {
+              "const": true
+            },
+            "decision_timestamp_timezone_aware": {
+              "const": true
+            },
+            "checked_after_formation": {
+              "const": true
+            },
+            "no_bind_invocation": {
+              "const": true
+            },
+            "no_trustlog_write": {
+              "const": true
+            }
+          }
+        },
+        "scope_limitations": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "const": "NOT_EXECUTION_AUTHORITY"
+            },
+            {
+              "const": "NOT_BIND_AUTHORIZATION"
+            },
+            {
+              "const": "NOT_BIND_RECEIPT"
+            },
+            {
+              "const": "NOT_BIND_INVOCATION"
+            },
+            {
+              "const": "NOT_ADAPTER_INVOCATION"
+            },
+            {
+              "const": "NOT_EXTERNAL_EFFECT"
+            },
+            {
+              "const": "NOT_OPERATION_COMMIT"
+            },
+            {
+              "const": "NOT_TRUSTLOG_WRITE"
+            },
+            {
+              "const": "NOT_LIVE_STATE_CHECK"
+            },
+            {
+              "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+            },
+            {
+              "const": "NOT_AUTHORITY_EVIDENCE"
+            },
+            {
+              "const": "NOT_HUMAN_APPROVAL"
+            }
+          ],
+          "items": false,
+          "minItems": 12,
+          "maxItems": 12
+        }
+      }
+    }
+  }
+}

--- a/veritas_os/policy/canonical_bind_preflight_adjudication.py
+++ b/veritas_os/policy/canonical_bind_preflight_adjudication.py
@@ -1,0 +1,300 @@
+"""Adjudicate deterministic local readiness for a future Bind boundary.
+
+This module verifies and preserves an exact pre-bind validation packet.  It
+does not authorize execution, invoke Bind, contact an adapter, or write an
+audit record.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from veritas_os.policy.bind_artifacts import (
+    ExecutionIntent,
+    canonical_execution_intent_json,
+    hash_execution_intent,
+)
+from veritas_os.policy.canonical_execution_intent_formation import (
+    EXECUTION_INTENT_FIELDS,
+)
+from veritas_os.policy.execution_intent_pre_bind_validation import (
+    CanonicalExecutionIntentPreBindValidationPacket,
+    ExecutionIntentPreBindValidationError,
+    verify_execution_intent_pre_bind_validation_packet,
+)
+
+FORMAT_VERSION = "canonical-bind-preflight-adjudication/v1"
+ADJUDICATION_MECHANISM = "adjudicate_bind_preflight_locally/v1"
+LOCAL_CHECKS_DOMAIN = "veritas.bind-preflight-adjudication.local-checks/v1"
+ENTRY_REQUIREMENTS_DOMAIN = (
+    "veritas.bind-preflight-adjudication.entry-requirements/v1"
+)
+PACKET_DOMAIN = "veritas.bind-preflight-adjudication.packet/v1"
+LOCAL_ADJUDICATION_CHECKS = {
+    "pre_bind_validation_verified": True,
+    "execution_intent_hash_verified": True,
+    "execution_intent_id_verified": True,
+    "source_formation_verified": True,
+    "field_mapping_verified": True,
+    "required_field_presence_verified": True,
+    "evidence_refs_non_empty": True,
+    "decision_timestamp_timezone_aware": True,
+    "adjudicated_after_pre_bind_validation": True,
+    "ttl_locally_well_formed": True,
+    "no_bind_invocation": True,
+    "no_adapter_invocation": True,
+    "no_bind_receipt_created": True,
+    "no_trustlog_write": True,
+    "no_live_state_check": True,
+    "no_runtime_risk_check": True,
+}
+BIND_ENTRY_REQUIREMENTS = {
+    key: True for key in (
+        "adapter_required", "adapter_snapshot_required",
+        "adapter_authority_revalidation_required",
+        "adapter_constraint_validation_required",
+        "runtime_risk_assessment_required",
+        "commit_boundary_evaluation_required",
+        "postcondition_verification_required",
+        "rollback_or_revert_path_required", "bind_receipt_required",
+        "trustlog_policy_required",
+    )
+}
+SCOPE_LIMITATIONS = (
+    "NOT_EXECUTION_AUTHORITY", "NOT_BIND_AUTHORIZATION", "NOT_BIND_RECEIPT",
+    "NOT_BIND_INVOCATION", "NOT_ADAPTER_INVOCATION", "NOT_EXTERNAL_EFFECT",
+    "NOT_OPERATION_COMMIT", "NOT_TRUSTLOG_WRITE", "NOT_LIVE_STATE_CHECK",
+    "NOT_RUNTIME_RISK_ACCEPTANCE", "NOT_AUTHORITY_REVALIDATION",
+    "NOT_CONSTRAINT_REVALIDATION", "NOT_POSTCONDITION_VERIFICATION",
+    "NOT_ROLLBACK_PROOF", "NOT_AUTHORITY_EVIDENCE", "NOT_HUMAN_APPROVAL",
+)
+
+
+class BindPreflightAdjudicationError(ValueError):
+    """Stable fail-closed local adjudication refusal."""
+
+
+class CanonicalBindPreflightAdjudicationPacket(BaseModel):
+    """Immutable proof of local structural readiness, not authorization."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    format_version: Literal["canonical-bind-preflight-adjudication/v1"]
+    bind_preflight_adjudication_id: str = Field(
+        pattern=r"^bpa:v1:sha256:[0-9a-f]{64}$"
+    )
+    bind_preflight_adjudication_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    adjudication_mechanism: Literal["adjudicate_bind_preflight_locally/v1"]
+    adjudicated_at: str
+    source_pre_bind_validation: dict[str, Any]
+    source_pre_bind_validation_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    source_pre_bind_validation_packet: dict[str, Any]
+    source_formation_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    source_readiness_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    source_eligibility_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    source_handoff_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    trusted_validation_context_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    validation_result_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    mapping_value_digest: str = Field(pattern=r"^[0-9a-f]{64}$")
+    execution_intent_contract_version: str
+    execution_intent: dict[str, Any]
+    execution_intent_id: str = Field(pattern=r"^ei:v1:sha256:[0-9a-f]{64}$")
+    execution_intent_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    bind_preflight_status: Literal["READY_FOR_BIND_ADJUDICATION"]
+    ready_for_bind_adjudication: Literal[True]
+    fail_closed: Literal[False]
+    local_adjudication_checks: dict[str, bool]
+    bind_entry_requirements: dict[str, bool]
+    source_to_execution_intent_mapping: dict[str, Any]
+    field_mapping_proof: dict[str, Any]
+    required_field_presence: dict[str, str]
+    source_decision_identity: dict[str, Any]
+    candidate_identity: dict[str, Any]
+    evidence_lineage: dict[str, Any]
+    replay_summary: dict[str, Any]
+    scope_limitations: tuple[str, ...]
+
+
+def _json_value(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        value = value.model_dump(mode="python")
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        if value != value or value in (float("inf"), float("-inf")):
+            raise BindPreflightAdjudicationError("BPA_PACKET_INVALID")
+        return value
+    if isinstance(value, datetime):
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise BindPreflightAdjudicationError("BPA_ADJUDICATED_AT_INVALID")
+        return value.isoformat()
+    if isinstance(value, (list, tuple)):
+        return [_json_value(item) for item in value]
+    if isinstance(value, dict) and all(isinstance(key, str) for key in value):
+        return {key: _json_value(item) for key, item in value.items()}
+    raise BindPreflightAdjudicationError("BPA_PACKET_INVALID")
+
+
+def _aware_iso(value: Any, code: str) -> datetime:
+    try:
+        parsed = value if isinstance(value, datetime) else datetime.fromisoformat(value)
+    except (TypeError, ValueError) as exc:
+        raise BindPreflightAdjudicationError(code) from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise BindPreflightAdjudicationError(code)
+    return parsed
+
+
+def _digest(domain: str, value: Any) -> str:
+    encoded = json.dumps(
+        {"domain": domain, "value": _json_value(value)}, allow_nan=False,
+        ensure_ascii=False, separators=(",", ":"), sort_keys=True,
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _packet_hash(raw: dict[str, Any]) -> str:
+    return _digest(PACKET_DOMAIN, {key: value for key, value in raw.items() if key not in {
+        "bind_preflight_adjudication_id", "bind_preflight_adjudication_hash"
+    }})
+
+
+def _verified_pre_bind(value: Any) -> CanonicalExecutionIntentPreBindValidationPacket:
+    try:
+        packet = verify_execution_intent_pre_bind_validation_packet(value)
+    except (ExecutionIntentPreBindValidationError, TypeError, ValueError) as exc:
+        raise BindPreflightAdjudicationError(
+            "BPA_PRE_BIND_VALIDATION_INVALID"
+        ) from exc
+    return packet
+
+
+def _intent(raw: dict[str, Any]) -> ExecutionIntent:
+    if set(raw) != {"execution_intent_id", *EXECUTION_INTENT_FIELDS}:
+        raise BindPreflightAdjudicationError("BPA_EXECUTION_INTENT_FIELD_MISMATCH")
+    refs, ttl = raw.get("evidence_refs"), raw.get("ttl_seconds")
+    if not isinstance(refs, list) or not refs or any(
+        not isinstance(ref, str) or not ref.strip() for ref in refs
+    ):
+        raise BindPreflightAdjudicationError("BPA_EVIDENCE_REFS_INVALID")
+    _aware_iso(raw.get("decision_ts"), "BPA_DECISION_TS_INVALID")
+    if ttl is not None and (isinstance(ttl, bool) or not isinstance(ttl, int) or ttl < 0):
+        raise BindPreflightAdjudicationError("BPA_TTL_INVALID")
+    try:
+        intent = ExecutionIntent(**raw)
+    except (TypeError, ValueError) as exc:
+        raise BindPreflightAdjudicationError(
+            "BPA_EXECUTION_INTENT_FIELD_MISMATCH"
+        ) from exc
+    if intent.to_dict() != raw:
+        raise BindPreflightAdjudicationError("BPA_EXECUTION_INTENT_FIELD_MISMATCH")
+    canonical_execution_intent_json(intent)
+    return intent
+
+
+def build_canonical_bind_preflight_adjudication_packet(
+    pre_bind_validation_packet: Any,
+    adjudicated_at: datetime,
+) -> CanonicalBindPreflightAdjudicationPacket:
+    """Build a local packet after independently verifying its full source."""
+    adjudicated = _aware_iso(adjudicated_at, "BPA_ADJUDICATED_AT_INVALID")
+    source_packet = _verified_pre_bind(_json_value(pre_bind_validation_packet))
+    source = source_packet.model_dump(mode="json")
+    checked = _aware_iso(source_packet.checked_at, "BPA_PRE_BIND_VALIDATION_INVALID")
+    if adjudicated < checked:
+        raise BindPreflightAdjudicationError(
+            "BPA_ADJUDICATED_BEFORE_PRE_BIND_CHECKED"
+        )
+    raw = {
+        "format_version": FORMAT_VERSION,
+        "adjudication_mechanism": ADJUDICATION_MECHANISM,
+        "adjudicated_at": adjudicated.isoformat(),
+        "source_pre_bind_validation": {key: source[key] for key in (
+            "pre_bind_validation_id", "pre_bind_validation_hash", "format_version",
+            "validation_mechanism", "checked_at", "execution_intent_id",
+            "execution_intent_hash", "pre_bind_status", "ready_for_bind_preflight",
+        )},
+        "source_pre_bind_validation_hash": source_packet.pre_bind_validation_hash,
+        "source_pre_bind_validation_packet": source,
+        **{key: source[key] for key in (
+            "source_formation_hash", "source_readiness_hash", "source_eligibility_hash",
+            "source_handoff_hash", "trusted_validation_context_hash",
+            "validation_result_hash", "mapping_value_digest",
+            "execution_intent_contract_version", "execution_intent",
+            "execution_intent_id", "execution_intent_hash",
+            "source_to_execution_intent_mapping", "field_mapping_proof",
+            "required_field_presence", "source_decision_identity", "candidate_identity",
+            "evidence_lineage", "replay_summary",
+        )},
+        "bind_preflight_status": "READY_FOR_BIND_ADJUDICATION",
+        "ready_for_bind_adjudication": True, "fail_closed": False,
+        "local_adjudication_checks": LOCAL_ADJUDICATION_CHECKS,
+        "bind_entry_requirements": BIND_ENTRY_REQUIREMENTS,
+        "scope_limitations": SCOPE_LIMITATIONS,
+    }
+    digest = _packet_hash(raw)
+    raw.update(bind_preflight_adjudication_hash=digest,
+               bind_preflight_adjudication_id=f"bpa:v1:sha256:{digest}")
+    return verify_canonical_bind_preflight_adjudication_packet(raw)
+
+
+def verify_canonical_bind_preflight_adjudication_packet(
+    packet: Any,
+) -> CanonicalBindPreflightAdjudicationPacket:
+    """Dump, revalidate, and independently recompute every source binding."""
+    try:
+        value = packet.model_dump(mode="json") if isinstance(packet, BaseModel) else _json_value(packet)
+        candidate = CanonicalBindPreflightAdjudicationPacket.model_validate(value)
+    except (ValidationError, BindPreflightAdjudicationError, TypeError) as exc:
+        raise BindPreflightAdjudicationError("BPA_PACKET_INVALID") from exc
+    raw = candidate.model_dump(mode="json")
+    source_packet = _verified_pre_bind(candidate.source_pre_bind_validation_packet)
+    source = source_packet.model_dump(mode="json")
+    summary_keys = tuple(candidate.source_pre_bind_validation)
+    if candidate.source_pre_bind_validation != {key: source[key] for key in summary_keys}:
+        raise BindPreflightAdjudicationError("BPA_PRE_BIND_VALIDATION_INVALID")
+    adjudicated = _aware_iso(candidate.adjudicated_at, "BPA_ADJUDICATED_AT_INVALID")
+    checked = _aware_iso(source_packet.checked_at, "BPA_PRE_BIND_VALIDATION_INVALID")
+    if adjudicated < checked:
+        raise BindPreflightAdjudicationError("BPA_ADJUDICATED_BEFORE_PRE_BIND_CHECKED")
+    copied = (
+        "source_formation_hash", "source_readiness_hash", "source_eligibility_hash",
+        "source_handoff_hash", "trusted_validation_context_hash", "validation_result_hash",
+        "mapping_value_digest", "execution_intent_contract_version", "execution_intent",
+        "execution_intent_id", "execution_intent_hash", "source_to_execution_intent_mapping",
+        "field_mapping_proof", "required_field_presence", "source_decision_identity",
+        "candidate_identity", "evidence_lineage", "replay_summary",
+    )
+    if candidate.source_pre_bind_validation_hash != source_packet.pre_bind_validation_hash or any(
+        getattr(candidate, key) != getattr(source_packet, key) for key in copied
+    ):
+        raise BindPreflightAdjudicationError("BPA_MAPPING_MISMATCH")
+    intent = _intent(candidate.execution_intent)
+    mapping = {key: candidate.execution_intent[key] for key in EXECUTION_INTENT_FIELDS}
+    if candidate.execution_intent_id != intent.execution_intent_id:
+        raise BindPreflightAdjudicationError("BPA_EXECUTION_INTENT_ID_MISMATCH")
+    if candidate.execution_intent_hash != hash_execution_intent(intent):
+        raise BindPreflightAdjudicationError("BPA_EXECUTION_INTENT_HASH_MISMATCH")
+    if candidate.source_to_execution_intent_mapping != mapping:
+        raise BindPreflightAdjudicationError("BPA_MAPPING_MISMATCH")
+    if candidate.field_mapping_proof != mapping:
+        raise BindPreflightAdjudicationError("BPA_FIELD_MAPPING_PROOF_MISMATCH")
+    if candidate.local_adjudication_checks != LOCAL_ADJUDICATION_CHECKS:
+        raise BindPreflightAdjudicationError("BPA_LOCAL_CHECKS_MISMATCH")
+    if candidate.bind_entry_requirements != BIND_ENTRY_REQUIREMENTS:
+        raise BindPreflightAdjudicationError("BPA_ENTRY_REQUIREMENTS_MISMATCH")
+    _digest(LOCAL_CHECKS_DOMAIN, candidate.local_adjudication_checks)
+    _digest(ENTRY_REQUIREMENTS_DOMAIN, candidate.bind_entry_requirements)
+    if candidate.scope_limitations != SCOPE_LIMITATIONS:
+        raise BindPreflightAdjudicationError("BPA_SCOPE_LIMITATIONS_MISSING")
+    digest = _packet_hash(raw)
+    if candidate.bind_preflight_adjudication_hash != digest:
+        raise BindPreflightAdjudicationError("BPA_PACKET_HASH_MISMATCH")
+    if candidate.bind_preflight_adjudication_id != f"bpa:v1:sha256:{digest}":
+        raise BindPreflightAdjudicationError("BPA_PACKET_ID_MISMATCH")
+    return candidate

--- a/veritas_os/policy/canonical_bind_preflight_adjudication.py
+++ b/veritas_os/policy/canonical_bind_preflight_adjudication.py
@@ -35,6 +35,17 @@ ENTRY_REQUIREMENTS_DOMAIN = (
     "veritas.bind-preflight-adjudication.entry-requirements/v1"
 )
 PACKET_DOMAIN = "veritas.bind-preflight-adjudication.packet/v1"
+SOURCE_PRE_BIND_VALIDATION_SUMMARY_KEYS = (
+    "pre_bind_validation_id",
+    "pre_bind_validation_hash",
+    "format_version",
+    "validation_mechanism",
+    "checked_at",
+    "execution_intent_id",
+    "execution_intent_hash",
+    "pre_bind_status",
+    "ready_for_bind_preflight",
+)
 LOCAL_ADJUDICATION_CHECKS = {
     "pre_bind_validation_verified": True,
     "execution_intent_hash_verified": True,
@@ -214,11 +225,10 @@ def build_canonical_bind_preflight_adjudication_packet(
         "format_version": FORMAT_VERSION,
         "adjudication_mechanism": ADJUDICATION_MECHANISM,
         "adjudicated_at": adjudicated.isoformat(),
-        "source_pre_bind_validation": {key: source[key] for key in (
-            "pre_bind_validation_id", "pre_bind_validation_hash", "format_version",
-            "validation_mechanism", "checked_at", "execution_intent_id",
-            "execution_intent_hash", "pre_bind_status", "ready_for_bind_preflight",
-        )},
+        "source_pre_bind_validation": {
+            key: source[key]
+            for key in SOURCE_PRE_BIND_VALIDATION_SUMMARY_KEYS
+        },
         "source_pre_bind_validation_hash": source_packet.pre_bind_validation_hash,
         "source_pre_bind_validation_packet": source,
         **{key: source[key] for key in (
@@ -255,8 +265,17 @@ def verify_canonical_bind_preflight_adjudication_packet(
     raw = candidate.model_dump(mode="json")
     source_packet = _verified_pre_bind(candidate.source_pre_bind_validation_packet)
     source = source_packet.model_dump(mode="json")
-    summary_keys = tuple(candidate.source_pre_bind_validation)
-    if candidate.source_pre_bind_validation != {key: source[key] for key in summary_keys}:
+    if set(candidate.source_pre_bind_validation) != set(
+        SOURCE_PRE_BIND_VALIDATION_SUMMARY_KEYS
+    ):
+        raise BindPreflightAdjudicationError(
+            "BPA_PRE_BIND_VALIDATION_INVALID"
+        )
+    expected_summary = {
+        key: source[key]
+        for key in SOURCE_PRE_BIND_VALIDATION_SUMMARY_KEYS
+    }
+    if candidate.source_pre_bind_validation != expected_summary:
         raise BindPreflightAdjudicationError("BPA_PRE_BIND_VALIDATION_INVALID")
     adjudicated = _aware_iso(candidate.adjudicated_at, "BPA_ADJUDICATED_AT_INVALID")
     checked = _aware_iso(source_packet.checked_at, "BPA_PRE_BIND_VALIDATION_INVALID")

--- a/veritas_os/tests/test_canonical_bind_preflight_adjudication.py
+++ b/veritas_os/tests/test_canonical_bind_preflight_adjudication.py
@@ -1,0 +1,216 @@
+"""Security tests for Canonical Bind Preflight Adjudication v1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from copy import deepcopy
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator, FormatChecker
+
+from veritas_os.policy.bind_artifacts import ExecutionIntent, hash_execution_intent
+from veritas_os.policy.canonical_bind_preflight_adjudication import (
+    BIND_ENTRY_REQUIREMENTS,
+    ENTRY_REQUIREMENTS_DOMAIN,
+    LOCAL_ADJUDICATION_CHECKS,
+    LOCAL_CHECKS_DOMAIN,
+    PACKET_DOMAIN,
+    SCOPE_LIMITATIONS,
+    BindPreflightAdjudicationError,
+    CanonicalBindPreflightAdjudicationPacket,
+    _packet_hash,
+    build_canonical_bind_preflight_adjudication_packet,
+    verify_canonical_bind_preflight_adjudication_packet,
+)
+from veritas_os.tests.test_execution_intent_pre_bind_validation import (
+    CHECKED_AT,
+    _packet as pre_bind_packet,
+)
+
+ADJUDICATED_AT = CHECKED_AT + timedelta(seconds=1)
+MODULE = Path("veritas_os/policy/canonical_bind_preflight_adjudication.py")
+SCHEMA = Path("schemas/canonical-bind-preflight-adjudication-v1.schema.json")
+
+
+def _packet(*, semantic_match: bool | None = None):
+    return build_canonical_bind_preflight_adjudication_packet(
+        pre_bind_packet(semantic_match=semantic_match), ADJUDICATED_AT
+    )
+
+
+def test_build_verify_integrity_and_preservation(monkeypatch) -> None:
+    import veritas_os.policy.canonical_bind_preflight_adjudication as module
+
+    actual = module.verify_execution_intent_pre_bind_validation_packet
+    calls = []
+
+    def recording(value):
+        calls.append(value)
+        return actual(value)
+
+    monkeypatch.setattr(
+        module, "verify_execution_intent_pre_bind_validation_packet", recording
+    )
+    source = pre_bind_packet()
+    packet = module.build_canonical_bind_preflight_adjudication_packet(
+        source, ADJUDICATED_AT
+    )
+    assert len(calls) == 2  # builder source verification and final verification
+    assert module.verify_canonical_bind_preflight_adjudication_packet(packet) == packet
+    assert len(calls) == 3
+    assert packet.bind_preflight_adjudication_id == (
+        f"bpa:v1:sha256:{packet.bind_preflight_adjudication_hash}"
+    )
+    assert packet.bind_preflight_adjudication_hash == _packet_hash(
+        packet.model_dump(mode="json")
+    )
+    intent = ExecutionIntent(**packet.execution_intent)
+    assert intent.to_dict() == packet.execution_intent
+    assert packet.execution_intent_hash == hash_execution_intent(intent)
+    assert packet.execution_intent_id == source.execution_intent_id
+    assert packet.source_to_execution_intent_mapping == (
+        source.source_to_execution_intent_mapping
+    )
+    assert packet.field_mapping_proof == source.field_mapping_proof
+    assert packet.local_adjudication_checks == LOCAL_ADJUDICATION_CHECKS
+    assert packet.bind_entry_requirements == BIND_ENTRY_REQUIREMENTS
+    for field in (
+        "required_field_presence", "source_decision_identity", "candidate_identity",
+        "evidence_lineage", "replay_summary",
+    ):
+        assert getattr(packet, field) == getattr(source, field)
+    assert not hasattr(packet, "bind_receipt")
+    assert not hasattr(packet, "trustlog_entry")
+
+
+@pytest.mark.parametrize("semantic_match", [True, False])
+def test_semantic_match_is_preserved_not_gated(semantic_match: bool) -> None:
+    packet = _packet(semantic_match=semantic_match)
+    assert packet.replay_summary["semantic_match"] is semantic_match
+    assert verify_canonical_bind_preflight_adjudication_packet(packet) == packet
+
+
+def test_invalid_source_and_timeline_refuse() -> None:
+    source = pre_bind_packet().model_dump(mode="json")
+    source["pre_bind_validation_hash"] = "0" * 64
+    with pytest.raises(BindPreflightAdjudicationError, match="BPA_PRE_BIND"):
+        build_canonical_bind_preflight_adjudication_packet(source, ADJUDICATED_AT)
+    with pytest.raises(BindPreflightAdjudicationError, match="BPA_ADJUDICATED_AT"):
+        build_canonical_bind_preflight_adjudication_packet(
+            pre_bind_packet(), ADJUDICATED_AT.replace(tzinfo=None)
+        )
+    with pytest.raises(BindPreflightAdjudicationError, match="BPA_ADJUDICATED_BEFORE"):
+        build_canonical_bind_preflight_adjudication_packet(
+            pre_bind_packet(), CHECKED_AT - timedelta(seconds=1)
+        )
+
+
+@pytest.mark.parametrize("path", [
+    ("bind_preflight_adjudication_id",),
+    ("bind_preflight_adjudication_hash",), ("adjudicated_at",),
+    ("source_pre_bind_validation", "checked_at"),
+    ("source_pre_bind_validation_hash",),
+    ("source_pre_bind_validation_packet", "pre_bind_validation_hash"),
+    ("source_formation_hash",), ("source_readiness_hash",),
+    ("source_eligibility_hash",), ("source_handoff_hash",),
+    ("trusted_validation_context_hash",), ("validation_result_hash",),
+    ("mapping_value_digest",), ("execution_intent", "decision_id"),
+    ("execution_intent_id",), ("execution_intent_hash",),
+    ("source_to_execution_intent_mapping", "decision_id"),
+    ("field_mapping_proof", "decision_id"),
+    ("local_adjudication_checks", "no_bind_invocation"),
+    ("bind_entry_requirements", "adapter_required"),
+    ("source_decision_identity", "request_id"),
+    ("candidate_identity", "actor_identity"),
+    ("evidence_lineage", "policy_snapshot_id"),
+    ("replay_summary", "semantic_match"),
+    ("replay_summary", "fields_changed"), ("scope_limitations",),
+])
+def test_single_field_tampering_refuses(path: tuple[str, ...]) -> None:
+    raw = _packet(semantic_match=True).model_dump(mode="json")
+    target = raw
+    for key in path[:-1]:
+        target = target[key]
+    key = path[-1]
+    if key.endswith("_id"):
+        prefix = "bpa:v1:sha256:" if key.startswith("bind_") else "ei:v1:sha256:"
+        target[key] = prefix + "0" * 64
+    elif key.endswith("hash") or key.endswith("digest"):
+        target[key] = "0" * 64
+    elif key == "adjudicated_at":
+        target[key] = (ADJUDICATED_AT + timedelta(seconds=1)).isoformat()
+    elif key in {"semantic_match", "no_bind_invocation", "adapter_required"}:
+        target[key] = not target[key]
+    elif key == "fields_changed":
+        target[key] = ["outcome.status"]
+    elif key == "scope_limitations":
+        target[key] = target[key][:-1]
+    else:
+        target[key] = "tampered"
+    with pytest.raises(BindPreflightAdjudicationError):
+        verify_canonical_bind_preflight_adjudication_packet(raw)
+
+
+@pytest.mark.parametrize("method", ["copy", "construct"])
+@pytest.mark.parametrize("updates", [
+    {"format_version": "wrong"},
+    {"bind_preflight_adjudication_hash": "0" * 64},
+    {"execution_intent": {}}, {"source_to_execution_intent_mapping": {}},
+    {"local_adjudication_checks": {}}, {"bind_entry_requirements": {}},
+    {"replay_summary": {}},
+])
+def test_typed_instance_bypass_refuses(method: str, updates: dict) -> None:
+    packet = _packet()
+    bypass = (
+        packet.model_copy(update=updates)
+        if method == "copy"
+        else CanonicalBindPreflightAdjudicationPacket.model_construct(
+            **{**packet.model_dump(mode="python"), **updates}
+        )
+    )
+    with pytest.raises(BindPreflightAdjudicationError):
+        verify_canonical_bind_preflight_adjudication_packet(bypass)
+
+
+def test_schema_accepts_valid_and_rejects_nested_extensions() -> None:
+    schema = json.loads(SCHEMA.read_text())
+    Draft202012Validator.check_schema(schema)
+    validator = Draft202012Validator(schema, format_checker=FormatChecker())
+    valid = _packet().model_dump(mode="json")
+    validator.validate(valid)
+    for path in (
+        ("execution_intent",), ("local_adjudication_checks",),
+        ("bind_entry_requirements",), ("source_pre_bind_validation",),
+    ):
+        invalid = deepcopy(valid)
+        invalid[path[0]]["unexpected"] = True
+        assert list(validator.iter_errors(invalid))
+
+
+def test_static_import_and_side_effect_boundary() -> None:
+    source = MODULE.read_text()
+    tree = ast.parse(source)
+    forbidden = {
+        "BindReceipt", "hash_bind_receipt", "append_bind_receipt_trustlog",
+        "append_execution_intent_trustlog", "build_execution_intent_trustlog_entry",
+        "execute_bind_boundary", "execute_bind_adjudication", "BindBoundaryAdapter",
+        "ReferenceBindAdapter", "WebhookBindAdapter", "bind_core", "requests",
+        "httpx", "subprocess", "uuid4",
+    }
+    imported = {
+        alias.name for node in ast.walk(tree)
+        if isinstance(node, (ast.Import, ast.ImportFrom)) for alias in node.names
+    }
+    assert imported.isdisjoint(forbidden)
+    assert "datetime.now" not in source
+    names = {node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)}
+    assert names.isdisjoint({
+        "execute", "commit", "dispatch", "send", "webhook", "adapter_call",
+        "write_trustlog", "append_trustlog", "create_bind_receipt", "invoke_bind",
+        "call_adapter",
+    })
+    assert "bind_receipt_id" not in source
+    assert len({LOCAL_CHECKS_DOMAIN, ENTRY_REQUIREMENTS_DOMAIN, PACKET_DOMAIN}) == 3

--- a/veritas_os/tests/test_canonical_bind_preflight_adjudication.py
+++ b/veritas_os/tests/test_canonical_bind_preflight_adjudication.py
@@ -108,6 +108,29 @@ def test_invalid_source_and_timeline_refuse() -> None:
         )
 
 
+@pytest.mark.parametrize(
+    ("mutation"),
+    [
+        lambda summary: summary.pop("ready_for_bind_preflight"),
+        lambda summary: summary.update(unexpected=True),
+    ],
+    ids=["missing-key", "extra-key"],
+)
+def test_recomputed_identity_cannot_bypass_exact_source_summary(mutation) -> None:
+    """Reject reduced or extended summaries even with recomputed identity."""
+    raw = _packet().model_dump(mode="json")
+    mutation(raw["source_pre_bind_validation"])
+    digest = _packet_hash(raw)
+    raw["bind_preflight_adjudication_hash"] = digest
+    raw["bind_preflight_adjudication_id"] = f"bpa:v1:sha256:{digest}"
+
+    with pytest.raises(
+        BindPreflightAdjudicationError,
+        match="BPA_PRE_BIND_VALIDATION_INVALID",
+    ):
+        verify_canonical_bind_preflight_adjudication_packet(raw)
+
+
 @pytest.mark.parametrize("path", [
     ("bind_preflight_adjudication_id",),
     ("bind_preflight_adjudication_hash",), ("adjudicated_at",),


### PR DESCRIPTION
### Motivation
- Provide a deterministic, local, side-effect-free adjudication step that proves an already-verified ExecutionIntent Pre-Bind Validation Packet is structurally ready to enter a future Bind adjudication boundary.
- Preserve and re-verify the exact Pre-Bind Validation Packet and its reconstructed `ExecutionIntent` without creating authority, invoking Bind, calling adapters, or writing TrustLog.
- Surface explicit, deterministic future Bind entry requirements and local adjudication checks while keeping the responsibility boundary strict and fail-closed.

### Description
- Add a new module `veritas_os.policy.canonical_bind_preflight_adjudication` exporting a frozen `CanonicalBindPreflightAdjudicationPacket` model, a builder `build_canonical_bind_preflight_adjudication_packet(...)`, and a verifier `verify_canonical_bind_preflight_adjudication_packet(...)`.
- Packet semantics: `format_version` = `canonical-bind-preflight-adjudication/v1`, content-addressed `bind_preflight_adjudication_id` = `bpa:v1:sha256:<64hex>`, and `bind_preflight_adjudication_hash` = 64-lowercase-hex; packet hash preimage excludes only the id and hash and uses strict canonical JSON.
- Builder re-runs `verify_execution_intent_pre_bind_validation_packet(...)`, reconstructs the `ExecutionIntent` (no new ID), recomputes `hash_execution_intent(...)`, enforces `adjudicated_at >= source.checked_at`, preserves required fields/mappings/evidence, and attaches deterministic `local_adjudication_checks` and explicit `bind_entry_requirements` (all recorded but not executed).
- Verifier independently dumps + validates the packet, re-runs the Pre-Bind Validation verifier over the embedded `source_pre_bind_validation_packet`, verifies the fixed canonical `source_pre_bind_validation` summary shape, recomputes hashes/IDs/mappings, and rejects any tamper or mismatch with stable `BPA_*` refusal reasons.
- Add a closed JSON Schema `schemas/canonical-bind-preflight-adjudication-v1.schema.json` and documentation `docs/en/architecture/canonical-bind-preflight-adjudication-v1.md` describing the artifact and explicit non-claims (no authorization, no Bind/TrustLog/adapters).
- Add focused tests `veritas_os/tests/test_canonical_bind_preflight_adjudication.py` covering successful build/verify, semantic-match preservation, single-field tamper/refusal matrix, typed-instance bypass rejection, schema validation, static import/side-effect boundary checks, and regression coverage for missing/extra `source_pre_bind_validation` summary keys even after recomputing packet hash/id.

### Security / non-claims
- Bind Preflight Adjudication does not authorize execution.
- Bind Preflight Adjudication does not invoke Bind.
- Bind Preflight Adjudication does not create `BindReceipt`.
- Bind Preflight Adjudication does not write TrustLog.
- Bind Preflight Adjudication does not call adapters.
- Bind Preflight Adjudication does not perform live state, runtime risk, authority, constraint, commit-boundary, postcondition, rollback, or idempotency replay checks.
- Bind Preflight Adjudication does not satisfy Authority Evidence or Human Approval.
- Bind Preflight Adjudication does not turn `semantic_match` into authorization.

### Testing
- Latest head SHA: `394dd98f5c49736132c57ceb155d549f39b596e1`.
- Local/static checks reported by Codex: `ruff check` on the new/changed files passed; `python -m py_compile veritas_os/policy/canonical_bind_preflight_adjudication.py` succeeded; `python3.12 -m json.tool schemas/canonical-bind-preflight-adjudication-v1.schema.json` validated JSON syntax; `git diff --check` and `git diff --cached --check` passed.
- GitHub CI #5062 completed successfully for this head.
- `test (py3.11)`: success.
- `test (py3.12)`: success.
- `test-postgresql (py3.12)`: success.
- `test-slow (py3.12)`: success.
- `lint`: success.
- `dependency-audit`: success.
- `future-dependency-compat`: success.
- `[Tier 1] governance-backend-fast`: success.
- `[Tier 1] governance-smoke`: success.
- `frontend-lint`: success.
- `frontend-test`: success.
- `frontend-e2e`: success.
- `Security Gates`: success.
- `CodeQL (custom)`: success.
- `Runtime Proof Evidence`: success.
- `Runtime Pickle Guard (Required)`: success.
- `Reviewer Evidence Packet Validation`: success.

### Final invariant
Canonical Bind Preflight Adjudication v1 verifies that an ExecutionIntent Pre-Bind Validation Packet is structurally ready to enter a future Bind adjudication boundary. It does not write TrustLog, does not create a BindReceipt, does not invoke Bind, does not call adapters, does not authorize execution, does not perform live state or runtime risk checks, and does not convert replay semantic_match into Authority Evidence, Human Approval, or execution authority.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a824270ded88326aff6321fe281716c)