### PR TITLE
feat(bind): add bind adapter contract selection dry-run v1

### DIFF
--- a/docs/en/architecture/bind-adapter-contract-selection-v1.md
+++ b/docs/en/architecture/bind-adapter-contract-selection-v1.md
@@ -1,0 +1,38 @@
+# Canonical Bind Adapter Contract Selection v1
+
+Canonical Bind Adapter Contract Selection associates an exact, verified
+Canonical Bind Preflight Adjudication Packet with an immutable pure-data adapter
+contract descriptor. The selection is deterministic and local. It stops before
+any live boundary.
+
+Bind Preflight Adjudication is **not** adapter invocation. Adapter Contract
+Selection is **not** Bind authorization, an adapter instance, an
+`adapter.snapshot`/`apply`/`revert` call, a BindReceipt, or a TrustLog write.
+Replay `semantic_match` (whether `true` or `false`) is preserved and is not
+Authority Evidence or Human Approval.
+
+## Sequence and stop boundary
+
+1. CDA
+2. Trust Link
+3. Replay Source/Evidence
+4. Replay Handoff Binding
+5. CanonicalDecisionHandoff validation
+6. Guarded Promotion Eligibility Packet
+7. ExecutionIntent Formation Readiness Packet
+8. Canonical ExecutionIntent Formation Packet
+9. ExecutionIntent Pre-Bind Validation Packet
+10. Canonical Bind Preflight Adjudication Packet
+11. Canonical Bind Adapter Contract Selection Packet
+12. **STOP**
+
+The descriptor only declares identity, scope, required future method names, and
+a no-effect profile. It contains no callback, client, file handle, or adapter
+object. Exact target equality is required in v1, so selection cannot broaden the
+ExecutionIntent target.
+
+Actual adapter instantiation, snapshotting, authority revalidation, constraint
+validation, runtime-risk assessment, Bind adjudication, operation commit,
+postcondition verification, rollback proof, BindReceipt creation, and TrustLog
+writes are intentionally deferred to future explicit PRs. This artifact is not
+a production, customer, or regulatory certification.

