### PR TITLE
feat(bind): add canonical adapter dry-run plan v1

### DIFF
--- a/docs/en/architecture/adapter-dry-run-plan-v1.md
+++ b/docs/en/architecture/adapter-dry-run-plan-v1.md
@@ -1,0 +1,40 @@
+# Canonical Adapter Dry-Run Plan v1
+
+Canonical Adapter Dry-Run Plan maps an exact, independently verified Canonical
+Bind Adapter Contract Selection Packet to seven immutable, inert future-call
+descriptors. It is deterministic and local, and stops before any live boundary.
+
+Adapter Contract Selection is **not** an Adapter Dry-Run Plan. An Adapter
+Dry-Run Plan is **not** dry-run execution, an adapter instance, an
+`adapter.snapshot`/`apply`/`revert` call, Bind authorization, a BindReceipt, or a
+TrustLog write. Replay `semantic_match` is preserved whether true or false;
+semantic match is not Authority Evidence or Human Approval.
+
+## Sequence and stop boundary
+
+1. CDA
+2. Trust Link
+3. Replay Source/Evidence
+4. Replay Handoff Binding
+5. CanonicalDecisionHandoff validation
+6. Guarded Promotion Eligibility Packet
+7. ExecutionIntent Formation Readiness Packet
+8. Canonical ExecutionIntent Formation Packet
+9. ExecutionIntent Pre-Bind Validation Packet
+10. Canonical Bind Preflight Adjudication Packet
+11. Canonical Bind Adapter Contract Selection Packet
+12. Canonical Adapter Dry-Run Plan Packet
+13. **STOP**
+
+The exact planned method-name order is `describe_target`,
+`build_idempotency_key`, `snapshot`, `fingerprint_state`, `validate_authority`,
+`validate_constraints`, and `assess_runtime_risk`. Every descriptor says that
+an adapter is required later while adapter calls, network access, filesystem
+access, external effects, TrustLog writes, and BindReceipt creation are forbidden
+now. `apply`, `verify_postconditions`, and `revert` are excluded.
+
+Actual adapter instantiation and dry-run execution, snapshots, authority
+revalidation, constraint validation, runtime-risk assessment, Bind adjudication,
+BindReceipt creation, TrustLog writing, and operation commit are intentionally
+deferred to future explicit PRs. This artifact is not a production, customer,
+or regulatory certification.

