### PR TITLE
feat(bind): add reference adapter in-memory rehearsal v1

### DIFF
--- a/docs/en/architecture/reference-adapter-in-memory-rehearsal-v1.md
+++ b/docs/en/architecture/reference-adapter-in-memory-rehearsal-v1.md
@@ -1,0 +1,61 @@
+# Canonical Reference Adapter In-Memory Rehearsal v1
+
+## Boundary
+
+The Canonical Reference Adapter In-Memory Rehearsal Packet records that an
+exact, verified Adapter Dry-Run Fixture Result Packet was passed through seven
+deterministic methods on a dedicated local rehearsal object. It is a no-effect
+artifact, not an execution artifact.
+
+These distinctions are mandatory:
+
+- Fixture Result **is not** Reference Adapter In-Memory Rehearsal.
+- Reference Adapter In-Memory Rehearsal **is not** live adapter dry-run
+  execution, Bind authorization, a BindReceipt, or a TrustLog write.
+- Reference adapter rehearsal signals **are not** Authority Evidence.
+- `semantic_match` **is not** Human Approval. Both `true` and `false` are
+  preserved without turning either value into execution authority.
+
+The dedicated adapter exists only inside the rehearsal module, holds only
+JSON-compatible values in memory, and is not registered with Bind execution.
+It cannot perform operation commit. The seven calls, in order, are
+`describe_target`, `build_idempotency_key`, `snapshot`, `fingerprint_state`,
+`validate_authority`, `validate_constraints`, and `assess_runtime_risk`.
+`apply`, postcondition verification, and rollback are excluded.
+
+## Artifact sequence
+
+The auditable chain is:
+
+1. CDA
+2. Trust Link
+3. Replay Source/Evidence
+4. Replay Handoff Binding
+5. CanonicalDecisionHandoff validation
+6. Guarded Promotion Eligibility Packet
+7. ExecutionIntent Formation Readiness Packet
+8. Canonical ExecutionIntent Formation Packet
+9. ExecutionIntent Pre-Bind Validation Packet
+10. Canonical Bind Preflight Adjudication Packet
+11. Canonical Bind Adapter Contract Selection Packet
+12. Canonical Adapter Dry-Run Plan Packet
+13. Canonical Adapter Dry-Run Fixture Result Packet
+14. Canonical Reference Adapter In-Memory Rehearsal Packet
+15. **STOP**
+
+The packet embeds the complete verified fixture-result packet. Its verifier
+re-verifies that source, reconstructs and hashes the ExecutionIntent, checks
+descriptor and lineage preservation, and recomputes every output, result, and
+packet digest. Compact summaries never replace source verification.
+
+## Deferred work and security non-claims
+
+Live adapter dry-run, a real adapter instance, the Webhook adapter, Bind
+adjudication, BindReceipt creation, TrustLog writes, network or filesystem
+access, external effects, live state and runtime-risk checks, `apply`,
+postconditions, rollback, and operation commit are intentionally deferred to
+future explicit PRs. Human Approval and Authority Evidence also remain future
+Bind-side requirements.
+
+This artifact makes no production, customer, or regulatory certification
+claim. Human review remains required for this governance-sensitive boundary.