--- a/schemas/bind-adapter-contract-selection-v1.schema.json
+++ b/schemas/bind-adapter-contract-selection-v1.schema.json
@@ -1,0 +1,3995 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://veritas-os.example/schemas/bind-adapter-contract-selection-v1.schema.json",
+  "title": "Canonical Bind Adapter Contract Selection Packet v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "format_version",
+    "adapter_contract_selection_id",
+    "adapter_contract_selection_hash",
+    "selection_mechanism",
+    "selected_at",
+    "source_bind_preflight_adjudication",
+    "source_bind_preflight_adjudication_hash",
+    "source_bind_preflight_adjudication_packet",
+    "adapter_contract_descriptor",
+    "adapter_contract_id",
+    "adapter_contract_hash",
+    "adapter_contract_version",
+    "execution_intent",
+    "execution_intent_id",
+    "execution_intent_hash",
+    "source_formation_hash",
+    "source_readiness_hash",
+    "source_eligibility_hash",
+    "source_handoff_hash",
+    "trusted_validation_context_hash",
+    "validation_result_hash",
+    "mapping_value_digest",
+    "execution_intent_contract_version",
+    "selection_status",
+    "ready_for_adapter_dry_run",
+    "fail_closed",
+    "local_selection_checks",
+    "future_bind_dry_run_requirements",
+    "source_to_execution_intent_mapping",
+    "field_mapping_proof",
+    "required_field_presence",
+    "source_decision_identity",
+    "candidate_identity",
+    "evidence_lineage",
+    "replay_summary",
+    "scope_limitations"
+  ],
+  "properties": {
+    "format_version": {
+      "const": "canonical-bind-adapter-contract-selection/v1"
+    },
+    "adapter_contract_selection_id": {
+      "type": "string",
+      "pattern": "^bac:v1:sha256:[0-9a-f]{64}$"
+    },
+    "adapter_contract_selection_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "selection_mechanism": {
+      "const": "select_bind_adapter_contract_without_invocation/v1"
+    },
+    "selected_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "source_bind_preflight_adjudication": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "bind_preflight_adjudication_id",
+        "bind_preflight_adjudication_hash",
+        "format_version",
+        "adjudication_mechanism",
+        "adjudicated_at",
+        "execution_intent_id",
+        "execution_intent_hash",
+        "bind_preflight_status",
+        "ready_for_bind_adjudication"
+      ],
+      "properties": {
+        "bind_preflight_adjudication_id": {},
+        "bind_preflight_adjudication_hash": {},
+        "format_version": {},
+        "adjudication_mechanism": {},
+        "adjudicated_at": {},
+        "execution_intent_id": {},
+        "execution_intent_hash": {},
+        "bind_preflight_status": {},
+        "ready_for_bind_adjudication": {}
+      }
+    },
+    "source_bind_preflight_adjudication_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "source_bind_preflight_adjudication_packet": {
+      "$ref": "#/$defs/bind_preflight_packet"
+    },
+    "adapter_contract_descriptor": {
+      "$ref": "#/$defs/descriptor"
+    },
+    "adapter_contract_id": {
+      "type": "string",
+      "pattern": "^adapter-contract:v1:sha256:[0-9a-f]{64}$"
+    },
+    "adapter_contract_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "adapter_contract_version": {
+      "const": "bind-adapter-contract/v1"
+    },
+    "execution_intent": {
+      "$ref": "#/$defs/execution_intent"
+    },
+    "execution_intent_id": {
+      "type": "string",
+      "pattern": "^ei:v1:sha256:[0-9a-f]{64}$"
+    },
+    "execution_intent_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "source_formation_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "source_readiness_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "source_eligibility_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "source_handoff_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "trusted_validation_context_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "validation_result_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "mapping_value_digest": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "execution_intent_contract_version": {
+      "type": "string"
+    },
+    "selection_status": {
+      "const": "ADAPTER_CONTRACT_SELECTED_FOR_DRY_RUN"
+    },
+    "ready_for_adapter_dry_run": {
+      "const": true
+    },
+    "fail_closed": {
+      "const": false
+    },
+    "local_selection_checks": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "bind_preflight_adjudication_verified",
+        "execution_intent_hash_verified",
+        "execution_intent_id_verified",
+        "adapter_descriptor_hash_verified",
+        "adapter_descriptor_scope_matches_intent",
+        "required_methods_declared",
+        "prohibited_methods_not_called",
+        "selected_after_bind_preflight_adjudication",
+        "no_adapter_instance",
+        "no_adapter_invocation",
+        "no_bind_invocation",
+        "no_bind_receipt_created",
+        "no_trustlog_write",
+        "no_network",
+        "no_filesystem",
+        "no_external_effect"
+      ],
+      "properties": {
+        "bind_preflight_adjudication_verified": {
+          "const": true
+        },
+        "execution_intent_hash_verified": {
+          "const": true
+        },
+        "execution_intent_id_verified": {
+          "const": true
+        },
+        "adapter_descriptor_hash_verified": {
+          "const": true
+        },
+        "adapter_descriptor_scope_matches_intent": {
+          "const": true
+        },
+        "required_methods_declared": {
+          "const": true
+        },
+        "prohibited_methods_not_called": {
+          "const": true
+        },
+        "selected_after_bind_preflight_adjudication": {
+          "const": true
+        },
+        "no_adapter_instance": {
+          "const": true
+        },
+        "no_adapter_invocation": {
+          "const": true
+        },
+        "no_bind_invocation": {
+          "const": true
+        },
+        "no_bind_receipt_created": {
+          "const": true
+        },
+        "no_trustlog_write": {
+          "const": true
+        },
+        "no_network": {
+          "const": true
+        },
+        "no_filesystem": {
+          "const": true
+        },
+        "no_external_effect": {
+          "const": true
+        }
+      }
+    },
+    "future_bind_dry_run_requirements": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "adapter_instance_required",
+        "snapshot_required",
+        "state_fingerprint_required",
+        "authority_revalidation_required",
+        "constraint_validation_required",
+        "runtime_risk_assessment_required",
+        "commit_boundary_evaluation_required",
+        "idempotency_key_required",
+        "postcondition_verification_required",
+        "rollback_or_revert_path_required",
+        "bind_receipt_required",
+        "trustlog_policy_required"
+      ],
+      "properties": {
+        "adapter_instance_required": {
+          "const": true
+        },
+        "snapshot_required": {
+          "const": true
+        },
+        "state_fingerprint_required": {
+          "const": true
+        },
+        "authority_revalidation_required": {
+          "const": true
+        },
+        "constraint_validation_required": {
+          "const": true
+        },
+        "runtime_risk_assessment_required": {
+          "const": true
+        },
+        "commit_boundary_evaluation_required": {
+          "const": true
+        },
+        "idempotency_key_required": {
+          "const": true
+        },
+        "postcondition_verification_required": {
+          "const": true
+        },
+        "rollback_or_revert_path_required": {
+          "const": true
+        },
+        "bind_receipt_required": {
+          "const": true
+        },
+        "trustlog_policy_required": {
+          "const": true
+        }
+      }
+    },
+    "source_to_execution_intent_mapping": {
+      "$ref": "#/$defs/mapping"
+    },
+    "field_mapping_proof": {
+      "$ref": "#/$defs/mapping"
+    },
+    "required_field_presence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "execution_intent_id",
+        "decision_id",
+        "request_id",
+        "policy_snapshot_id",
+        "actor_identity",
+        "target_system",
+        "target_resource",
+        "intended_action",
+        "evidence_refs",
+        "decision_hash",
+        "decision_ts",
+        "ttl_seconds",
+        "expected_state_fingerprint",
+        "approval_context",
+        "policy_lineage"
+      ],
+      "properties": {
+        "execution_intent_id": {
+          "const": "intentionally_deferred"
+        },
+        "decision_id": {
+          "const": "mapped"
+        },
+        "request_id": {
+          "const": "mapped"
+        },
+        "policy_snapshot_id": {
+          "const": "mapped"
+        },
+        "actor_identity": {
+          "const": "mapped"
+        },
+        "target_system": {
+          "const": "mapped"
+        },
+        "target_resource": {
+          "const": "mapped"
+        },
+        "intended_action": {
+          "const": "mapped"
+        },
+        "evidence_refs": {
+          "const": "mapped"
+        },
+        "decision_hash": {
+          "const": "mapped"
+        },
+        "decision_ts": {
+          "const": "mapped"
+        },
+        "ttl_seconds": {
+          "const": "intentionally_deferred"
+        },
+        "expected_state_fingerprint": {
+          "const": "mapped"
+        },
+        "approval_context": {
+          "const": "mapped"
+        },
+        "policy_lineage": {
+          "const": "mapped"
+        }
+      }
+    },
+    "source_decision_identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "request_id",
+        "canonical_decision_id",
+        "canonical_decision_hash",
+        "canonical_decision_ts"
+      ],
+      "properties": {
+        "request_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "canonical_decision_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "canonical_decision_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "canonical_decision_ts": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "candidate_identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "candidate_id",
+        "candidate_hash",
+        "actor_identity",
+        "target_system",
+        "target_resource",
+        "action_contract_id",
+        "action_contract_version"
+      ],
+      "properties": {
+        "candidate_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "candidate_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "actor_identity": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_system": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_resource": {
+          "type": "string",
+          "minLength": 1
+        },
+        "action_contract_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "action_contract_version": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "evidence_lineage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "trustlog_artifact_ref",
+        "trustlog_chain_hash",
+        "replay_artifact_ref",
+        "replay_artifact_hash",
+        "authority_evidence_ref",
+        "authority_evidence_hash",
+        "human_approval_receipt_ref",
+        "human_approval_receipt_hash",
+        "policy_snapshot_id",
+        "policy_version",
+        "policy_semantic_digest",
+        "expected_state_fingerprint",
+        "expected_state_source_ref"
+      ],
+      "properties": {
+        "trustlog_artifact_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "trustlog_chain_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "replay_artifact_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "replay_artifact_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "authority_evidence_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "authority_evidence_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "human_approval_receipt_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "human_approval_receipt_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_snapshot_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_semantic_digest": {
+          "type": "string",
+          "minLength": 1
+        },
+        "expected_state_fingerprint": {
+          "type": "string",
+          "minLength": 1
+        },
+        "expected_state_source_ref": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "replay_summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "original_decision_id",
+        "replay_decision_id",
+        "original_request_id",
+        "replay_request_id",
+        "semantic_profile",
+        "semantic_match",
+        "fields_changed",
+        "severity",
+        "divergence_level"
+      ],
+      "properties": {
+        "original_decision_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "replay_decision_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "original_request_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "replay_request_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "semantic_profile": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "semantic_match": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "fields_changed": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "severity": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "divergence_level": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "scope_limitations": {
+      "type": "array",
+      "prefixItems": [
+        {
+          "const": "NOT_EXECUTION_AUTHORITY"
+        },
+        {
+          "const": "NOT_BIND_AUTHORIZATION"
+        },
+        {
+          "const": "NOT_BIND_RECEIPT"
+        },
+        {
+          "const": "NOT_BIND_INVOCATION"
+        },
+        {
+          "const": "NOT_ADAPTER_INSTANCE"
+        },
+        {
+          "const": "NOT_ADAPTER_INVOCATION"
+        },
+        {
+          "const": "NOT_EXTERNAL_EFFECT"
+        },
+        {
+          "const": "NOT_OPERATION_COMMIT"
+        },
+        {
+          "const": "NOT_TRUSTLOG_WRITE"
+        },
+        {
+          "const": "NOT_LIVE_STATE_CHECK"
+        },
+        {
+          "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+        },
+        {
+          "const": "NOT_AUTHORITY_REVALIDATION"
+        },
+        {
+          "const": "NOT_CONSTRAINT_REVALIDATION"
+        },
+        {
+          "const": "NOT_POSTCONDITION_VERIFICATION"
+        },
+        {
+          "const": "NOT_ROLLBACK_PROOF"
+        },
+        {
+          "const": "NOT_AUTHORITY_EVIDENCE"
+        },
+        {
+          "const": "NOT_HUMAN_APPROVAL"
+        }
+      ],
+      "items": false,
+      "minItems": 17,
+      "maxItems": 17
+    }
+  },
+  "$defs": {
+    "execution_intent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "execution_intent_id",
+        "decision_id",
+        "request_id",
+        "policy_snapshot_id",
+        "actor_identity",
+        "target_system",
+        "target_resource",
+        "intended_action",
+        "evidence_refs",
+        "decision_hash",
+        "decision_ts",
+        "ttl_seconds",
+        "expected_state_fingerprint",
+        "approval_context",
+        "policy_lineage"
+      ],
+      "properties": {
+        "execution_intent_id": {
+          "type": "string",
+          "pattern": "^ei:v1:sha256:[0-9a-f]{64}$"
+        },
+        "decision_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "request_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_snapshot_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "actor_identity": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_system": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_resource": {
+          "type": "string",
+          "minLength": 1
+        },
+        "intended_action": {
+          "type": "string",
+          "minLength": 1
+        },
+        "evidence_refs": {
+          "type": "array",
+          "minItems": 5,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "decision_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "decision_ts": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "ttl_seconds": {
+          "type": "null"
+        },
+        "expected_state_fingerprint": {
+          "type": "string",
+          "minLength": 1
+        },
+        "approval_context": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "human_approval_receipt_ref",
+            "human_approval_receipt_hash"
+          ],
+          "properties": {
+            "human_approval_receipt_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "human_approval_receipt_hash": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "policy_lineage": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "policy_snapshot_id",
+            "policy_version",
+            "policy_semantic_digest"
+          ],
+          "properties": {
+            "policy_snapshot_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_version": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_semantic_digest": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    },
+    "mapping": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "decision_id",
+        "request_id",
+        "policy_snapshot_id",
+        "actor_identity",
+        "target_system",
+        "target_resource",
+        "intended_action",
+        "evidence_refs",
+        "decision_hash",
+        "decision_ts",
+        "ttl_seconds",
+        "expected_state_fingerprint",
+        "approval_context",
+        "policy_lineage"
+      ],
+      "properties": {
+        "decision_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "request_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_snapshot_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "actor_identity": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_system": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_resource": {
+          "type": "string",
+          "minLength": 1
+        },
+        "intended_action": {
+          "type": "string",
+          "minLength": 1
+        },
+        "evidence_refs": {
+          "type": "array",
+          "minItems": 5,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "decision_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "decision_ts": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "ttl_seconds": {
+          "type": "null"
+        },
+        "expected_state_fingerprint": {
+          "type": "string",
+          "minLength": 1
+        },
+        "approval_context": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "human_approval_receipt_ref",
+            "human_approval_receipt_hash"
+          ],
+          "properties": {
+            "human_approval_receipt_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "human_approval_receipt_hash": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "policy_lineage": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "policy_snapshot_id",
+            "policy_version",
+            "policy_semantic_digest"
+          ],
+          "properties": {
+            "policy_snapshot_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_version": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_semantic_digest": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    },
+    "formation_packet": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "format_version",
+        "formation_id",
+        "formation_hash",
+        "formation_mechanism",
+        "formed_at",
+        "source_readiness",
+        "source_readiness_hash",
+        "source_readiness_packet",
+        "source_eligibility_hash",
+        "source_handoff_hash",
+        "trusted_validation_context_hash",
+        "validation_result_hash",
+        "mapping_value_digest",
+        "execution_intent_contract_version",
+        "execution_intent",
+        "execution_intent_id",
+        "execution_intent_hash",
+        "source_to_execution_intent_mapping",
+        "field_mapping_proof",
+        "required_field_presence",
+        "source_decision_identity",
+        "candidate_identity",
+        "evidence_lineage",
+        "replay_summary",
+        "scope_limitations"
+      ],
+      "properties": {
+        "format_version": {
+          "const": "canonical-execution-intent-formation/v1"
+        },
+        "formation_id": {
+          "type": "string",
+          "pattern": "^eif:v1:sha256:[0-9a-f]{64}$"
+        },
+        "formation_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "formation_mechanism": {
+          "const": "build_execution_intent_from_readiness/v1"
+        },
+        "formed_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "source_readiness": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "readiness_id",
+            "readiness_hash",
+            "format_version",
+            "checked_at",
+            "formation_status",
+            "ready_for_execution_intent_formation"
+          ],
+          "properties": {
+            "readiness_id": {
+              "type": "string",
+              "pattern": "^eifr:v1:sha256:[0-9a-f]{64}$"
+            },
+            "readiness_hash": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "format_version": {
+              "const": "canonical-execution-intent-formation-readiness/v1"
+            },
+            "checked_at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "formation_status": {
+              "const": "READY_FOR_EXECUTION_INTENT_FORMATION"
+            },
+            "ready_for_execution_intent_formation": {
+              "const": true
+            }
+          }
+        },
+        "source_readiness_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_readiness_packet": {
+          "$ref": "#/$defs/readiness"
+        },
+        "source_eligibility_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_handoff_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "trusted_validation_context_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "validation_result_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "mapping_value_digest": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "execution_intent_contract_version": {
+          "const": "execution-intent-contract/v1"
+        },
+        "execution_intent": {
+          "$ref": "#/$defs/execution_intent"
+        },
+        "execution_intent_id": {
+          "type": "string",
+          "pattern": "^ei:v1:sha256:[0-9a-f]{64}$"
+        },
+        "execution_intent_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_to_execution_intent_mapping": {
+          "$ref": "#/$defs/mapping"
+        },
+        "field_mapping_proof": {
+          "$ref": "#/$defs/mapping"
+        },
+        "required_field_presence": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "execution_intent_id",
+            "decision_id",
+            "request_id",
+            "policy_snapshot_id",
+            "actor_identity",
+            "target_system",
+            "target_resource",
+            "intended_action",
+            "evidence_refs",
+            "decision_hash",
+            "decision_ts",
+            "ttl_seconds",
+            "expected_state_fingerprint",
+            "approval_context",
+            "policy_lineage"
+          ],
+          "properties": {
+            "execution_intent_id": {
+              "const": "intentionally_deferred"
+            },
+            "decision_id": {
+              "const": "mapped"
+            },
+            "request_id": {
+              "const": "mapped"
+            },
+            "policy_snapshot_id": {
+              "const": "mapped"
+            },
+            "actor_identity": {
+              "const": "mapped"
+            },
+            "target_system": {
+              "const": "mapped"
+            },
+            "target_resource": {
+              "const": "mapped"
+            },
+            "intended_action": {
+              "const": "mapped"
+            },
+            "evidence_refs": {
+              "const": "mapped"
+            },
+            "decision_hash": {
+              "const": "mapped"
+            },
+            "decision_ts": {
+              "const": "mapped"
+            },
+            "ttl_seconds": {
+              "const": "intentionally_deferred"
+            },
+            "expected_state_fingerprint": {
+              "const": "mapped"
+            },
+            "approval_context": {
+              "const": "mapped"
+            },
+            "policy_lineage": {
+              "const": "mapped"
+            }
+          }
+        },
+        "source_decision_identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "request_id",
+            "canonical_decision_id",
+            "canonical_decision_hash",
+            "canonical_decision_ts"
+          ],
+          "properties": {
+            "request_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "canonical_decision_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "canonical_decision_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "canonical_decision_ts": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "candidate_identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "candidate_id",
+            "candidate_hash",
+            "actor_identity",
+            "target_system",
+            "target_resource",
+            "action_contract_id",
+            "action_contract_version"
+          ],
+          "properties": {
+            "candidate_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "candidate_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "actor_identity": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target_system": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target_resource": {
+              "type": "string",
+              "minLength": 1
+            },
+            "action_contract_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "action_contract_version": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "evidence_lineage": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "trustlog_artifact_ref",
+            "trustlog_chain_hash",
+            "replay_artifact_ref",
+            "replay_artifact_hash",
+            "authority_evidence_ref",
+            "authority_evidence_hash",
+            "human_approval_receipt_ref",
+            "human_approval_receipt_hash",
+            "policy_snapshot_id",
+            "policy_version",
+            "policy_semantic_digest",
+            "expected_state_fingerprint",
+            "expected_state_source_ref"
+          ],
+          "properties": {
+            "trustlog_artifact_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "trustlog_chain_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "replay_artifact_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "replay_artifact_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "authority_evidence_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "authority_evidence_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "human_approval_receipt_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "human_approval_receipt_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_snapshot_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_version": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_semantic_digest": {
+              "type": "string",
+              "minLength": 1
+            },
+            "expected_state_fingerprint": {
+              "type": "string",
+              "minLength": 1
+            },
+            "expected_state_source_ref": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "replay_summary": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "original_decision_id",
+            "replay_decision_id",
+            "original_request_id",
+            "replay_request_id",
+            "semantic_profile",
+            "semantic_match",
+            "fields_changed",
+            "severity",
+            "divergence_level"
+          ],
+          "properties": {
+            "original_decision_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "replay_decision_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "original_request_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "replay_request_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "semantic_profile": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "semantic_match": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "fields_changed": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "severity": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "divergence_level": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        "scope_limitations": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "const": "NOT_EXECUTION_AUTHORITY"
+            },
+            {
+              "const": "NOT_BIND_AUTHORIZATION"
+            },
+            {
+              "const": "NOT_BIND_RECEIPT"
+            },
+            {
+              "const": "NOT_BIND_INVOCATION"
+            },
+            {
+              "const": "NOT_EXTERNAL_EFFECT"
+            },
+            {
+              "const": "NOT_ADAPTER_INVOCATION"
+            },
+            {
+              "const": "NOT_OPERATION_COMMIT"
+            },
+            {
+              "const": "NOT_TRUSTLOG_WRITE"
+            },
+            {
+              "const": "NOT_AUTHORITY_EVIDENCE"
+            },
+            {
+              "const": "NOT_HUMAN_APPROVAL"
+            }
+          ],
+          "items": false,
+          "minItems": 10,
+          "maxItems": 10
+        }
+      }
+    },
+    "readiness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "format_version",
+        "readiness_id",
+        "readiness_hash",
+        "verification_mechanism",
+        "checked_at",
+        "source_eligibility",
+        "source_eligibility_hash",
+        "source_eligibility_packet",
+        "source_handoff_hash",
+        "trusted_validation_context_hash",
+        "validation_result_hash",
+        "formation_status",
+        "ready_for_execution_intent_formation",
+        "fail_closed",
+        "execution_intent_contract_version",
+        "execution_intent_required_fields",
+        "source_to_execution_intent_mapping",
+        "mapping_value_digest",
+        "required_field_presence",
+        "source_decision_identity",
+        "candidate_identity",
+        "evidence_lineage",
+        "replay_summary",
+        "scope_limitations"
+      ],
+      "properties": {
+        "format_version": {
+          "const": "canonical-execution-intent-formation-readiness/v1"
+        },
+        "readiness_id": {
+          "type": "string",
+          "pattern": "^eifr:v1:sha256:[0-9a-f]{64}$"
+        },
+        "readiness_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "verification_mechanism": {
+          "const": "verify_guarded_promotion_eligibility_packet/v1"
+        },
+        "checked_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "source_eligibility": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "eligibility_id",
+            "eligibility_hash",
+            "format_version",
+            "validation_mechanism",
+            "handoff_validator_version",
+            "issued_at",
+            "evaluated_at"
+          ],
+          "properties": {
+            "eligibility_id": {
+              "type": "string",
+              "pattern": "^gpe:v1:sha256:[0-9a-f]{64}$"
+            },
+            "eligibility_hash": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "format_version": {
+              "const": "canonical-guarded-promotion-eligibility-packet/v1"
+            },
+            "validation_mechanism": {
+              "const": "validate_canonical_decision_handoff/v1"
+            },
+            "handoff_validator_version": {
+              "type": "string",
+              "minLength": 1
+            },
+            "issued_at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "evaluated_at": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "source_eligibility_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_eligibility_packet": {
+          "$ref": "#/$defs/eligibility"
+        },
+        "source_handoff_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "trusted_validation_context_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "validation_result_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "formation_status": {
+          "const": "READY_FOR_EXECUTION_INTENT_FORMATION"
+        },
+        "ready_for_execution_intent_formation": {
+          "const": true
+        },
+        "fail_closed": {
+          "const": false
+        },
+        "execution_intent_contract_version": {
+          "const": "execution-intent-contract/v1"
+        },
+        "execution_intent_required_fields": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "const": "execution_intent_id"
+            },
+            {
+              "const": "decision_id"
+            },
+            {
+              "const": "request_id"
+            },
+            {
+              "const": "policy_snapshot_id"
+            },
+            {
+              "const": "actor_identity"
+            },
+            {
+              "const": "target_system"
+            },
+            {
+              "const": "target_resource"
+            },
+            {
+              "const": "intended_action"
+            },
+            {
+              "const": "evidence_refs"
+            },
+            {
+              "const": "decision_hash"
+            },
+            {
+              "const": "decision_ts"
+            },
+            {
+              "const": "ttl_seconds"
+            },
+            {
+              "const": "expected_state_fingerprint"
+            },
+            {
+              "const": "approval_context"
+            },
+            {
+              "const": "policy_lineage"
+            }
+          ],
+          "items": false,
+          "minItems": 15,
+          "maxItems": 15
+        },
+        "source_to_execution_intent_mapping": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "decision_id",
+            "request_id",
+            "policy_snapshot_id",
+            "actor_identity",
+            "target_system",
+            "target_resource",
+            "intended_action",
+            "evidence_refs",
+            "decision_hash",
+            "decision_ts",
+            "ttl_seconds",
+            "expected_state_fingerprint",
+            "approval_context",
+            "policy_lineage"
+          ],
+          "properties": {
+            "decision_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "request_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_snapshot_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "actor_identity": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target_system": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target_resource": {
+              "type": "string",
+              "minLength": 1
+            },
+            "intended_action": {
+              "type": "string",
+              "minLength": 1
+            },
+            "evidence_refs": {
+              "type": "array",
+              "minItems": 5,
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "decision_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "decision_ts": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "ttl_seconds": {
+              "type": "null"
+            },
+            "expected_state_fingerprint": {
+              "type": "string",
+              "minLength": 1
+            },
+            "approval_context": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "human_approval_receipt_ref",
+                "human_approval_receipt_hash"
+              ],
+              "properties": {
+                "human_approval_receipt_ref": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "human_approval_receipt_hash": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            },
+            "policy_lineage": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "policy_snapshot_id",
+                "policy_version",
+                "policy_semantic_digest"
+              ],
+              "properties": {
+                "policy_snapshot_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "policy_version": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "policy_semantic_digest": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            }
+          }
+        },
+        "mapping_value_digest": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "required_field_presence": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "execution_intent_id",
+            "decision_id",
+            "request_id",
+            "policy_snapshot_id",
+            "actor_identity",
+            "target_system",
+            "target_resource",
+            "intended_action",
+            "evidence_refs",
+            "decision_hash",
+            "decision_ts",
+            "ttl_seconds",
+            "expected_state_fingerprint",
+            "approval_context",
+            "policy_lineage"
+          ],
+          "properties": {
+            "execution_intent_id": {
+              "const": "intentionally_deferred"
+            },
+            "decision_id": {
+              "const": "mapped"
+            },
+            "request_id": {
+              "const": "mapped"
+            },
+            "policy_snapshot_id": {
+              "const": "mapped"
+            },
+            "actor_identity": {
+              "const": "mapped"
+            },
+            "target_system": {
+              "const": "mapped"
+            },
+            "target_resource": {
+              "const": "mapped"
+            },
+            "intended_action": {
+              "const": "mapped"
+            },
+            "evidence_refs": {
+              "const": "mapped"
+            },
+            "decision_hash": {
+              "const": "mapped"
+            },
+            "decision_ts": {
+              "const": "mapped"
+            },
+            "ttl_seconds": {
+              "const": "intentionally_deferred"
+            },
+            "expected_state_fingerprint": {
+              "const": "mapped"
+            },
+            "approval_context": {
+              "const": "mapped"
+            },
+            "policy_lineage": {
+              "const": "mapped"
+            }
+          }
+        },
+        "source_decision_identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "request_id",
+            "canonical_decision_id",
+            "canonical_decision_hash",
+            "canonical_decision_ts"
+          ],
+          "properties": {
+            "request_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "canonical_decision_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "canonical_decision_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "canonical_decision_ts": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "candidate_identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "candidate_id",
+            "candidate_hash",
+            "actor_identity",
+            "target_system",
+            "target_resource",
+            "action_contract_id",
+            "action_contract_version"
+          ],
+          "properties": {
+            "candidate_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "candidate_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "actor_identity": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target_system": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target_resource": {
+              "type": "string",
+              "minLength": 1
+            },
+            "action_contract_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "action_contract_version": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "evidence_lineage": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "trustlog_artifact_ref",
+            "trustlog_chain_hash",
+            "replay_artifact_ref",
+            "replay_artifact_hash",
+            "authority_evidence_ref",
+            "authority_evidence_hash",
+            "human_approval_receipt_ref",
+            "human_approval_receipt_hash",
+            "policy_snapshot_id",
+            "policy_version",
+            "policy_semantic_digest",
+            "expected_state_fingerprint",
+            "expected_state_source_ref"
+          ],
+          "properties": {
+            "trustlog_artifact_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "trustlog_chain_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "replay_artifact_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "replay_artifact_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "authority_evidence_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "authority_evidence_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "human_approval_receipt_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "human_approval_receipt_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_snapshot_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_version": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_semantic_digest": {
+              "type": "string",
+              "minLength": 1
+            },
+            "expected_state_fingerprint": {
+              "type": "string",
+              "minLength": 1
+            },
+            "expected_state_source_ref": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "replay_summary": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "original_decision_id",
+            "replay_decision_id",
+            "original_request_id",
+            "replay_request_id",
+            "semantic_profile",
+            "semantic_match",
+            "fields_changed",
+            "severity",
+            "divergence_level"
+          ],
+          "properties": {
+            "original_decision_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "replay_decision_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "original_request_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "replay_request_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "semantic_profile": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "semantic_match": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "fields_changed": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "severity": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "divergence_level": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        "scope_limitations": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "const": "NOT_EXECUTION_INTENT"
+            },
+            {
+              "const": "NOT_EXECUTION_AUTHORITY"
+            },
+            {
+              "const": "NOT_BIND_AUTHORIZATION"
+            },
+            {
+              "const": "NOT_BIND_RECEIPT"
+            },
+            {
+              "const": "NOT_EXTERNAL_EFFECT"
+            },
+            {
+              "const": "NOT_ADAPTER_INVOCATION"
+            },
+            {
+              "const": "NOT_OPERATION_COMMIT"
+            },
+            {
+              "const": "NOT_TRUSTLOG_WRITE"
+            }
+          ],
+          "items": false,
+          "minItems": 8,
+          "maxItems": 8
+        }
+      }
+    },
+    "eligibility": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "format_version",
+        "eligibility_id",
+        "eligibility_hash",
+        "validation_mechanism",
+        "handoff_validator_version",
+        "issued_at",
+        "evaluated_at",
+        "validation_status",
+        "ready_for_guarded_promotion",
+        "fail_closed",
+        "source_handoff",
+        "source_handoff_hash",
+        "trusted_validation_context",
+        "trusted_validation_context_hash",
+        "validation_result",
+        "validation_result_hash",
+        "verified_provenance_paths",
+        "source_decision_identity",
+        "candidate_identity",
+        "evidence_lineage",
+        "replay_summary",
+        "scope_limitations"
+      ],
+      "properties": {
+        "format_version": {
+          "const": "canonical-guarded-promotion-eligibility-packet/v1"
+        },
+        "eligibility_id": {
+          "type": "string",
+          "pattern": "^gpe:v1:sha256:[0-9a-f]{64}$"
+        },
+        "eligibility_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "validation_mechanism": {
+          "const": "validate_canonical_decision_handoff/v1"
+        },
+        "handoff_validator_version": {
+          "type": "string"
+        },
+        "issued_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "evaluated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "validation_status": {
+          "const": "READY_FOR_GUARDED_PROMOTION"
+        },
+        "ready_for_guarded_promotion": {
+          "const": true
+        },
+        "fail_closed": {
+          "const": false
+        },
+        "source_handoff": {
+          "type": "object"
+        },
+        "source_handoff_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "trusted_validation_context": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "value_assertions",
+            "candidate_hash_binding",
+            "authority_requirement_binding"
+          ],
+          "properties": {
+            "value_assertions": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/valueAssertion"
+              }
+            },
+            "candidate_hash_binding": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/candidateBinding"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "authority_requirement_binding": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/authorityBinding"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        },
+        "trusted_validation_context_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "validation_result": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "status",
+            "reason_codes",
+            "structure_valid",
+            "declared_status",
+            "declared_status_matches",
+            "declared_reason_codes",
+            "declared_reason_codes_match",
+            "verified_provenance_paths",
+            "validation_version",
+            "ready_for_guarded_promotion",
+            "fail_closed",
+            "requires_review"
+          ],
+          "properties": {
+            "status": {
+              "const": "READY_FOR_GUARDED_PROMOTION"
+            },
+            "reason_codes": {
+              "const": []
+            },
+            "structure_valid": {
+              "const": true
+            },
+            "declared_status": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "declared_status_matches": {
+              "type": "boolean"
+            },
+            "declared_reason_codes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "declared_reason_codes_match": {
+              "type": "boolean"
+            },
+            "verified_provenance_paths": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "validation_version": {
+              "type": "string"
+            },
+            "ready_for_guarded_promotion": {
+              "const": true
+            },
+            "fail_closed": {
+              "const": false
+            },
+            "requires_review": {
+              "const": false
+            }
+          }
+        },
+        "validation_result_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "verified_provenance_paths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source_decision_identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "request_id",
+            "canonical_decision_id",
+            "canonical_decision_hash",
+            "canonical_decision_ts"
+          ],
+          "properties": {
+            "request_id": {
+              "type": "string"
+            },
+            "canonical_decision_id": {
+              "type": "string"
+            },
+            "canonical_decision_hash": {
+              "type": "string"
+            },
+            "canonical_decision_ts": {
+              "type": "string"
+            }
+          }
+        },
+        "candidate_identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "candidate_id",
+            "candidate_hash",
+            "actor_identity",
+            "target_system",
+            "target_resource",
+            "action_contract_id",
+            "action_contract_version"
+          ],
+          "properties": {
+            "candidate_id": {
+              "type": "string"
+            },
+            "candidate_hash": {
+              "type": "string"
+            },
+            "actor_identity": {
+              "type": "string"
+            },
+            "target_system": {
+              "type": "string"
+            },
+            "target_resource": {
+              "type": "string"
+            },
+            "action_contract_id": {
+              "type": "string"
+            },
+            "action_contract_version": {
+              "type": "string"
+            }
+          }
+        },
+        "evidence_lineage": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "trustlog_artifact_ref",
+            "trustlog_chain_hash",
+            "replay_artifact_ref",
+            "replay_artifact_hash",
+            "authority_evidence_ref",
+            "authority_evidence_hash",
+            "human_approval_receipt_ref",
+            "human_approval_receipt_hash",
+            "policy_snapshot_id",
+            "policy_version",
+            "policy_semantic_digest",
+            "expected_state_fingerprint",
+            "expected_state_source_ref"
+          ],
+          "properties": {
+            "trustlog_artifact_ref": {
+              "type": "string"
+            },
+            "trustlog_chain_hash": {
+              "type": "string"
+            },
+            "replay_artifact_ref": {
+              "type": "string"
+            },
+            "replay_artifact_hash": {
+              "type": "string"
+            },
+            "authority_evidence_ref": {
+              "type": "string"
+            },
+            "authority_evidence_hash": {
+              "type": "string"
+            },
+            "human_approval_receipt_ref": {
+              "type": "string"
+            },
+            "human_approval_receipt_hash": {
+              "type": "string"
+            },
+            "policy_snapshot_id": {
+              "type": "string"
+            },
+            "policy_version": {
+              "type": "string"
+            },
+            "policy_semantic_digest": {
+              "type": "string"
+            },
+            "expected_state_fingerprint": {
+              "type": "string"
+            },
+            "expected_state_source_ref": {
+              "type": "string"
+            }
+          }
+        },
+        "replay_summary": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "original_decision_id",
+            "replay_decision_id",
+            "original_request_id",
+            "replay_request_id",
+            "semantic_profile",
+            "semantic_match",
+            "fields_changed",
+            "severity",
+            "divergence_level"
+          ],
+          "properties": {
+            "original_decision_id": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "replay_decision_id": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "original_request_id": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "replay_request_id": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "semantic_profile": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "semantic_match": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "fields_changed": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "severity": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "divergence_level": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        },
+        "scope_limitations": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "const": "NOT_EXECUTION_AUTHORITY"
+            },
+            {
+              "const": "NOT_EXECUTION_INTENT"
+            },
+            {
+              "const": "NOT_BIND_AUTHORIZATION"
+            },
+            {
+              "const": "NOT_BIND_RECEIPT"
+            },
+            {
+              "const": "NOT_EXTERNAL_EFFECT"
+            },
+            {
+              "const": "NOT_AUTHORITY_EVIDENCE"
+            },
+            {
+              "const": "NOT_HUMAN_APPROVAL"
+            },
+            {
+              "const": "NOT_TRUSTLOG_SUBSTITUTE"
+            }
+          ],
+          "items": false,
+          "minItems": 8,
+          "maxItems": 8
+        }
+      }
+    },
+    "valueAssertion": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "field_path",
+        "value_digest",
+        "verification_mechanism",
+        "source_artifact_ref",
+        "source_hash",
+        "verified_at",
+        "claims"
+      ],
+      "properties": {
+        "field_path": {
+          "type": "string"
+        },
+        "value_digest": {
+          "type": "string"
+        },
+        "verification_mechanism": {
+          "type": "string"
+        },
+        "source_artifact_ref": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "source_hash": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "verified_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "claims": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "candidateBinding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "candidate_value_digest",
+        "asserted_candidate_hash",
+        "candidate_hash_profile",
+        "verification_mechanism",
+        "claim",
+        "source_artifact_ref",
+        "source_hash",
+        "verified_at"
+      ],
+      "properties": {
+        "candidate_value_digest": {
+          "type": "string"
+        },
+        "asserted_candidate_hash": {
+          "type": "string"
+        },
+        "candidate_hash_profile": {
+          "type": "string"
+        },
+        "verification_mechanism": {
+          "type": "string"
+        },
+        "claim": {
+          "type": "string"
+        },
+        "source_artifact_ref": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "source_hash": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "verified_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "authorityBinding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "authority_requirement_value_digest",
+        "authority_evidence_value_digest",
+        "verification_mechanism",
+        "claim",
+        "source_artifact_ref",
+        "source_hash",
+        "verified_at"
+      ],
+      "properties": {
+        "authority_requirement_value_digest": {
+          "type": "string"
+        },
+        "authority_evidence_value_digest": {
+          "type": "string"
+        },
+        "verification_mechanism": {
+          "type": "string"
+        },
+        "claim": {
+          "type": "string"
+        },
+        "source_artifact_ref": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "source_hash": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "verified_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "pre_bind_validation_packet": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "format_version",
+        "pre_bind_validation_id",
+        "pre_bind_validation_hash",
+        "validation_mechanism",
+        "checked_at",
+        "source_formation",
+        "source_formation_hash",
+        "source_formation_packet",
+        "source_readiness_hash",
+        "source_eligibility_hash",
+        "source_handoff_hash",
+        "trusted_validation_context_hash",
+        "validation_result_hash",
+        "mapping_value_digest",
+        "execution_intent_contract_version",
+        "execution_intent",
+        "execution_intent_id",
+        "execution_intent_hash",
+        "source_to_execution_intent_mapping",
+        "field_mapping_proof",
+        "required_field_presence",
+        "source_decision_identity",
+        "candidate_identity",
+        "evidence_lineage",
+        "replay_summary",
+        "pre_bind_status",
+        "ready_for_bind_preflight",
+        "fail_closed",
+        "local_validation_checks",
+        "scope_limitations"
+      ],
+      "properties": {
+        "format_version": {
+          "const": "canonical-execution-intent-pre-bind-validation/v1"
+        },
+        "pre_bind_validation_id": {
+          "type": "string",
+          "pattern": "^eipbv:v1:sha256:[0-9a-f]{64}$"
+        },
+        "pre_bind_validation_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "validation_mechanism": {
+          "const": "validate_execution_intent_before_bind/v1"
+        },
+        "checked_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "source_formation": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "formation_id",
+            "formation_hash",
+            "format_version",
+            "formation_mechanism",
+            "formed_at",
+            "execution_intent_id",
+            "execution_intent_hash"
+          ],
+          "properties": {
+            "formation_id": {
+              "type": "string",
+              "pattern": "^eif:v1:sha256:[0-9a-f]{64}$"
+            },
+            "formation_hash": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "format_version": {
+              "const": "canonical-execution-intent-formation/v1"
+            },
+            "formation_mechanism": {
+              "const": "build_execution_intent_from_readiness/v1"
+            },
+            "formed_at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "execution_intent_id": {
+              "type": "string",
+              "pattern": "^ei:v1:sha256:[0-9a-f]{64}$"
+            },
+            "execution_intent_hash": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            }
+          }
+        },
+        "source_formation_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_formation_packet": {
+          "$ref": "#/$defs/formation_packet"
+        },
+        "source_readiness_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_eligibility_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_handoff_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "trusted_validation_context_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "validation_result_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "mapping_value_digest": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "execution_intent_contract_version": {
+          "const": "execution-intent-contract/v1"
+        },
+        "execution_intent": {
+          "$ref": "#/$defs/execution_intent"
+        },
+        "execution_intent_id": {
+          "type": "string",
+          "pattern": "^ei:v1:sha256:[0-9a-f]{64}$"
+        },
+        "execution_intent_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_to_execution_intent_mapping": {
+          "$ref": "#/$defs/mapping"
+        },
+        "field_mapping_proof": {
+          "$ref": "#/$defs/mapping"
+        },
+        "required_field_presence": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "execution_intent_id",
+            "decision_id",
+            "request_id",
+            "policy_snapshot_id",
+            "actor_identity",
+            "target_system",
+            "target_resource",
+            "intended_action",
+            "evidence_refs",
+            "decision_hash",
+            "decision_ts",
+            "ttl_seconds",
+            "expected_state_fingerprint",
+            "approval_context",
+            "policy_lineage"
+          ],
+          "properties": {
+            "execution_intent_id": {
+              "const": "intentionally_deferred"
+            },
+            "decision_id": {
+              "const": "mapped"
+            },
+            "request_id": {
+              "const": "mapped"
+            },
+            "policy_snapshot_id": {
+              "const": "mapped"
+            },
+            "actor_identity": {
+              "const": "mapped"
+            },
+            "target_system": {
+              "const": "mapped"
+            },
+            "target_resource": {
+              "const": "mapped"
+            },
+            "intended_action": {
+              "const": "mapped"
+            },
+            "evidence_refs": {
+              "const": "mapped"
+            },
+            "decision_hash": {
+              "const": "mapped"
+            },
+            "decision_ts": {
+              "const": "mapped"
+            },
+            "ttl_seconds": {
+              "const": "intentionally_deferred"
+            },
+            "expected_state_fingerprint": {
+              "const": "mapped"
+            },
+            "approval_context": {
+              "const": "mapped"
+            },
+            "policy_lineage": {
+              "const": "mapped"
+            }
+          }
+        },
+        "source_decision_identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "request_id",
+            "canonical_decision_id",
+            "canonical_decision_hash",
+            "canonical_decision_ts"
+          ],
+          "properties": {
+            "request_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "canonical_decision_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "canonical_decision_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "canonical_decision_ts": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "candidate_identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "candidate_id",
+            "candidate_hash",
+            "actor_identity",
+            "target_system",
+            "target_resource",
+            "action_contract_id",
+            "action_contract_version"
+          ],
+          "properties": {
+            "candidate_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "candidate_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "actor_identity": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target_system": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target_resource": {
+              "type": "string",
+              "minLength": 1
+            },
+            "action_contract_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "action_contract_version": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "evidence_lineage": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "trustlog_artifact_ref",
+            "trustlog_chain_hash",
+            "replay_artifact_ref",
+            "replay_artifact_hash",
+            "authority_evidence_ref",
+            "authority_evidence_hash",
+            "human_approval_receipt_ref",
+            "human_approval_receipt_hash",
+            "policy_snapshot_id",
+            "policy_version",
+            "policy_semantic_digest",
+            "expected_state_fingerprint",
+            "expected_state_source_ref"
+          ],
+          "properties": {
+            "trustlog_artifact_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "trustlog_chain_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "replay_artifact_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "replay_artifact_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "authority_evidence_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "authority_evidence_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "human_approval_receipt_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "human_approval_receipt_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_snapshot_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_version": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_semantic_digest": {
+              "type": "string",
+              "minLength": 1
+            },
+            "expected_state_fingerprint": {
+              "type": "string",
+              "minLength": 1
+            },
+            "expected_state_source_ref": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "replay_summary": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "original_decision_id",
+            "replay_decision_id",
+            "original_request_id",
+            "replay_request_id",
+            "semantic_profile",
+            "semantic_match",
+            "fields_changed",
+            "severity",
+            "divergence_level"
+          ],
+          "properties": {
+            "original_decision_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "replay_decision_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "original_request_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "replay_request_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "semantic_profile": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "semantic_match": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "fields_changed": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "severity": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "divergence_level": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        "pre_bind_status": {
+          "const": "READY_FOR_BIND_PREFLIGHT"
+        },
+        "ready_for_bind_preflight": {
+          "const": true
+        },
+        "fail_closed": {
+          "const": false
+        },
+        "local_validation_checks": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "formation_verified",
+            "execution_intent_hash_verified",
+            "execution_intent_id_verified",
+            "field_mapping_verified",
+            "required_field_presence_verified",
+            "evidence_refs_non_empty",
+            "decision_timestamp_timezone_aware",
+            "checked_after_formation",
+            "no_bind_invocation",
+            "no_trustlog_write"
+          ],
+          "properties": {
+            "formation_verified": {
+              "const": true
+            },
+            "execution_intent_hash_verified": {
+              "const": true
+            },
+            "execution_intent_id_verified": {
+              "const": true
+            },
+            "field_mapping_verified": {
+              "const": true
+            },
+            "required_field_presence_verified": {
+              "const": true
+            },
+            "evidence_refs_non_empty": {
+              "const": true
+            },
+            "decision_timestamp_timezone_aware": {
+              "const": true
+            },
+            "checked_after_formation": {
+              "const": true
+            },
+            "no_bind_invocation": {
+              "const": true
+            },
+            "no_trustlog_write": {
+              "const": true
+            }
+          }
+        },
+        "scope_limitations": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "const": "NOT_EXECUTION_AUTHORITY"
+            },
+            {
+              "const": "NOT_BIND_AUTHORIZATION"
+            },
+            {
+              "const": "NOT_BIND_RECEIPT"
+            },
+            {
+              "const": "NOT_BIND_INVOCATION"
+            },
+            {
+              "const": "NOT_ADAPTER_INVOCATION"
+            },
+            {
+              "const": "NOT_EXTERNAL_EFFECT"
+            },
+            {
+              "const": "NOT_OPERATION_COMMIT"
+            },
+            {
+              "const": "NOT_TRUSTLOG_WRITE"
+            },
+            {
+              "const": "NOT_LIVE_STATE_CHECK"
+            },
+            {
+              "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+            },
+            {
+              "const": "NOT_AUTHORITY_EVIDENCE"
+            },
+            {
+              "const": "NOT_HUMAN_APPROVAL"
+            }
+          ],
+          "items": false,
+          "minItems": 12,
+          "maxItems": 12
+        }
+      }
+    },
+    "bind_preflight_packet": {
+      "title": "Canonical Bind Preflight Adjudication Packet v1",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "format_version",
+        "bind_preflight_adjudication_id",
+        "bind_preflight_adjudication_hash",
+        "adjudication_mechanism",
+        "adjudicated_at",
+        "source_pre_bind_validation",
+        "source_pre_bind_validation_hash",
+        "source_pre_bind_validation_packet",
+        "source_formation_hash",
+        "source_readiness_hash",
+        "source_eligibility_hash",
+        "source_handoff_hash",
+        "trusted_validation_context_hash",
+        "validation_result_hash",
+        "mapping_value_digest",
+        "execution_intent_contract_version",
+        "execution_intent",
+        "execution_intent_id",
+        "execution_intent_hash",
+        "source_to_execution_intent_mapping",
+        "field_mapping_proof",
+        "required_field_presence",
+        "source_decision_identity",
+        "candidate_identity",
+        "evidence_lineage",
+        "replay_summary",
+        "bind_preflight_status",
+        "ready_for_bind_adjudication",
+        "fail_closed",
+        "local_adjudication_checks",
+        "bind_entry_requirements",
+        "scope_limitations"
+      ],
+      "properties": {
+        "format_version": {
+          "const": "canonical-bind-preflight-adjudication/v1"
+        },
+        "bind_preflight_adjudication_id": {
+          "type": "string",
+          "pattern": "^bpa:v1:sha256:[0-9a-f]{64}$"
+        },
+        "bind_preflight_adjudication_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "adjudication_mechanism": {
+          "const": "adjudicate_bind_preflight_locally/v1"
+        },
+        "adjudicated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "source_pre_bind_validation": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "pre_bind_validation_id",
+            "pre_bind_validation_hash",
+            "format_version",
+            "validation_mechanism",
+            "checked_at",
+            "execution_intent_id",
+            "execution_intent_hash",
+            "pre_bind_status",
+            "ready_for_bind_preflight"
+          ],
+          "properties": {
+            "pre_bind_validation_id": {
+              "type": "string",
+              "pattern": "^eipbv:v1:sha256:[0-9a-f]{64}$"
+            },
+            "pre_bind_validation_hash": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "format_version": {
+              "const": "canonical-execution-intent-pre-bind-validation/v1"
+            },
+            "validation_mechanism": {
+              "const": "validate_execution_intent_before_bind/v1"
+            },
+            "checked_at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "execution_intent_id": {
+              "type": "string",
+              "pattern": "^ei:v1:sha256:[0-9a-f]{64}$"
+            },
+            "execution_intent_hash": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "pre_bind_status": {
+              "const": "READY_FOR_BIND_PREFLIGHT"
+            },
+            "ready_for_bind_preflight": {
+              "const": true
+            }
+          }
+        },
+        "source_pre_bind_validation_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_pre_bind_validation_packet": {
+          "$ref": "#/$defs/pre_bind_validation_packet"
+        },
+        "source_formation_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_readiness_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_eligibility_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_handoff_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "trusted_validation_context_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "validation_result_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "mapping_value_digest": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "execution_intent_contract_version": {
+          "const": "execution-intent-contract/v1"
+        },
+        "execution_intent": {
+          "$ref": "#/$defs/execution_intent"
+        },
+        "execution_intent_id": {
+          "type": "string",
+          "pattern": "^ei:v1:sha256:[0-9a-f]{64}$"
+        },
+        "execution_intent_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_to_execution_intent_mapping": {
+          "$ref": "#/$defs/mapping"
+        },
+        "field_mapping_proof": {
+          "$ref": "#/$defs/mapping"
+        },
+        "required_field_presence": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "execution_intent_id",
+            "decision_id",
+            "request_id",
+            "policy_snapshot_id",
+            "actor_identity",
+            "target_system",
+            "target_resource",
+            "intended_action",
+            "evidence_refs",
+            "decision_hash",
+            "decision_ts",
+            "ttl_seconds",
+            "expected_state_fingerprint",
+            "approval_context",
+            "policy_lineage"
+          ],
+          "properties": {
+            "execution_intent_id": {
+              "const": "intentionally_deferred"
+            },
+            "decision_id": {
+              "const": "mapped"
+            },
+            "request_id": {
+              "const": "mapped"
+            },
+            "policy_snapshot_id": {
+              "const": "mapped"
+            },
+            "actor_identity": {
+              "const": "mapped"
+            },
+            "target_system": {
+              "const": "mapped"
+            },
+            "target_resource": {
+              "const": "mapped"
+            },
+            "intended_action": {
+              "const": "mapped"
+            },
+            "evidence_refs": {
+              "const": "mapped"
+            },
+            "decision_hash": {
+              "const": "mapped"
+            },
+            "decision_ts": {
+              "const": "mapped"
+            },
+            "ttl_seconds": {
+              "const": "intentionally_deferred"
+            },
+            "expected_state_fingerprint": {
+              "const": "mapped"
+            },
+            "approval_context": {
+              "const": "mapped"
+            },
+            "policy_lineage": {
+              "const": "mapped"
+            }
+          }
+        },
+        "source_decision_identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "request_id",
+            "canonical_decision_id",
+            "canonical_decision_hash",
+            "canonical_decision_ts"
+          ],
+          "properties": {
+            "request_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "canonical_decision_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "canonical_decision_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "canonical_decision_ts": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "candidate_identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "candidate_id",
+            "candidate_hash",
+            "actor_identity",
+            "target_system",
+            "target_resource",
+            "action_contract_id",
+            "action_contract_version"
+          ],
+          "properties": {
+            "candidate_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "candidate_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "actor_identity": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target_system": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target_resource": {
+              "type": "string",
+              "minLength": 1
+            },
+            "action_contract_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "action_contract_version": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "evidence_lineage": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "trustlog_artifact_ref",
+            "trustlog_chain_hash",
+            "replay_artifact_ref",
+            "replay_artifact_hash",
+            "authority_evidence_ref",
+            "authority_evidence_hash",
+            "human_approval_receipt_ref",
+            "human_approval_receipt_hash",
+            "policy_snapshot_id",
+            "policy_version",
+            "policy_semantic_digest",
+            "expected_state_fingerprint",
+            "expected_state_source_ref"
+          ],
+          "properties": {
+            "trustlog_artifact_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "trustlog_chain_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "replay_artifact_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "replay_artifact_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "authority_evidence_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "authority_evidence_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "human_approval_receipt_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "human_approval_receipt_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_snapshot_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_version": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_semantic_digest": {
+              "type": "string",
+              "minLength": 1
+            },
+            "expected_state_fingerprint": {
+              "type": "string",
+              "minLength": 1
+            },
+            "expected_state_source_ref": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "replay_summary": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "original_decision_id",
+            "replay_decision_id",
+            "original_request_id",
+            "replay_request_id",
+            "semantic_profile",
+            "semantic_match",
+            "fields_changed",
+            "severity",
+            "divergence_level"
+          ],
+          "properties": {
+            "original_decision_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "replay_decision_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "original_request_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "replay_request_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "semantic_profile": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "semantic_match": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "fields_changed": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "severity": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "divergence_level": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        "bind_preflight_status": {
+          "const": "READY_FOR_BIND_ADJUDICATION"
+        },
+        "ready_for_bind_adjudication": {
+          "const": true
+        },
+        "fail_closed": {
+          "const": false
+        },
+        "local_adjudication_checks": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "pre_bind_validation_verified",
+            "execution_intent_hash_verified",
+            "execution_intent_id_verified",
+            "source_formation_verified",
+            "field_mapping_verified",
+            "required_field_presence_verified",
+            "evidence_refs_non_empty",
+            "decision_timestamp_timezone_aware",
+            "adjudicated_after_pre_bind_validation",
+            "ttl_locally_well_formed",
+            "no_bind_invocation",
+            "no_adapter_invocation",
+            "no_bind_receipt_created",
+            "no_trustlog_write",
+            "no_live_state_check",
+            "no_runtime_risk_check"
+          ],
+          "properties": {
+            "pre_bind_validation_verified": {
+              "const": true
+            },
+            "execution_intent_hash_verified": {
+              "const": true
+            },
+            "execution_intent_id_verified": {
+              "const": true
+            },
+            "source_formation_verified": {
+              "const": true
+            },
+            "field_mapping_verified": {
+              "const": true
+            },
+            "required_field_presence_verified": {
+              "const": true
+            },
+            "evidence_refs_non_empty": {
+              "const": true
+            },
+            "decision_timestamp_timezone_aware": {
+              "const": true
+            },
+            "adjudicated_after_pre_bind_validation": {
+              "const": true
+            },
+            "ttl_locally_well_formed": {
+              "const": true
+            },
+            "no_bind_invocation": {
+              "const": true
+            },
+            "no_adapter_invocation": {
+              "const": true
+            },
+            "no_bind_receipt_created": {
+              "const": true
+            },
+            "no_trustlog_write": {
+              "const": true
+            },
+            "no_live_state_check": {
+              "const": true
+            },
+            "no_runtime_risk_check": {
+              "const": true
+            }
+          }
+        },
+        "bind_entry_requirements": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "adapter_required",
+            "adapter_snapshot_required",
+            "adapter_authority_revalidation_required",
+            "adapter_constraint_validation_required",
+            "runtime_risk_assessment_required",
+            "commit_boundary_evaluation_required",
+            "postcondition_verification_required",
+            "rollback_or_revert_path_required",
+            "bind_receipt_required",
+            "trustlog_policy_required"
+          ],
+          "properties": {
+            "adapter_required": {
+              "const": true
+            },
+            "adapter_snapshot_required": {
+              "const": true
+            },
+            "adapter_authority_revalidation_required": {
+              "const": true
+            },
+            "adapter_constraint_validation_required": {
+              "const": true
+            },
+            "runtime_risk_assessment_required": {
+              "const": true
+            },
+            "commit_boundary_evaluation_required": {
+              "const": true
+            },
+            "postcondition_verification_required": {
+              "const": true
+            },
+            "rollback_or_revert_path_required": {
+              "const": true
+            },
+            "bind_receipt_required": {
+              "const": true
+            },
+            "trustlog_policy_required": {
+              "const": true
+            }
+          }
+        },
+        "scope_limitations": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "const": "NOT_EXECUTION_AUTHORITY"
+            },
+            {
+              "const": "NOT_BIND_AUTHORIZATION"
+            },
+            {
+              "const": "NOT_BIND_RECEIPT"
+            },
+            {
+              "const": "NOT_BIND_INVOCATION"
+            },
+            {
+              "const": "NOT_ADAPTER_INVOCATION"
+            },
+            {
+              "const": "NOT_EXTERNAL_EFFECT"
+            },
+            {
+              "const": "NOT_OPERATION_COMMIT"
+            },
+            {
+              "const": "NOT_TRUSTLOG_WRITE"
+            },
+            {
+              "const": "NOT_LIVE_STATE_CHECK"
+            },
+            {
+              "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+            },
+            {
+              "const": "NOT_AUTHORITY_REVALIDATION"
+            },
+            {
+              "const": "NOT_CONSTRAINT_REVALIDATION"
+            },
+            {
+              "const": "NOT_POSTCONDITION_VERIFICATION"
+            },
+            {
+              "const": "NOT_ROLLBACK_PROOF"
+            },
+            {
+              "const": "NOT_AUTHORITY_EVIDENCE"
+            },
+            {
+              "const": "NOT_HUMAN_APPROVAL"
+            }
+          ],
+          "items": false,
+          "minItems": 16,
+          "maxItems": 16
+        }
+      }
+    },
+    "descriptor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "adapter_contract_id",
+        "adapter_contract_hash",
+        "adapter_contract_version",
+        "adapter_kind",
+        "adapter_name",
+        "target_system",
+        "target_resource_scope",
+        "supported_methods",
+        "required_methods",
+        "prohibited_during_selection",
+        "effect_profile",
+        "declared_by",
+        "declared_at",
+        "descriptor_scope_limitations"
+      ],
+      "properties": {
+        "adapter_contract_id": {
+          "type": "string",
+          "pattern": "^adapter-contract:v1:sha256:[0-9a-f]{64}$"
+        },
+        "adapter_contract_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "adapter_contract_version": {
+          "const": "bind-adapter-contract/v1"
+        },
+        "adapter_kind": {
+          "enum": [
+            "reference",
+            "webhook",
+            "external",
+            "custom"
+          ]
+        },
+        "adapter_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_system": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_resource_scope": {
+          "type": "string",
+          "minLength": 1
+        },
+        "supported_methods": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "const": "snapshot"
+            },
+            {
+              "const": "fingerprint_state"
+            },
+            {
+              "const": "validate_authority"
+            },
+            {
+              "const": "validate_constraints"
+            },
+            {
+              "const": "assess_runtime_risk"
+            },
+            {
+              "const": "apply"
+            },
+            {
+              "const": "verify_postconditions"
+            },
+            {
+              "const": "revert"
+            },
+            {
+              "const": "describe_target"
+            },
+            {
+              "const": "build_idempotency_key"
+            }
+          ],
+          "items": false,
+          "minItems": 10,
+          "maxItems": 10
+        },
+        "required_methods": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "const": "snapshot"
+            },
+            {
+              "const": "fingerprint_state"
+            },
+            {
+              "const": "validate_authority"
+            },
+            {
+              "const": "validate_constraints"
+            },
+            {
+              "const": "assess_runtime_risk"
+            },
+            {
+              "const": "apply"
+            },
+            {
+              "const": "verify_postconditions"
+            },
+            {
+              "const": "revert"
+            },
+            {
+              "const": "describe_target"
+            },
+            {
+              "const": "build_idempotency_key"
+            }
+          ],
+          "items": false,
+          "minItems": 10,
+          "maxItems": 10
+        },
+        "prohibited_during_selection": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "const": "snapshot"
+            },
+            {
+              "const": "fingerprint_state"
+            },
+            {
+              "const": "validate_authority"
+            },
+            {
+              "const": "validate_constraints"
+            },
+            {
+              "const": "assess_runtime_risk"
+            },
+            {
+              "const": "apply"
+            },
+            {
+              "const": "verify_postconditions"
+            },
+            {
+              "const": "revert"
+            },
+            {
+              "const": "build_idempotency_key"
+            },
+            {
+              "const": "execute_bind_adjudication"
+            },
+            {
+              "const": "execute_bind_boundary"
+            },
+            {
+              "const": "BindReceipt"
+            },
+            {
+              "const": "TrustLogWrite"
+            }
+          ],
+          "items": false,
+          "minItems": 13,
+          "maxItems": 13
+        },
+        "effect_profile": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "selection_phase",
+            "adapter_instantiated",
+            "adapter_methods_called",
+            "network_allowed",
+            "filesystem_allowed",
+            "external_effect_allowed",
+            "trustlog_write_allowed",
+            "bind_receipt_allowed"
+          ],
+          "properties": {
+            "selection_phase": {
+              "const": "no_effect"
+            },
+            "adapter_instantiated": {
+              "const": false
+            },
+            "adapter_methods_called": {
+              "const": false
+            },
+            "network_allowed": {
+              "const": false
+            },
+            "filesystem_allowed": {
+              "const": false
+            },
+            "external_effect_allowed": {
+              "const": false
+            },
+            "trustlog_write_allowed": {
+              "const": false
+            },
+            "bind_receipt_allowed": {
+              "const": false
+            }
+          }
+        },
+        "declared_by": {
+          "type": "string",
+          "minLength": 1
+        },
+        "declared_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "descriptor_scope_limitations": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "const": "NOT_ADAPTER_INSTANCE"
+            },
+            {
+              "const": "NOT_ADAPTER_AUTHORIZATION"
+            },
+            {
+              "const": "NOT_ADAPTER_INVOCATION"
+            },
+            {
+              "const": "NOT_BIND_INVOCATION"
+            },
+            {
+              "const": "NOT_BIND_RECEIPT"
+            },
+            {
+              "const": "NOT_TRUSTLOG_WRITE"
+            },
+            {
+              "const": "NOT_EXTERNAL_EFFECT"
+            },
+            {
+              "const": "NOT_AUTHORITY_REVALIDATION"
+            },
+            {
+              "const": "NOT_CONSTRAINT_REVALIDATION"
+            },
+            {
+              "const": "NOT_RUNTIME_RISK_CHECK"
+            },
+            {
+              "const": "NOT_POSTCONDITION_VERIFICATION"
+            },
+            {
+              "const": "NOT_ROLLBACK_PROOF"
+            }
+          ],
+          "items": false,
+          "minItems": 12,
+          "maxItems": 12
+        }
+      }
+    }
+  }
+}