--- a/schemas/adapter-dry-run-plan-v1.schema.json
+++ b/schemas/adapter-dry-run-plan-v1.schema.json
@@ -1,0 +1,4475 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://veritas-os.example/schemas/adapter-dry-run-plan-v1.schema.json",
+  "title": "Canonical Adapter Dry-Run Plan Packet v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "format_version",
+    "adapter_dry_run_plan_id",
+    "adapter_dry_run_plan_hash",
+    "plan_mechanism",
+    "planned_at",
+    "source_adapter_contract_selection",
+    "source_adapter_contract_selection_hash",
+    "source_adapter_contract_selection_packet",
+    "adapter_contract_descriptor",
+    "adapter_contract_id",
+    "adapter_contract_hash",
+    "adapter_contract_version",
+    "execution_intent",
+    "execution_intent_id",
+    "execution_intent_hash",
+    "source_bind_preflight_adjudication_hash",
+    "source_formation_hash",
+    "source_readiness_hash",
+    "source_eligibility_hash",
+    "source_handoff_hash",
+    "trusted_validation_context_hash",
+    "validation_result_hash",
+    "mapping_value_digest",
+    "execution_intent_contract_version",
+    "dry_run_plan_status",
+    "ready_for_adapter_dry_run_execution",
+    "fail_closed",
+    "planned_steps",
+    "planned_step_digest",
+    "local_plan_checks",
+    "future_dry_run_execution_requirements",
+    "source_to_execution_intent_mapping",
+    "field_mapping_proof",
+    "required_field_presence",
+    "source_decision_identity",
+    "candidate_identity",
+    "evidence_lineage",
+    "replay_summary",
+    "scope_limitations"
+  ],
+  "properties": {
+    "format_version": {
+      "const": "canonical-adapter-dry-run-plan/v1"
+    },
+    "adapter_dry_run_plan_id": {
+      "type": "string",
+      "pattern": "^adp:v1:sha256:[0-9a-f]{64}$"
+    },
+    "adapter_dry_run_plan_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "plan_mechanism": {
+      "const": "plan_adapter_dry_run_without_invocation/v1"
+    },
+    "planned_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "source_adapter_contract_selection": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "adapter_contract_selection_id",
+        "adapter_contract_selection_hash",
+        "format_version",
+        "selection_mechanism",
+        "selected_at",
+        "adapter_contract_id",
+        "adapter_contract_hash",
+        "execution_intent_id",
+        "execution_intent_hash",
+        "selection_status",
+        "ready_for_adapter_dry_run"
+      ],
+      "properties": {
+        "adapter_contract_selection_id": {},
+        "adapter_contract_selection_hash": {},
+        "format_version": {},
+        "selection_mechanism": {},
+        "selected_at": {},
+        "adapter_contract_id": {},
+        "adapter_contract_hash": {},
+        "execution_intent_id": {},
+        "execution_intent_hash": {},
+        "selection_status": {},
+        "ready_for_adapter_dry_run": {}
+      }
+    },
+    "source_adapter_contract_selection_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "source_adapter_contract_selection_packet": {
+      "$ref": "#/$defs/bind_adapter_contract_selection_packet"
+    },
+    "adapter_contract_descriptor": {
+      "$ref": "#/$defs/descriptor"
+    },
+    "adapter_contract_id": {
+      "type": "string",
+      "pattern": "^adapter-contract:v1:sha256:[0-9a-f]{64}$"
+    },
+    "adapter_contract_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "adapter_contract_version": {
+      "const": "bind-adapter-contract/v1"
+    },
+    "execution_intent": {
+      "$ref": "#/$defs/execution_intent"
+    },
+    "execution_intent_id": {
+      "type": "string",
+      "pattern": "^ei:v1:sha256:[0-9a-f]{64}$"
+    },
+    "execution_intent_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "source_bind_preflight_adjudication_hash": {},
+    "source_formation_hash": {},
+    "source_readiness_hash": {},
+    "source_eligibility_hash": {},
+    "source_handoff_hash": {},
+    "trusted_validation_context_hash": {},
+    "validation_result_hash": {},
+    "mapping_value_digest": {},
+    "execution_intent_contract_version": {},
+    "dry_run_plan_status": {
+      "const": "ADAPTER_DRY_RUN_PLANNED_NO_EFFECT"
+    },
+    "ready_for_adapter_dry_run_execution": {
+      "const": true
+    },
+    "fail_closed": {
+      "const": false
+    },
+    "planned_steps": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "step_id",
+          "ordinal",
+          "phase",
+          "planned_adapter_method",
+          "execution_mode",
+          "required_input_refs",
+          "expected_output_ref",
+          "effect_policy",
+          "refusal_if_missing_later",
+          "step_scope_limitations"
+        ],
+        "properties": {
+          "step_id": {
+            "type": "string",
+            "pattern": "^dry-run-step:v1:[1-9][0-9]*:[a-z0-9-]+$"
+          },
+          "ordinal": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "phase": {
+            "enum": [
+              "prepare",
+              "observe",
+              "validate",
+              "assess",
+              "finalize"
+            ]
+          },
+          "planned_adapter_method": {
+            "enum": [
+              "snapshot",
+              "fingerprint_state",
+              "validate_authority",
+              "validate_constraints",
+              "assess_runtime_risk",
+              "describe_target",
+              "build_idempotency_key"
+            ]
+          },
+          "execution_mode": {
+            "const": "planned_no_effect"
+          },
+          "required_input_refs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "expected_output_ref": {
+            "type": "string"
+          },
+          "effect_policy": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "adapter_instance_required_later",
+              "adapter_method_call_allowed_now",
+              "network_allowed",
+              "filesystem_allowed",
+              "external_effect_allowed",
+              "trustlog_write_allowed",
+              "bind_receipt_allowed"
+            ],
+            "properties": {
+              "adapter_instance_required_later": {
+                "const": true
+              },
+              "adapter_method_call_allowed_now": {
+                "const": false
+              },
+              "network_allowed": {
+                "const": false
+              },
+              "filesystem_allowed": {
+                "const": false
+              },
+              "external_effect_allowed": {
+                "const": false
+              },
+              "trustlog_write_allowed": {
+                "const": false
+              },
+              "bind_receipt_allowed": {
+                "const": false
+              }
+            }
+          },
+          "refusal_if_missing_later": {
+            "type": "string"
+          },
+          "step_scope_limitations": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "minItems": 7,
+      "maxItems": 7
+    },
+    "planned_step_digest": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "local_plan_checks": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "adapter_contract_selection_verified",
+        "execution_intent_hash_verified",
+        "execution_intent_id_verified",
+        "adapter_descriptor_hash_verified",
+        "adapter_descriptor_scope_matches_intent",
+        "planned_steps_ordered",
+        "planned_methods_declared",
+        "no_apply_step",
+        "no_postcondition_step",
+        "no_revert_step",
+        "planned_after_adapter_contract_selection",
+        "no_adapter_instance",
+        "no_adapter_invocation",
+        "no_bind_invocation",
+        "no_bind_receipt_created",
+        "no_trustlog_write",
+        "no_network",
+        "no_filesystem",
+        "no_external_effect"
+      ],
+      "properties": {
+        "adapter_contract_selection_verified": {
+          "const": true
+        },
+        "execution_intent_hash_verified": {
+          "const": true
+        },
+        "execution_intent_id_verified": {
+          "const": true
+        },
+        "adapter_descriptor_hash_verified": {
+          "const": true
+        },
+        "adapter_descriptor_scope_matches_intent": {
+          "const": true
+        },
+        "planned_steps_ordered": {
+          "const": true
+        },
+        "planned_methods_declared": {
+          "const": true
+        },
+        "no_apply_step": {
+          "const": true
+        },
+        "no_postcondition_step": {
+          "const": true
+        },
+        "no_revert_step": {
+          "const": true
+        },
+        "planned_after_adapter_contract_selection": {
+          "const": true
+        },
+        "no_adapter_instance": {
+          "const": true
+        },
+        "no_adapter_invocation": {
+          "const": true
+        },
+        "no_bind_invocation": {
+          "const": true
+        },
+        "no_bind_receipt_created": {
+          "const": true
+        },
+        "no_trustlog_write": {
+          "const": true
+        },
+        "no_network": {
+          "const": true
+        },
+        "no_filesystem": {
+          "const": true
+        },
+        "no_external_effect": {
+          "const": true
+        }
+      }
+    },
+    "future_dry_run_execution_requirements": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "adapter_instance_required",
+        "describe_target_call_required",
+        "idempotency_key_plan_required",
+        "snapshot_call_required",
+        "state_fingerprint_call_required",
+        "authority_revalidation_call_required",
+        "constraint_validation_call_required",
+        "runtime_risk_assessment_call_required",
+        "dry_run_result_packet_required",
+        "trustlog_policy_still_deferred",
+        "bind_receipt_still_deferred",
+        "apply_still_forbidden"
+      ],
+      "properties": {
+        "adapter_instance_required": {
+          "const": true
+        },
+        "describe_target_call_required": {
+          "const": true
+        },
+        "idempotency_key_plan_required": {
+          "const": true
+        },
+        "snapshot_call_required": {
+          "const": true
+        },
+        "state_fingerprint_call_required": {
+          "const": true
+        },
+        "authority_revalidation_call_required": {
+          "const": true
+        },
+        "constraint_validation_call_required": {
+          "const": true
+        },
+        "runtime_risk_assessment_call_required": {
+          "const": true
+        },
+        "dry_run_result_packet_required": {
+          "const": true
+        },
+        "trustlog_policy_still_deferred": {
+          "const": true
+        },
+        "bind_receipt_still_deferred": {
+          "const": true
+        },
+        "apply_still_forbidden": {
+          "const": true
+        }
+      }
+    },
+    "source_to_execution_intent_mapping": {
+      "type": "object"
+    },
+    "field_mapping_proof": {
+      "type": "object"
+    },
+    "required_field_presence": {
+      "type": "object"
+    },
+    "source_decision_identity": {
+      "type": "object"
+    },
+    "candidate_identity": {
+      "type": "object"
+    },
+    "evidence_lineage": {
+      "type": "object"
+    },
+    "replay_summary": {
+      "type": "object"
+    },
+    "scope_limitations": {
+      "type": "array",
+      "prefixItems": [
+        {
+          "const": "NOT_EXECUTION_AUTHORITY"
+        },
+        {
+          "const": "NOT_BIND_AUTHORIZATION"
+        },
+        {
+          "const": "NOT_BIND_RECEIPT"
+        },
+        {
+          "const": "NOT_BIND_INVOCATION"
+        },
+        {
+          "const": "NOT_ADAPTER_INSTANCE"
+        },
+        {
+          "const": "NOT_ADAPTER_INVOCATION"
+        },
+        {
+          "const": "NOT_ADAPTER_DRY_RUN_EXECUTION"
+        },
+        {
+          "const": "NOT_EXTERNAL_EFFECT"
+        },
+        {
+          "const": "NOT_OPERATION_COMMIT"
+        },
+        {
+          "const": "NOT_TRUSTLOG_WRITE"
+        },
+        {
+          "const": "NOT_LIVE_STATE_CHECK"
+        },
+        {
+          "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+        },
+        {
+          "const": "NOT_AUTHORITY_REVALIDATION"
+        },
+        {
+          "const": "NOT_CONSTRAINT_REVALIDATION"
+        },
+        {
+          "const": "NOT_POSTCONDITION_VERIFICATION"
+        },
+        {
+          "const": "NOT_ROLLBACK_PROOF"
+        },
+        {
+          "const": "NOT_AUTHORITY_EVIDENCE"
+        },
+        {
+          "const": "NOT_HUMAN_APPROVAL"
+        }
+      ],
+      "items": false,
+      "minItems": 18,
+      "maxItems": 18
+    }
+  },
+  "$defs": {
+    "execution_intent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "execution_intent_id",
+        "decision_id",
+        "request_id",
+        "policy_snapshot_id",
+        "actor_identity",
+        "target_system",
+        "target_resource",
+        "intended_action",
+        "evidence_refs",
+        "decision_hash",
+        "decision_ts",
+        "ttl_seconds",
+        "expected_state_fingerprint",
+        "approval_context",
+        "policy_lineage"
+      ],
+      "properties": {
+        "execution_intent_id": {
+          "type": "string",
+          "pattern": "^ei:v1:sha256:[0-9a-f]{64}$"
+        },
+        "decision_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "request_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_snapshot_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "actor_identity": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_system": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_resource": {
+          "type": "string",
+          "minLength": 1
+        },
+        "intended_action": {
+          "type": "string",
+          "minLength": 1
+        },
+        "evidence_refs": {
+          "type": "array",
+          "minItems": 5,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "decision_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "decision_ts": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "ttl_seconds": {
+          "type": "null"
+        },
+        "expected_state_fingerprint": {
+          "type": "string",
+          "minLength": 1
+        },
+        "approval_context": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "human_approval_receipt_ref",
+            "human_approval_receipt_hash"
+          ],
+          "properties": {
+            "human_approval_receipt_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "human_approval_receipt_hash": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "policy_lineage": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "policy_snapshot_id",
+            "policy_version",
+            "policy_semantic_digest"
+          ],
+          "properties": {
+            "policy_snapshot_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_version": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_semantic_digest": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    },
+    "mapping": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "decision_id",
+        "request_id",
+        "policy_snapshot_id",
+        "actor_identity",
+        "target_system",
+        "target_resource",
+        "intended_action",
+        "evidence_refs",
+        "decision_hash",
+        "decision_ts",
+        "ttl_seconds",
+        "expected_state_fingerprint",
+        "approval_context",
+        "policy_lineage"
+      ],
+      "properties": {
+        "decision_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "request_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_snapshot_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "actor_identity": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_system": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_resource": {
+          "type": "string",
+          "minLength": 1
+        },
+        "intended_action": {
+          "type": "string",
+          "minLength": 1
+        },
+        "evidence_refs": {
+          "type": "array",
+          "minItems": 5,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "decision_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "decision_ts": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "ttl_seconds": {
+          "type": "null"
+        },
+        "expected_state_fingerprint": {
+          "type": "string",
+          "minLength": 1
+        },
+        "approval_context": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "human_approval_receipt_ref",
+            "human_approval_receipt_hash"
+          ],
+          "properties": {
+            "human_approval_receipt_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "human_approval_receipt_hash": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "policy_lineage": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "policy_snapshot_id",
+            "policy_version",
+            "policy_semantic_digest"
+          ],
+          "properties": {
+            "policy_snapshot_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_version": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_semantic_digest": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    },
+    "formation_packet": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "format_version",
+        "formation_id",
+        "formation_hash",
+        "formation_mechanism",
+        "formed_at",
+        "source_readiness",
+        "source_readiness_hash",
+        "source_readiness_packet",
+        "source_eligibility_hash",
+        "source_handoff_hash",
+        "trusted_validation_context_hash",
+        "validation_result_hash",
+        "mapping_value_digest",
+        "execution_intent_contract_version",
+        "execution_intent",
+        "execution_intent_id",
+        "execution_intent_hash",
+        "source_to_execution_intent_mapping",
+        "field_mapping_proof",
+        "required_field_presence",
+        "source_decision_identity",
+        "candidate_identity",
+        "evidence_lineage",
+        "replay_summary",
+        "scope_limitations"
+      ],
+      "properties": {
+        "format_version": {
+          "const": "canonical-execution-intent-formation/v1"
+        },
+        "formation_id": {
+          "type": "string",
+          "pattern": "^eif:v1:sha256:[0-9a-f]{64}$"
+        },
+        "formation_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "formation_mechanism": {
+          "const": "build_execution_intent_from_readiness/v1"
+        },
+        "formed_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "source_readiness": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "readiness_id",
+            "readiness_hash",
+            "format_version",
+            "checked_at",
+            "formation_status",
+            "ready_for_execution_intent_formation"
+          ],
+          "properties": {
+            "readiness_id": {
+              "type": "string",
+              "pattern": "^eifr:v1:sha256:[0-9a-f]{64}$"
+            },
+            "readiness_hash": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "format_version": {
+              "const": "canonical-execution-intent-formation-readiness/v1"
+            },
+            "checked_at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "formation_status": {
+              "const": "READY_FOR_EXECUTION_INTENT_FORMATION"
+            },
+            "ready_for_execution_intent_formation": {
+              "const": true
+            }
+          }
+        },
+        "source_readiness_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_readiness_packet": {
+          "$ref": "#/$defs/readiness"
+        },
+        "source_eligibility_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_handoff_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "trusted_validation_context_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "validation_result_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "mapping_value_digest": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "execution_intent_contract_version": {
+          "const": "execution-intent-contract/v1"
+        },
+        "execution_intent": {
+          "$ref": "#/$defs/execution_intent"
+        },
+        "execution_intent_id": {
+          "type": "string",
+          "pattern": "^ei:v1:sha256:[0-9a-f]{64}$"
+        },
+        "execution_intent_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_to_execution_intent_mapping": {
+          "$ref": "#/$defs/mapping"
+        },
+        "field_mapping_proof": {
+          "$ref": "#/$defs/mapping"
+        },
+        "required_field_presence": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "execution_intent_id",
+            "decision_id",
+            "request_id",
+            "policy_snapshot_id",
+            "actor_identity",
+            "target_system",
+            "target_resource",
+            "intended_action",
+            "evidence_refs",
+            "decision_hash",
+            "decision_ts",
+            "ttl_seconds",
+            "expected_state_fingerprint",
+            "approval_context",
+            "policy_lineage"
+          ],
+          "properties": {
+            "execution_intent_id": {
+              "const": "intentionally_deferred"
+            },
+            "decision_id": {
+              "const": "mapped"
+            },
+            "request_id": {
+              "const": "mapped"
+            },
+            "policy_snapshot_id": {
+              "const": "mapped"
+            },
+            "actor_identity": {
+              "const": "mapped"
+            },
+            "target_system": {
+              "const": "mapped"
+            },
+            "target_resource": {
+              "const": "mapped"
+            },
+            "intended_action": {
+              "const": "mapped"
+            },
+            "evidence_refs": {
+              "const": "mapped"
+            },
+            "decision_hash": {
+              "const": "mapped"
+            },
+            "decision_ts": {
+              "const": "mapped"
+            },
+            "ttl_seconds": {
+              "const": "intentionally_deferred"
+            },
+            "expected_state_fingerprint": {
+              "const": "mapped"
+            },
+            "approval_context": {
+              "const": "mapped"
+            },
+            "policy_lineage": {
+              "const": "mapped"
+            }
+          }
+        },
+        "source_decision_identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "request_id",
+            "canonical_decision_id",
+            "canonical_decision_hash",
+            "canonical_decision_ts"
+          ],
+          "properties": {
+            "request_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "canonical_decision_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "canonical_decision_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "canonical_decision_ts": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "candidate_identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "candidate_id",
+            "candidate_hash",
+            "actor_identity",
+            "target_system",
+            "target_resource",
+            "action_contract_id",
+            "action_contract_version"
+          ],
+          "properties": {
+            "candidate_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "candidate_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "actor_identity": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target_system": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target_resource": {
+              "type": "string",
+              "minLength": 1
+            },
+            "action_contract_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "action_contract_version": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "evidence_lineage": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "trustlog_artifact_ref",
+            "trustlog_chain_hash",
+            "replay_artifact_ref",
+            "replay_artifact_hash",
+            "authority_evidence_ref",
+            "authority_evidence_hash",
+            "human_approval_receipt_ref",
+            "human_approval_receipt_hash",
+            "policy_snapshot_id",
+            "policy_version",
+            "policy_semantic_digest",
+            "expected_state_fingerprint",
+            "expected_state_source_ref"
+          ],
+          "properties": {
+            "trustlog_artifact_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "trustlog_chain_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "replay_artifact_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "replay_artifact_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "authority_evidence_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "authority_evidence_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "human_approval_receipt_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "human_approval_receipt_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_snapshot_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_version": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_semantic_digest": {
+              "type": "string",
+              "minLength": 1
+            },
+            "expected_state_fingerprint": {
+              "type": "string",
+              "minLength": 1
+            },
+            "expected_state_source_ref": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "replay_summary": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "original_decision_id",
+            "replay_decision_id",
+            "original_request_id",
+            "replay_request_id",
+            "semantic_profile",
+            "semantic_match",
+            "fields_changed",
+            "severity",
+            "divergence_level"
+          ],
+          "properties": {
+            "original_decision_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "replay_decision_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "original_request_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "replay_request_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "semantic_profile": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "semantic_match": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "fields_changed": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "severity": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "divergence_level": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        "scope_limitations": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "const": "NOT_EXECUTION_AUTHORITY"
+            },
+            {
+              "const": "NOT_BIND_AUTHORIZATION"
+            },
+            {
+              "const": "NOT_BIND_RECEIPT"
+            },
+            {
+              "const": "NOT_BIND_INVOCATION"
+            },
+            {
+              "const": "NOT_EXTERNAL_EFFECT"
+            },
+            {
+              "const": "NOT_ADAPTER_INVOCATION"
+            },
+            {
+              "const": "NOT_OPERATION_COMMIT"
+            },
+            {
+              "const": "NOT_TRUSTLOG_WRITE"
+            },
+            {
+              "const": "NOT_AUTHORITY_EVIDENCE"
+            },
+            {
+              "const": "NOT_HUMAN_APPROVAL"
+            }
+          ],
+          "items": false,
+          "minItems": 10,
+          "maxItems": 10
+        }
+      }
+    },
+    "readiness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "format_version",
+        "readiness_id",
+        "readiness_hash",
+        "verification_mechanism",
+        "checked_at",
+        "source_eligibility",
+        "source_eligibility_hash",
+        "source_eligibility_packet",
+        "source_handoff_hash",
+        "trusted_validation_context_hash",
+        "validation_result_hash",
+        "formation_status",
+        "ready_for_execution_intent_formation",
+        "fail_closed",
+        "execution_intent_contract_version",
+        "execution_intent_required_fields",
+        "source_to_execution_intent_mapping",
+        "mapping_value_digest",
+        "required_field_presence",
+        "source_decision_identity",
+        "candidate_identity",
+        "evidence_lineage",
+        "replay_summary",
+        "scope_limitations"
+      ],
+      "properties": {
+        "format_version": {
+          "const": "canonical-execution-intent-formation-readiness/v1"
+        },
+        "readiness_id": {
+          "type": "string",
+          "pattern": "^eifr:v1:sha256:[0-9a-f]{64}$"
+        },
+        "readiness_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "verification_mechanism": {
+          "const": "verify_guarded_promotion_eligibility_packet/v1"
+        },
+        "checked_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "source_eligibility": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "eligibility_id",
+            "eligibility_hash",
+            "format_version",
+            "validation_mechanism",
+            "handoff_validator_version",
+            "issued_at",
+            "evaluated_at"
+          ],
+          "properties": {
+            "eligibility_id": {
+              "type": "string",
+              "pattern": "^gpe:v1:sha256:[0-9a-f]{64}$"
+            },
+            "eligibility_hash": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "format_version": {
+              "const": "canonical-guarded-promotion-eligibility-packet/v1"
+            },
+            "validation_mechanism": {
+              "const": "validate_canonical_decision_handoff/v1"
+            },
+            "handoff_validator_version": {
+              "type": "string",
+              "minLength": 1
+            },
+            "issued_at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "evaluated_at": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "source_eligibility_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_eligibility_packet": {
+          "$ref": "#/$defs/eligibility"
+        },
+        "source_handoff_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "trusted_validation_context_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "validation_result_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "formation_status": {
+          "const": "READY_FOR_EXECUTION_INTENT_FORMATION"
+        },
+        "ready_for_execution_intent_formation": {
+          "const": true
+        },
+        "fail_closed": {
+          "const": false
+        },
+        "execution_intent_contract_version": {
+          "const": "execution-intent-contract/v1"
+        },
+        "execution_intent_required_fields": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "const": "execution_intent_id"
+            },
+            {
+              "const": "decision_id"
+            },
+            {
+              "const": "request_id"
+            },
+            {
+              "const": "policy_snapshot_id"
+            },
+            {
+              "const": "actor_identity"
+            },
+            {
+              "const": "target_system"
+            },
+            {
+              "const": "target_resource"
+            },
+            {
+              "const": "intended_action"
+            },
+            {
+              "const": "evidence_refs"
+            },
+            {
+              "const": "decision_hash"
+            },
+            {
+              "const": "decision_ts"
+            },
+            {
+              "const": "ttl_seconds"
+            },
+            {
+              "const": "expected_state_fingerprint"
+            },
+            {
+              "const": "approval_context"
+            },
+            {
+              "const": "policy_lineage"
+            }
+          ],
+          "items": false,
+          "minItems": 15,
+          "maxItems": 15
+        },
+        "source_to_execution_intent_mapping": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "decision_id",
+            "request_id",
+            "policy_snapshot_id",
+            "actor_identity",
+            "target_system",
+            "target_resource",
+            "intended_action",
+            "evidence_refs",
+            "decision_hash",
+            "decision_ts",
+            "ttl_seconds",
+            "expected_state_fingerprint",
+            "approval_context",
+            "policy_lineage"
+          ],
+          "properties": {
+            "decision_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "request_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_snapshot_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "actor_identity": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target_system": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target_resource": {
+              "type": "string",
+              "minLength": 1
+            },
+            "intended_action": {
+              "type": "string",
+              "minLength": 1
+            },
+            "evidence_refs": {
+              "type": "array",
+              "minItems": 5,
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "decision_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "decision_ts": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "ttl_seconds": {
+              "type": "null"
+            },
+            "expected_state_fingerprint": {
+              "type": "string",
+              "minLength": 1
+            },
+            "approval_context": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "human_approval_receipt_ref",
+                "human_approval_receipt_hash"
+              ],
+              "properties": {
+                "human_approval_receipt_ref": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "human_approval_receipt_hash": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            },
+            "policy_lineage": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "policy_snapshot_id",
+                "policy_version",
+                "policy_semantic_digest"
+              ],
+              "properties": {
+                "policy_snapshot_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "policy_version": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "policy_semantic_digest": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            }
+          }
+        },
+        "mapping_value_digest": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "required_field_presence": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "execution_intent_id",
+            "decision_id",
+            "request_id",
+            "policy_snapshot_id",
+            "actor_identity",
+            "target_system",
+            "target_resource",
+            "intended_action",
+            "evidence_refs",
+            "decision_hash",
+            "decision_ts",
+            "ttl_seconds",
+            "expected_state_fingerprint",
+            "approval_context",
+            "policy_lineage"
+          ],
+          "properties": {
+            "execution_intent_id": {
+              "const": "intentionally_deferred"
+            },
+            "decision_id": {
+              "const": "mapped"
+            },
+            "request_id": {
+              "const": "mapped"
+            },
+            "policy_snapshot_id": {
+              "const": "mapped"
+            },
+            "actor_identity": {
+              "const": "mapped"
+            },
+            "target_system": {
+              "const": "mapped"
+            },
+            "target_resource": {
+              "const": "mapped"
+            },
+            "intended_action": {
+              "const": "mapped"
+            },
+            "evidence_refs": {
+              "const": "mapped"
+            },
+            "decision_hash": {
+              "const": "mapped"
+            },
+            "decision_ts": {
+              "const": "mapped"
+            },
+            "ttl_seconds": {
+              "const": "intentionally_deferred"
+            },
+            "expected_state_fingerprint": {
+              "const": "mapped"
+            },
+            "approval_context": {
+              "const": "mapped"
+            },
+            "policy_lineage": {
+              "const": "mapped"
+            }
+          }
+        },
+        "source_decision_identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "request_id",
+            "canonical_decision_id",
+            "canonical_decision_hash",
+            "canonical_decision_ts"
+          ],
+          "properties": {
+            "request_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "canonical_decision_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "canonical_decision_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "canonical_decision_ts": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "candidate_identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "candidate_id",
+            "candidate_hash",
+            "actor_identity",
+            "target_system",
+            "target_resource",
+            "action_contract_id",
+            "action_contract_version"
+          ],
+          "properties": {
+            "candidate_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "candidate_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "actor_identity": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target_system": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target_resource": {
+              "type": "string",
+              "minLength": 1
+            },
+            "action_contract_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "action_contract_version": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "evidence_lineage": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "trustlog_artifact_ref",
+            "trustlog_chain_hash",
+            "replay_artifact_ref",
+            "replay_artifact_hash",
+            "authority_evidence_ref",
+            "authority_evidence_hash",
+            "human_approval_receipt_ref",
+            "human_approval_receipt_hash",
+            "policy_snapshot_id",
+            "policy_version",
+            "policy_semantic_digest",
+            "expected_state_fingerprint",
+            "expected_state_source_ref"
+          ],
+          "properties": {
+            "trustlog_artifact_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "trustlog_chain_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "replay_artifact_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "replay_artifact_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "authority_evidence_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "authority_evidence_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "human_approval_receipt_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "human_approval_receipt_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_snapshot_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_version": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_semantic_digest": {
+              "type": "string",
+              "minLength": 1
+            },
+            "expected_state_fingerprint": {
+              "type": "string",
+              "minLength": 1
+            },
+            "expected_state_source_ref": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "replay_summary": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "original_decision_id",
+            "replay_decision_id",
+            "original_request_id",
+            "replay_request_id",
+            "semantic_profile",
+            "semantic_match",
+            "fields_changed",
+            "severity",
+            "divergence_level"
+          ],
+          "properties": {
+            "original_decision_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "replay_decision_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "original_request_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "replay_request_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "semantic_profile": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "semantic_match": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "fields_changed": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "severity": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "divergence_level": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        "scope_limitations": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "const": "NOT_EXECUTION_INTENT"
+            },
+            {
+              "const": "NOT_EXECUTION_AUTHORITY"
+            },
+            {
+              "const": "NOT_BIND_AUTHORIZATION"
+            },
+            {
+              "const": "NOT_BIND_RECEIPT"
+            },
+            {
+              "const": "NOT_EXTERNAL_EFFECT"
+            },
+            {
+              "const": "NOT_ADAPTER_INVOCATION"
+            },
+            {
+              "const": "NOT_OPERATION_COMMIT"
+            },
+            {
+              "const": "NOT_TRUSTLOG_WRITE"
+            }
+          ],
+          "items": false,
+          "minItems": 8,
+          "maxItems": 8
+        }
+      }
+    },
+    "eligibility": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "format_version",
+        "eligibility_id",
+        "eligibility_hash",
+        "validation_mechanism",
+        "handoff_validator_version",
+        "issued_at",
+        "evaluated_at",
+        "validation_status",
+        "ready_for_guarded_promotion",
+        "fail_closed",
+        "source_handoff",
+        "source_handoff_hash",
+        "trusted_validation_context",
+        "trusted_validation_context_hash",
+        "validation_result",
+        "validation_result_hash",
+        "verified_provenance_paths",
+        "source_decision_identity",
+        "candidate_identity",
+        "evidence_lineage",
+        "replay_summary",
+        "scope_limitations"
+      ],
+      "properties": {
+        "format_version": {
+          "const": "canonical-guarded-promotion-eligibility-packet/v1"
+        },
+        "eligibility_id": {
+          "type": "string",
+          "pattern": "^gpe:v1:sha256:[0-9a-f]{64}$"
+        },
+        "eligibility_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "validation_mechanism": {
+          "const": "validate_canonical_decision_handoff/v1"
+        },
+        "handoff_validator_version": {
+          "type": "string"
+        },
+        "issued_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "evaluated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "validation_status": {
+          "const": "READY_FOR_GUARDED_PROMOTION"
+        },
+        "ready_for_guarded_promotion": {
+          "const": true
+        },
+        "fail_closed": {
+          "const": false
+        },
+        "source_handoff": {
+          "type": "object"
+        },
+        "source_handoff_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "trusted_validation_context": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "value_assertions",
+            "candidate_hash_binding",
+            "authority_requirement_binding"
+          ],
+          "properties": {
+            "value_assertions": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/valueAssertion"
+              }
+            },
+            "candidate_hash_binding": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/candidateBinding"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "authority_requirement_binding": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/authorityBinding"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        },
+        "trusted_validation_context_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "validation_result": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "status",
+            "reason_codes",
+            "structure_valid",
+            "declared_status",
+            "declared_status_matches",
+            "declared_reason_codes",
+            "declared_reason_codes_match",
+            "verified_provenance_paths",
+            "validation_version",
+            "ready_for_guarded_promotion",
+            "fail_closed",
+            "requires_review"
+          ],
+          "properties": {
+            "status": {
+              "const": "READY_FOR_GUARDED_PROMOTION"
+            },
+            "reason_codes": {
+              "const": []
+            },
+            "structure_valid": {
+              "const": true
+            },
+            "declared_status": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "declared_status_matches": {
+              "type": "boolean"
+            },
+            "declared_reason_codes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "declared_reason_codes_match": {
+              "type": "boolean"
+            },
+            "verified_provenance_paths": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "validation_version": {
+              "type": "string"
+            },
+            "ready_for_guarded_promotion": {
+              "const": true
+            },
+            "fail_closed": {
+              "const": false
+            },
+            "requires_review": {
+              "const": false
+            }
+          }
+        },
+        "validation_result_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "verified_provenance_paths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source_decision_identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "request_id",
+            "canonical_decision_id",
+            "canonical_decision_hash",
+            "canonical_decision_ts"
+          ],
+          "properties": {
+            "request_id": {
+              "type": "string"
+            },
+            "canonical_decision_id": {
+              "type": "string"
+            },
+            "canonical_decision_hash": {
+              "type": "string"
+            },
+            "canonical_decision_ts": {
+              "type": "string"
+            }
+          }
+        },
+        "candidate_identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "candidate_id",
+            "candidate_hash",
+            "actor_identity",
+            "target_system",
+            "target_resource",
+            "action_contract_id",
+            "action_contract_version"
+          ],
+          "properties": {
+            "candidate_id": {
+              "type": "string"
+            },
+            "candidate_hash": {
+              "type": "string"
+            },
+            "actor_identity": {
+              "type": "string"
+            },
+            "target_system": {
+              "type": "string"
+            },
+            "target_resource": {
+              "type": "string"
+            },
+            "action_contract_id": {
+              "type": "string"
+            },
+            "action_contract_version": {
+              "type": "string"
+            }
+          }
+        },
+        "evidence_lineage": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "trustlog_artifact_ref",
+            "trustlog_chain_hash",
+            "replay_artifact_ref",
+            "replay_artifact_hash",
+            "authority_evidence_ref",
+            "authority_evidence_hash",
+            "human_approval_receipt_ref",
+            "human_approval_receipt_hash",
+            "policy_snapshot_id",
+            "policy_version",
+            "policy_semantic_digest",
+            "expected_state_fingerprint",
+            "expected_state_source_ref"
+          ],
+          "properties": {
+            "trustlog_artifact_ref": {
+              "type": "string"
+            },
+            "trustlog_chain_hash": {
+              "type": "string"
+            },
+            "replay_artifact_ref": {
+              "type": "string"
+            },
+            "replay_artifact_hash": {
+              "type": "string"
+            },
+            "authority_evidence_ref": {
+              "type": "string"
+            },
+            "authority_evidence_hash": {
+              "type": "string"
+            },
+            "human_approval_receipt_ref": {
+              "type": "string"
+            },
+            "human_approval_receipt_hash": {
+              "type": "string"
+            },
+            "policy_snapshot_id": {
+              "type": "string"
+            },
+            "policy_version": {
+              "type": "string"
+            },
+            "policy_semantic_digest": {
+              "type": "string"
+            },
+            "expected_state_fingerprint": {
+              "type": "string"
+            },
+            "expected_state_source_ref": {
+              "type": "string"
+            }
+          }
+        },
+        "replay_summary": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "original_decision_id",
+            "replay_decision_id",
+            "original_request_id",
+            "replay_request_id",
+            "semantic_profile",
+            "semantic_match",
+            "fields_changed",
+            "severity",
+            "divergence_level"
+          ],
+          "properties": {
+            "original_decision_id": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "replay_decision_id": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "original_request_id": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "replay_request_id": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "semantic_profile": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "semantic_match": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "fields_changed": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "severity": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "divergence_level": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        },
+        "scope_limitations": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "const": "NOT_EXECUTION_AUTHORITY"
+            },
+            {
+              "const": "NOT_EXECUTION_INTENT"
+            },
+            {
+              "const": "NOT_BIND_AUTHORIZATION"
+            },
+            {
+              "const": "NOT_BIND_RECEIPT"
+            },
+            {
+              "const": "NOT_EXTERNAL_EFFECT"
+            },
+            {
+              "const": "NOT_AUTHORITY_EVIDENCE"
+            },
+            {
+              "const": "NOT_HUMAN_APPROVAL"
+            },
+            {
+              "const": "NOT_TRUSTLOG_SUBSTITUTE"
+            }
+          ],
+          "items": false,
+          "minItems": 8,
+          "maxItems": 8
+        }
+      }
+    },
+    "valueAssertion": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "field_path",
+        "value_digest",
+        "verification_mechanism",
+        "source_artifact_ref",
+        "source_hash",
+        "verified_at",
+        "claims"
+      ],
+      "properties": {
+        "field_path": {
+          "type": "string"
+        },
+        "value_digest": {
+          "type": "string"
+        },
+        "verification_mechanism": {
+          "type": "string"
+        },
+        "source_artifact_ref": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "source_hash": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "verified_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "claims": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "candidateBinding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "candidate_value_digest",
+        "asserted_candidate_hash",
+        "candidate_hash_profile",
+        "verification_mechanism",
+        "claim",
+        "source_artifact_ref",
+        "source_hash",
+        "verified_at"
+      ],
+      "properties": {
+        "candidate_value_digest": {
+          "type": "string"
+        },
+        "asserted_candidate_hash": {
+          "type": "string"
+        },
+        "candidate_hash_profile": {
+          "type": "string"
+        },
+        "verification_mechanism": {
+          "type": "string"
+        },
+        "claim": {
+          "type": "string"
+        },
+        "source_artifact_ref": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "source_hash": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "verified_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "authorityBinding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "authority_requirement_value_digest",
+        "authority_evidence_value_digest",
+        "verification_mechanism",
+        "claim",
+        "source_artifact_ref",
+        "source_hash",
+        "verified_at"
+      ],
+      "properties": {
+        "authority_requirement_value_digest": {
+          "type": "string"
+        },
+        "authority_evidence_value_digest": {
+          "type": "string"
+        },
+        "verification_mechanism": {
+          "type": "string"
+        },
+        "claim": {
+          "type": "string"
+        },
+        "source_artifact_ref": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "source_hash": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "verified_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "pre_bind_validation_packet": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "format_version",
+        "pre_bind_validation_id",
+        "pre_bind_validation_hash",
+        "validation_mechanism",
+        "checked_at",
+        "source_formation",
+        "source_formation_hash",
+        "source_formation_packet",
+        "source_readiness_hash",
+        "source_eligibility_hash",
+        "source_handoff_hash",
+        "trusted_validation_context_hash",
+        "validation_result_hash",
+        "mapping_value_digest",
+        "execution_intent_contract_version",
+        "execution_intent",
+        "execution_intent_id",
+        "execution_intent_hash",
+        "source_to_execution_intent_mapping",
+        "field_mapping_proof",
+        "required_field_presence",
+        "source_decision_identity",
+        "candidate_identity",
+        "evidence_lineage",
+        "replay_summary",
+        "pre_bind_status",
+        "ready_for_bind_preflight",
+        "fail_closed",
+        "local_validation_checks",
+        "scope_limitations"
+      ],
+      "properties": {
+        "format_version": {
+          "const": "canonical-execution-intent-pre-bind-validation/v1"
+        },
+        "pre_bind_validation_id": {
+          "type": "string",
+          "pattern": "^eipbv:v1:sha256:[0-9a-f]{64}$"
+        },
+        "pre_bind_validation_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "validation_mechanism": {
+          "const": "validate_execution_intent_before_bind/v1"
+        },
+        "checked_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "source_formation": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "formation_id",
+            "formation_hash",
+            "format_version",
+            "formation_mechanism",
+            "formed_at",
+            "execution_intent_id",
+            "execution_intent_hash"
+          ],
+          "properties": {
+            "formation_id": {
+              "type": "string",
+              "pattern": "^eif:v1:sha256:[0-9a-f]{64}$"
+            },
+            "formation_hash": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "format_version": {
+              "const": "canonical-execution-intent-formation/v1"
+            },
+            "formation_mechanism": {
+              "const": "build_execution_intent_from_readiness/v1"
+            },
+            "formed_at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "execution_intent_id": {
+              "type": "string",
+              "pattern": "^ei:v1:sha256:[0-9a-f]{64}$"
+            },
+            "execution_intent_hash": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            }
+          }
+        },
+        "source_formation_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_formation_packet": {
+          "$ref": "#/$defs/formation_packet"
+        },
+        "source_readiness_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_eligibility_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_handoff_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "trusted_validation_context_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "validation_result_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "mapping_value_digest": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "execution_intent_contract_version": {
+          "const": "execution-intent-contract/v1"
+        },
+        "execution_intent": {
+          "$ref": "#/$defs/execution_intent"
+        },
+        "execution_intent_id": {
+          "type": "string",
+          "pattern": "^ei:v1:sha256:[0-9a-f]{64}$"
+        },
+        "execution_intent_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_to_execution_intent_mapping": {
+          "$ref": "#/$defs/mapping"
+        },
+        "field_mapping_proof": {
+          "$ref": "#/$defs/mapping"
+        },
+        "required_field_presence": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "execution_intent_id",
+            "decision_id",
+            "request_id",
+            "policy_snapshot_id",
+            "actor_identity",
+            "target_system",
+            "target_resource",
+            "intended_action",
+            "evidence_refs",
+            "decision_hash",
+            "decision_ts",
+            "ttl_seconds",
+            "expected_state_fingerprint",
+            "approval_context",
+            "policy_lineage"
+          ],
+          "properties": {
+            "execution_intent_id": {
+              "const": "intentionally_deferred"
+            },
+            "decision_id": {
+              "const": "mapped"
+            },
+            "request_id": {
+              "const": "mapped"
+            },
+            "policy_snapshot_id": {
+              "const": "mapped"
+            },
+            "actor_identity": {
+              "const": "mapped"
+            },
+            "target_system": {
+              "const": "mapped"
+            },
+            "target_resource": {
+              "const": "mapped"
+            },
+            "intended_action": {
+              "const": "mapped"
+            },
+            "evidence_refs": {
+              "const": "mapped"
+            },
+            "decision_hash": {
+              "const": "mapped"
+            },
+            "decision_ts": {
+              "const": "mapped"
+            },
+            "ttl_seconds": {
+              "const": "intentionally_deferred"
+            },
+            "expected_state_fingerprint": {
+              "const": "mapped"
+            },
+            "approval_context": {
+              "const": "mapped"
+            },
+            "policy_lineage": {
+              "const": "mapped"
+            }
+          }
+        },
+        "source_decision_identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "request_id",
+            "canonical_decision_id",
+            "canonical_decision_hash",
+            "canonical_decision_ts"
+          ],
+          "properties": {
+            "request_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "canonical_decision_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "canonical_decision_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "canonical_decision_ts": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "candidate_identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "candidate_id",
+            "candidate_hash",
+            "actor_identity",
+            "target_system",
+            "target_resource",
+            "action_contract_id",
+            "action_contract_version"
+          ],
+          "properties": {
+            "candidate_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "candidate_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "actor_identity": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target_system": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target_resource": {
+              "type": "string",
+              "minLength": 1
+            },
+            "action_contract_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "action_contract_version": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "evidence_lineage": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "trustlog_artifact_ref",
+            "trustlog_chain_hash",
+            "replay_artifact_ref",
+            "replay_artifact_hash",
+            "authority_evidence_ref",
+            "authority_evidence_hash",
+            "human_approval_receipt_ref",
+            "human_approval_receipt_hash",
+            "policy_snapshot_id",
+            "policy_version",
+            "policy_semantic_digest",
+            "expected_state_fingerprint",
+            "expected_state_source_ref"
+          ],
+          "properties": {
+            "trustlog_artifact_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "trustlog_chain_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "replay_artifact_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "replay_artifact_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "authority_evidence_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "authority_evidence_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "human_approval_receipt_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "human_approval_receipt_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_snapshot_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_version": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_semantic_digest": {
+              "type": "string",
+              "minLength": 1
+            },
+            "expected_state_fingerprint": {
+              "type": "string",
+              "minLength": 1
+            },
+            "expected_state_source_ref": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "replay_summary": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "original_decision_id",
+            "replay_decision_id",
+            "original_request_id",
+            "replay_request_id",
+            "semantic_profile",
+            "semantic_match",
+            "fields_changed",
+            "severity",
+            "divergence_level"
+          ],
+          "properties": {
+            "original_decision_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "replay_decision_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "original_request_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "replay_request_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "semantic_profile": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "semantic_match": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "fields_changed": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "severity": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "divergence_level": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        "pre_bind_status": {
+          "const": "READY_FOR_BIND_PREFLIGHT"
+        },
+        "ready_for_bind_preflight": {
+          "const": true
+        },
+        "fail_closed": {
+          "const": false
+        },
+        "local_validation_checks": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "formation_verified",
+            "execution_intent_hash_verified",
+            "execution_intent_id_verified",
+            "field_mapping_verified",
+            "required_field_presence_verified",
+            "evidence_refs_non_empty",
+            "decision_timestamp_timezone_aware",
+            "checked_after_formation",
+            "no_bind_invocation",
+            "no_trustlog_write"
+          ],
+          "properties": {
+            "formation_verified": {
+              "const": true
+            },
+            "execution_intent_hash_verified": {
+              "const": true
+            },
+            "execution_intent_id_verified": {
+              "const": true
+            },
+            "field_mapping_verified": {
+              "const": true
+            },
+            "required_field_presence_verified": {
+              "const": true
+            },
+            "evidence_refs_non_empty": {
+              "const": true
+            },
+            "decision_timestamp_timezone_aware": {
+              "const": true
+            },
+            "checked_after_formation": {
+              "const": true
+            },
+            "no_bind_invocation": {
+              "const": true
+            },
+            "no_trustlog_write": {
+              "const": true
+            }
+          }
+        },
+        "scope_limitations": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "const": "NOT_EXECUTION_AUTHORITY"
+            },
+            {
+              "const": "NOT_BIND_AUTHORIZATION"
+            },
+            {
+              "const": "NOT_BIND_RECEIPT"
+            },
+            {
+              "const": "NOT_BIND_INVOCATION"
+            },
+            {
+              "const": "NOT_ADAPTER_INVOCATION"
+            },
+            {
+              "const": "NOT_EXTERNAL_EFFECT"
+            },
+            {
+              "const": "NOT_OPERATION_COMMIT"
+            },
+            {
+              "const": "NOT_TRUSTLOG_WRITE"
+            },
+            {
+              "const": "NOT_LIVE_STATE_CHECK"
+            },
+            {
+              "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+            },
+            {
+              "const": "NOT_AUTHORITY_EVIDENCE"
+            },
+            {
+              "const": "NOT_HUMAN_APPROVAL"
+            }
+          ],
+          "items": false,
+          "minItems": 12,
+          "maxItems": 12
+        }
+      }
+    },
+    "bind_preflight_packet": {
+      "title": "Canonical Bind Preflight Adjudication Packet v1",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "format_version",
+        "bind_preflight_adjudication_id",
+        "bind_preflight_adjudication_hash",
+        "adjudication_mechanism",
+        "adjudicated_at",
+        "source_pre_bind_validation",
+        "source_pre_bind_validation_hash",
+        "source_pre_bind_validation_packet",
+        "source_formation_hash",
+        "source_readiness_hash",
+        "source_eligibility_hash",
+        "source_handoff_hash",
+        "trusted_validation_context_hash",
+        "validation_result_hash",
+        "mapping_value_digest",
+        "execution_intent_contract_version",
+        "execution_intent",
+        "execution_intent_id",
+        "execution_intent_hash",
+        "source_to_execution_intent_mapping",
+        "field_mapping_proof",
+        "required_field_presence",
+        "source_decision_identity",
+        "candidate_identity",
+        "evidence_lineage",
+        "replay_summary",
+        "bind_preflight_status",
+        "ready_for_bind_adjudication",
+        "fail_closed",
+        "local_adjudication_checks",
+        "bind_entry_requirements",
+        "scope_limitations"
+      ],
+      "properties": {
+        "format_version": {
+          "const": "canonical-bind-preflight-adjudication/v1"
+        },
+        "bind_preflight_adjudication_id": {
+          "type": "string",
+          "pattern": "^bpa:v1:sha256:[0-9a-f]{64}$"
+        },
+        "bind_preflight_adjudication_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "adjudication_mechanism": {
+          "const": "adjudicate_bind_preflight_locally/v1"
+        },
+        "adjudicated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "source_pre_bind_validation": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "pre_bind_validation_id",
+            "pre_bind_validation_hash",
+            "format_version",
+            "validation_mechanism",
+            "checked_at",
+            "execution_intent_id",
+            "execution_intent_hash",
+            "pre_bind_status",
+            "ready_for_bind_preflight"
+          ],
+          "properties": {
+            "pre_bind_validation_id": {
+              "type": "string",
+              "pattern": "^eipbv:v1:sha256:[0-9a-f]{64}$"
+            },
+            "pre_bind_validation_hash": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "format_version": {
+              "const": "canonical-execution-intent-pre-bind-validation/v1"
+            },
+            "validation_mechanism": {
+              "const": "validate_execution_intent_before_bind/v1"
+            },
+            "checked_at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "execution_intent_id": {
+              "type": "string",
+              "pattern": "^ei:v1:sha256:[0-9a-f]{64}$"
+            },
+            "execution_intent_hash": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "pre_bind_status": {
+              "const": "READY_FOR_BIND_PREFLIGHT"
+            },
+            "ready_for_bind_preflight": {
+              "const": true
+            }
+          }
+        },
+        "source_pre_bind_validation_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_pre_bind_validation_packet": {
+          "$ref": "#/$defs/pre_bind_validation_packet"
+        },
+        "source_formation_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_readiness_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_eligibility_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_handoff_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "trusted_validation_context_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "validation_result_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "mapping_value_digest": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "execution_intent_contract_version": {
+          "const": "execution-intent-contract/v1"
+        },
+        "execution_intent": {
+          "$ref": "#/$defs/execution_intent"
+        },
+        "execution_intent_id": {
+          "type": "string",
+          "pattern": "^ei:v1:sha256:[0-9a-f]{64}$"
+        },
+        "execution_intent_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_to_execution_intent_mapping": {
+          "$ref": "#/$defs/mapping"
+        },
+        "field_mapping_proof": {
+          "$ref": "#/$defs/mapping"
+        },
+        "required_field_presence": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "execution_intent_id",
+            "decision_id",
+            "request_id",
+            "policy_snapshot_id",
+            "actor_identity",
+            "target_system",
+            "target_resource",
+            "intended_action",
+            "evidence_refs",
+            "decision_hash",
+            "decision_ts",
+            "ttl_seconds",
+            "expected_state_fingerprint",
+            "approval_context",
+            "policy_lineage"
+          ],
+          "properties": {
+            "execution_intent_id": {
+              "const": "intentionally_deferred"
+            },
+            "decision_id": {
+              "const": "mapped"
+            },
+            "request_id": {
+              "const": "mapped"
+            },
+            "policy_snapshot_id": {
+              "const": "mapped"
+            },
+            "actor_identity": {
+              "const": "mapped"
+            },
+            "target_system": {
+              "const": "mapped"
+            },
+            "target_resource": {
+              "const": "mapped"
+            },
+            "intended_action": {
+              "const": "mapped"
+            },
+            "evidence_refs": {
+              "const": "mapped"
+            },
+            "decision_hash": {
+              "const": "mapped"
+            },
+            "decision_ts": {
+              "const": "mapped"
+            },
+            "ttl_seconds": {
+              "const": "intentionally_deferred"
+            },
+            "expected_state_fingerprint": {
+              "const": "mapped"
+            },
+            "approval_context": {
+              "const": "mapped"
+            },
+            "policy_lineage": {
+              "const": "mapped"
+            }
+          }
+        },
+        "source_decision_identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "request_id",
+            "canonical_decision_id",
+            "canonical_decision_hash",
+            "canonical_decision_ts"
+          ],
+          "properties": {
+            "request_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "canonical_decision_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "canonical_decision_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "canonical_decision_ts": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "candidate_identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "candidate_id",
+            "candidate_hash",
+            "actor_identity",
+            "target_system",
+            "target_resource",
+            "action_contract_id",
+            "action_contract_version"
+          ],
+          "properties": {
+            "candidate_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "candidate_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "actor_identity": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target_system": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target_resource": {
+              "type": "string",
+              "minLength": 1
+            },
+            "action_contract_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "action_contract_version": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "evidence_lineage": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "trustlog_artifact_ref",
+            "trustlog_chain_hash",
+            "replay_artifact_ref",
+            "replay_artifact_hash",
+            "authority_evidence_ref",
+            "authority_evidence_hash",
+            "human_approval_receipt_ref",
+            "human_approval_receipt_hash",
+            "policy_snapshot_id",
+            "policy_version",
+            "policy_semantic_digest",
+            "expected_state_fingerprint",
+            "expected_state_source_ref"
+          ],
+          "properties": {
+            "trustlog_artifact_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "trustlog_chain_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "replay_artifact_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "replay_artifact_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "authority_evidence_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "authority_evidence_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "human_approval_receipt_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "human_approval_receipt_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_snapshot_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_version": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_semantic_digest": {
+              "type": "string",
+              "minLength": 1
+            },
+            "expected_state_fingerprint": {
+              "type": "string",
+              "minLength": 1
+            },
+            "expected_state_source_ref": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "replay_summary": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "original_decision_id",
+            "replay_decision_id",
+            "original_request_id",
+            "replay_request_id",
+            "semantic_profile",
+            "semantic_match",
+            "fields_changed",
+            "severity",
+            "divergence_level"
+          ],
+          "properties": {
+            "original_decision_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "replay_decision_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "original_request_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "replay_request_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "semantic_profile": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "semantic_match": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "fields_changed": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "severity": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "divergence_level": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        "bind_preflight_status": {
+          "const": "READY_FOR_BIND_ADJUDICATION"
+        },
+        "ready_for_bind_adjudication": {
+          "const": true
+        },
+        "fail_closed": {
+          "const": false
+        },
+        "local_adjudication_checks": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "pre_bind_validation_verified",
+            "execution_intent_hash_verified",
+            "execution_intent_id_verified",
+            "source_formation_verified",
+            "field_mapping_verified",
+            "required_field_presence_verified",
+            "evidence_refs_non_empty",
+            "decision_timestamp_timezone_aware",
+            "adjudicated_after_pre_bind_validation",
+            "ttl_locally_well_formed",
+            "no_bind_invocation",
+            "no_adapter_invocation",
+            "no_bind_receipt_created",
+            "no_trustlog_write",
+            "no_live_state_check",
+            "no_runtime_risk_check"
+          ],
+          "properties": {
+            "pre_bind_validation_verified": {
+              "const": true
+            },
+            "execution_intent_hash_verified": {
+              "const": true
+            },
+            "execution_intent_id_verified": {
+              "const": true
+            },
+            "source_formation_verified": {
+              "const": true
+            },
+            "field_mapping_verified": {
+              "const": true
+            },
+            "required_field_presence_verified": {
+              "const": true
+            },
+            "evidence_refs_non_empty": {
+              "const": true
+            },
+            "decision_timestamp_timezone_aware": {
+              "const": true
+            },
+            "adjudicated_after_pre_bind_validation": {
+              "const": true
+            },
+            "ttl_locally_well_formed": {
+              "const": true
+            },
+            "no_bind_invocation": {
+              "const": true
+            },
+            "no_adapter_invocation": {
+              "const": true
+            },
+            "no_bind_receipt_created": {
+              "const": true
+            },
+            "no_trustlog_write": {
+              "const": true
+            },
+            "no_live_state_check": {
+              "const": true
+            },
+            "no_runtime_risk_check": {
+              "const": true
+            }
+          }
+        },
+        "bind_entry_requirements": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "adapter_required",
+            "adapter_snapshot_required",
+            "adapter_authority_revalidation_required",
+            "adapter_constraint_validation_required",
+            "runtime_risk_assessment_required",
+            "commit_boundary_evaluation_required",
+            "postcondition_verification_required",
+            "rollback_or_revert_path_required",
+            "bind_receipt_required",
+            "trustlog_policy_required"
+          ],
+          "properties": {
+            "adapter_required": {
+              "const": true
+            },
+            "adapter_snapshot_required": {
+              "const": true
+            },
+            "adapter_authority_revalidation_required": {
+              "const": true
+            },
+            "adapter_constraint_validation_required": {
+              "const": true
+            },
+            "runtime_risk_assessment_required": {
+              "const": true
+            },
+            "commit_boundary_evaluation_required": {
+              "const": true
+            },
+            "postcondition_verification_required": {
+              "const": true
+            },
+            "rollback_or_revert_path_required": {
+              "const": true
+            },
+            "bind_receipt_required": {
+              "const": true
+            },
+            "trustlog_policy_required": {
+              "const": true
+            }
+          }
+        },
+        "scope_limitations": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "const": "NOT_EXECUTION_AUTHORITY"
+            },
+            {
+              "const": "NOT_BIND_AUTHORIZATION"
+            },
+            {
+              "const": "NOT_BIND_RECEIPT"
+            },
+            {
+              "const": "NOT_BIND_INVOCATION"
+            },
+            {
+              "const": "NOT_ADAPTER_INVOCATION"
+            },
+            {
+              "const": "NOT_EXTERNAL_EFFECT"
+            },
+            {
+              "const": "NOT_OPERATION_COMMIT"
+            },
+            {
+              "const": "NOT_TRUSTLOG_WRITE"
+            },
+            {
+              "const": "NOT_LIVE_STATE_CHECK"
+            },
+            {
+              "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+            },
+            {
+              "const": "NOT_AUTHORITY_REVALIDATION"
+            },
+            {
+              "const": "NOT_CONSTRAINT_REVALIDATION"
+            },
+            {
+              "const": "NOT_POSTCONDITION_VERIFICATION"
+            },
+            {
+              "const": "NOT_ROLLBACK_PROOF"
+            },
+            {
+              "const": "NOT_AUTHORITY_EVIDENCE"
+            },
+            {
+              "const": "NOT_HUMAN_APPROVAL"
+            }
+          ],
+          "items": false,
+          "minItems": 16,
+          "maxItems": 16
+        }
+      }
+    },
+    "descriptor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "adapter_contract_id",
+        "adapter_contract_hash",
+        "adapter_contract_version",
+        "adapter_kind",
+        "adapter_name",
+        "target_system",
+        "target_resource_scope",
+        "supported_methods",
+        "required_methods",
+        "prohibited_during_selection",
+        "effect_profile",
+        "declared_by",
+        "declared_at",
+        "descriptor_scope_limitations"
+      ],
+      "properties": {
+        "adapter_contract_id": {
+          "type": "string",
+          "pattern": "^adapter-contract:v1:sha256:[0-9a-f]{64}$"
+        },
+        "adapter_contract_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "adapter_contract_version": {
+          "const": "bind-adapter-contract/v1"
+        },
+        "adapter_kind": {
+          "enum": [
+            "reference",
+            "webhook",
+            "external",
+            "custom"
+          ]
+        },
+        "adapter_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_system": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_resource_scope": {
+          "type": "string",
+          "minLength": 1
+        },
+        "supported_methods": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "const": "snapshot"
+            },
+            {
+              "const": "fingerprint_state"
+            },
+            {
+              "const": "validate_authority"
+            },
+            {
+              "const": "validate_constraints"
+            },
+            {
+              "const": "assess_runtime_risk"
+            },
+            {
+              "const": "apply"
+            },
+            {
+              "const": "verify_postconditions"
+            },
+            {
+              "const": "revert"
+            },
+            {
+              "const": "describe_target"
+            },
+            {
+              "const": "build_idempotency_key"
+            }
+          ],
+          "items": false,
+          "minItems": 10,
+          "maxItems": 10
+        },
+        "required_methods": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "const": "snapshot"
+            },
+            {
+              "const": "fingerprint_state"
+            },
+            {
+              "const": "validate_authority"
+            },
+            {
+              "const": "validate_constraints"
+            },
+            {
+              "const": "assess_runtime_risk"
+            },
+            {
+              "const": "apply"
+            },
+            {
+              "const": "verify_postconditions"
+            },
+            {
+              "const": "revert"
+            },
+            {
+              "const": "describe_target"
+            },
+            {
+              "const": "build_idempotency_key"
+            }
+          ],
+          "items": false,
+          "minItems": 10,
+          "maxItems": 10
+        },
+        "prohibited_during_selection": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "const": "snapshot"
+            },
+            {
+              "const": "fingerprint_state"
+            },
+            {
+              "const": "validate_authority"
+            },
+            {
+              "const": "validate_constraints"
+            },
+            {
+              "const": "assess_runtime_risk"
+            },
+            {
+              "const": "apply"
+            },
+            {
+              "const": "verify_postconditions"
+            },
+            {
+              "const": "revert"
+            },
+            {
+              "const": "build_idempotency_key"
+            },
+            {
+              "const": "execute_bind_adjudication"
+            },
+            {
+              "const": "execute_bind_boundary"
+            },
+            {
+              "const": "BindReceipt"
+            },
+            {
+              "const": "TrustLogWrite"
+            }
+          ],
+          "items": false,
+          "minItems": 13,
+          "maxItems": 13
+        },
+        "effect_profile": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "selection_phase",
+            "adapter_instantiated",
+            "adapter_methods_called",
+            "network_allowed",
+            "filesystem_allowed",
+            "external_effect_allowed",
+            "trustlog_write_allowed",
+            "bind_receipt_allowed"
+          ],
+          "properties": {
+            "selection_phase": {
+              "const": "no_effect"
+            },
+            "adapter_instantiated": {
+              "const": false
+            },
+            "adapter_methods_called": {
+              "const": false
+            },
+            "network_allowed": {
+              "const": false
+            },
+            "filesystem_allowed": {
+              "const": false
+            },
+            "external_effect_allowed": {
+              "const": false
+            },
+            "trustlog_write_allowed": {
+              "const": false
+            },
+            "bind_receipt_allowed": {
+              "const": false
+            }
+          }
+        },
+        "declared_by": {
+          "type": "string",
+          "minLength": 1
+        },
+        "declared_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "descriptor_scope_limitations": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "const": "NOT_ADAPTER_INSTANCE"
+            },
+            {
+              "const": "NOT_ADAPTER_AUTHORIZATION"
+            },
+            {
+              "const": "NOT_ADAPTER_INVOCATION"
+            },
+            {
+              "const": "NOT_BIND_INVOCATION"
+            },
+            {
+              "const": "NOT_BIND_RECEIPT"
+            },
+            {
+              "const": "NOT_TRUSTLOG_WRITE"
+            },
+            {
+              "const": "NOT_EXTERNAL_EFFECT"
+            },
+            {
+              "const": "NOT_AUTHORITY_REVALIDATION"
+            },
+            {
+              "const": "NOT_CONSTRAINT_REVALIDATION"
+            },
+            {
+              "const": "NOT_RUNTIME_RISK_CHECK"
+            },
+            {
+              "const": "NOT_POSTCONDITION_VERIFICATION"
+            },
+            {
+              "const": "NOT_ROLLBACK_PROOF"
+            }
+          ],
+          "items": false,
+          "minItems": 12,
+          "maxItems": 12
+        }
+      }
+    },
+    "bind_adapter_contract_selection_packet": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "format_version",
+        "adapter_contract_selection_id",
+        "adapter_contract_selection_hash",
+        "selection_mechanism",
+        "selected_at",
+        "source_bind_preflight_adjudication",
+        "source_bind_preflight_adjudication_hash",
+        "source_bind_preflight_adjudication_packet",
+        "adapter_contract_descriptor",
+        "adapter_contract_id",
+        "adapter_contract_hash",
+        "adapter_contract_version",
+        "execution_intent",
+        "execution_intent_id",
+        "execution_intent_hash",
+        "source_formation_hash",
+        "source_readiness_hash",
+        "source_eligibility_hash",
+        "source_handoff_hash",
+        "trusted_validation_context_hash",
+        "validation_result_hash",
+        "mapping_value_digest",
+        "execution_intent_contract_version",
+        "selection_status",
+        "ready_for_adapter_dry_run",
+        "fail_closed",
+        "local_selection_checks",
+        "future_bind_dry_run_requirements",
+        "source_to_execution_intent_mapping",
+        "field_mapping_proof",
+        "required_field_presence",
+        "source_decision_identity",
+        "candidate_identity",
+        "evidence_lineage",
+        "replay_summary",
+        "scope_limitations"
+      ],
+      "properties": {
+        "format_version": {
+          "const": "canonical-bind-adapter-contract-selection/v1"
+        },
+        "adapter_contract_selection_id": {
+          "type": "string",
+          "pattern": "^bac:v1:sha256:[0-9a-f]{64}$"
+        },
+        "adapter_contract_selection_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "selection_mechanism": {
+          "const": "select_bind_adapter_contract_without_invocation/v1"
+        },
+        "selected_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "source_bind_preflight_adjudication": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "bind_preflight_adjudication_id",
+            "bind_preflight_adjudication_hash",
+            "format_version",
+            "adjudication_mechanism",
+            "adjudicated_at",
+            "execution_intent_id",
+            "execution_intent_hash",
+            "bind_preflight_status",
+            "ready_for_bind_adjudication"
+          ],
+          "properties": {
+            "bind_preflight_adjudication_id": {},
+            "bind_preflight_adjudication_hash": {},
+            "format_version": {},
+            "adjudication_mechanism": {},
+            "adjudicated_at": {},
+            "execution_intent_id": {},
+            "execution_intent_hash": {},
+            "bind_preflight_status": {},
+            "ready_for_bind_adjudication": {}
+          }
+        },
+        "source_bind_preflight_adjudication_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_bind_preflight_adjudication_packet": {
+          "$ref": "#/$defs/bind_preflight_packet"
+        },
+        "adapter_contract_descriptor": {
+          "$ref": "#/$defs/descriptor"
+        },
+        "adapter_contract_id": {
+          "type": "string",
+          "pattern": "^adapter-contract:v1:sha256:[0-9a-f]{64}$"
+        },
+        "adapter_contract_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "adapter_contract_version": {
+          "const": "bind-adapter-contract/v1"
+        },
+        "execution_intent": {
+          "$ref": "#/$defs/execution_intent"
+        },
+        "execution_intent_id": {
+          "type": "string",
+          "pattern": "^ei:v1:sha256:[0-9a-f]{64}$"
+        },
+        "execution_intent_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_formation_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_readiness_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_eligibility_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_handoff_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "trusted_validation_context_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "validation_result_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "mapping_value_digest": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "execution_intent_contract_version": {
+          "type": "string"
+        },
+        "selection_status": {
+          "const": "ADAPTER_CONTRACT_SELECTED_FOR_DRY_RUN"
+        },
+        "ready_for_adapter_dry_run": {
+          "const": true
+        },
+        "fail_closed": {
+          "const": false
+        },
+        "local_selection_checks": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "bind_preflight_adjudication_verified",
+            "execution_intent_hash_verified",
+            "execution_intent_id_verified",
+            "adapter_descriptor_hash_verified",
+            "adapter_descriptor_scope_matches_intent",
+            "required_methods_declared",
+            "prohibited_methods_not_called",
+            "selected_after_bind_preflight_adjudication",
+            "no_adapter_instance",
+            "no_adapter_invocation",
+            "no_bind_invocation",
+            "no_bind_receipt_created",
+            "no_trustlog_write",
+            "no_network",
+            "no_filesystem",
+            "no_external_effect"
+          ],
+          "properties": {
+            "bind_preflight_adjudication_verified": {
+              "const": true
+            },
+            "execution_intent_hash_verified": {
+              "const": true
+            },
+            "execution_intent_id_verified": {
+              "const": true
+            },
+            "adapter_descriptor_hash_verified": {
+              "const": true
+            },
+            "adapter_descriptor_scope_matches_intent": {
+              "const": true
+            },
+            "required_methods_declared": {
+              "const": true
+            },
+            "prohibited_methods_not_called": {
+              "const": true
+            },
+            "selected_after_bind_preflight_adjudication": {
+              "const": true
+            },
+            "no_adapter_instance": {
+              "const": true
+            },
+            "no_adapter_invocation": {
+              "const": true
+            },
+            "no_bind_invocation": {
+              "const": true
+            },
+            "no_bind_receipt_created": {
+              "const": true
+            },
+            "no_trustlog_write": {
+              "const": true
+            },
+            "no_network": {
+              "const": true
+            },
+            "no_filesystem": {
+              "const": true
+            },
+            "no_external_effect": {
+              "const": true
+            }
+          }
+        },
+        "future_bind_dry_run_requirements": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "adapter_instance_required",
+            "snapshot_required",
+            "state_fingerprint_required",
+            "authority_revalidation_required",
+            "constraint_validation_required",
+            "runtime_risk_assessment_required",
+            "commit_boundary_evaluation_required",
+            "idempotency_key_required",
+            "postcondition_verification_required",
+            "rollback_or_revert_path_required",
+            "bind_receipt_required",
+            "trustlog_policy_required"
+          ],
+          "properties": {
+            "adapter_instance_required": {
+              "const": true
+            },
+            "snapshot_required": {
+              "const": true
+            },
+            "state_fingerprint_required": {
+              "const": true
+            },
+            "authority_revalidation_required": {
+              "const": true
+            },
+            "constraint_validation_required": {
+              "const": true
+            },
+            "runtime_risk_assessment_required": {
+              "const": true
+            },
+            "commit_boundary_evaluation_required": {
+              "const": true
+            },
+            "idempotency_key_required": {
+              "const": true
+            },
+            "postcondition_verification_required": {
+              "const": true
+            },
+            "rollback_or_revert_path_required": {
+              "const": true
+            },
+            "bind_receipt_required": {
+              "const": true
+            },
+            "trustlog_policy_required": {
+              "const": true
+            }
+          }
+        },
+        "source_to_execution_intent_mapping": {
+          "$ref": "#/$defs/mapping"
+        },
+        "field_mapping_proof": {
+          "$ref": "#/$defs/mapping"
+        },
+        "required_field_presence": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "execution_intent_id",
+            "decision_id",
+            "request_id",
+            "policy_snapshot_id",
+            "actor_identity",
+            "target_system",
+            "target_resource",
+            "intended_action",
+            "evidence_refs",
+            "decision_hash",
+            "decision_ts",
+            "ttl_seconds",
+            "expected_state_fingerprint",
+            "approval_context",
+            "policy_lineage"
+          ],
+          "properties": {
+            "execution_intent_id": {
+              "const": "intentionally_deferred"
+            },
+            "decision_id": {
+              "const": "mapped"
+            },
+            "request_id": {
+              "const": "mapped"
+            },
+            "policy_snapshot_id": {
+              "const": "mapped"
+            },
+            "actor_identity": {
+              "const": "mapped"
+            },
+            "target_system": {
+              "const": "mapped"
+            },
+            "target_resource": {
+              "const": "mapped"
+            },
+            "intended_action": {
+              "const": "mapped"
+            },
+            "evidence_refs": {
+              "const": "mapped"
+            },
+            "decision_hash": {
+              "const": "mapped"
+            },
+            "decision_ts": {
+              "const": "mapped"
+            },
+            "ttl_seconds": {
+              "const": "intentionally_deferred"
+            },
+            "expected_state_fingerprint": {
+              "const": "mapped"
+            },
+            "approval_context": {
+              "const": "mapped"
+            },
+            "policy_lineage": {
+              "const": "mapped"
+            }
+          }
+        },
+        "source_decision_identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "request_id",
+            "canonical_decision_id",
+            "canonical_decision_hash",
+            "canonical_decision_ts"
+          ],
+          "properties": {
+            "request_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "canonical_decision_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "canonical_decision_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "canonical_decision_ts": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "candidate_identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "candidate_id",
+            "candidate_hash",
+            "actor_identity",
+            "target_system",
+            "target_resource",
+            "action_contract_id",
+            "action_contract_version"
+          ],
+          "properties": {
+            "candidate_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "candidate_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "actor_identity": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target_system": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target_resource": {
+              "type": "string",
+              "minLength": 1
+            },
+            "action_contract_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "action_contract_version": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "evidence_lineage": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "trustlog_artifact_ref",
+            "trustlog_chain_hash",
+            "replay_artifact_ref",
+            "replay_artifact_hash",
+            "authority_evidence_ref",
+            "authority_evidence_hash",
+            "human_approval_receipt_ref",
+            "human_approval_receipt_hash",
+            "policy_snapshot_id",
+            "policy_version",
+            "policy_semantic_digest",
+            "expected_state_fingerprint",
+            "expected_state_source_ref"
+          ],
+          "properties": {
+            "trustlog_artifact_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "trustlog_chain_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "replay_artifact_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "replay_artifact_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "authority_evidence_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "authority_evidence_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "human_approval_receipt_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "human_approval_receipt_hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_snapshot_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_version": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_semantic_digest": {
+              "type": "string",
+              "minLength": 1
+            },
+            "expected_state_fingerprint": {
+              "type": "string",
+              "minLength": 1
+            },
+            "expected_state_source_ref": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "replay_summary": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "original_decision_id",
+            "replay_decision_id",
+            "original_request_id",
+            "replay_request_id",
+            "semantic_profile",
+            "semantic_match",
+            "fields_changed",
+            "severity",
+            "divergence_level"
+          ],
+          "properties": {
+            "original_decision_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "replay_decision_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "original_request_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "replay_request_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "semantic_profile": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "semantic_match": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "fields_changed": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "severity": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "divergence_level": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        "scope_limitations": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "const": "NOT_EXECUTION_AUTHORITY"
+            },
+            {
+              "const": "NOT_BIND_AUTHORIZATION"
+            },
+            {
+              "const": "NOT_BIND_RECEIPT"
+            },
+            {
+              "const": "NOT_BIND_INVOCATION"
+            },
+            {
+              "const": "NOT_ADAPTER_INSTANCE"
+            },
+            {
+              "const": "NOT_ADAPTER_INVOCATION"
+            },
+            {
+              "const": "NOT_EXTERNAL_EFFECT"
+            },
+            {
+              "const": "NOT_OPERATION_COMMIT"
+            },
+            {
+              "const": "NOT_TRUSTLOG_WRITE"
+            },
+            {
+              "const": "NOT_LIVE_STATE_CHECK"
+            },
+            {
+              "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+            },
+            {
+              "const": "NOT_AUTHORITY_REVALIDATION"
+            },
+            {
+              "const": "NOT_CONSTRAINT_REVALIDATION"
+            },
+            {
+              "const": "NOT_POSTCONDITION_VERIFICATION"
+            },
+            {
+              "const": "NOT_ROLLBACK_PROOF"
+            },
+            {
+              "const": "NOT_AUTHORITY_EVIDENCE"
+            },
+            {
+              "const": "NOT_HUMAN_APPROVAL"
+            }
+          ],
+          "items": false,
+          "minItems": 17,
+          "maxItems": 17
+        }
+      }
+    }
+  }
+}