--- a/schemas/reference-adapter-in-memory-rehearsal-v1.schema.json
+++ b/schemas/reference-adapter-in-memory-rehearsal-v1.schema.json
@@ -1,0 +1,1174 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://veritas-os.org/schemas/reference-adapter-in-memory-rehearsal-v1.schema.json",
+  "title": "Canonical Reference Adapter In-Memory Rehearsal v1",
+  "type": "object",
+  "required": [
+    "source_adapter_dry_run_fixture_result",
+    "adapter_contract_descriptor",
+    "execution_intent",
+    "local_rehearsal_checks",
+    "future_live_adapter_dry_run_requirements",
+    "source_to_execution_intent_mapping",
+    "field_mapping_proof",
+    "required_field_presence",
+    "source_decision_identity",
+    "candidate_identity",
+    "evidence_lineage",
+    "replay_summary",
+    "format_version",
+    "reference_rehearsal_id",
+    "reference_rehearsal_hash",
+    "rehearsal_mechanism",
+    "rehearsed_at",
+    "source_adapter_dry_run_fixture_result_packet",
+    "reference_rehearsal_status",
+    "ready_for_live_adapter_dry_run_request",
+    "fail_closed",
+    "planned_steps",
+    "fixture_step_results",
+    "reference_rehearsal_results",
+    "scope_limitations",
+    "source_adapter_dry_run_fixture_result_hash",
+    "adapter_contract_id",
+    "adapter_contract_hash",
+    "adapter_contract_version",
+    "execution_intent_id",
+    "execution_intent_hash",
+    "source_adapter_dry_run_plan_hash",
+    "source_adapter_contract_selection_hash",
+    "source_bind_preflight_adjudication_hash",
+    "source_formation_hash",
+    "source_readiness_hash",
+    "source_eligibility_hash",
+    "source_handoff_hash",
+    "trusted_validation_context_hash",
+    "validation_result_hash",
+    "mapping_value_digest",
+    "execution_intent_contract_version",
+    "planned_step_digest",
+    "fixture_result_digest",
+    "reference_rehearsal_result_digest"
+  ],
+  "properties": {
+    "source_adapter_dry_run_fixture_result": {
+      "type": "object",
+      "patternProperties": {
+        "^.*$": {}
+      },
+      "additionalProperties": false
+    },
+    "adapter_contract_descriptor": {
+      "type": "object",
+      "patternProperties": {
+        "^.*$": {}
+      },
+      "additionalProperties": false
+    },
+    "execution_intent": {
+      "type": "object",
+      "patternProperties": {
+        "^.*$": {}
+      },
+      "additionalProperties": false
+    },
+    "local_rehearsal_checks": {
+      "type": "object",
+      "patternProperties": {
+        "^.*$": {}
+      },
+      "additionalProperties": false
+    },
+    "future_live_adapter_dry_run_requirements": {
+      "type": "object",
+      "patternProperties": {
+        "^.*$": {}
+      },
+      "additionalProperties": false
+    },
+    "source_to_execution_intent_mapping": {
+      "type": "object",
+      "patternProperties": {
+        "^.*$": {}
+      },
+      "additionalProperties": false
+    },
+    "field_mapping_proof": {
+      "type": "object",
+      "patternProperties": {
+        "^.*$": {}
+      },
+      "additionalProperties": false
+    },
+    "required_field_presence": {
+      "type": "object",
+      "patternProperties": {
+        "^.*$": {}
+      },
+      "additionalProperties": false
+    },
+    "source_decision_identity": {
+      "type": "object",
+      "patternProperties": {
+        "^.*$": {}
+      },
+      "additionalProperties": false
+    },
+    "candidate_identity": {
+      "type": "object",
+      "patternProperties": {
+        "^.*$": {}
+      },
+      "additionalProperties": false
+    },
+    "evidence_lineage": {
+      "type": "object",
+      "patternProperties": {
+        "^.*$": {}
+      },
+      "additionalProperties": false
+    },
+    "replay_summary": {
+      "type": "object",
+      "patternProperties": {
+        "^.*$": {}
+      },
+      "additionalProperties": false
+    },
+    "format_version": {
+      "const": "canonical-reference-adapter-in-memory-rehearsal/v1"
+    },
+    "reference_rehearsal_id": {
+      "pattern": "^rar:v1:sha256:[0-9a-f]{64}$"
+    },
+    "reference_rehearsal_hash": {
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "rehearsal_mechanism": {
+      "const": "run_reference_adapter_in_memory_rehearsal_without_bind/v1"
+    },
+    "rehearsed_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "source_adapter_dry_run_fixture_result_packet": {
+      "$ref": "adapter-dry-run-fixture-result-v1.schema.json"
+    },
+    "reference_rehearsal_status": {
+      "const": "REFERENCE_ADAPTER_IN_MEMORY_REHEARSAL_COMPLETED_NO_EFFECT"
+    },
+    "ready_for_live_adapter_dry_run_request": {
+      "const": true
+    },
+    "fail_closed": {
+      "const": false
+    },
+    "planned_steps": {
+      "type": "array",
+      "minItems": 7,
+      "maxItems": 7,
+      "items": {
+        "type": "object",
+        "patternProperties": {
+          "^.*$": {}
+        },
+        "additionalProperties": false
+      }
+    },
+    "fixture_step_results": {
+      "type": "array",
+      "minItems": 7,
+      "maxItems": 7,
+      "items": {
+        "type": "object",
+        "patternProperties": {
+          "^.*$": {}
+        },
+        "additionalProperties": false
+      }
+    },
+    "reference_rehearsal_results": {
+      "type": "array",
+      "minItems": 7,
+      "maxItems": 7,
+      "prefixItems": [
+        {
+          "type": "object",
+          "required": [
+            "rehearsal_step_result_id",
+            "planned_step_id",
+            "fixture_step_result_id",
+            "ordinal",
+            "planned_adapter_method",
+            "rehearsal_mode",
+            "reference_adapter_instance_created",
+            "reference_adapter_method_called",
+            "live_adapter_instance_created",
+            "live_adapter_method_called",
+            "network_used",
+            "filesystem_used",
+            "external_effect_used",
+            "trustlog_written",
+            "bind_receipt_created",
+            "bind_invoked",
+            "output_summary",
+            "output_digest",
+            "matched_expected_output_ref",
+            "rehearsal_scope_limitations"
+          ],
+          "properties": {
+            "rehearsal_step_result_id": {
+              "pattern": "^reference-rehearsal-result:v1:[1-9][0-9]*:[a-z0-9-]+$"
+            },
+            "planned_step_id": {
+              "type": "string"
+            },
+            "fixture_step_result_id": {
+              "type": "string"
+            },
+            "ordinal": {
+              "const": 1
+            },
+            "planned_adapter_method": {
+              "const": "describe_target"
+            },
+            "rehearsal_mode": {
+              "const": "reference_in_memory_no_effect"
+            },
+            "reference_adapter_instance_created": {
+              "const": true
+            },
+            "reference_adapter_method_called": {
+              "const": true
+            },
+            "live_adapter_instance_created": {
+              "const": false
+            },
+            "live_adapter_method_called": {
+              "const": false
+            },
+            "network_used": {
+              "const": false
+            },
+            "filesystem_used": {
+              "const": false
+            },
+            "external_effect_used": {
+              "const": false
+            },
+            "trustlog_written": {
+              "const": false
+            },
+            "bind_receipt_created": {
+              "const": false
+            },
+            "bind_invoked": {
+              "const": false
+            },
+            "output_summary": {
+              "type": "object",
+              "patternProperties": {
+                "^.*$": {}
+              },
+              "additionalProperties": false
+            },
+            "output_digest": {
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "matched_expected_output_ref": {
+              "type": "string"
+            },
+            "rehearsal_scope_limitations": {
+              "type": "array",
+              "prefixItems": [
+                {
+                  "const": "NOT_LIVE_ADAPTER_RESULT"
+                },
+                {
+                  "const": "NOT_LIVE_STATE"
+                },
+                {
+                  "const": "NOT_LIVE_AUTHORITY_REVALIDATION"
+                },
+                {
+                  "const": "NOT_LIVE_CONSTRAINT_REVALIDATION"
+                },
+                {
+                  "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+                },
+                {
+                  "const": "NOT_BIND_AUTHORIZATION"
+                },
+                {
+                  "const": "NOT_BIND_RECEIPT"
+                },
+                {
+                  "const": "NOT_TRUSTLOG_WRITE"
+                },
+                {
+                  "const": "NOT_OPERATION_COMMIT"
+                }
+              ],
+              "items": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "rehearsal_step_result_id",
+            "planned_step_id",
+            "fixture_step_result_id",
+            "ordinal",
+            "planned_adapter_method",
+            "rehearsal_mode",
+            "reference_adapter_instance_created",
+            "reference_adapter_method_called",
+            "live_adapter_instance_created",
+            "live_adapter_method_called",
+            "network_used",
+            "filesystem_used",
+            "external_effect_used",
+            "trustlog_written",
+            "bind_receipt_created",
+            "bind_invoked",
+            "output_summary",
+            "output_digest",
+            "matched_expected_output_ref",
+            "rehearsal_scope_limitations"
+          ],
+          "properties": {
+            "rehearsal_step_result_id": {
+              "pattern": "^reference-rehearsal-result:v1:[1-9][0-9]*:[a-z0-9-]+$"
+            },
+            "planned_step_id": {
+              "type": "string"
+            },
+            "fixture_step_result_id": {
+              "type": "string"
+            },
+            "ordinal": {
+              "const": 2
+            },
+            "planned_adapter_method": {
+              "const": "build_idempotency_key"
+            },
+            "rehearsal_mode": {
+              "const": "reference_in_memory_no_effect"
+            },
+            "reference_adapter_instance_created": {
+              "const": true
+            },
+            "reference_adapter_method_called": {
+              "const": true
+            },
+            "live_adapter_instance_created": {
+              "const": false
+            },
+            "live_adapter_method_called": {
+              "const": false
+            },
+            "network_used": {
+              "const": false
+            },
+            "filesystem_used": {
+              "const": false
+            },
+            "external_effect_used": {
+              "const": false
+            },
+            "trustlog_written": {
+              "const": false
+            },
+            "bind_receipt_created": {
+              "const": false
+            },
+            "bind_invoked": {
+              "const": false
+            },
+            "output_summary": {
+              "type": "object",
+              "patternProperties": {
+                "^.*$": {}
+              },
+              "additionalProperties": false
+            },
+            "output_digest": {
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "matched_expected_output_ref": {
+              "type": "string"
+            },
+            "rehearsal_scope_limitations": {
+              "type": "array",
+              "prefixItems": [
+                {
+                  "const": "NOT_LIVE_ADAPTER_RESULT"
+                },
+                {
+                  "const": "NOT_LIVE_STATE"
+                },
+                {
+                  "const": "NOT_LIVE_AUTHORITY_REVALIDATION"
+                },
+                {
+                  "const": "NOT_LIVE_CONSTRAINT_REVALIDATION"
+                },
+                {
+                  "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+                },
+                {
+                  "const": "NOT_BIND_AUTHORIZATION"
+                },
+                {
+                  "const": "NOT_BIND_RECEIPT"
+                },
+                {
+                  "const": "NOT_TRUSTLOG_WRITE"
+                },
+                {
+                  "const": "NOT_OPERATION_COMMIT"
+                }
+              ],
+              "items": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "rehearsal_step_result_id",
+            "planned_step_id",
+            "fixture_step_result_id",
+            "ordinal",
+            "planned_adapter_method",
+            "rehearsal_mode",
+            "reference_adapter_instance_created",
+            "reference_adapter_method_called",
+            "live_adapter_instance_created",
+            "live_adapter_method_called",
+            "network_used",
+            "filesystem_used",
+            "external_effect_used",
+            "trustlog_written",
+            "bind_receipt_created",
+            "bind_invoked",
+            "output_summary",
+            "output_digest",
+            "matched_expected_output_ref",
+            "rehearsal_scope_limitations"
+          ],
+          "properties": {
+            "rehearsal_step_result_id": {
+              "pattern": "^reference-rehearsal-result:v1:[1-9][0-9]*:[a-z0-9-]+$"
+            },
+            "planned_step_id": {
+              "type": "string"
+            },
+            "fixture_step_result_id": {
+              "type": "string"
+            },
+            "ordinal": {
+              "const": 3
+            },
+            "planned_adapter_method": {
+              "const": "snapshot"
+            },
+            "rehearsal_mode": {
+              "const": "reference_in_memory_no_effect"
+            },
+            "reference_adapter_instance_created": {
+              "const": true
+            },
+            "reference_adapter_method_called": {
+              "const": true
+            },
+            "live_adapter_instance_created": {
+              "const": false
+            },
+            "live_adapter_method_called": {
+              "const": false
+            },
+            "network_used": {
+              "const": false
+            },
+            "filesystem_used": {
+              "const": false
+            },
+            "external_effect_used": {
+              "const": false
+            },
+            "trustlog_written": {
+              "const": false
+            },
+            "bind_receipt_created": {
+              "const": false
+            },
+            "bind_invoked": {
+              "const": false
+            },
+            "output_summary": {
+              "type": "object",
+              "patternProperties": {
+                "^.*$": {}
+              },
+              "additionalProperties": false
+            },
+            "output_digest": {
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "matched_expected_output_ref": {
+              "type": "string"
+            },
+            "rehearsal_scope_limitations": {
+              "type": "array",
+              "prefixItems": [
+                {
+                  "const": "NOT_LIVE_ADAPTER_RESULT"
+                },
+                {
+                  "const": "NOT_LIVE_STATE"
+                },
+                {
+                  "const": "NOT_LIVE_AUTHORITY_REVALIDATION"
+                },
+                {
+                  "const": "NOT_LIVE_CONSTRAINT_REVALIDATION"
+                },
+                {
+                  "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+                },
+                {
+                  "const": "NOT_BIND_AUTHORIZATION"
+                },
+                {
+                  "const": "NOT_BIND_RECEIPT"
+                },
+                {
+                  "const": "NOT_TRUSTLOG_WRITE"
+                },
+                {
+                  "const": "NOT_OPERATION_COMMIT"
+                }
+              ],
+              "items": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "rehearsal_step_result_id",
+            "planned_step_id",
+            "fixture_step_result_id",
+            "ordinal",
+            "planned_adapter_method",
+            "rehearsal_mode",
+            "reference_adapter_instance_created",
+            "reference_adapter_method_called",
+            "live_adapter_instance_created",
+            "live_adapter_method_called",
+            "network_used",
+            "filesystem_used",
+            "external_effect_used",
+            "trustlog_written",
+            "bind_receipt_created",
+            "bind_invoked",
+            "output_summary",
+            "output_digest",
+            "matched_expected_output_ref",
+            "rehearsal_scope_limitations"
+          ],
+          "properties": {
+            "rehearsal_step_result_id": {
+              "pattern": "^reference-rehearsal-result:v1:[1-9][0-9]*:[a-z0-9-]+$"
+            },
+            "planned_step_id": {
+              "type": "string"
+            },
+            "fixture_step_result_id": {
+              "type": "string"
+            },
+            "ordinal": {
+              "const": 4
+            },
+            "planned_adapter_method": {
+              "const": "fingerprint_state"
+            },
+            "rehearsal_mode": {
+              "const": "reference_in_memory_no_effect"
+            },
+            "reference_adapter_instance_created": {
+              "const": true
+            },
+            "reference_adapter_method_called": {
+              "const": true
+            },
+            "live_adapter_instance_created": {
+              "const": false
+            },
+            "live_adapter_method_called": {
+              "const": false
+            },
+            "network_used": {
+              "const": false
+            },
+            "filesystem_used": {
+              "const": false
+            },
+            "external_effect_used": {
+              "const": false
+            },
+            "trustlog_written": {
+              "const": false
+            },
+            "bind_receipt_created": {
+              "const": false
+            },
+            "bind_invoked": {
+              "const": false
+            },
+            "output_summary": {
+              "type": "object",
+              "patternProperties": {
+                "^.*$": {}
+              },
+              "additionalProperties": false
+            },
+            "output_digest": {
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "matched_expected_output_ref": {
+              "type": "string"
+            },
+            "rehearsal_scope_limitations": {
+              "type": "array",
+              "prefixItems": [
+                {
+                  "const": "NOT_LIVE_ADAPTER_RESULT"
+                },
+                {
+                  "const": "NOT_LIVE_STATE"
+                },
+                {
+                  "const": "NOT_LIVE_AUTHORITY_REVALIDATION"
+                },
+                {
+                  "const": "NOT_LIVE_CONSTRAINT_REVALIDATION"
+                },
+                {
+                  "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+                },
+                {
+                  "const": "NOT_BIND_AUTHORIZATION"
+                },
+                {
+                  "const": "NOT_BIND_RECEIPT"
+                },
+                {
+                  "const": "NOT_TRUSTLOG_WRITE"
+                },
+                {
+                  "const": "NOT_OPERATION_COMMIT"
+                }
+              ],
+              "items": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "rehearsal_step_result_id",
+            "planned_step_id",
+            "fixture_step_result_id",
+            "ordinal",
+            "planned_adapter_method",
+            "rehearsal_mode",
+            "reference_adapter_instance_created",
+            "reference_adapter_method_called",
+            "live_adapter_instance_created",
+            "live_adapter_method_called",
+            "network_used",
+            "filesystem_used",
+            "external_effect_used",
+            "trustlog_written",
+            "bind_receipt_created",
+            "bind_invoked",
+            "output_summary",
+            "output_digest",
+            "matched_expected_output_ref",
+            "rehearsal_scope_limitations"
+          ],
+          "properties": {
+            "rehearsal_step_result_id": {
+              "pattern": "^reference-rehearsal-result:v1:[1-9][0-9]*:[a-z0-9-]+$"
+            },
+            "planned_step_id": {
+              "type": "string"
+            },
+            "fixture_step_result_id": {
+              "type": "string"
+            },
+            "ordinal": {
+              "const": 5
+            },
+            "planned_adapter_method": {
+              "const": "validate_authority"
+            },
+            "rehearsal_mode": {
+              "const": "reference_in_memory_no_effect"
+            },
+            "reference_adapter_instance_created": {
+              "const": true
+            },
+            "reference_adapter_method_called": {
+              "const": true
+            },
+            "live_adapter_instance_created": {
+              "const": false
+            },
+            "live_adapter_method_called": {
+              "const": false
+            },
+            "network_used": {
+              "const": false
+            },
+            "filesystem_used": {
+              "const": false
+            },
+            "external_effect_used": {
+              "const": false
+            },
+            "trustlog_written": {
+              "const": false
+            },
+            "bind_receipt_created": {
+              "const": false
+            },
+            "bind_invoked": {
+              "const": false
+            },
+            "output_summary": {
+              "type": "object",
+              "patternProperties": {
+                "^.*$": {}
+              },
+              "additionalProperties": false
+            },
+            "output_digest": {
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "matched_expected_output_ref": {
+              "type": "string"
+            },
+            "rehearsal_scope_limitations": {
+              "type": "array",
+              "prefixItems": [
+                {
+                  "const": "NOT_LIVE_ADAPTER_RESULT"
+                },
+                {
+                  "const": "NOT_LIVE_STATE"
+                },
+                {
+                  "const": "NOT_LIVE_AUTHORITY_REVALIDATION"
+                },
+                {
+                  "const": "NOT_LIVE_CONSTRAINT_REVALIDATION"
+                },
+                {
+                  "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+                },
+                {
+                  "const": "NOT_BIND_AUTHORIZATION"
+                },
+                {
+                  "const": "NOT_BIND_RECEIPT"
+                },
+                {
+                  "const": "NOT_TRUSTLOG_WRITE"
+                },
+                {
+                  "const": "NOT_OPERATION_COMMIT"
+                }
+              ],
+              "items": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "rehearsal_step_result_id",
+            "planned_step_id",
+            "fixture_step_result_id",
+            "ordinal",
+            "planned_adapter_method",
+            "rehearsal_mode",
+            "reference_adapter_instance_created",
+            "reference_adapter_method_called",
+            "live_adapter_instance_created",
+            "live_adapter_method_called",
+            "network_used",
+            "filesystem_used",
+            "external_effect_used",
+            "trustlog_written",
+            "bind_receipt_created",
+            "bind_invoked",
+            "output_summary",
+            "output_digest",
+            "matched_expected_output_ref",
+            "rehearsal_scope_limitations"
+          ],
+          "properties": {
+            "rehearsal_step_result_id": {
+              "pattern": "^reference-rehearsal-result:v1:[1-9][0-9]*:[a-z0-9-]+$"
+            },
+            "planned_step_id": {
+              "type": "string"
+            },
+            "fixture_step_result_id": {
+              "type": "string"
+            },
+            "ordinal": {
+              "const": 6
+            },
+            "planned_adapter_method": {
+              "const": "validate_constraints"
+            },
+            "rehearsal_mode": {
+              "const": "reference_in_memory_no_effect"
+            },
+            "reference_adapter_instance_created": {
+              "const": true
+            },
+            "reference_adapter_method_called": {
+              "const": true
+            },
+            "live_adapter_instance_created": {
+              "const": false
+            },
+            "live_adapter_method_called": {
+              "const": false
+            },
+            "network_used": {
+              "const": false
+            },
+            "filesystem_used": {
+              "const": false
+            },
+            "external_effect_used": {
+              "const": false
+            },
+            "trustlog_written": {
+              "const": false
+            },
+            "bind_receipt_created": {
+              "const": false
+            },
+            "bind_invoked": {
+              "const": false
+            },
+            "output_summary": {
+              "type": "object",
+              "patternProperties": {
+                "^.*$": {}
+              },
+              "additionalProperties": false
+            },
+            "output_digest": {
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "matched_expected_output_ref": {
+              "type": "string"
+            },
+            "rehearsal_scope_limitations": {
+              "type": "array",
+              "prefixItems": [
+                {
+                  "const": "NOT_LIVE_ADAPTER_RESULT"
+                },
+                {
+                  "const": "NOT_LIVE_STATE"
+                },
+                {
+                  "const": "NOT_LIVE_AUTHORITY_REVALIDATION"
+                },
+                {
+                  "const": "NOT_LIVE_CONSTRAINT_REVALIDATION"
+                },
+                {
+                  "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+                },
+                {
+                  "const": "NOT_BIND_AUTHORIZATION"
+                },
+                {
+                  "const": "NOT_BIND_RECEIPT"
+                },
+                {
+                  "const": "NOT_TRUSTLOG_WRITE"
+                },
+                {
+                  "const": "NOT_OPERATION_COMMIT"
+                }
+              ],
+              "items": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "rehearsal_step_result_id",
+            "planned_step_id",
+            "fixture_step_result_id",
+            "ordinal",
+            "planned_adapter_method",
+            "rehearsal_mode",
+            "reference_adapter_instance_created",
+            "reference_adapter_method_called",
+            "live_adapter_instance_created",
+            "live_adapter_method_called",
+            "network_used",
+            "filesystem_used",
+            "external_effect_used",
+            "trustlog_written",
+            "bind_receipt_created",
+            "bind_invoked",
+            "output_summary",
+            "output_digest",
+            "matched_expected_output_ref",
+            "rehearsal_scope_limitations"
+          ],
+          "properties": {
+            "rehearsal_step_result_id": {
+              "pattern": "^reference-rehearsal-result:v1:[1-9][0-9]*:[a-z0-9-]+$"
+            },
+            "planned_step_id": {
+              "type": "string"
+            },
+            "fixture_step_result_id": {
+              "type": "string"
+            },
+            "ordinal": {
+              "const": 7
+            },
+            "planned_adapter_method": {
+              "const": "assess_runtime_risk"
+            },
+            "rehearsal_mode": {
+              "const": "reference_in_memory_no_effect"
+            },
+            "reference_adapter_instance_created": {
+              "const": true
+            },
+            "reference_adapter_method_called": {
+              "const": true
+            },
+            "live_adapter_instance_created": {
+              "const": false
+            },
+            "live_adapter_method_called": {
+              "const": false
+            },
+            "network_used": {
+              "const": false
+            },
+            "filesystem_used": {
+              "const": false
+            },
+            "external_effect_used": {
+              "const": false
+            },
+            "trustlog_written": {
+              "const": false
+            },
+            "bind_receipt_created": {
+              "const": false
+            },
+            "bind_invoked": {
+              "const": false
+            },
+            "output_summary": {
+              "type": "object",
+              "patternProperties": {
+                "^.*$": {}
+              },
+              "additionalProperties": false
+            },
+            "output_digest": {
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "matched_expected_output_ref": {
+              "type": "string"
+            },
+            "rehearsal_scope_limitations": {
+              "type": "array",
+              "prefixItems": [
+                {
+                  "const": "NOT_LIVE_ADAPTER_RESULT"
+                },
+                {
+                  "const": "NOT_LIVE_STATE"
+                },
+                {
+                  "const": "NOT_LIVE_AUTHORITY_REVALIDATION"
+                },
+                {
+                  "const": "NOT_LIVE_CONSTRAINT_REVALIDATION"
+                },
+                {
+                  "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+                },
+                {
+                  "const": "NOT_BIND_AUTHORIZATION"
+                },
+                {
+                  "const": "NOT_BIND_RECEIPT"
+                },
+                {
+                  "const": "NOT_TRUSTLOG_WRITE"
+                },
+                {
+                  "const": "NOT_OPERATION_COMMIT"
+                }
+              ],
+              "items": false
+            }
+          },
+          "additionalProperties": false
+        }
+      ],
+      "items": false
+    },
+    "scope_limitations": {
+      "type": "array",
+      "prefixItems": [
+        {
+          "const": "NOT_EXECUTION_AUTHORITY"
+        },
+        {
+          "const": "NOT_BIND_AUTHORIZATION"
+        },
+        {
+          "const": "NOT_BIND_RECEIPT"
+        },
+        {
+          "const": "NOT_BIND_INVOCATION"
+        },
+        {
+          "const": "NOT_LIVE_ADAPTER_INSTANCE"
+        },
+        {
+          "const": "NOT_LIVE_ADAPTER_INVOCATION"
+        },
+        {
+          "const": "NOT_LIVE_ADAPTER_RESULT"
+        },
+        {
+          "const": "NOT_EXTERNAL_EFFECT"
+        },
+        {
+          "const": "NOT_OPERATION_COMMIT"
+        },
+        {
+          "const": "NOT_TRUSTLOG_WRITE"
+        },
+        {
+          "const": "NOT_LIVE_STATE_CHECK"
+        },
+        {
+          "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+        },
+        {
+          "const": "NOT_LIVE_AUTHORITY_REVALIDATION"
+        },
+        {
+          "const": "NOT_LIVE_CONSTRAINT_REVALIDATION"
+        },
+        {
+          "const": "NOT_POSTCONDITION_VERIFICATION"
+        },
+        {
+          "const": "NOT_ROLLBACK_PROOF"
+        },
+        {
+          "const": "NOT_AUTHORITY_EVIDENCE"
+        },
+        {
+          "const": "NOT_HUMAN_APPROVAL"
+        }
+      ],
+      "items": false
+    },
+    "source_adapter_dry_run_fixture_result_hash": {
+      "type": "string"
+    },
+    "adapter_contract_id": {
+      "type": "string"
+    },
+    "adapter_contract_hash": {
+      "type": "string"
+    },
+    "adapter_contract_version": {
+      "type": "string"
+    },
+    "execution_intent_id": {
+      "type": "string"
+    },
+    "execution_intent_hash": {
+      "type": "string"
+    },
+    "source_adapter_dry_run_plan_hash": {
+      "type": "string"
+    },
+    "source_adapter_contract_selection_hash": {
+      "type": "string"
+    },
+    "source_bind_preflight_adjudication_hash": {
+      "type": "string"
+    },
+    "source_formation_hash": {
+      "type": "string"
+    },
+    "source_readiness_hash": {
+      "type": "string"
+    },
+    "source_eligibility_hash": {
+      "type": "string"
+    },
+    "source_handoff_hash": {
+      "type": "string"
+    },
+    "trusted_validation_context_hash": {
+      "type": "string"
+    },
+    "validation_result_hash": {
+      "type": "string"
+    },
+    "mapping_value_digest": {
+      "type": "string"
+    },
+    "execution_intent_contract_version": {
+      "type": "string"
+    },
+    "planned_step_digest": {
+      "type": "string"
+    },
+    "fixture_result_digest": {
+      "type": "string"
+    },
+    "reference_rehearsal_result_digest": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false
+}

--- a/veritas_os/policy/reference_adapter_rehearsal.py
+++ b/veritas_os/policy/reference_adapter_rehearsal.py
@@ -1,0 +1,582 @@
+"""Deterministic, no-effect reference-adapter rehearsal boundary.
+
+This module deliberately owns a tiny in-memory rehearsal adapter rather than
+using the execution-side reference adapter.  It performs seven descriptive
+calls and cannot commit, persist, communicate, or construct execution receipts.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from veritas_os.policy.adapter_dry_run_plan import STEPS_DOMAIN, _digest as plan_digest
+from veritas_os.policy.adapter_dry_run_result import (
+    RESULTS_DOMAIN as FIXTURE_RESULTS_DOMAIN,
+    AdapterDryRunFixtureResultError,
+    CanonicalAdapterDryRunFixtureResultPacket,
+    verify_adapter_dry_run_fixture_result_packet,
+)
+from veritas_os.policy.bind_artifacts import (
+    ExecutionIntent,
+    canonical_execution_intent_json,
+    hash_execution_intent,
+)
+
+FORMAT_VERSION = "canonical-reference-adapter-in-memory-rehearsal/v1"
+REHEARSAL_MECHANISM = "run_reference_adapter_in_memory_rehearsal_without_bind/v1"
+OUTPUT_DOMAIN = "veritas.reference-adapter-in-memory-rehearsal.output/v1"
+RESULTS_DOMAIN = "veritas.reference-adapter-in-memory-rehearsal.results/v1"
+LOCAL_CHECKS_DOMAIN = "veritas.reference-adapter-in-memory-rehearsal.local-checks/v1"
+FUTURE_REQUIREMENTS_DOMAIN = (
+    "veritas.reference-adapter-in-memory-rehearsal.future-requirements/v1"
+)
+PACKET_DOMAIN = "veritas.reference-adapter-in-memory-rehearsal.packet/v1"
+SOURCE_SUMMARY_KEYS = (
+    "adapter_dry_run_result_id",
+    "adapter_dry_run_result_hash",
+    "format_version",
+    "result_mechanism",
+    "resulted_at",
+    "execution_intent_id",
+    "execution_intent_hash",
+    "dry_run_fixture_result_status",
+    "ready_for_reference_adapter_rehearsal",
+)
+PLANNED_METHODS = (
+    "describe_target",
+    "build_idempotency_key",
+    "snapshot",
+    "fingerprint_state",
+    "validate_authority",
+    "validate_constraints",
+    "assess_runtime_risk",
+)
+STEP_LIMITATIONS = (
+    "NOT_LIVE_ADAPTER_RESULT",
+    "NOT_LIVE_STATE",
+    "NOT_LIVE_AUTHORITY_REVALIDATION",
+    "NOT_LIVE_CONSTRAINT_REVALIDATION",
+    "NOT_RUNTIME_RISK_ACCEPTANCE",
+    "NOT_BIND_AUTHORIZATION",
+    "NOT_BIND_RECEIPT",
+    "NOT_TRUSTLOG_WRITE",
+    "NOT_OPERATION_COMMIT",
+)
+LOCAL_REHEARSAL_CHECKS = {
+    key: True
+    for key in (
+        "adapter_dry_run_fixture_result_verified",
+        "execution_intent_hash_verified",
+        "execution_intent_id_verified",
+        "adapter_descriptor_preserved",
+        "planned_steps_preserved",
+        "fixture_results_preserved",
+        "planned_step_digest_verified",
+        "fixture_result_digest_verified",
+        "reference_rehearsal_results_ordered",
+        "reference_rehearsal_results_match_planned_steps",
+        "reference_outputs_digest_verified",
+        "no_apply_rehearsal",
+        "no_postcondition_rehearsal",
+        "no_revert_rehearsal",
+        "rehearsed_after_fixture_result",
+        "reference_adapter_instance_created",
+        "reference_adapter_methods_called",
+        "no_live_adapter_instance",
+        "no_live_adapter_invocation",
+        "no_bind_invocation",
+        "no_bind_receipt_created",
+        "no_trustlog_write",
+        "no_network",
+        "no_filesystem",
+        "no_external_effect",
+        "no_live_state_claim",
+        "no_live_authority_revalidation_claim",
+        "no_live_constraint_revalidation_claim",
+        "no_runtime_risk_acceptance_claim",
+    )
+}
+FUTURE_LIVE_ADAPTER_DRY_RUN_REQUIREMENTS = {
+    key: True
+    for key in (
+        "live_adapter_instance_required",
+        "live_describe_target_required",
+        "live_idempotency_key_required",
+        "live_snapshot_required",
+        "live_state_fingerprint_required",
+        "live_authority_revalidation_required",
+        "live_constraint_validation_required",
+        "live_runtime_risk_assessment_required",
+        "live_dry_run_result_packet_required",
+        "human_approval_still_required",
+        "authority_evidence_still_required",
+        "trustlog_policy_still_deferred",
+        "bind_receipt_still_deferred",
+        "apply_still_forbidden",
+    )
+}
+SCOPE_LIMITATIONS = (
+    "NOT_EXECUTION_AUTHORITY",
+    "NOT_BIND_AUTHORIZATION",
+    "NOT_BIND_RECEIPT",
+    "NOT_BIND_INVOCATION",
+    "NOT_LIVE_ADAPTER_INSTANCE",
+    "NOT_LIVE_ADAPTER_INVOCATION",
+    "NOT_LIVE_ADAPTER_RESULT",
+    "NOT_EXTERNAL_EFFECT",
+    "NOT_OPERATION_COMMIT",
+    "NOT_TRUSTLOG_WRITE",
+    "NOT_LIVE_STATE_CHECK",
+    "NOT_RUNTIME_RISK_ACCEPTANCE",
+    "NOT_LIVE_AUTHORITY_REVALIDATION",
+    "NOT_LIVE_CONSTRAINT_REVALIDATION",
+    "NOT_POSTCONDITION_VERIFICATION",
+    "NOT_ROLLBACK_PROOF",
+    "NOT_AUTHORITY_EVIDENCE",
+    "NOT_HUMAN_APPROVAL",
+)
+
+
+class ReferenceAdapterRehearsalError(ValueError):
+    """Stable fail-closed refusal for reference rehearsal processing."""
+
+
+class ReferenceAdapterInMemoryStepResult(BaseModel):
+    """Immutable pure-data observation of one permitted rehearsal call."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    rehearsal_step_result_id: str = Field(
+        pattern=r"^reference-rehearsal-result:v1:[1-9][0-9]*:[a-z0-9-]+$"
+    )
+    planned_step_id: str
+    fixture_step_result_id: str
+    ordinal: int = Field(ge=1)
+    planned_adapter_method: Literal[
+        "describe_target",
+        "build_idempotency_key",
+        "snapshot",
+        "fingerprint_state",
+        "validate_authority",
+        "validate_constraints",
+        "assess_runtime_risk",
+    ]
+    rehearsal_mode: Literal["reference_in_memory_no_effect"]
+    reference_adapter_instance_created: Literal[True]
+    reference_adapter_method_called: Literal[True]
+    live_adapter_instance_created: Literal[False]
+    live_adapter_method_called: Literal[False]
+    network_used: Literal[False]
+    filesystem_used: Literal[False]
+    external_effect_used: Literal[False]
+    trustlog_written: Literal[False]
+    bind_receipt_created: Literal[False]
+    bind_invoked: Literal[False]
+    output_summary: dict[str, Any]
+    output_digest: str = Field(pattern=r"^[0-9a-f]{64}$")
+    matched_expected_output_ref: str
+    rehearsal_scope_limitations: tuple[str, ...]
+
+
+class CanonicalReferenceAdapterInMemoryRehearsalPacket(BaseModel):
+    """Strict content-addressed packet for a verified local rehearsal."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    format_version: Literal["canonical-reference-adapter-in-memory-rehearsal/v1"]
+    reference_rehearsal_id: str = Field(pattern=r"^rar:v1:sha256:[0-9a-f]{64}$")
+    reference_rehearsal_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    rehearsal_mechanism: Literal[
+        "run_reference_adapter_in_memory_rehearsal_without_bind/v1"
+    ]
+    rehearsed_at: str
+    source_adapter_dry_run_fixture_result: dict[str, Any]
+    source_adapter_dry_run_fixture_result_hash: str
+    source_adapter_dry_run_fixture_result_packet: dict[str, Any]
+    adapter_contract_descriptor: dict[str, Any]
+    adapter_contract_id: str
+    adapter_contract_hash: str
+    adapter_contract_version: str
+    execution_intent: dict[str, Any]
+    execution_intent_id: str
+    execution_intent_hash: str
+    source_adapter_dry_run_plan_hash: str
+    source_adapter_contract_selection_hash: str
+    source_bind_preflight_adjudication_hash: str
+    source_formation_hash: str
+    source_readiness_hash: str
+    source_eligibility_hash: str
+    source_handoff_hash: str
+    trusted_validation_context_hash: str
+    validation_result_hash: str
+    mapping_value_digest: str
+    execution_intent_contract_version: str
+    reference_rehearsal_status: Literal[
+        "REFERENCE_ADAPTER_IN_MEMORY_REHEARSAL_COMPLETED_NO_EFFECT"
+    ]
+    ready_for_live_adapter_dry_run_request: Literal[True]
+    fail_closed: Literal[False]
+    planned_steps: tuple[dict[str, Any], ...]
+    planned_step_digest: str
+    fixture_step_results: tuple[dict[str, Any], ...]
+    fixture_result_digest: str
+    reference_rehearsal_results: tuple[ReferenceAdapterInMemoryStepResult, ...]
+    reference_rehearsal_result_digest: str
+    local_rehearsal_checks: dict[str, bool]
+    future_live_adapter_dry_run_requirements: dict[str, bool]
+    source_to_execution_intent_mapping: dict[str, Any]
+    field_mapping_proof: dict[str, Any]
+    required_field_presence: dict[str, str]
+    source_decision_identity: dict[str, Any]
+    candidate_identity: dict[str, Any]
+    evidence_lineage: dict[str, Any]
+    replay_summary: dict[str, Any]
+    scope_limitations: tuple[str, ...]
+
+
+def _json_value(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        value = value.model_dump(mode="python")
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        if value != value or value in (float("inf"), float("-inf")):
+            raise ReferenceAdapterRehearsalError("RAR_PACKET_INVALID")
+        return value
+    if isinstance(value, datetime):
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ReferenceAdapterRehearsalError("RAR_REHEARSED_AT_INVALID")
+        return value.isoformat()
+    if isinstance(value, (list, tuple)):
+        return [_json_value(item) for item in value]
+    if isinstance(value, dict) and all(isinstance(key, str) for key in value):
+        return {key: _json_value(item) for key, item in value.items()}
+    raise ReferenceAdapterRehearsalError("RAR_PACKET_INVALID")
+
+
+def _aware(value: Any, code: str) -> datetime:
+    try:
+        parsed = value if isinstance(value, datetime) else datetime.fromisoformat(value)
+    except (TypeError, ValueError) as exc:
+        raise ReferenceAdapterRehearsalError(code) from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ReferenceAdapterRehearsalError(code)
+    return parsed
+
+
+def _digest(domain: str, value: Any) -> str:
+    encoded = json.dumps(
+        {"domain": domain, "value": _json_value(value)},
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _packet_hash(raw: dict[str, Any]) -> str:
+    return _digest(
+        PACKET_DOMAIN,
+        {
+            key: value
+            for key, value in raw.items()
+            if key not in {"reference_rehearsal_id", "reference_rehearsal_hash"}
+        },
+    )
+
+
+def _verified_source(value: Any) -> CanonicalAdapterDryRunFixtureResultPacket:
+    try:
+        return verify_adapter_dry_run_fixture_result_packet(value)
+    except (AdapterDryRunFixtureResultError, TypeError, ValueError) as exc:
+        raise ReferenceAdapterRehearsalError("RAR_FIXTURE_RESULT_INVALID") from exc
+
+
+def _intent(raw: dict[str, Any]) -> ExecutionIntent:
+    try:
+        intent = ExecutionIntent(**raw)
+        canonical_execution_intent_json(intent)
+    except (TypeError, ValueError) as exc:
+        raise ReferenceAdapterRehearsalError("RAR_PACKET_INVALID") from exc
+    if intent.to_dict() != raw:
+        raise ReferenceAdapterRehearsalError("RAR_PACKET_INVALID")
+    return intent
+
+
+class InMemoryReferenceRehearsalAdapter:
+    """Seven-method local adapter with no execution or I/O capabilities."""
+
+    def __init__(self, intent: ExecutionIntent, fixture: dict[str, Any]) -> None:
+        self._intent = intent.to_dict()
+        self._fixture = fixture
+
+    def rehearse(self, method: str, ordinal: int) -> dict[str, Any]:
+        """Return a deterministic JSON descriptor for one allowlisted method."""
+        if method not in PLANNED_METHODS:
+            raise ReferenceAdapterRehearsalError("RAR_FORBIDDEN_EXECUTION_STEP")
+        return {
+            "method": method,
+            "ordinal": ordinal,
+            "mode": "reference_in_memory_no_effect",
+            "intent_digest": _digest(OUTPUT_DOMAIN, self._intent),
+            "fixture_digest": _digest(OUTPUT_DOMAIN, self._fixture),
+            "target_system": self._intent["target_system"],
+            "target_resource": self._intent["target_resource"],
+        }
+
+
+def _results(
+    source: CanonicalAdapterDryRunFixtureResultPacket, fixture: dict[str, Any]
+) -> list[dict[str, Any]]:
+    adapter = InMemoryReferenceRehearsalAdapter(
+        _intent(source.execution_intent), fixture
+    )
+    results = []
+    for step, fixture_result in zip(
+        source.planned_steps, source.fixture_step_results, strict=True
+    ):
+        summary = adapter.rehearse(step.planned_adapter_method, step.ordinal)
+        results.append(
+            {
+                "rehearsal_step_result_id": (
+                    f"reference-rehearsal-result:v1:{step.ordinal}:"
+                    f"{step.planned_adapter_method.replace('_', '-')}"
+                ),
+                "planned_step_id": step.step_id,
+                "fixture_step_result_id": fixture_result.step_result_id,
+                "ordinal": step.ordinal,
+                "planned_adapter_method": step.planned_adapter_method,
+                "rehearsal_mode": "reference_in_memory_no_effect",
+                "reference_adapter_instance_created": True,
+                "reference_adapter_method_called": True,
+                "live_adapter_instance_created": False,
+                "live_adapter_method_called": False,
+                "network_used": False,
+                "filesystem_used": False,
+                "external_effect_used": False,
+                "trustlog_written": False,
+                "bind_receipt_created": False,
+                "bind_invoked": False,
+                "output_summary": summary,
+                "output_digest": _digest(OUTPUT_DOMAIN, summary),
+                "matched_expected_output_ref": step.expected_output_ref,
+                "rehearsal_scope_limitations": STEP_LIMITATIONS,
+            }
+        )
+    return results
+
+
+_COPIED_FIELDS = (
+    "adapter_contract_descriptor",
+    "adapter_contract_id",
+    "adapter_contract_hash",
+    "adapter_contract_version",
+    "execution_intent",
+    "execution_intent_id",
+    "execution_intent_hash",
+    "source_adapter_dry_run_plan_hash",
+    "source_adapter_contract_selection_hash",
+    "source_bind_preflight_adjudication_hash",
+    "source_formation_hash",
+    "source_readiness_hash",
+    "source_eligibility_hash",
+    "source_handoff_hash",
+    "trusted_validation_context_hash",
+    "validation_result_hash",
+    "mapping_value_digest",
+    "execution_intent_contract_version",
+    "source_to_execution_intent_mapping",
+    "field_mapping_proof",
+    "required_field_presence",
+    "source_decision_identity",
+    "candidate_identity",
+    "evidence_lineage",
+    "replay_summary",
+)
+
+
+def build_reference_adapter_in_memory_rehearsal_packet(
+    adapter_dry_run_fixture_result_packet: Any,
+    reference_rehearsal_fixture: Any,
+    rehearsed_at: datetime,
+) -> CanonicalReferenceAdapterInMemoryRehearsalPacket:
+    """Build and reverify a no-effect rehearsal packet from verified input."""
+    rehearsed = _aware(rehearsed_at, "RAR_REHEARSED_AT_INVALID")
+    fixture = _json_value(reference_rehearsal_fixture)
+    if not isinstance(fixture, dict):
+        raise ReferenceAdapterRehearsalError("RAR_PACKET_INVALID")
+    source_packet = _verified_source(_json_value(adapter_dry_run_fixture_result_packet))
+    source = source_packet.model_dump(mode="json")
+    if rehearsed < _aware(source_packet.resulted_at, "RAR_FIXTURE_RESULT_INVALID"):
+        raise ReferenceAdapterRehearsalError("RAR_REHEARSED_BEFORE_FIXTURE_RESULT")
+    intent = _intent(source_packet.execution_intent)
+    if intent.execution_intent_id != source_packet.execution_intent_id:
+        raise ReferenceAdapterRehearsalError("RAR_EXECUTION_INTENT_ID_MISMATCH")
+    if hash_execution_intent(intent) != source_packet.execution_intent_hash:
+        raise ReferenceAdapterRehearsalError("RAR_EXECUTION_INTENT_HASH_MISMATCH")
+    descriptor = source_packet.adapter_contract_descriptor
+    if (
+        descriptor["target_system"] != intent.target_system
+        or descriptor["target_resource_scope"] != intent.target_resource
+    ):
+        raise ReferenceAdapterRehearsalError("RAR_DESCRIPTOR_MISMATCH")
+    steps = [item.model_dump(mode="json") for item in source_packet.planned_steps]
+    fixtures = [
+        item.model_dump(mode="json") for item in source_packet.fixture_step_results
+    ]
+    results = _results(source_packet, fixture)
+    raw = {
+        "format_version": FORMAT_VERSION,
+        "rehearsal_mechanism": REHEARSAL_MECHANISM,
+        "rehearsed_at": rehearsed.isoformat(),
+        "source_adapter_dry_run_fixture_result": {
+            key: source[key] for key in SOURCE_SUMMARY_KEYS
+        },
+        "source_adapter_dry_run_fixture_result_hash": source_packet.adapter_dry_run_result_hash,
+        "source_adapter_dry_run_fixture_result_packet": source,
+        **{key: source[key] for key in _COPIED_FIELDS},
+        "reference_rehearsal_status": "REFERENCE_ADAPTER_IN_MEMORY_REHEARSAL_COMPLETED_NO_EFFECT",
+        "ready_for_live_adapter_dry_run_request": True,
+        "fail_closed": False,
+        "planned_steps": steps,
+        "planned_step_digest": source_packet.planned_step_digest,
+        "fixture_step_results": fixtures,
+        "fixture_result_digest": source_packet.fixture_result_digest,
+        "reference_rehearsal_results": results,
+        "reference_rehearsal_result_digest": _digest(RESULTS_DOMAIN, results),
+        "local_rehearsal_checks": LOCAL_REHEARSAL_CHECKS,
+        "future_live_adapter_dry_run_requirements": FUTURE_LIVE_ADAPTER_DRY_RUN_REQUIREMENTS,
+        "scope_limitations": SCOPE_LIMITATIONS,
+    }
+    digest = _packet_hash(raw)
+    raw.update(
+        reference_rehearsal_hash=digest,
+        reference_rehearsal_id=f"rar:v1:sha256:{digest}",
+    )
+    return verify_reference_adapter_in_memory_rehearsal_packet(raw)
+
+
+def verify_reference_adapter_in_memory_rehearsal_packet(
+    packet: Any,
+) -> CanonicalReferenceAdapterInMemoryRehearsalPacket:
+    """Independently revalidate all source, result, and identity bindings."""
+    try:
+        value = (
+            packet.model_dump(mode="json")
+            if isinstance(packet, BaseModel)
+            else _json_value(packet)
+        )
+        candidate = CanonicalReferenceAdapterInMemoryRehearsalPacket.model_validate(
+            value
+        )
+    except (ValidationError, ReferenceAdapterRehearsalError, TypeError) as exc:
+        raise ReferenceAdapterRehearsalError("RAR_PACKET_INVALID") from exc
+    raw = candidate.model_dump(mode="json")
+    source_packet = _verified_source(
+        candidate.source_adapter_dry_run_fixture_result_packet
+    )
+    source = source_packet.model_dump(mode="json")
+    if (
+        set(candidate.source_adapter_dry_run_fixture_result) != set(SOURCE_SUMMARY_KEYS)
+        or candidate.source_adapter_dry_run_fixture_result
+        != {key: source[key] for key in SOURCE_SUMMARY_KEYS}
+        or candidate.source_adapter_dry_run_fixture_result_hash
+        != source_packet.adapter_dry_run_result_hash
+    ):
+        raise ReferenceAdapterRehearsalError("RAR_SOURCE_SUMMARY_MISMATCH")
+    if _aware(candidate.rehearsed_at, "RAR_REHEARSED_AT_INVALID") < _aware(
+        source_packet.resulted_at, "RAR_FIXTURE_RESULT_INVALID"
+    ):
+        raise ReferenceAdapterRehearsalError("RAR_REHEARSED_BEFORE_FIXTURE_RESULT")
+    if any(
+        getattr(candidate, key) != getattr(source_packet, key) for key in _COPIED_FIELDS
+    ):
+        raise ReferenceAdapterRehearsalError("RAR_SOURCE_SUMMARY_MISMATCH")
+    intent = _intent(candidate.execution_intent)
+    if intent.execution_intent_id != candidate.execution_intent_id:
+        raise ReferenceAdapterRehearsalError("RAR_EXECUTION_INTENT_ID_MISMATCH")
+    if hash_execution_intent(intent) != candidate.execution_intent_hash:
+        raise ReferenceAdapterRehearsalError("RAR_EXECUTION_INTENT_HASH_MISMATCH")
+    descriptor = candidate.adapter_contract_descriptor
+    if (
+        descriptor["target_system"] != intent.target_system
+        or descriptor["target_resource_scope"] != intent.target_resource
+    ):
+        raise ReferenceAdapterRehearsalError("RAR_DESCRIPTOR_MISMATCH")
+    steps = [item.model_dump(mode="json") for item in source_packet.planned_steps]
+    fixtures = [
+        item.model_dump(mode="json") for item in source_packet.fixture_step_results
+    ]
+    if list(candidate.planned_steps) != steps:
+        raise ReferenceAdapterRehearsalError("RAR_PLANNED_STEPS_MISMATCH")
+    if (
+        candidate.planned_step_digest != source_packet.planned_step_digest
+        or candidate.planned_step_digest != plan_digest(STEPS_DOMAIN, steps)
+    ):
+        raise ReferenceAdapterRehearsalError("RAR_PLANNED_STEPS_MISMATCH")
+    if list(candidate.fixture_step_results) != fixtures:
+        raise ReferenceAdapterRehearsalError("RAR_FIXTURE_RESULTS_MISMATCH")
+    if (
+        candidate.fixture_result_digest != source_packet.fixture_result_digest
+        or candidate.fixture_result_digest != _digest(FIXTURE_RESULTS_DOMAIN, fixtures)
+    ):
+        raise ReferenceAdapterRehearsalError("RAR_FIXTURE_RESULTS_MISMATCH")
+    results = [
+        item.model_dump(mode="json") for item in candidate.reference_rehearsal_results
+    ]
+    if len(results) != 7 or [
+        item["planned_adapter_method"] for item in results
+    ] != list(PLANNED_METHODS):
+        raise ReferenceAdapterRehearsalError("RAR_REHEARSAL_RESULTS_INVALID")
+    for result, step, fixture in zip(results, steps, fixtures, strict=True):
+        expected_id = f"reference-rehearsal-result:v1:{step['ordinal']}:{step['planned_adapter_method'].replace('_', '-')}"
+        if (
+            result["rehearsal_step_result_id"] != expected_id
+            or result["planned_step_id"] != step["step_id"]
+            or result["fixture_step_result_id"] != fixture["step_result_id"]
+            or result["ordinal"] != step["ordinal"]
+            or result["matched_expected_output_ref"] != step["expected_output_ref"]
+            or tuple(result["rehearsal_scope_limitations"]) != STEP_LIMITATIONS
+        ):
+            raise ReferenceAdapterRehearsalError("RAR_REHEARSAL_RESULTS_INVALID")
+        flags = (
+            result["reference_adapter_instance_created"],
+            result["reference_adapter_method_called"],
+            not result["live_adapter_instance_created"],
+            not result["live_adapter_method_called"],
+            not result["network_used"],
+            not result["filesystem_used"],
+            not result["external_effect_used"],
+            not result["trustlog_written"],
+            not result["bind_receipt_created"],
+            not result["bind_invoked"],
+        )
+        if not all(flags):
+            raise ReferenceAdapterRehearsalError("RAR_EXTERNAL_EFFECT_FORBIDDEN")
+        if result["output_digest"] != _digest(OUTPUT_DOMAIN, result["output_summary"]):
+            raise ReferenceAdapterRehearsalError("RAR_OUTPUT_DIGEST_MISMATCH")
+    if candidate.reference_rehearsal_result_digest != _digest(RESULTS_DOMAIN, results):
+        raise ReferenceAdapterRehearsalError("RAR_REHEARSAL_RESULTS_INVALID")
+    if candidate.local_rehearsal_checks != LOCAL_REHEARSAL_CHECKS:
+        raise ReferenceAdapterRehearsalError("RAR_LOCAL_CHECKS_MISMATCH")
+    if (
+        candidate.future_live_adapter_dry_run_requirements
+        != FUTURE_LIVE_ADAPTER_DRY_RUN_REQUIREMENTS
+    ):
+        raise ReferenceAdapterRehearsalError("RAR_FUTURE_REQUIREMENTS_MISMATCH")
+    _digest(LOCAL_CHECKS_DOMAIN, candidate.local_rehearsal_checks)
+    _digest(
+        FUTURE_REQUIREMENTS_DOMAIN, candidate.future_live_adapter_dry_run_requirements
+    )
+    if candidate.scope_limitations != SCOPE_LIMITATIONS:
+        raise ReferenceAdapterRehearsalError("RAR_SCOPE_LIMITATIONS_MISSING")
+    digest = _packet_hash(raw)
+    if candidate.reference_rehearsal_hash != digest:
+        raise ReferenceAdapterRehearsalError("RAR_PACKET_HASH_MISMATCH")
+    if candidate.reference_rehearsal_id != f"rar:v1:sha256:{digest}":
+        raise ReferenceAdapterRehearsalError("RAR_PACKET_ID_MISMATCH")
+    return candidate

--- a/veritas_os/policy/reference_adapter_rehearsal.py
+++ b/veritas_os/policy/reference_adapter_rehearsal.py
@@ -339,17 +339,25 @@ def _results(
     for step, fixture_result in zip(
         source.planned_steps, source.fixture_step_results, strict=True
     ):
-        summary = adapter.rehearse(step.planned_adapter_method, step.ordinal)
+        step_json = _json_value(step)
+        fixture_result_json = _json_value(fixture_result)
+        if not isinstance(step_json, dict) or not isinstance(
+            fixture_result_json, dict
+        ):
+            raise ReferenceAdapterRehearsalError("RAR_PACKET_INVALID")
+        method = step_json["planned_adapter_method"]
+        ordinal = step_json["ordinal"]
+        summary = adapter.rehearse(method, ordinal)
         results.append(
             {
                 "rehearsal_step_result_id": (
-                    f"reference-rehearsal-result:v1:{step.ordinal}:"
-                    f"{step.planned_adapter_method.replace('_', '-')}"
+                    f"reference-rehearsal-result:v1:{ordinal}:"
+                    f"{method.replace('_', '-')}"
                 ),
-                "planned_step_id": step.step_id,
-                "fixture_step_result_id": fixture_result.step_result_id,
-                "ordinal": step.ordinal,
-                "planned_adapter_method": step.planned_adapter_method,
+                "planned_step_id": step_json["step_id"],
+                "fixture_step_result_id": fixture_result_json["step_result_id"],
+                "ordinal": ordinal,
+                "planned_adapter_method": method,
                 "rehearsal_mode": "reference_in_memory_no_effect",
                 "reference_adapter_instance_created": True,
                 "reference_adapter_method_called": True,
@@ -363,7 +371,7 @@ def _results(
                 "bind_invoked": False,
                 "output_summary": summary,
                 "output_digest": _digest(OUTPUT_DOMAIN, summary),
-                "matched_expected_output_ref": step.expected_output_ref,
+                "matched_expected_output_ref": step_json["expected_output_ref"],
                 "rehearsal_scope_limitations": STEP_LIMITATIONS,
             }
         )
@@ -424,10 +432,8 @@ def build_reference_adapter_in_memory_rehearsal_packet(
         or descriptor["target_resource_scope"] != intent.target_resource
     ):
         raise ReferenceAdapterRehearsalError("RAR_DESCRIPTOR_MISMATCH")
-    steps = [item.model_dump(mode="json") for item in source_packet.planned_steps]
-    fixtures = [
-        item.model_dump(mode="json") for item in source_packet.fixture_step_results
-    ]
+    steps = [_json_value(item) for item in source_packet.planned_steps]
+    fixtures = [_json_value(item) for item in source_packet.fixture_step_results]
     results = _results(source_packet, fixture)
     raw = {
         "format_version": FORMAT_VERSION,
@@ -507,10 +513,8 @@ def verify_reference_adapter_in_memory_rehearsal_packet(
         or descriptor["target_resource_scope"] != intent.target_resource
     ):
         raise ReferenceAdapterRehearsalError("RAR_DESCRIPTOR_MISMATCH")
-    steps = [item.model_dump(mode="json") for item in source_packet.planned_steps]
-    fixtures = [
-        item.model_dump(mode="json") for item in source_packet.fixture_step_results
-    ]
+    steps = [_json_value(item) for item in source_packet.planned_steps]
+    fixtures = [_json_value(item) for item in source_packet.fixture_step_results]
     if list(candidate.planned_steps) != steps:
         raise ReferenceAdapterRehearsalError("RAR_PLANNED_STEPS_MISMATCH")
     if (
@@ -525,9 +529,7 @@ def verify_reference_adapter_in_memory_rehearsal_packet(
         or candidate.fixture_result_digest != _digest(FIXTURE_RESULTS_DOMAIN, fixtures)
     ):
         raise ReferenceAdapterRehearsalError("RAR_FIXTURE_RESULTS_MISMATCH")
-    results = [
-        item.model_dump(mode="json") for item in candidate.reference_rehearsal_results
-    ]
+    results = [_json_value(item) for item in candidate.reference_rehearsal_results]
     if len(results) != 7 or [
         item["planned_adapter_method"] for item in results
     ] != list(PLANNED_METHODS):

--- a/veritas_os/tests/test_reference_adapter_rehearsal.py
+++ b/veritas_os/tests/test_reference_adapter_rehearsal.py
@@ -1,0 +1,265 @@
+"""Security tests for reference adapter in-memory rehearsal v1."""
+
+from __future__ import annotations
+
+import ast
+from copy import deepcopy
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+
+from veritas_os.policy.reference_adapter_rehearsal import (
+    OUTPUT_DOMAIN,
+    PACKET_DOMAIN,
+    PLANNED_METHODS,
+    RESULTS_DOMAIN,
+    ReferenceAdapterRehearsalError,
+    _digest,
+    _packet_hash,
+    build_reference_adapter_in_memory_rehearsal_packet,
+    verify_reference_adapter_in_memory_rehearsal_packet,
+)
+from veritas_os.tests.test_adapter_dry_run_fixture_result import (
+    RESULTED_AT,
+    _packet as fixture_packet,
+)
+
+REHEARSED_AT = RESULTED_AT + timedelta(seconds=1)
+MODULE = Path("veritas_os/policy/reference_adapter_rehearsal.py")
+
+
+def _packet(*, semantic_match: bool = True):
+    return build_reference_adapter_in_memory_rehearsal_packet(
+        fixture_packet(semantic_match=semantic_match),
+        {"scenario": "deterministic-reference-v1"},
+        REHEARSED_AT,
+    )
+
+
+def _rehash(raw):
+    digest = _packet_hash(raw)
+    raw["reference_rehearsal_hash"] = digest
+    raw["reference_rehearsal_id"] = f"rar:v1:sha256:{digest}"
+
+
+def test_build_verify_preserves_source_and_records_no_effects(monkeypatch) -> None:
+    import veritas_os.policy.reference_adapter_rehearsal as module
+
+    actual = module.verify_adapter_dry_run_fixture_result_packet
+    calls = []
+
+    def recording(value):
+        calls.append(value)
+        return actual(value)
+
+    monkeypatch.setattr(
+        module, "verify_adapter_dry_run_fixture_result_packet", recording
+    )
+    source = fixture_packet(semantic_match=False)
+    packet = module.build_reference_adapter_in_memory_rehearsal_packet(
+        source, {"scenario": "deterministic-reference-v1"}, REHEARSED_AT
+    )
+    assert len(calls) == 2  # builder source verification and final verifier
+    assert module.verify_reference_adapter_in_memory_rehearsal_packet(packet) == packet
+    assert len(calls) == 3
+    assert packet.reference_rehearsal_id == (
+        f"rar:v1:sha256:{packet.reference_rehearsal_hash}"
+    )
+    assert packet.reference_rehearsal_hash == _packet_hash(
+        packet.model_dump(mode="json")
+    )
+    assert packet.source_adapter_dry_run_fixture_result_packet == source.model_dump(
+        mode="json"
+    )
+    for field in (
+        "adapter_contract_descriptor",
+        "execution_intent",
+        "planned_steps",
+        "fixture_step_results",
+        "source_decision_identity",
+        "candidate_identity",
+        "evidence_lineage",
+        "replay_summary",
+    ):
+        assert getattr(packet, field) == getattr(source, field)
+    assert packet.replay_summary["semantic_match"] is False
+    results = list(packet.reference_rehearsal_results)
+    assert [item.planned_adapter_method for item in results] == list(PLANNED_METHODS)
+    assert set(PLANNED_METHODS).isdisjoint({"apply", "verify_postconditions", "revert"})
+    for result in results:
+        assert result.reference_adapter_instance_created is True
+        assert result.reference_adapter_method_called is True
+        assert result.live_adapter_instance_created is False
+        assert result.live_adapter_method_called is False
+        assert not any(
+            (
+                result.network_used,
+                result.filesystem_used,
+                result.external_effect_used,
+                result.bind_invoked,
+                result.bind_receipt_created,
+                result.trustlog_written,
+            )
+        )
+        assert result.output_digest == _digest(OUTPUT_DOMAIN, result.output_summary)
+    raw_results = [item.model_dump(mode="json") for item in results]
+    assert packet.reference_rehearsal_result_digest == _digest(
+        RESULTS_DOMAIN, raw_results
+    )
+
+
+@pytest.mark.parametrize("semantic_match", [True, False])
+def test_semantic_match_is_preserved(semantic_match) -> None:
+    packet = _packet(semantic_match=semantic_match)
+    assert packet.replay_summary["semantic_match"] is semantic_match
+    assert verify_reference_adapter_in_memory_rehearsal_packet(packet) == packet
+
+
+def test_invalid_source_and_timeline_refuse() -> None:
+    source = fixture_packet().model_dump(mode="json")
+    source["adapter_dry_run_result_hash"] = "0" * 64
+    with pytest.raises(
+        ReferenceAdapterRehearsalError, match="RAR_FIXTURE_RESULT_INVALID"
+    ):
+        build_reference_adapter_in_memory_rehearsal_packet(source, {}, REHEARSED_AT)
+    with pytest.raises(
+        ReferenceAdapterRehearsalError, match="RAR_REHEARSED_AT_INVALID"
+    ):
+        build_reference_adapter_in_memory_rehearsal_packet(
+            fixture_packet(), {}, REHEARSED_AT.replace(tzinfo=None)
+        )
+    with pytest.raises(
+        ReferenceAdapterRehearsalError,
+        match="RAR_REHEARSED_BEFORE_FIXTURE_RESULT",
+    ):
+        build_reference_adapter_in_memory_rehearsal_packet(
+            fixture_packet(), {}, RESULTED_AT - timedelta(seconds=1)
+        )
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "missing",
+        "extra",
+        "reordered",
+        "method",
+        "output",
+        "live_instance",
+        "live_call",
+        "network",
+        "filesystem",
+        "effect",
+        "bind",
+        "receipt",
+        "trustlog",
+        "planned",
+        "fixture",
+        "checks",
+        "future",
+        "scope",
+        "hash",
+        "id",
+    ],
+)
+def test_tampering_is_refused_even_when_rehashed(mutation) -> None:
+    raw = _packet().model_dump(mode="json")
+    results = raw["reference_rehearsal_results"]
+    if mutation == "missing":
+        results.pop()
+    elif mutation == "extra":
+        results.append(deepcopy(results[-1]))
+    elif mutation == "reordered":
+        results[0], results[1] = results[1], results[0]
+    elif mutation == "method":
+        results[0]["planned_adapter_method"] = "snapshot"
+    elif mutation == "output":
+        results[0]["output_summary"]["ordinal"] = 99
+    elif mutation == "live_instance":
+        results[0]["live_adapter_instance_created"] = True
+    elif mutation == "live_call":
+        results[0]["live_adapter_method_called"] = True
+    elif mutation in {"network", "filesystem", "effect", "bind", "receipt", "trustlog"}:
+        key = {
+            "effect": "external_effect_used",
+            "bind": "bind_invoked",
+            "receipt": "bind_receipt_created",
+            "trustlog": "trustlog_written",
+        }.get(mutation, f"{mutation}_used")
+        results[0][key] = True
+    elif mutation == "planned":
+        raw["planned_steps"][0]["expected_output_ref"] = "changed"
+    elif mutation == "fixture":
+        raw["fixture_step_results"][0]["fixture_input_ref"] = "changed"
+    elif mutation == "checks":
+        raw["local_rehearsal_checks"]["no_network"] = False
+    elif mutation == "future":
+        raw["future_live_adapter_dry_run_requirements"][
+            "live_adapter_instance_required"
+        ] = False
+    elif mutation == "scope":
+        raw["scope_limitations"].pop()
+    elif mutation == "hash":
+        raw["reference_rehearsal_hash"] = "0" * 64
+    elif mutation == "id":
+        raw["reference_rehearsal_id"] = "rar:v1:sha256:" + "0" * 64
+    if mutation not in {"hash", "id"}:
+        _rehash(raw)
+    with pytest.raises(ReferenceAdapterRehearsalError):
+        verify_reference_adapter_in_memory_rehearsal_packet(raw)
+
+
+def test_model_validation_bypasses_are_refused() -> None:
+    packet = _packet()
+    copied = packet.model_copy(update={"reference_rehearsal_hash": "0" * 64})
+    constructed = type(packet).model_construct(
+        **{**packet.model_dump(mode="python"), "fail_closed": True}
+    )
+    for candidate in (copied, constructed):
+        with pytest.raises(ReferenceAdapterRehearsalError):
+            verify_reference_adapter_in_memory_rehearsal_packet(candidate)
+
+
+def test_static_execution_boundary() -> None:
+    tree = ast.parse(MODULE.read_text(encoding="utf-8"))
+    forbidden = {
+        "BindReceipt",
+        "hash_bind_receipt",
+        "append_bind_receipt_trustlog",
+        "append_execution_intent_trustlog",
+        "build_execution_intent_trustlog_entry",
+        "execute_bind_boundary",
+        "execute_bind_adjudication",
+        "WebhookBindAdapter",
+        "requests",
+        "httpx",
+        "subprocess",
+        "uuid4",
+        "now",
+        "apply",
+        "revert",
+        "verify_postconditions",
+        "create_bind_receipt",
+        "write_trustlog",
+        "append_trustlog",
+    }
+    imported = {
+        alias.name.split(".")[0]
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.Import, ast.ImportFrom))
+        for alias in node.names
+    }
+    called = {
+        node.func.attr if isinstance(node.func, ast.Attribute) else node.func.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, (ast.Name, ast.Attribute))
+    }
+    defined = {
+        node.name
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    assert forbidden.isdisjoint(imported | called | defined)
+    assert PACKET_DOMAIN != RESULTS_DOMAIN

--- a/veritas_os/tests/test_reference_adapter_rehearsal.py
+++ b/veritas_os/tests/test_reference_adapter_rehearsal.py
@@ -29,6 +29,17 @@ REHEARSED_AT = RESULTED_AT + timedelta(seconds=1)
 MODULE = Path("veritas_os/policy/reference_adapter_rehearsal.py")
 
 
+def _jsonified(value):
+    """Recursively convert typed test values to canonical JSON representations."""
+    if hasattr(value, "model_dump"):
+        return _jsonified(value.model_dump(mode="json"))
+    if isinstance(value, dict):
+        return {key: _jsonified(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonified(item) for item in value]
+    return value
+
+
 def _packet(*, semantic_match: bool = True):
     return build_reference_adapter_in_memory_rehearsal_packet(
         fixture_packet(semantic_match=semantic_match),
@@ -83,7 +94,9 @@ def test_build_verify_preserves_source_and_records_no_effects(monkeypatch) -> No
         "evidence_lineage",
         "replay_summary",
     ):
-        assert getattr(packet, field) == getattr(source, field)
+        assert _jsonified(getattr(packet, field)) == _jsonified(
+            getattr(source, field)
+        )
     assert packet.replay_summary["semantic_match"] is False
     results = list(packet.reference_rehearsal_results)
     assert [item.planned_adapter_method for item in results] == list(PLANNED_METHODS)

--- a/veritas_os/tests/test_reference_adapter_rehearsal.py
+++ b/veritas_os/tests/test_reference_adapter_rehearsal.py
@@ -57,6 +57,7 @@ def test_build_verify_preserves_source_and_records_no_effects(monkeypatch) -> No
         module, "verify_adapter_dry_run_fixture_result_packet", recording
     )
     source = fixture_packet(semantic_match=False)
+    assert all(isinstance(step, dict) for step in source.planned_steps)
     packet = module.build_reference_adapter_in_memory_rehearsal_packet(
         source, {"scenario": "deterministic-reference-v1"}, REHEARSED_AT
     )


### PR DESCRIPTION
### Motivation

Add the first deterministic in-memory reference adapter rehearsal boundary after Adapter Dry-Run Fixture Result, while still stopping before live adapters, Webhook adapters, Bind, BindReceipt, TrustLog, or external effects.

### Description

- Add `veritas_os/policy/reference_adapter_rehearsal.py` implementing `CanonicalReferenceAdapterInMemoryRehearsalPacket`, `ReferenceAdapterInMemoryStepResult`, the builder `build_reference_adapter_in_memory_rehearsal_packet`, and the verifier `verify_reference_adapter_in_memory_rehearsal_packet` with strict JSON normalization and content-addressed identity (`rar:v1:sha256:<hash>`).
- Implement a deterministic local `InMemoryReferenceRehearsalAdapter` that only rehearses the seven safe methods in order: `describe_target`, `build_idempotency_key`, `snapshot`, `fingerprint_state`, `validate_authority`, `validate_constraints`, and `assess_runtime_risk`.
- Record pure JSON `output_summary` / `output_digest` values with explicit no-live/no-effect flags.
- Preserve and re-verify the full source Canonical Adapter Dry-Run Fixture Result Packet.
- Preserve ExecutionIntent identity/hash, adapter descriptor identity/hash/version, planned steps, fixture step results, source identities, evidence lineage, and replay summary.
- Preserve `semantic_match` exactly and do not convert it into Authority Evidence, Human Approval, Bind authorization, or execution authority.
- Add closed JSON Schema `schemas/reference-adapter-in-memory-rehearsal-v1.schema.json`.
- Add docs `docs/en/architecture/reference-adapter-in-memory-rehearsal-v1.md`.
- Add focused tests `veritas_os/tests/test_reference_adapter_rehearsal.py` covering positive flows, refusal/tamper cases, typed-instance bypass, schema validation, and static import-boundary checks.

### Security / non-claims

- Reference Adapter In-Memory Rehearsal does not authorize execution.
- Reference Adapter In-Memory Rehearsal does not invoke Bind.
- Reference Adapter In-Memory Rehearsal does not create BindReceipt.
- Reference Adapter In-Memory Rehearsal does not write TrustLog.
- Reference Adapter In-Memory Rehearsal does not call live adapters.
- Reference Adapter In-Memory Rehearsal does not call Webhook adapter.
- Reference Adapter In-Memory Rehearsal does not perform network, filesystem, provider, webhook, subprocess, database, or external-system effects.
- Reference Adapter In-Memory Rehearsal does not call `apply`, `verify_postconditions`, or `revert`.
- Reference Adapter In-Memory Rehearsal does not perform live state verification, live authority revalidation, live constraint validation, or live runtime risk acceptance.
- Reference Adapter In-Memory Rehearsal does not satisfy Authority Evidence or Human Approval.
- Reference Adapter In-Memory Rehearsal does not turn replay `semantic_match` into authorization.

### Testing

- Latest head SHA: `d36f521aeba0e3c735f8f427d1a0e64e7e80baea`.
- GitHub CI #5073 completed successfully for this head.
- `test (py3.11)`: success.
- `test (py3.12)`: success.
- `test-postgresql (py3.12)`: success.
- `test-slow (py3.12)`: success.
- `lint`: success.
- `dependency-audit`: success.
- `future-dependency-compat`: success.
- `[Tier 1] governance-backend-fast`: success.
- `[Tier 1] governance-smoke`: success.
- `frontend-lint`: success.
- `frontend-test`: success.
- `frontend-e2e`: success.
- `Security Gates`: success.
- `CodeQL (custom)`: success.
- `Runtime Proof Evidence`: success.
- `Runtime Pickle Guard (Required)`: success.
- `Reviewer Evidence Packet Validation`: success.

### Final invariant

Canonical Reference Adapter In-Memory Rehearsal v1 now replays a verified Canonical Adapter Dry-Run Fixture Result Packet through exact deterministic in-memory reference adapter rehearsal steps without live adapter access, without Webhook adapter access, without invoking Bind, without creating a BindReceipt, without writing TrustLog, without external effects, and without converting replay `semantic_match` into Authority Evidence, Human Approval, or execution authority.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a82a2ca5d588326b6ad1717a15839cb)