--- a/veritas_os/policy/bind_adapter_contract_selection.py
+++ b/veritas_os/policy/bind_adapter_contract_selection.py
@@ -1,0 +1,383 @@
+"""Select an inert Bind adapter contract descriptor without invoking Bind.
+
+The packet produced here is local, deterministic evidence of association only.
+It never creates an adapter, calls an adapter, authorizes execution, or writes
+TrustLog.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from veritas_os.policy.bind_artifacts import (
+    ExecutionIntent,
+    canonical_execution_intent_json,
+    hash_execution_intent,
+)
+from veritas_os.policy.canonical_bind_preflight_adjudication import (
+    BindPreflightAdjudicationError,
+    CanonicalBindPreflightAdjudicationPacket,
+    verify_canonical_bind_preflight_adjudication_packet,
+)
+
+FORMAT_VERSION = "canonical-bind-adapter-contract-selection/v1"
+SELECTION_MECHANISM = "select_bind_adapter_contract_without_invocation/v1"
+DESCRIPTOR_DOMAIN = "veritas.bind-adapter-contract-selection.descriptor/v1"
+LOCAL_CHECKS_DOMAIN = "veritas.bind-adapter-contract-selection.local-checks/v1"
+FUTURE_REQUIREMENTS_DOMAIN = (
+    "veritas.bind-adapter-contract-selection.future-requirements/v1"
+)
+PACKET_DOMAIN = "veritas.bind-adapter-contract-selection.packet/v1"
+SOURCE_SUMMARY_KEYS = (
+    "bind_preflight_adjudication_id", "bind_preflight_adjudication_hash",
+    "format_version", "adjudication_mechanism", "adjudicated_at",
+    "execution_intent_id", "execution_intent_hash", "bind_preflight_status",
+    "ready_for_bind_adjudication",
+)
+ADAPTER_METHODS = (
+    "snapshot", "fingerprint_state", "validate_authority",
+    "validate_constraints", "assess_runtime_risk", "apply",
+    "verify_postconditions", "revert", "describe_target",
+    "build_idempotency_key",
+)
+PROHIBITED_DURING_SELECTION = (
+    "snapshot", "fingerprint_state", "validate_authority",
+    "validate_constraints", "assess_runtime_risk", "apply",
+    "verify_postconditions", "revert", "build_idempotency_key",
+    "execute_bind_adjudication", "execute_bind_boundary", "BindReceipt",
+    "TrustLogWrite",
+)
+EFFECT_PROFILE = {
+    "selection_phase": "no_effect", "adapter_instantiated": False,
+    "adapter_methods_called": False, "network_allowed": False,
+    "filesystem_allowed": False, "external_effect_allowed": False,
+    "trustlog_write_allowed": False, "bind_receipt_allowed": False,
+}
+DESCRIPTOR_SCOPE_LIMITATIONS = (
+    "NOT_ADAPTER_INSTANCE", "NOT_ADAPTER_AUTHORIZATION",
+    "NOT_ADAPTER_INVOCATION", "NOT_BIND_INVOCATION", "NOT_BIND_RECEIPT",
+    "NOT_TRUSTLOG_WRITE", "NOT_EXTERNAL_EFFECT",
+    "NOT_AUTHORITY_REVALIDATION", "NOT_CONSTRAINT_REVALIDATION",
+    "NOT_RUNTIME_RISK_CHECK", "NOT_POSTCONDITION_VERIFICATION",
+    "NOT_ROLLBACK_PROOF",
+)
+LOCAL_SELECTION_CHECKS = {key: True for key in (
+    "bind_preflight_adjudication_verified", "execution_intent_hash_verified",
+    "execution_intent_id_verified", "adapter_descriptor_hash_verified",
+    "adapter_descriptor_scope_matches_intent", "required_methods_declared",
+    "prohibited_methods_not_called", "selected_after_bind_preflight_adjudication",
+    "no_adapter_instance", "no_adapter_invocation", "no_bind_invocation",
+    "no_bind_receipt_created", "no_trustlog_write", "no_network",
+    "no_filesystem", "no_external_effect",
+)}
+FUTURE_BIND_DRY_RUN_REQUIREMENTS = {key: True for key in (
+    "adapter_instance_required", "snapshot_required",
+    "state_fingerprint_required", "authority_revalidation_required",
+    "constraint_validation_required", "runtime_risk_assessment_required",
+    "commit_boundary_evaluation_required", "idempotency_key_required",
+    "postcondition_verification_required", "rollback_or_revert_path_required",
+    "bind_receipt_required", "trustlog_policy_required",
+)}
+SCOPE_LIMITATIONS = (
+    "NOT_EXECUTION_AUTHORITY", "NOT_BIND_AUTHORIZATION", "NOT_BIND_RECEIPT",
+    "NOT_BIND_INVOCATION", "NOT_ADAPTER_INSTANCE", "NOT_ADAPTER_INVOCATION",
+    "NOT_EXTERNAL_EFFECT", "NOT_OPERATION_COMMIT", "NOT_TRUSTLOG_WRITE",
+    "NOT_LIVE_STATE_CHECK", "NOT_RUNTIME_RISK_ACCEPTANCE",
+    "NOT_AUTHORITY_REVALIDATION", "NOT_CONSTRAINT_REVALIDATION",
+    "NOT_POSTCONDITION_VERIFICATION", "NOT_ROLLBACK_PROOF",
+    "NOT_AUTHORITY_EVIDENCE", "NOT_HUMAN_APPROVAL",
+)
+
+
+class BindAdapterContractSelectionError(ValueError):
+    """Stable fail-closed refusal for local contract selection."""
+
+
+class BindAdapterContractDescriptor(BaseModel):
+    """Immutable pure-data declaration; never an adapter instance."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    adapter_contract_id: str = Field(
+        pattern=r"^adapter-contract:v1:sha256:[0-9a-f]{64}$"
+    )
+    adapter_contract_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    adapter_contract_version: Literal["bind-adapter-contract/v1"]
+    adapter_kind: Literal["reference", "webhook", "external", "custom"]
+    adapter_name: str = Field(min_length=1)
+    target_system: str = Field(min_length=1)
+    target_resource_scope: str = Field(min_length=1)
+    supported_methods: tuple[str, ...]
+    required_methods: tuple[str, ...]
+    prohibited_during_selection: tuple[str, ...]
+    effect_profile: dict[str, Any]
+    declared_by: str = Field(min_length=1)
+    declared_at: str
+    descriptor_scope_limitations: tuple[str, ...]
+
+
+class CanonicalBindAdapterContractSelectionPacket(BaseModel):
+    """Immutable association proof that conveys no execution authority."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    format_version: Literal["canonical-bind-adapter-contract-selection/v1"]
+    adapter_contract_selection_id: str = Field(
+        pattern=r"^bac:v1:sha256:[0-9a-f]{64}$"
+    )
+    adapter_contract_selection_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    selection_mechanism: Literal[
+        "select_bind_adapter_contract_without_invocation/v1"
+    ]
+    selected_at: str
+    source_bind_preflight_adjudication: dict[str, Any]
+    source_bind_preflight_adjudication_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    source_bind_preflight_adjudication_packet: dict[str, Any]
+    adapter_contract_descriptor: dict[str, Any]
+    adapter_contract_id: str
+    adapter_contract_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    adapter_contract_version: Literal["bind-adapter-contract/v1"]
+    execution_intent: dict[str, Any]
+    execution_intent_id: str = Field(pattern=r"^ei:v1:sha256:[0-9a-f]{64}$")
+    execution_intent_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    source_formation_hash: str
+    source_readiness_hash: str
+    source_eligibility_hash: str
+    source_handoff_hash: str
+    trusted_validation_context_hash: str
+    validation_result_hash: str
+    mapping_value_digest: str
+    execution_intent_contract_version: str
+    selection_status: Literal["ADAPTER_CONTRACT_SELECTED_FOR_DRY_RUN"]
+    ready_for_adapter_dry_run: Literal[True]
+    fail_closed: Literal[False]
+    local_selection_checks: dict[str, bool]
+    future_bind_dry_run_requirements: dict[str, bool]
+    source_to_execution_intent_mapping: dict[str, Any]
+    field_mapping_proof: dict[str, Any]
+    required_field_presence: dict[str, str]
+    source_decision_identity: dict[str, Any]
+    candidate_identity: dict[str, Any]
+    evidence_lineage: dict[str, Any]
+    replay_summary: dict[str, Any]
+    scope_limitations: tuple[str, ...]
+
+
+def _json_value(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        value = value.model_dump(mode="python")
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        if value != value or value in (float("inf"), float("-inf")):
+            raise BindAdapterContractSelectionError("BAC_PACKET_INVALID")
+        return value
+    if isinstance(value, datetime):
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise BindAdapterContractSelectionError("BAC_SELECTED_AT_INVALID")
+        return value.isoformat()
+    if isinstance(value, (list, tuple)):
+        return [_json_value(item) for item in value]
+    if isinstance(value, dict) and all(isinstance(key, str) for key in value):
+        return {key: _json_value(item) for key, item in value.items()}
+    raise BindAdapterContractSelectionError("BAC_PACKET_INVALID")
+
+
+def _aware_iso(value: Any, code: str) -> datetime:
+    try:
+        parsed = value if isinstance(value, datetime) else datetime.fromisoformat(value)
+    except (TypeError, ValueError) as exc:
+        raise BindAdapterContractSelectionError(code) from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise BindAdapterContractSelectionError(code)
+    return parsed
+
+
+def _digest(domain: str, value: Any) -> str:
+    encoded = json.dumps(
+        {"domain": domain, "value": _json_value(value)}, allow_nan=False,
+        ensure_ascii=False, separators=(",", ":"), sort_keys=True,
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _descriptor_hash(raw: dict[str, Any]) -> str:
+    return _digest(DESCRIPTOR_DOMAIN, {key: value for key, value in raw.items()
+                                      if key not in {"adapter_contract_id",
+                                                     "adapter_contract_hash"}})
+
+
+def _packet_hash(raw: dict[str, Any]) -> str:
+    return _digest(PACKET_DOMAIN, {key: value for key, value in raw.items()
+                                  if key not in {"adapter_contract_selection_id",
+                                                 "adapter_contract_selection_hash"}})
+
+
+def _verified_source(value: Any) -> CanonicalBindPreflightAdjudicationPacket:
+    try:
+        return verify_canonical_bind_preflight_adjudication_packet(value)
+    except (BindPreflightAdjudicationError, TypeError, ValueError) as exc:
+        raise BindAdapterContractSelectionError("BAC_BIND_PREFLIGHT_INVALID") from exc
+
+
+def _intent(raw: dict[str, Any]) -> ExecutionIntent:
+    try:
+        intent = ExecutionIntent(**raw)
+        canonical_execution_intent_json(intent)
+    except (TypeError, ValueError) as exc:
+        raise BindAdapterContractSelectionError("BAC_EXECUTION_INTENT_INVALID") from exc
+    if intent.to_dict() != raw:
+        raise BindAdapterContractSelectionError("BAC_EXECUTION_INTENT_INVALID")
+    return intent
+
+
+def _descriptor(value: Any, intent: ExecutionIntent) -> BindAdapterContractDescriptor:
+    try:
+        raw = _json_value(value)
+        if not isinstance(raw, dict):
+            raise BindAdapterContractSelectionError("BAC_DESCRIPTOR_INVALID")
+        supplied_id = raw.pop("adapter_contract_id", None)
+        supplied_hash = raw.pop("adapter_contract_hash", None)
+        digest = _descriptor_hash(raw)
+        if supplied_hash is not None and supplied_hash != digest:
+            raise BindAdapterContractSelectionError("BAC_DESCRIPTOR_HASH_MISMATCH")
+        expected_id = f"adapter-contract:v1:sha256:{digest}"
+        if supplied_id is not None and supplied_id != expected_id:
+            raise BindAdapterContractSelectionError("BAC_DESCRIPTOR_ID_MISMATCH")
+        raw.update(adapter_contract_hash=digest, adapter_contract_id=expected_id)
+        descriptor = BindAdapterContractDescriptor.model_validate(raw)
+    except ValidationError as exc:
+        raise BindAdapterContractSelectionError("BAC_DESCRIPTOR_INVALID") from exc
+    _aware_iso(descriptor.declared_at, "BAC_DESCRIPTOR_INVALID")
+    if (descriptor.target_system != intent.target_system or
+            descriptor.target_resource_scope != intent.target_resource):
+        raise BindAdapterContractSelectionError("BAC_DESCRIPTOR_TARGET_MISMATCH")
+    if (descriptor.supported_methods != ADAPTER_METHODS or
+            descriptor.required_methods != ADAPTER_METHODS or
+            descriptor.prohibited_during_selection != PROHIBITED_DURING_SELECTION):
+        raise BindAdapterContractSelectionError("BAC_METHODS_MISMATCH")
+    if descriptor.effect_profile != EFFECT_PROFILE:
+        raise BindAdapterContractSelectionError("BAC_EFFECT_PROFILE_INVALID")
+    if descriptor.descriptor_scope_limitations != DESCRIPTOR_SCOPE_LIMITATIONS:
+        raise BindAdapterContractSelectionError("BAC_SCOPE_LIMITATIONS_MISSING")
+    return descriptor
+
+
+def build_bind_adapter_contract_selection_packet(
+    bind_preflight_adjudication_packet: Any,
+    adapter_contract_descriptor: Any,
+    selected_at: datetime,
+) -> CanonicalBindAdapterContractSelectionPacket:
+    """Build a no-effect association after verifying the complete source."""
+    selected = _aware_iso(selected_at, "BAC_SELECTED_AT_INVALID")
+    source_packet = _verified_source(_json_value(bind_preflight_adjudication_packet))
+    source = source_packet.model_dump(mode="json")
+    adjudicated = _aware_iso(source_packet.adjudicated_at, "BAC_BIND_PREFLIGHT_INVALID")
+    if selected < adjudicated:
+        raise BindAdapterContractSelectionError("BAC_SELECTED_BEFORE_BIND_PREFLIGHT")
+    intent = _intent(source_packet.execution_intent)
+    if intent.execution_intent_id != source_packet.execution_intent_id:
+        raise BindAdapterContractSelectionError("BAC_EXECUTION_INTENT_ID_MISMATCH")
+    if hash_execution_intent(intent) != source_packet.execution_intent_hash:
+        raise BindAdapterContractSelectionError("BAC_EXECUTION_INTENT_HASH_MISMATCH")
+    descriptor = _descriptor(adapter_contract_descriptor, intent)
+    descriptor_raw = descriptor.model_dump(mode="json")
+    copied = (
+        "source_formation_hash", "source_readiness_hash", "source_eligibility_hash",
+        "source_handoff_hash", "trusted_validation_context_hash",
+        "validation_result_hash", "mapping_value_digest",
+        "execution_intent_contract_version", "execution_intent",
+        "execution_intent_id", "execution_intent_hash",
+        "source_to_execution_intent_mapping", "field_mapping_proof",
+        "required_field_presence", "source_decision_identity", "candidate_identity",
+        "evidence_lineage", "replay_summary",
+    )
+    raw = {
+        "format_version": FORMAT_VERSION, "selection_mechanism": SELECTION_MECHANISM,
+        "selected_at": selected.isoformat(),
+        "source_bind_preflight_adjudication": {
+            key: source[key] for key in SOURCE_SUMMARY_KEYS
+        },
+        "source_bind_preflight_adjudication_hash": source_packet.bind_preflight_adjudication_hash,
+        "source_bind_preflight_adjudication_packet": source,
+        "adapter_contract_descriptor": descriptor_raw,
+        "adapter_contract_id": descriptor.adapter_contract_id,
+        "adapter_contract_hash": descriptor.adapter_contract_hash,
+        "adapter_contract_version": descriptor.adapter_contract_version,
+        **{key: source[key] for key in copied},
+        "selection_status": "ADAPTER_CONTRACT_SELECTED_FOR_DRY_RUN",
+        "ready_for_adapter_dry_run": True, "fail_closed": False,
+        "local_selection_checks": LOCAL_SELECTION_CHECKS,
+        "future_bind_dry_run_requirements": FUTURE_BIND_DRY_RUN_REQUIREMENTS,
+        "scope_limitations": SCOPE_LIMITATIONS,
+    }
+    digest = _packet_hash(raw)
+    raw.update(adapter_contract_selection_hash=digest,
+               adapter_contract_selection_id=f"bac:v1:sha256:{digest}")
+    return verify_bind_adapter_contract_selection_packet(raw)
+
+
+def verify_bind_adapter_contract_selection_packet(
+    packet: Any,
+) -> CanonicalBindAdapterContractSelectionPacket:
+    """Revalidate and independently recompute every selection packet binding."""
+    try:
+        value = packet.model_dump(mode="json") if isinstance(packet, BaseModel) else _json_value(packet)
+        candidate = CanonicalBindAdapterContractSelectionPacket.model_validate(value)
+    except (ValidationError, BindAdapterContractSelectionError, TypeError) as exc:
+        raise BindAdapterContractSelectionError("BAC_PACKET_INVALID") from exc
+    raw = candidate.model_dump(mode="json")
+    source_packet = _verified_source(candidate.source_bind_preflight_adjudication_packet)
+    source = source_packet.model_dump(mode="json")
+    if set(candidate.source_bind_preflight_adjudication) != set(SOURCE_SUMMARY_KEYS):
+        raise BindAdapterContractSelectionError("BAC_SOURCE_SUMMARY_MISMATCH")
+    if candidate.source_bind_preflight_adjudication != {
+            key: source[key] for key in SOURCE_SUMMARY_KEYS}:
+        raise BindAdapterContractSelectionError("BAC_SOURCE_SUMMARY_MISMATCH")
+    selected = _aware_iso(candidate.selected_at, "BAC_SELECTED_AT_INVALID")
+    adjudicated = _aware_iso(source_packet.adjudicated_at, "BAC_BIND_PREFLIGHT_INVALID")
+    if selected < adjudicated:
+        raise BindAdapterContractSelectionError("BAC_SELECTED_BEFORE_BIND_PREFLIGHT")
+    copied = (
+        "source_formation_hash", "source_readiness_hash", "source_eligibility_hash",
+        "source_handoff_hash", "trusted_validation_context_hash",
+        "validation_result_hash", "mapping_value_digest",
+        "execution_intent_contract_version", "execution_intent",
+        "execution_intent_id", "execution_intent_hash",
+        "source_to_execution_intent_mapping", "field_mapping_proof",
+        "required_field_presence", "source_decision_identity", "candidate_identity",
+        "evidence_lineage", "replay_summary",
+    )
+    if (candidate.source_bind_preflight_adjudication_hash !=
+            source_packet.bind_preflight_adjudication_hash or
+            any(getattr(candidate, key) != getattr(source_packet, key)
+                for key in copied)):
+        raise BindAdapterContractSelectionError("BAC_SOURCE_SUMMARY_MISMATCH")
+    intent = _intent(candidate.execution_intent)
+    if intent.execution_intent_id != candidate.execution_intent_id:
+        raise BindAdapterContractSelectionError("BAC_EXECUTION_INTENT_ID_MISMATCH")
+    if hash_execution_intent(intent) != candidate.execution_intent_hash:
+        raise BindAdapterContractSelectionError("BAC_EXECUTION_INTENT_HASH_MISMATCH")
+    descriptor = _descriptor(candidate.adapter_contract_descriptor, intent)
+    if (candidate.adapter_contract_descriptor != descriptor.model_dump(mode="json") or
+            candidate.adapter_contract_id != descriptor.adapter_contract_id or
+            candidate.adapter_contract_hash != descriptor.adapter_contract_hash or
+            candidate.adapter_contract_version != descriptor.adapter_contract_version):
+        raise BindAdapterContractSelectionError("BAC_DESCRIPTOR_HASH_MISMATCH")
+    if candidate.local_selection_checks != LOCAL_SELECTION_CHECKS:
+        raise BindAdapterContractSelectionError("BAC_LOCAL_CHECKS_MISMATCH")
+    if candidate.future_bind_dry_run_requirements != FUTURE_BIND_DRY_RUN_REQUIREMENTS:
+        raise BindAdapterContractSelectionError("BAC_FUTURE_REQUIREMENTS_MISMATCH")
+    _digest(LOCAL_CHECKS_DOMAIN, candidate.local_selection_checks)
+    _digest(FUTURE_REQUIREMENTS_DOMAIN, candidate.future_bind_dry_run_requirements)
+    if candidate.scope_limitations != SCOPE_LIMITATIONS:
+        raise BindAdapterContractSelectionError("BAC_SCOPE_LIMITATIONS_MISSING")
+    digest = _packet_hash(raw)
+    if candidate.adapter_contract_selection_hash != digest:
+        raise BindAdapterContractSelectionError("BAC_PACKET_HASH_MISMATCH")
+    if candidate.adapter_contract_selection_id != f"bac:v1:sha256:{digest}":
+        raise BindAdapterContractSelectionError("BAC_PACKET_ID_MISMATCH")
+    return candidate

--- a/veritas_os/tests/test_bind_adapter_contract_selection.py
+++ b/veritas_os/tests/test_bind_adapter_contract_selection.py
@@ -1,0 +1,274 @@
+"""Security tests for Canonical Bind Adapter Contract Selection v1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from copy import deepcopy
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator, FormatChecker
+
+from veritas_os.policy.bind_artifacts import ExecutionIntent, hash_execution_intent
+from veritas_os.policy.bind_adapter_contract_selection import (
+    ADAPTER_METHODS,
+    DESCRIPTOR_SCOPE_LIMITATIONS,
+    EFFECT_PROFILE,
+    FUTURE_BIND_DRY_RUN_REQUIREMENTS,
+    LOCAL_SELECTION_CHECKS,
+    PROHIBITED_DURING_SELECTION,
+    SCOPE_LIMITATIONS,
+    BindAdapterContractSelectionError,
+    CanonicalBindAdapterContractSelectionPacket,
+    _descriptor_hash,
+    _packet_hash,
+    build_bind_adapter_contract_selection_packet,
+    verify_bind_adapter_contract_selection_packet,
+)
+from veritas_os.tests.test_canonical_bind_preflight_adjudication import (
+    ADJUDICATED_AT,
+    _packet as preflight_packet,
+)
+
+SELECTED_AT = ADJUDICATED_AT + timedelta(seconds=1)
+MODULE = Path("veritas_os/policy/bind_adapter_contract_selection.py")
+SCHEMA = Path("schemas/bind-adapter-contract-selection-v1.schema.json")
+
+
+def _descriptor() -> dict:
+    source = preflight_packet()
+    return {
+        "adapter_contract_version": "bind-adapter-contract/v1",
+        "adapter_kind": "reference",
+        "adapter_name": "inert-reference-declaration",
+        "target_system": source.execution_intent["target_system"],
+        "target_resource_scope": source.execution_intent["target_resource"],
+        "supported_methods": list(ADAPTER_METHODS),
+        "required_methods": list(ADAPTER_METHODS),
+        "prohibited_during_selection": list(PROHIBITED_DURING_SELECTION),
+        "effect_profile": EFFECT_PROFILE,
+        "declared_by": "local-test",
+        "declared_at": ADJUDICATED_AT.isoformat(),
+        "descriptor_scope_limitations": list(DESCRIPTOR_SCOPE_LIMITATIONS),
+    }
+
+
+def _packet(*, semantic_match: bool | None = None):
+    return build_bind_adapter_contract_selection_packet(
+        preflight_packet(semantic_match=semantic_match), _descriptor(), SELECTED_AT
+    )
+
+
+def test_build_verify_integrity_preservation_and_no_effects(monkeypatch) -> None:
+    import veritas_os.policy.bind_adapter_contract_selection as module
+
+    actual = module.verify_canonical_bind_preflight_adjudication_packet
+    calls = []
+
+    def recording(value):
+        calls.append(value)
+        return actual(value)
+
+    monkeypatch.setattr(
+        module, "verify_canonical_bind_preflight_adjudication_packet", recording
+    )
+    source = preflight_packet()
+    packet = module.build_bind_adapter_contract_selection_packet(
+        source, _descriptor(), SELECTED_AT
+    )
+    assert len(calls) == 2
+    assert module.verify_bind_adapter_contract_selection_packet(packet) == packet
+    assert len(calls) == 3
+    assert packet.adapter_contract_selection_id == (
+        f"bac:v1:sha256:{packet.adapter_contract_selection_hash}"
+    )
+    assert packet.adapter_contract_selection_hash == _packet_hash(
+        packet.model_dump(mode="json")
+    )
+    descriptor = packet.adapter_contract_descriptor
+    assert descriptor["adapter_contract_hash"] == _descriptor_hash(descriptor)
+    assert descriptor["adapter_contract_id"] == (
+        f"adapter-contract:v1:sha256:{descriptor['adapter_contract_hash']}"
+    )
+    intent = ExecutionIntent(**packet.execution_intent)
+    assert intent.to_dict() == packet.execution_intent
+    assert packet.execution_intent_hash == hash_execution_intent(intent)
+    assert packet.execution_intent_id == source.execution_intent_id
+    assert descriptor["target_system"] == intent.target_system
+    assert descriptor["target_resource_scope"] == intent.target_resource
+    assert tuple(descriptor["supported_methods"]) == ADAPTER_METHODS
+    assert tuple(descriptor["required_methods"]) == ADAPTER_METHODS
+    assert tuple(descriptor["prohibited_during_selection"]) == PROHIBITED_DURING_SELECTION
+    assert descriptor["effect_profile"] == EFFECT_PROFILE
+    assert packet.local_selection_checks == LOCAL_SELECTION_CHECKS
+    assert packet.future_bind_dry_run_requirements == FUTURE_BIND_DRY_RUN_REQUIREMENTS
+    for field in (
+        "required_field_presence", "source_decision_identity", "candidate_identity",
+        "evidence_lineage", "replay_summary",
+    ):
+        assert getattr(packet, field) == getattr(source, field)
+    assert not hasattr(packet, "bind_receipt")
+    assert "adapter_instance" not in packet.model_dump(mode="json")
+
+
+@pytest.mark.parametrize("semantic_match", [True, False])
+def test_semantic_match_is_preserved_not_gated(semantic_match: bool) -> None:
+    packet = _packet(semantic_match=semantic_match)
+    assert packet.replay_summary["semantic_match"] is semantic_match
+    assert verify_bind_adapter_contract_selection_packet(packet) == packet
+
+
+@pytest.mark.parametrize("field", ["adapter_name", "adapter_kind"])
+def test_missing_descriptor_fields_refuse(field: str) -> None:
+    descriptor = _descriptor()
+    descriptor.pop(field)
+    with pytest.raises(BindAdapterContractSelectionError, match="BAC_DESCRIPTOR_INVALID"):
+        build_bind_adapter_contract_selection_packet(
+            preflight_packet(), descriptor, SELECTED_AT
+        )
+
+
+@pytest.mark.parametrize(
+    ("path", "value", "code"),
+    [
+        (("adapter_kind",), "unknown", "BAC_DESCRIPTOR_INVALID"),
+        (("target_system",), "other", "BAC_DESCRIPTOR_TARGET_MISMATCH"),
+        (("target_resource_scope",), "broader", "BAC_DESCRIPTOR_TARGET_MISMATCH"),
+        (("supported_methods",), ["apply"], "BAC_METHODS_MISMATCH"),
+        (("required_methods",), ["revert"], "BAC_METHODS_MISMATCH"),
+        (("prohibited_during_selection",), ["snapshot"], "BAC_METHODS_MISMATCH"),
+        (("effect_profile", "adapter_instantiated"), True, "BAC_EFFECT_PROFILE_INVALID"),
+        (("effect_profile", "adapter_methods_called"), True, "BAC_EFFECT_PROFILE_INVALID"),
+        (("effect_profile", "network_allowed"), True, "BAC_EFFECT_PROFILE_INVALID"),
+        (("effect_profile", "filesystem_allowed"), True, "BAC_EFFECT_PROFILE_INVALID"),
+        (("effect_profile", "external_effect_allowed"), True, "BAC_EFFECT_PROFILE_INVALID"),
+        (("effect_profile", "trustlog_write_allowed"), True, "BAC_EFFECT_PROFILE_INVALID"),
+        (("effect_profile", "bind_receipt_allowed"), True, "BAC_EFFECT_PROFILE_INVALID"),
+    ],
+)
+def test_descriptor_refusals(path, value, code) -> None:
+    descriptor = deepcopy(_descriptor())
+    target = descriptor
+    for key in path[:-1]:
+        target = target[key]
+    target[path[-1]] = value
+    with pytest.raises(BindAdapterContractSelectionError, match=code):
+        build_bind_adapter_contract_selection_packet(
+            preflight_packet(), descriptor, SELECTED_AT
+        )
+
+
+def test_invalid_source_and_timeline_refuse() -> None:
+    source = preflight_packet().model_dump(mode="json")
+    source["bind_preflight_adjudication_hash"] = "0" * 64
+    with pytest.raises(BindAdapterContractSelectionError, match="BAC_BIND_PREFLIGHT"):
+        build_bind_adapter_contract_selection_packet(source, _descriptor(), SELECTED_AT)
+    with pytest.raises(BindAdapterContractSelectionError, match="BAC_SELECTED_AT"):
+        build_bind_adapter_contract_selection_packet(
+            preflight_packet(), _descriptor(), SELECTED_AT.replace(tzinfo=None)
+        )
+    with pytest.raises(BindAdapterContractSelectionError, match="BAC_SELECTED_BEFORE"):
+        build_bind_adapter_contract_selection_packet(
+            preflight_packet(), _descriptor(), ADJUDICATED_AT - timedelta(seconds=1)
+        )
+
+
+@pytest.mark.parametrize("path", [
+    ("adapter_contract_selection_id",), ("adapter_contract_selection_hash",),
+    ("selected_at",), ("source_bind_preflight_adjudication", "adjudicated_at"),
+    ("source_bind_preflight_adjudication_hash",),
+    ("source_bind_preflight_adjudication_packet", "bind_preflight_adjudication_hash"),
+    ("adapter_contract_descriptor", "adapter_name"), ("adapter_contract_id",),
+    ("adapter_contract_hash",), ("adapter_contract_version",),
+    ("execution_intent", "decision_id"), ("execution_intent_id",),
+    ("execution_intent_hash",), ("source_formation_hash",),
+    ("source_readiness_hash",), ("source_eligibility_hash",),
+    ("source_handoff_hash",), ("trusted_validation_context_hash",),
+    ("validation_result_hash",), ("mapping_value_digest",),
+    ("source_to_execution_intent_mapping", "decision_id"),
+    ("field_mapping_proof", "decision_id"),
+    ("local_selection_checks", "no_bind_invocation"),
+    ("future_bind_dry_run_requirements", "snapshot_required"),
+    ("source_decision_identity", "request_id"),
+    ("candidate_identity", "actor_identity"),
+    ("evidence_lineage", "policy_snapshot_id"),
+    ("replay_summary", "semantic_match"), ("replay_summary", "fields_changed"),
+    ("scope_limitations",),
+])
+def test_single_field_tampering_refuses(path) -> None:
+    raw = _packet(semantic_match=True).model_dump(mode="json")
+    target = raw
+    for key in path[:-1]:
+        target = target[key]
+    key = path[-1]
+    old = target[key]
+    target[key] = (not old if isinstance(old, bool) else
+                   [*old, "tampered"] if isinstance(old, list) else "tampered")
+    with pytest.raises(BindAdapterContractSelectionError):
+        verify_bind_adapter_contract_selection_packet(raw)
+
+
+@pytest.mark.parametrize("method", ["copy", "construct"])
+@pytest.mark.parametrize("updates", [
+    {"format_version": "wrong"}, {"adapter_contract_selection_hash": "0" * 64},
+    {"execution_intent": {}}, {"adapter_contract_descriptor": {}},
+    {"local_selection_checks": {}}, {"future_bind_dry_run_requirements": {}},
+    {"source_bind_preflight_adjudication": {}}, {"replay_summary": {}},
+])
+def test_typed_instance_bypass_refuses(method: str, updates: dict) -> None:
+    packet = _packet()
+    bypass = (
+        packet.model_copy(update=updates) if method == "copy" else
+        CanonicalBindAdapterContractSelectionPacket.model_construct(
+            **{**packet.model_dump(mode="python"), **updates}
+        )
+    )
+    with pytest.raises(BindAdapterContractSelectionError):
+        verify_bind_adapter_contract_selection_packet(bypass)
+
+
+def test_schema_accepts_valid_and_rejects_extensions() -> None:
+    schema = json.loads(SCHEMA.read_text())
+    Draft202012Validator.check_schema(schema)
+    validator = Draft202012Validator(schema, format_checker=FormatChecker())
+    valid = _packet().model_dump(mode="json")
+    validator.validate(valid)
+    for key in ("adapter_contract_descriptor", "local_selection_checks",
+                "source_bind_preflight_adjudication"):
+        invalid = deepcopy(valid)
+        invalid[key]["unexpected"] = True
+        assert list(validator.iter_errors(invalid))
+
+
+def test_static_import_and_side_effect_boundary() -> None:
+    tree = ast.parse(MODULE.read_text())
+    forbidden_imports = {
+        "BindReceipt", "hash_bind_receipt", "append_bind_receipt_trustlog",
+        "append_execution_intent_trustlog", "build_execution_intent_trustlog_entry",
+        "execute_bind_boundary", "execute_bind_adjudication", "BindAdapterContract",
+        "BindBoundaryAdapter", "ReferenceBindAdapter", "WebhookBindAdapter",
+        "bind_core", "requests", "httpx", "subprocess", "uuid4",
+    }
+    imported = set()
+    functions = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name.split(".")[-1] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imported.update(alias.name for alias in node.names)
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            functions.add(node.name)
+        assert not (
+            isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "datetime" and node.func.attr == "now"
+        )
+    assert imported.isdisjoint(forbidden_imports)
+    assert functions.isdisjoint({
+        "execute", "commit", "dispatch", "send", "webhook", "adapter_call",
+        "write_trustlog", "append_trustlog", "create_bind_receipt", "invoke_bind",
+        "call_adapter", "instantiate_adapter", "snapshot", "apply", "revert",
+        "validate_authority",
+    })