--- a/veritas_os/policy/adapter_dry_run_plan.py
+++ b/veritas_os/policy/adapter_dry_run_plan.py
@@ -1,0 +1,364 @@
+"""Plan a future adapter dry run without creating or invoking an adapter.
+
+This module is deliberately pure data: it verifies an exact adapter contract
+selection and records seven inert method-name descriptors.  It performs no I/O,
+Bind activity, adapter activity, receipt construction, or TrustLog write.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from veritas_os.policy.bind_adapter_contract_selection import (
+    BindAdapterContractSelectionError,
+    CanonicalBindAdapterContractSelectionPacket,
+    verify_bind_adapter_contract_selection_packet,
+)
+from veritas_os.policy.bind_artifacts import (
+    ExecutionIntent,
+    canonical_execution_intent_json,
+    hash_execution_intent,
+)
+
+FORMAT_VERSION = "canonical-adapter-dry-run-plan/v1"
+PLAN_MECHANISM = "plan_adapter_dry_run_without_invocation/v1"
+STEPS_DOMAIN = "veritas.adapter-dry-run-plan.steps/v1"
+LOCAL_CHECKS_DOMAIN = "veritas.adapter-dry-run-plan.local-checks/v1"
+FUTURE_REQUIREMENTS_DOMAIN = "veritas.adapter-dry-run-plan.future-requirements/v1"
+PACKET_DOMAIN = "veritas.adapter-dry-run-plan.packet/v1"
+SOURCE_SUMMARY_KEYS = (
+    "adapter_contract_selection_id", "adapter_contract_selection_hash",
+    "format_version", "selection_mechanism", "selected_at",
+    "adapter_contract_id", "adapter_contract_hash", "execution_intent_id",
+    "execution_intent_hash", "selection_status", "ready_for_adapter_dry_run",
+)
+STEP_LIMITATIONS = (
+    "NOT_EXECUTED", "NOT_ADAPTER_INVOCATION", "NOT_LIVE_STATE",
+    "NOT_AUTHORITY_REVALIDATION", "NOT_CONSTRAINT_REVALIDATION",
+    "NOT_RUNTIME_RISK_ACCEPTANCE", "NOT_BIND_AUTHORIZATION",
+    "NOT_BIND_RECEIPT", "NOT_TRUSTLOG_WRITE",
+)
+EFFECT_POLICY = {
+    "adapter_instance_required_later": True,
+    "adapter_method_call_allowed_now": False,
+    "network_allowed": False,
+    "filesystem_allowed": False,
+    "external_effect_allowed": False,
+    "trustlog_write_allowed": False,
+    "bind_receipt_allowed": False,
+}
+STEP_SPECS = (
+    ("prepare", "describe_target", "planned_target_description_ref",
+     "DRY_RUN_TARGET_DESCRIPTION_MISSING"),
+    ("prepare", "build_idempotency_key", "planned_idempotency_key_ref",
+     "DRY_RUN_IDEMPOTENCY_KEY_MISSING"),
+    ("observe", "snapshot", "planned_snapshot_ref",
+     "DRY_RUN_SNAPSHOT_MISSING"),
+    ("observe", "fingerprint_state", "planned_state_fingerprint_ref",
+     "DRY_RUN_STATE_FINGERPRINT_MISSING"),
+    ("validate", "validate_authority", "planned_authority_signal_ref",
+     "DRY_RUN_AUTHORITY_SIGNAL_MISSING"),
+    ("validate", "validate_constraints", "planned_constraint_signal_ref",
+     "DRY_RUN_CONSTRAINT_SIGNAL_MISSING"),
+    ("assess", "assess_runtime_risk", "planned_runtime_risk_signal_ref",
+     "DRY_RUN_RUNTIME_RISK_SIGNAL_MISSING"),
+)
+LOCAL_PLAN_CHECKS = {key: True for key in (
+    "adapter_contract_selection_verified", "execution_intent_hash_verified",
+    "execution_intent_id_verified", "adapter_descriptor_hash_verified",
+    "adapter_descriptor_scope_matches_intent", "planned_steps_ordered",
+    "planned_methods_declared", "no_apply_step", "no_postcondition_step",
+    "no_revert_step", "planned_after_adapter_contract_selection",
+    "no_adapter_instance", "no_adapter_invocation", "no_bind_invocation",
+    "no_bind_receipt_created", "no_trustlog_write", "no_network",
+    "no_filesystem", "no_external_effect",
+)}
+FUTURE_DRY_RUN_EXECUTION_REQUIREMENTS = {key: True for key in (
+    "adapter_instance_required", "describe_target_call_required",
+    "idempotency_key_plan_required", "snapshot_call_required",
+    "state_fingerprint_call_required", "authority_revalidation_call_required",
+    "constraint_validation_call_required", "runtime_risk_assessment_call_required",
+    "dry_run_result_packet_required", "trustlog_policy_still_deferred",
+    "bind_receipt_still_deferred", "apply_still_forbidden",
+)}
+SCOPE_LIMITATIONS = (
+    "NOT_EXECUTION_AUTHORITY", "NOT_BIND_AUTHORIZATION", "NOT_BIND_RECEIPT",
+    "NOT_BIND_INVOCATION", "NOT_ADAPTER_INSTANCE", "NOT_ADAPTER_INVOCATION",
+    "NOT_ADAPTER_DRY_RUN_EXECUTION", "NOT_EXTERNAL_EFFECT",
+    "NOT_OPERATION_COMMIT", "NOT_TRUSTLOG_WRITE", "NOT_LIVE_STATE_CHECK",
+    "NOT_RUNTIME_RISK_ACCEPTANCE", "NOT_AUTHORITY_REVALIDATION",
+    "NOT_CONSTRAINT_REVALIDATION", "NOT_POSTCONDITION_VERIFICATION",
+    "NOT_ROLLBACK_PROOF", "NOT_AUTHORITY_EVIDENCE", "NOT_HUMAN_APPROVAL",
+)
+
+
+class AdapterDryRunPlanError(ValueError):
+    """Stable fail-closed refusal for dry-run plan processing."""
+
+
+class AdapterDryRunStepDescriptor(BaseModel):
+    """Immutable description of a future call, never an executable call."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    step_id: str = Field(pattern=r"^dry-run-step:v1:[1-9][0-9]*:[a-z0-9-]+$")
+    ordinal: int = Field(ge=1)
+    phase: Literal["prepare", "observe", "validate", "assess", "finalize"]
+    planned_adapter_method: Literal[
+        "snapshot", "fingerprint_state", "validate_authority",
+        "validate_constraints", "assess_runtime_risk", "describe_target",
+        "build_idempotency_key",
+    ]
+    execution_mode: Literal["planned_no_effect"]
+    required_input_refs: tuple[str, ...]
+    expected_output_ref: str
+    effect_policy: dict[str, bool]
+    refusal_if_missing_later: str
+    step_scope_limitations: tuple[str, ...]
+
+
+class CanonicalAdapterDryRunPlanPacket(BaseModel):
+    """Strict immutable packet representing only a no-effect plan."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    format_version: Literal["canonical-adapter-dry-run-plan/v1"]
+    adapter_dry_run_plan_id: str = Field(pattern=r"^adp:v1:sha256:[0-9a-f]{64}$")
+    adapter_dry_run_plan_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    plan_mechanism: Literal["plan_adapter_dry_run_without_invocation/v1"]
+    planned_at: str
+    source_adapter_contract_selection: dict[str, Any]
+    source_adapter_contract_selection_hash: str
+    source_adapter_contract_selection_packet: dict[str, Any]
+    adapter_contract_descriptor: dict[str, Any]
+    adapter_contract_id: str
+    adapter_contract_hash: str
+    adapter_contract_version: Literal["bind-adapter-contract/v1"]
+    execution_intent: dict[str, Any]
+    execution_intent_id: str
+    execution_intent_hash: str
+    source_bind_preflight_adjudication_hash: str
+    source_formation_hash: str
+    source_readiness_hash: str
+    source_eligibility_hash: str
+    source_handoff_hash: str
+    trusted_validation_context_hash: str
+    validation_result_hash: str
+    mapping_value_digest: str
+    execution_intent_contract_version: str
+    dry_run_plan_status: Literal["ADAPTER_DRY_RUN_PLANNED_NO_EFFECT"]
+    ready_for_adapter_dry_run_execution: Literal[True]
+    fail_closed: Literal[False]
+    planned_steps: tuple[AdapterDryRunStepDescriptor, ...]
+    planned_step_digest: str
+    local_plan_checks: dict[str, bool]
+    future_dry_run_execution_requirements: dict[str, bool]
+    source_to_execution_intent_mapping: dict[str, Any]
+    field_mapping_proof: dict[str, Any]
+    required_field_presence: dict[str, str]
+    source_decision_identity: dict[str, Any]
+    candidate_identity: dict[str, Any]
+    evidence_lineage: dict[str, Any]
+    replay_summary: dict[str, Any]
+    scope_limitations: tuple[str, ...]
+
+
+def _json_value(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        value = value.model_dump(mode="python")
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        if value != value or value in (float("inf"), float("-inf")):
+            raise AdapterDryRunPlanError("ADP_PACKET_INVALID")
+        return value
+    if isinstance(value, datetime):
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise AdapterDryRunPlanError("ADP_PLANNED_AT_INVALID")
+        return value.isoformat()
+    if isinstance(value, (list, tuple)):
+        return [_json_value(item) for item in value]
+    if isinstance(value, dict) and all(isinstance(key, str) for key in value):
+        return {key: _json_value(item) for key, item in value.items()}
+    raise AdapterDryRunPlanError("ADP_PACKET_INVALID")
+
+
+def _aware(value: Any, code: str) -> datetime:
+    try:
+        parsed = value if isinstance(value, datetime) else datetime.fromisoformat(value)
+    except (TypeError, ValueError) as exc:
+        raise AdapterDryRunPlanError(code) from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise AdapterDryRunPlanError(code)
+    return parsed
+
+
+def _digest(domain: str, value: Any) -> str:
+    encoded = json.dumps(
+        {"domain": domain, "value": _json_value(value)}, allow_nan=False,
+        ensure_ascii=False, separators=(",", ":"), sort_keys=True,
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _packet_hash(raw: dict[str, Any]) -> str:
+    return _digest(PACKET_DOMAIN, {
+        key: value for key, value in raw.items()
+        if key not in {"adapter_dry_run_plan_id", "adapter_dry_run_plan_hash"}
+    })
+
+
+def _verified_source(value: Any) -> CanonicalBindAdapterContractSelectionPacket:
+    try:
+        return verify_bind_adapter_contract_selection_packet(value)
+    except (BindAdapterContractSelectionError, TypeError, ValueError) as exc:
+        raise AdapterDryRunPlanError("ADP_ADAPTER_SELECTION_INVALID") from exc
+
+
+def _intent(raw: dict[str, Any]) -> ExecutionIntent:
+    try:
+        intent = ExecutionIntent(**raw)
+        canonical_execution_intent_json(intent)
+    except (TypeError, ValueError) as exc:
+        raise AdapterDryRunPlanError("ADP_PACKET_INVALID") from exc
+    if intent.to_dict() != raw:
+        raise AdapterDryRunPlanError("ADP_PACKET_INVALID")
+    return intent
+
+
+def _planned_steps() -> list[dict[str, Any]]:
+    result = []
+    for ordinal, (phase, method, output, refusal) in enumerate(STEP_SPECS, 1):
+        slug = method.replace("_", "-")
+        inputs = ["execution_intent", "adapter_contract_descriptor",
+                  "source_bind_preflight_adjudication_packet"]
+        result.append({
+            "step_id": f"dry-run-step:v1:{ordinal}:{slug}", "ordinal": ordinal,
+            "phase": phase, "planned_adapter_method": method,
+            "execution_mode": "planned_no_effect", "required_input_refs": inputs,
+            "expected_output_ref": output, "effect_policy": EFFECT_POLICY,
+            "refusal_if_missing_later": refusal,
+            "step_scope_limitations": STEP_LIMITATIONS,
+        })
+    return result
+
+
+def build_adapter_dry_run_plan_packet(
+    adapter_contract_selection_packet: Any,
+    planned_at: datetime,
+) -> CanonicalAdapterDryRunPlanPacket:
+    """Build an inert plan after verifying the complete selection packet."""
+    planned = _aware(planned_at, "ADP_PLANNED_AT_INVALID")
+    source_packet = _verified_source(_json_value(adapter_contract_selection_packet))
+    source = source_packet.model_dump(mode="json")
+    if planned < _aware(source_packet.selected_at, "ADP_ADAPTER_SELECTION_INVALID"):
+        raise AdapterDryRunPlanError("ADP_PLANNED_BEFORE_SELECTION")
+    intent = _intent(source_packet.execution_intent)
+    if intent.execution_intent_id != source_packet.execution_intent_id:
+        raise AdapterDryRunPlanError("ADP_EXECUTION_INTENT_ID_MISMATCH")
+    if hash_execution_intent(intent) != source_packet.execution_intent_hash:
+        raise AdapterDryRunPlanError("ADP_EXECUTION_INTENT_HASH_MISMATCH")
+    descriptor = source_packet.adapter_contract_descriptor
+    if (descriptor["target_system"] != intent.target_system or
+            descriptor["target_resource_scope"] != intent.target_resource):
+        raise AdapterDryRunPlanError("ADP_DESCRIPTOR_TARGET_MISMATCH")
+    steps = _planned_steps()
+    copied = (
+        "adapter_contract_descriptor", "adapter_contract_id",
+        "adapter_contract_hash", "adapter_contract_version", "execution_intent",
+        "execution_intent_id", "execution_intent_hash",
+        "source_bind_preflight_adjudication_hash", "source_formation_hash",
+        "source_readiness_hash", "source_eligibility_hash", "source_handoff_hash",
+        "trusted_validation_context_hash", "validation_result_hash",
+        "mapping_value_digest", "execution_intent_contract_version",
+        "source_to_execution_intent_mapping", "field_mapping_proof",
+        "required_field_presence", "source_decision_identity", "candidate_identity",
+        "evidence_lineage", "replay_summary",
+    )
+    raw = {
+        "format_version": FORMAT_VERSION, "plan_mechanism": PLAN_MECHANISM,
+        "planned_at": planned.isoformat(),
+        "source_adapter_contract_selection": {
+            key: source[key] for key in SOURCE_SUMMARY_KEYS
+        },
+        "source_adapter_contract_selection_hash": source_packet.adapter_contract_selection_hash,
+        "source_adapter_contract_selection_packet": source,
+        **{key: source[key] for key in copied},
+        "dry_run_plan_status": "ADAPTER_DRY_RUN_PLANNED_NO_EFFECT",
+        "ready_for_adapter_dry_run_execution": True, "fail_closed": False,
+        "planned_steps": steps,
+        "planned_step_digest": _digest(STEPS_DOMAIN, steps),
+        "local_plan_checks": LOCAL_PLAN_CHECKS,
+        "future_dry_run_execution_requirements": FUTURE_DRY_RUN_EXECUTION_REQUIREMENTS,
+        "scope_limitations": SCOPE_LIMITATIONS,
+    }
+    digest = _packet_hash(raw)
+    raw.update(adapter_dry_run_plan_hash=digest,
+               adapter_dry_run_plan_id=f"adp:v1:sha256:{digest}")
+    return verify_adapter_dry_run_plan_packet(raw)
+
+
+def verify_adapter_dry_run_plan_packet(
+    packet: Any,
+) -> CanonicalAdapterDryRunPlanPacket:
+    """Dump, revalidate, and independently recompute every packet binding."""
+    try:
+        value = packet.model_dump(mode="json") if isinstance(packet, BaseModel) else _json_value(packet)
+        candidate = CanonicalAdapterDryRunPlanPacket.model_validate(value)
+    except (ValidationError, AdapterDryRunPlanError, TypeError) as exc:
+        raise AdapterDryRunPlanError("ADP_PACKET_INVALID") from exc
+    raw = candidate.model_dump(mode="json")
+    source_packet = _verified_source(candidate.source_adapter_contract_selection_packet)
+    source = source_packet.model_dump(mode="json")
+    if (set(candidate.source_adapter_contract_selection) != set(SOURCE_SUMMARY_KEYS) or
+            candidate.source_adapter_contract_selection != {
+                key: source[key] for key in SOURCE_SUMMARY_KEYS
+            } or candidate.source_adapter_contract_selection_hash !=
+            source_packet.adapter_contract_selection_hash):
+        raise AdapterDryRunPlanError("ADP_SOURCE_SUMMARY_MISMATCH")
+    if _aware(candidate.planned_at, "ADP_PLANNED_AT_INVALID") < _aware(
+            source_packet.selected_at, "ADP_ADAPTER_SELECTION_INVALID"):
+        raise AdapterDryRunPlanError("ADP_PLANNED_BEFORE_SELECTION")
+    copied = (
+        "adapter_contract_descriptor", "adapter_contract_id",
+        "adapter_contract_hash", "adapter_contract_version", "execution_intent",
+        "execution_intent_id", "execution_intent_hash",
+        "source_bind_preflight_adjudication_hash", "source_formation_hash",
+        "source_readiness_hash", "source_eligibility_hash", "source_handoff_hash",
+        "trusted_validation_context_hash", "validation_result_hash",
+        "mapping_value_digest", "execution_intent_contract_version",
+        "source_to_execution_intent_mapping", "field_mapping_proof",
+        "required_field_presence", "source_decision_identity", "candidate_identity",
+        "evidence_lineage", "replay_summary",
+    )
+    if any(getattr(candidate, key) != getattr(source_packet, key) for key in copied):
+        raise AdapterDryRunPlanError("ADP_SOURCE_SUMMARY_MISMATCH")
+    intent = _intent(candidate.execution_intent)
+    if intent.execution_intent_id != candidate.execution_intent_id:
+        raise AdapterDryRunPlanError("ADP_EXECUTION_INTENT_ID_MISMATCH")
+    if hash_execution_intent(intent) != candidate.execution_intent_hash:
+        raise AdapterDryRunPlanError("ADP_EXECUTION_INTENT_HASH_MISMATCH")
+    if candidate.planned_steps != tuple(
+            AdapterDryRunStepDescriptor.model_validate(item)
+            for item in _planned_steps()):
+        raise AdapterDryRunPlanError("ADP_PLANNED_STEPS_INVALID")
+    steps_raw = [step.model_dump(mode="json") for step in candidate.planned_steps]
+    if candidate.planned_step_digest != _digest(STEPS_DOMAIN, steps_raw):
+        raise AdapterDryRunPlanError("ADP_PLANNED_STEP_DIGEST_MISMATCH")
+    if candidate.local_plan_checks != LOCAL_PLAN_CHECKS:
+        raise AdapterDryRunPlanError("ADP_LOCAL_CHECKS_MISMATCH")
+    if candidate.future_dry_run_execution_requirements != FUTURE_DRY_RUN_EXECUTION_REQUIREMENTS:
+        raise AdapterDryRunPlanError("ADP_FUTURE_REQUIREMENTS_MISMATCH")
+    _digest(LOCAL_CHECKS_DOMAIN, candidate.local_plan_checks)
+    _digest(FUTURE_REQUIREMENTS_DOMAIN, candidate.future_dry_run_execution_requirements)
+    if candidate.scope_limitations != SCOPE_LIMITATIONS:
+        raise AdapterDryRunPlanError("ADP_SCOPE_LIMITATIONS_MISSING")
+    digest = _packet_hash(raw)
+    if candidate.adapter_dry_run_plan_hash != digest:
+        raise AdapterDryRunPlanError("ADP_PACKET_HASH_MISMATCH")
+    if candidate.adapter_dry_run_plan_id != f"adp:v1:sha256:{digest}":
+        raise AdapterDryRunPlanError("ADP_PACKET_ID_MISMATCH")
+    return candidate

--- a/veritas_os/tests/test_adapter_dry_run_plan.py
+++ b/veritas_os/tests/test_adapter_dry_run_plan.py
@@ -1,0 +1,270 @@
+"""Security and integrity tests for Canonical Adapter Dry-Run Plan v1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from copy import deepcopy
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator, FormatChecker
+
+from veritas_os.policy.adapter_dry_run_plan import (
+    EFFECT_POLICY,
+    FUTURE_DRY_RUN_EXECUTION_REQUIREMENTS,
+    LOCAL_PLAN_CHECKS,
+    SCOPE_LIMITATIONS,
+    STEPS_DOMAIN,
+    AdapterDryRunPlanError,
+    CanonicalAdapterDryRunPlanPacket,
+    _digest,
+    _packet_hash,
+    build_adapter_dry_run_plan_packet,
+    verify_adapter_dry_run_plan_packet,
+)
+from veritas_os.policy.bind_artifacts import ExecutionIntent, hash_execution_intent
+from veritas_os.tests.test_bind_adapter_contract_selection import (
+    SELECTED_AT,
+    _packet as selection_packet,
+)
+
+PLANNED_AT = SELECTED_AT + timedelta(seconds=1)
+MODULE = Path("veritas_os/policy/adapter_dry_run_plan.py")
+SCHEMA = Path("schemas/adapter-dry-run-plan-v1.schema.json")
+
+
+def _packet(*, semantic_match: bool | None = None):
+    return build_adapter_dry_run_plan_packet(
+        selection_packet(semantic_match=semantic_match), PLANNED_AT
+    )
+
+
+def _rehash(raw: dict) -> None:
+    digest = _packet_hash(raw)
+    raw["adapter_dry_run_plan_hash"] = digest
+    raw["adapter_dry_run_plan_id"] = f"adp:v1:sha256:{digest}"
+
+
+def test_build_verify_integrity_and_no_effects(monkeypatch) -> None:
+    import veritas_os.policy.adapter_dry_run_plan as module
+
+    actual = module.verify_bind_adapter_contract_selection_packet
+    calls = []
+
+    def recording(value):
+        calls.append(value)
+        return actual(value)
+
+    monkeypatch.setattr(
+        module, "verify_bind_adapter_contract_selection_packet", recording
+    )
+    source = selection_packet()
+    packet = module.build_adapter_dry_run_plan_packet(source, PLANNED_AT)
+    assert len(calls) == 2
+    assert module.verify_adapter_dry_run_plan_packet(packet) == packet
+    assert len(calls) == 3
+    assert packet.adapter_dry_run_plan_id == (
+        f"adp:v1:sha256:{packet.adapter_dry_run_plan_hash}"
+    )
+    assert packet.adapter_dry_run_plan_hash == _packet_hash(
+        packet.model_dump(mode="json")
+    )
+    intent = ExecutionIntent(**packet.execution_intent)
+    assert intent.to_dict() == packet.execution_intent
+    assert packet.execution_intent_hash == hash_execution_intent(intent)
+    assert packet.execution_intent_id == source.execution_intent_id
+    assert packet.adapter_contract_descriptor == source.adapter_contract_descriptor
+    methods = [step.planned_adapter_method for step in packet.planned_steps]
+    assert methods == [
+        "describe_target", "build_idempotency_key", "snapshot",
+        "fingerprint_state", "validate_authority", "validate_constraints",
+        "assess_runtime_risk",
+    ]
+    assert set(methods).isdisjoint({"apply", "verify_postconditions", "revert"})
+    assert [step.ordinal for step in packet.planned_steps] == list(range(1, 8))
+    assert all(step.execution_mode == "planned_no_effect"
+               and step.effect_policy == EFFECT_POLICY
+               for step in packet.planned_steps)
+    steps = [step.model_dump(mode="json") for step in packet.planned_steps]
+    assert packet.planned_step_digest == _digest(STEPS_DOMAIN, steps)
+    assert packet.local_plan_checks == LOCAL_PLAN_CHECKS
+    assert (packet.future_dry_run_execution_requirements ==
+            FUTURE_DRY_RUN_EXECUTION_REQUIREMENTS)
+    for field in (
+        "required_field_presence", "source_decision_identity",
+        "candidate_identity", "evidence_lineage", "replay_summary",
+    ):
+        assert getattr(packet, field) == getattr(source, field)
+    raw = packet.model_dump(mode="json")
+    assert "bind_receipt_id" not in json.dumps(raw)
+    assert "adapter_instance" not in raw and "adapter_result" not in raw
+
+
+@pytest.mark.parametrize("semantic_match", [True, False])
+def test_semantic_match_is_preserved_not_gated(semantic_match: bool) -> None:
+    packet = _packet(semantic_match=semantic_match)
+    assert packet.replay_summary["semantic_match"] is semantic_match
+    assert verify_adapter_dry_run_plan_packet(packet) == packet
+
+
+def test_invalid_source_and_timeline_refuse() -> None:
+    source = selection_packet().model_dump(mode="json")
+    source["adapter_contract_selection_hash"] = "0" * 64
+    with pytest.raises(AdapterDryRunPlanError, match="ADP_ADAPTER_SELECTION_INVALID"):
+        build_adapter_dry_run_plan_packet(source, PLANNED_AT)
+    with pytest.raises(AdapterDryRunPlanError, match="ADP_PLANNED_AT_INVALID"):
+        build_adapter_dry_run_plan_packet(
+            selection_packet(), PLANNED_AT.replace(tzinfo=None)
+        )
+    with pytest.raises(AdapterDryRunPlanError, match="ADP_PLANNED_BEFORE_SELECTION"):
+        build_adapter_dry_run_plan_packet(
+            selection_packet(), SELECTED_AT - timedelta(seconds=1)
+        )
+
+
+@pytest.mark.parametrize("path", [
+    ("adapter_dry_run_plan_id",), ("adapter_dry_run_plan_hash",), ("planned_at",),
+    ("source_adapter_contract_selection", "selected_at"),
+    ("source_adapter_contract_selection_hash",),
+    ("source_adapter_contract_selection_packet", "adapter_contract_selection_hash"),
+    ("adapter_contract_descriptor", "adapter_name"), ("adapter_contract_id",),
+    ("adapter_contract_hash",), ("adapter_contract_version",),
+    ("execution_intent", "decision_id"), ("execution_intent_id",),
+    ("execution_intent_hash",), ("source_bind_preflight_adjudication_hash",),
+    ("source_formation_hash",), ("source_readiness_hash",),
+    ("source_eligibility_hash",), ("source_handoff_hash",),
+    ("trusted_validation_context_hash",), ("validation_result_hash",),
+    ("mapping_value_digest",), ("planned_steps", 0, "planned_adapter_method"),
+    ("planned_step_digest",), ("source_to_execution_intent_mapping", "decision_id"),
+    ("field_mapping_proof", "decision_id"),
+    ("local_plan_checks", "no_bind_invocation"),
+    ("future_dry_run_execution_requirements", "snapshot_call_required"),
+    ("source_decision_identity", "request_id"),
+    ("candidate_identity", "actor_identity"),
+    ("evidence_lineage", "policy_snapshot_id"),
+    ("replay_summary", "semantic_match"), ("replay_summary", "fields_changed"),
+    ("scope_limitations",),
+])
+def test_single_field_tampering_refuses(path) -> None:
+    raw = _packet(semantic_match=True).model_dump(mode="json")
+    target = raw
+    for key in path[:-1]:
+        target = target[key]
+    key = path[-1]
+    old = target[key]
+    target[key] = (not old if isinstance(old, bool) else
+                   [*old, "tampered"] if isinstance(old, list) else "tampered")
+    with pytest.raises(AdapterDryRunPlanError):
+        verify_adapter_dry_run_plan_packet(raw)
+
+
+@pytest.mark.parametrize("mutation", [
+    "missing", "extra", "reordered", "mode", "method", "apply",
+    "verify_postconditions", "revert", "adapter_call", "network", "filesystem",
+    "external", "trustlog", "receipt",
+])
+def test_step_and_effect_policy_refusals(mutation: str) -> None:
+    raw = _packet().model_dump(mode="json")
+    steps = raw["planned_steps"]
+    if mutation == "missing":
+        steps.pop()
+    elif mutation == "extra":
+        steps.append(deepcopy(steps[-1]))
+    elif mutation == "reordered":
+        steps[0], steps[1] = steps[1], steps[0]
+    elif mutation == "mode":
+        steps[0]["execution_mode"] = "effect"
+    elif mutation in {"method", "apply", "verify_postconditions", "revert"}:
+        steps[0]["planned_adapter_method"] = mutation
+    else:
+        key = {
+            "adapter_call": "adapter_method_call_allowed_now", "network": "network_allowed",
+            "filesystem": "filesystem_allowed", "external": "external_effect_allowed",
+            "trustlog": "trustlog_write_allowed", "receipt": "bind_receipt_allowed",
+        }[mutation]
+        steps[0]["effect_policy"][key] = True
+    raw["planned_step_digest"] = _digest(STEPS_DOMAIN, steps)
+    _rehash(raw)
+    with pytest.raises(AdapterDryRunPlanError):
+        verify_adapter_dry_run_plan_packet(raw)
+
+
+@pytest.mark.parametrize("method", ["copy", "construct"])
+@pytest.mark.parametrize("updates", [
+    {"format_version": "wrong"}, {"adapter_dry_run_plan_hash": "0" * 64},
+    {"execution_intent": {}}, {"adapter_contract_descriptor": {}},
+    {"planned_steps": ()}, {"local_plan_checks": {}},
+    {"future_dry_run_execution_requirements": {}},
+    {"source_adapter_contract_selection": {}}, {"replay_summary": {}},
+])
+def test_typed_instance_bypass_refuses(method: str, updates: dict) -> None:
+    packet = _packet()
+    bypass = (
+        packet.model_copy(update=updates) if method == "copy" else
+        CanonicalAdapterDryRunPlanPacket.model_construct(
+            **{**packet.model_dump(mode="python"), **updates}
+        )
+    )
+    with pytest.raises(AdapterDryRunPlanError):
+        verify_adapter_dry_run_plan_packet(bypass)
+
+
+def test_source_summary_closed_and_scope_exact() -> None:
+    for operation in ("missing", "extra"):
+        raw = _packet().model_dump(mode="json")
+        if operation == "missing":
+            raw["source_adapter_contract_selection"].pop("selected_at")
+        else:
+            raw["source_adapter_contract_selection"]["unexpected"] = True
+        _rehash(raw)
+        with pytest.raises(AdapterDryRunPlanError, match="ADP_SOURCE_SUMMARY_MISMATCH"):
+            verify_adapter_dry_run_plan_packet(raw)
+    assert _packet().scope_limitations == SCOPE_LIMITATIONS
+
+
+def test_schema_accepts_valid_and_rejects_extensions() -> None:
+    schema = json.loads(SCHEMA.read_text())
+    Draft202012Validator.check_schema(schema)
+    validator = Draft202012Validator(schema, format_checker=FormatChecker())
+    valid = _packet().model_dump(mode="json")
+    validator.validate(valid)
+    for key in ("source_adapter_contract_selection", "planned_steps",
+                "local_plan_checks"):
+        invalid = deepcopy(valid)
+        target = invalid[key][0] if key == "planned_steps" else invalid[key]
+        target["unexpected"] = True
+        assert list(validator.iter_errors(invalid))
+
+
+def test_static_import_and_side_effect_boundary() -> None:
+    tree = ast.parse(MODULE.read_text())
+    forbidden = {
+        "BindReceipt", "hash_bind_receipt", "append_bind_receipt_trustlog",
+        "append_execution_intent_trustlog", "build_execution_intent_trustlog_entry",
+        "execute_bind_boundary", "execute_bind_adjudication", "BindAdapterContract",
+        "BindBoundaryAdapter", "ReferenceBindAdapter", "WebhookBindAdapter",
+        "bind_core", "requests", "httpx", "subprocess", "uuid4",
+    }
+    imported, functions = set(), set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name.split(".")[-1] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imported.update(alias.name for alias in node.names)
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            functions.add(node.name)
+        assert not (isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Attribute)
+                    and isinstance(node.func.value, ast.Name)
+                    and node.func.value.id == "datetime"
+                    and node.func.attr == "now")
+    assert imported.isdisjoint(forbidden)
+    assert functions.isdisjoint({
+        "execute", "commit", "dispatch", "send", "webhook", "adapter_call",
+        "write_trustlog", "append_trustlog", "create_bind_receipt", "invoke_bind",
+        "call_adapter", "instantiate_adapter", "snapshot", "apply", "revert",
+        "validate_authority", "validate_constraints", "assess_runtime_risk",
+        "verify_postconditions", "describe_target", "build_idempotency_key",
+    })


### PR DESCRIPTION
### Motivation

- Record a deterministic, local, side-effect-free boundary that maps a verified Canonical Bind Adapter Contract Selection Packet into an exact no-effect future dry-run plan, stopping before any adapter instantiation or adapter method invocation.
- Preserve fail-closed safety semantics and retain exact source packet provenance so later Bind/execution phases must revalidate and perform live checks.

### Description

- Add `veritas_os/policy/adapter_dry_run_plan.py` implementing `CanonicalAdapterDryRunPlanPacket`, `AdapterDryRunStepDescriptor`, the builder `build_adapter_dry_run_plan_packet(...)`, and the independent verifier `verify_adapter_dry_run_plan_packet(...)` with content-addressed `adp:v1:sha256:<hash>` identity and strict canonical JSON hashing domains.
- Define and record seven inert planned steps in exact order: `describe_target`, `build_idempotency_key`, `snapshot`, `fingerprint_state`, `validate_authority`, `validate_constraints`, `assess_runtime_risk`, and enforce `execution_mode == "planned_no_effect"` and an effect policy forbidding adapter calls, network, filesystem, TrustLog writes, and BindReceipt creation now.
- Add closed JSON Schema `schemas/adapter-dry-run-plan-v1.schema.json` and English documentation `docs/en/architecture/adapter-dry-run-plan-v1.md` that explicitly distinguish plan formation from adapter execution and Bind authorization.
- Add focused tests `veritas_os/tests/test_adapter_dry_run_plan.py` covering builder/verifier integrity, tamper/refusal cases, typed-instance bypass, schema acceptance/rejection, static import/side-effect boundary checks, and preservation of replay `semantic_match`; and ensure the module does not import or call any adapter, Bind, TrustLog, network, subprocess, or `uuid4`/`datetime.now` helpers.