### PR DESCRIPTION
### Motivation

- Record a deterministic, local, side-effect-free adapter contract selection boundary that sits after a verified Canonical Bind Preflight Adjudication Packet and stops before any adapter instantiation, adapter method calls, Bind invocation, BindReceipt creation, TrustLog writes, or external effects.
- Provide a stable, content-addressed, strict JSON packet that preserves the verified source packet and an explicit pure-data adapter contract descriptor for later Bind dry-run/selection steps without granting authority.

### Description

- Add `veritas_os/policy/bind_adapter_contract_selection.py` implementing `BindAdapterContractDescriptor`, `CanonicalBindAdapterContractSelectionPacket`, deterministic JSON normalization, content-addressed hashing domains, `_descriptor_hash`, `_packet_hash`, and strict builder `build_bind_adapter_contract_selection_packet(...)` and verifier `verify_bind_adapter_contract_selection_packet(...)` that both call `verify_canonical_bind_preflight_adjudication_packet(...)` to trust only re-verified source data.
- Enforce v1 constraints: exact `execution_intent` reconstruction and `hash_execution_intent(...)` verification, strict descriptor target equality, explicit `supported_methods`/`required_methods`/`prohibited_during_selection`, immutable `effect_profile` (no-effect), and pinned local-selection checks and future dry-run requirements.
- Add closed JSON Schema `schemas/bind-adapter-contract-selection-v1.schema.json` and documentation `docs/en/architecture/bind-adapter-contract-selection-v1.md` describing the stop boundary and non-authorizing semantics.
- Add focused tests `veritas_os/tests/test_bind_adapter_contract_selection.py` covering builder/verifier behavior, content-addressed ids/hashes, descriptor refusals, timeline checks, tamper/bypass protections, schema validation, and static import/side-effect boundaries.