### Security / non-claims

- Adapter Dry-Run Plan does not authorize execution.
- Adapter Dry-Run Plan does not execute adapter dry-run.
- Adapter Dry-Run Plan does not instantiate or call adapters.
- Adapter Dry-Run Plan does not create `BindReceipt`.
- Adapter Dry-Run Plan does not write TrustLog.
- Adapter Dry-Run Plan does not perform live state, runtime risk, authority, constraint, commit-boundary, postcondition, rollback, or idempotency replay checks.
- Adapter Dry-Run Plan does not satisfy Authority Evidence or Human Approval.
- Adapter Dry-Run Plan does not turn `semantic_match` into authorization.

### Testing

- Latest head SHA: `8b483cb3eb32769611ced4e7ccbf14af98aaab2b`.
- Local/static checks reported by Codex: `ruff check` on changed files passed; `python -m py_compile veritas_os/policy/adapter_dry_run_plan.py` succeeded; `python -m json.tool schemas/adapter-dry-run-plan-v1.schema.json` validated JSON syntax; focused static/assertion checks in `veritas_os/tests/test_adapter_dry_run_plan.py` passed where dependencies were available.
- GitHub CI #5066 completed successfully for this head.
- `test (py3.11)`: success.
- `test (py3.12)`: success.
- `test-postgresql (py3.12)`: success.
- `test-slow (py3.12)`: success.
- `lint`: success.
- `dependency-audit`: success.
- `future-dependency-compat`: success.
- `[Tier 1] governance-backend-fast`: success.
- `[Tier 1] governance-smoke`: success.
- `frontend-lint`: success.
- `frontend-test`: success.
- `frontend-e2e`: success.
- `Security Gates`: success.
- `CodeQL (custom)`: success.
- `Runtime Proof Evidence`: success.
- `Runtime Pickle Guard (Required)`: success.
- `Reviewer Evidence Packet Validation`: success.

### Final invariant

Canonical Adapter Dry-Run Plan v1 now maps a verified Canonical Bind Adapter Contract Selection Packet into an exact no-effect future dry-run plan without creating an adapter instance, without calling adapter methods, without invoking Bind, without creating a BindReceipt, without writing TrustLog, without external effects, and without converting replay semantic_match into Authority Evidence, Human Approval, or execution authority.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a827b5f216883268ac865bb32eda8f8)