### Security / non-claims

- Adapter Contract Selection does not authorize execution.
- Adapter Contract Selection does not invoke Bind.
- Adapter Contract Selection does not instantiate or call adapters.
- Adapter Contract Selection does not create `BindReceipt`.
- Adapter Contract Selection does not write TrustLog.
- Adapter Contract Selection does not perform live state, runtime risk, authority, constraint, commit-boundary, postcondition, rollback, or idempotency replay checks.
- Adapter Contract Selection does not satisfy Authority Evidence or Human Approval.
- Adapter Contract Selection does not turn `semantic_match` into authorization.

### Testing

- Latest head SHA: `f605da3a0aaeac8c303b22129c777eab31e0b309`.
- Local/static checks reported by Codex: `pytest -q veritas_os/tests/test_bind_adapter_contract_selection.py` completed successfully with `67 passed`; `ruff` on the new/changed files passed; `python -m py_compile veritas_os/policy/bind_adapter_contract_selection.py` succeeded; `python -m json.tool schemas/bind-adapter-contract-selection-v1.schema.json` validated JSON syntax.
- GitHub CI #5064 completed successfully for this head.
- `test (py3.11)`: success.
- `test (py3.12)`: success.
- `test-postgresql (py3.12)`: success.
- `test-slow (py3.12)`: success.
- `lint`: success.
- `dependency-audit`: success.
- `future-dependency-compat`: success.
- `[Tier 1] governance-backend-fast`: success.
- `[Tier 1] governance-smoke`: success.
- `frontend-lint`: success.
- `frontend-test`: success.
- `frontend-e2e`: success.
- `Security Gates`: success.
- `CodeQL (custom)`: success.
- `Runtime Proof Evidence`: success.
- `Runtime Pickle Guard (Required)`: success.
- `Reviewer Evidence Packet Validation`: success.

### Final invariant

Canonical Bind Adapter Contract Selection v1 now binds a verified Canonical Bind Preflight Adjudication Packet to an explicit local adapter contract descriptor without creating an adapter instance, without calling adapter methods, without invoking Bind, without creating a BindReceipt, without writing TrustLog, without external effects, and without converting replay semantic_match into Authority Evidence, Human Approval, or execution authority.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8257a2fffc83269ec0757dfe6112d4)