### PR TITLE
feat(bind): add live adapter dry-run request readiness v1

### DIFF
--- a/docs/en/architecture/live-adapter-dry-run-readiness-v1.md
+++ b/docs/en/architecture/live-adapter-dry-run-readiness-v1.md
@@ -1,0 +1,54 @@
+# Canonical Live Adapter Dry-Run Request Readiness Packet v1
+
+## Boundary
+
+This packet is deterministic, local evidence that one **verified** Canonical
+Reference Adapter In-Memory Rehearsal Packet passed readiness checks for a
+future request. Reference Adapter In-Memory Rehearsal is not Live Adapter
+Dry-Run Request Readiness, and readiness is not a live adapter dry-run request,
+live adapter execution, Webhook invocation, Bind authorization, BindReceipt, or
+TrustLog write. Readiness is not Authority Evidence. A replay
+`semantic_match` value is preserved, but is not Human Approval.
+
+The builder embeds the complete verified rehearsal packet, preserves its
+ExecutionIntent, adapter descriptor, planned steps, fixture results, rehearsal
+results, identities, evidence lineage, and replay summary, and records sixteen
+ordered local checks. The verifier independently verifies the embedded source
+again and recomputes all content-addressed identities and digests. A false
+`semantic_match` remains false and is not used as an authorization gate.
+
+## Sequence and stop point
+
+1. CDA
+2. Trust Link
+3. Replay Source/Evidence
+4. Replay Handoff Binding
+5. CanonicalDecisionHandoff validation
+6. Guarded Promotion Eligibility Packet
+7. ExecutionIntent Formation Readiness Packet
+8. Canonical ExecutionIntent Formation Packet
+9. ExecutionIntent Pre-Bind Validation Packet
+10. Canonical Bind Preflight Adjudication Packet
+11. Canonical Bind Adapter Contract Selection Packet
+12. Canonical Adapter Dry-Run Plan Packet
+13. Canonical Adapter Dry-Run Fixture Result Packet
+14. Canonical Reference Adapter In-Memory Rehearsal Packet
+15. Canonical Live Adapter Dry-Run Request Readiness Packet
+16. **STOP**
+
+Actual request creation, a real adapter instance, Webhook adapter access,
+network access, Bind adjudication, BindReceipt creation, TrustLog writing,
+`apply`, postcondition verification, rollback, and operation commit are all
+intentionally deferred to future explicit changes. The packet neither performs
+nor authorizes these operations and makes no production, customer, or
+regulatory-certification claim.
+
+## Security properties and non-claims
+
+Every readiness check says that no live observation, network, filesystem,
+credential, adapter instance or method, Bind invocation, BindReceipt, TrustLog
+write, or external effect was used. Future request construction must separately
+supply an explicit request packet, a reviewed adapter descriptor and endpoint
+allowlist, read-only scope, credential review, timeout, rate limit, idempotency,
+and no-apply/no-commit policy. Authority evidence and policy-required human
+approval remain separate requirements.

--- a/schemas/live-adapter-dry-run-readiness-v1.schema.json
+++ b/schemas/live-adapter-dry-run-readiness-v1.schema.json
@@ -1,0 +1,2525 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json",
+  "title": "Canonical Live Adapter Dry-Run Request Readiness v1",
+  "type": "object",
+  "required": [
+    "format_version",
+    "live_adapter_dry_run_readiness_id",
+    "live_adapter_dry_run_readiness_hash",
+    "readiness_mechanism",
+    "readiness_evaluated_at",
+    "source_reference_rehearsal",
+    "source_reference_rehearsal_hash",
+    "source_reference_rehearsal_packet",
+    "adapter_contract_descriptor",
+    "adapter_contract_id",
+    "adapter_contract_hash",
+    "adapter_contract_version",
+    "execution_intent",
+    "execution_intent_id",
+    "execution_intent_hash",
+    "source_adapter_dry_run_fixture_result_hash",
+    "source_adapter_dry_run_plan_hash",
+    "source_adapter_contract_selection_hash",
+    "source_bind_preflight_adjudication_hash",
+    "source_formation_hash",
+    "source_readiness_hash",
+    "source_eligibility_hash",
+    "source_handoff_hash",
+    "trusted_validation_context_hash",
+    "validation_result_hash",
+    "mapping_value_digest",
+    "execution_intent_contract_version",
+    "live_adapter_dry_run_request_readiness_status",
+    "ready_for_live_adapter_dry_run_request_packet",
+    "fail_closed",
+    "planned_steps",
+    "planned_step_digest",
+    "fixture_step_results",
+    "fixture_result_digest",
+    "reference_rehearsal_results",
+    "reference_rehearsal_result_digest",
+    "readiness_checks",
+    "readiness_check_digest",
+    "local_readiness_checks",
+    "future_live_adapter_dry_run_request_packet_requirements",
+    "source_to_execution_intent_mapping",
+    "field_mapping_proof",
+    "required_field_presence",
+    "source_decision_identity",
+    "candidate_identity",
+    "evidence_lineage",
+    "replay_summary",
+    "scope_limitations"
+  ],
+  "properties": {
+    "format_version": {
+      "const": "canonical-live-adapter-dry-run-request-readiness/v1"
+    },
+    "live_adapter_dry_run_readiness_id": {
+      "type": "string",
+      "pattern": "^ladr:v1:sha256:[0-9a-f]{64}$"
+    },
+    "live_adapter_dry_run_readiness_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "readiness_mechanism": {
+      "const": "evaluate_live_adapter_dry_run_request_readiness_without_request/v1"
+    },
+    "readiness_evaluated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "source_reference_rehearsal": {
+      "type": "object",
+      "required": [
+        "reference_rehearsal_id",
+        "reference_rehearsal_hash",
+        "format_version",
+        "rehearsal_mechanism",
+        "rehearsed_at",
+        "execution_intent_id",
+        "execution_intent_hash",
+        "reference_rehearsal_status",
+        "ready_for_live_adapter_dry_run_request"
+      ],
+      "properties": {
+        "reference_rehearsal_id": {
+          "type": "string"
+        },
+        "reference_rehearsal_hash": {
+          "type": "string"
+        },
+        "format_version": {
+          "const": "canonical-reference-adapter-in-memory-rehearsal/v1"
+        },
+        "rehearsal_mechanism": {
+          "type": "string"
+        },
+        "rehearsed_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "execution_intent_id": {
+          "type": "string"
+        },
+        "execution_intent_hash": {
+          "type": "string"
+        },
+        "reference_rehearsal_status": {
+          "const": "REFERENCE_ADAPTER_IN_MEMORY_REHEARSAL_COMPLETED_NO_EFFECT"
+        },
+        "ready_for_live_adapter_dry_run_request": {
+          "const": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "source_reference_rehearsal_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "source_reference_rehearsal_packet": {
+      "$ref": "reference-adapter-in-memory-rehearsal-v1.schema.json"
+    },
+    "adapter_contract_descriptor": {
+      "type": "object",
+      "patternProperties": {
+        "^.*$": {}
+      },
+      "additionalProperties": false
+    },
+    "adapter_contract_id": {
+      "type": "string"
+    },
+    "adapter_contract_hash": {
+      "type": "string"
+    },
+    "adapter_contract_version": {
+      "type": "string"
+    },
+    "execution_intent": {
+      "type": "object",
+      "patternProperties": {
+        "^.*$": {}
+      },
+      "additionalProperties": false
+    },
+    "execution_intent_id": {
+      "type": "string"
+    },
+    "execution_intent_hash": {
+      "type": "string"
+    },
+    "source_adapter_dry_run_fixture_result_hash": {
+      "type": "string"
+    },
+    "source_adapter_dry_run_plan_hash": {
+      "type": "string"
+    },
+    "source_adapter_contract_selection_hash": {
+      "type": "string"
+    },
+    "source_bind_preflight_adjudication_hash": {
+      "type": "string"
+    },
+    "source_formation_hash": {
+      "type": "string"
+    },
+    "source_readiness_hash": {
+      "type": "string"
+    },
+    "source_eligibility_hash": {
+      "type": "string"
+    },
+    "source_handoff_hash": {
+      "type": "string"
+    },
+    "trusted_validation_context_hash": {
+      "type": "string"
+    },
+    "validation_result_hash": {
+      "type": "string"
+    },
+    "mapping_value_digest": {
+      "type": "string"
+    },
+    "execution_intent_contract_version": {
+      "type": "string"
+    },
+    "live_adapter_dry_run_request_readiness_status": {
+      "const": "LIVE_ADAPTER_DRY_RUN_REQUEST_READY_BUT_NOT_REQUESTED"
+    },
+    "ready_for_live_adapter_dry_run_request_packet": {
+      "const": true
+    },
+    "fail_closed": {
+      "const": false
+    },
+    "planned_steps": {
+      "$ref": "reference-adapter-in-memory-rehearsal-v1.schema.json#/properties/planned_steps"
+    },
+    "planned_step_digest": {
+      "type": "string"
+    },
+    "fixture_step_results": {
+      "$ref": "reference-adapter-in-memory-rehearsal-v1.schema.json#/properties/fixture_step_results"
+    },
+    "fixture_result_digest": {
+      "type": "string"
+    },
+    "reference_rehearsal_results": {
+      "$ref": "reference-adapter-in-memory-rehearsal-v1.schema.json#/properties/reference_rehearsal_results"
+    },
+    "reference_rehearsal_result_digest": {
+      "type": "string"
+    },
+    "readiness_checks": {
+      "type": "array",
+      "prefixItems": [
+        {
+          "allOf": [
+            {
+              "type": "object",
+              "required": [
+                "readiness_check_id",
+                "ordinal",
+                "check_name",
+                "check_mode",
+                "passed",
+                "evidence_ref",
+                "live_observation_used",
+                "network_used",
+                "filesystem_used",
+                "credential_accessed",
+                "adapter_instance_created",
+                "adapter_method_called",
+                "bind_invoked",
+                "bind_receipt_created",
+                "trustlog_written",
+                "external_effect_used",
+                "check_scope_limitations"
+              ],
+              "properties": {
+                "readiness_check_id": {
+                  "type": "string"
+                },
+                "ordinal": {
+                  "type": "integer"
+                },
+                "check_name": {
+                  "type": "string"
+                },
+                "check_mode": {
+                  "const": "deterministic_local_readiness_only"
+                },
+                "passed": {
+                  "const": true
+                },
+                "evidence_ref": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "live_observation_used": {
+                  "const": false
+                },
+                "network_used": {
+                  "const": false
+                },
+                "filesystem_used": {
+                  "const": false
+                },
+                "credential_accessed": {
+                  "const": false
+                },
+                "adapter_instance_created": {
+                  "const": false
+                },
+                "adapter_method_called": {
+                  "const": false
+                },
+                "bind_invoked": {
+                  "const": false
+                },
+                "bind_receipt_created": {
+                  "const": false
+                },
+                "trustlog_written": {
+                  "const": false
+                },
+                "external_effect_used": {
+                  "const": false
+                },
+                "check_scope_limitations": {
+                  "type": "array",
+                  "prefixItems": [
+                    {
+                      "const": "NOT_LIVE_ADAPTER_RESULT"
+                    },
+                    {
+                      "const": "NOT_LIVE_STATE"
+                    },
+                    {
+                      "const": "NOT_LIVE_AUTHORITY_REVALIDATION"
+                    },
+                    {
+                      "const": "NOT_LIVE_CONSTRAINT_REVALIDATION"
+                    },
+                    {
+                      "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+                    },
+                    {
+                      "const": "NOT_BIND_AUTHORIZATION"
+                    },
+                    {
+                      "const": "NOT_BIND_RECEIPT"
+                    },
+                    {
+                      "const": "NOT_TRUSTLOG_WRITE"
+                    },
+                    {
+                      "const": "NOT_OPERATION_COMMIT"
+                    }
+                  ],
+                  "items": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 1
+                },
+                "check_name": {
+                  "const": "source_reference_rehearsal_verified"
+                },
+                "readiness_check_id": {
+                  "const": "live-adapter-dry-run-readiness-check:v1:1:source-reference-rehearsal-verified"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "type": "object",
+              "required": [
+                "readiness_check_id",
+                "ordinal",
+                "check_name",
+                "check_mode",
+                "passed",
+                "evidence_ref",
+                "live_observation_used",
+                "network_used",
+                "filesystem_used",
+                "credential_accessed",
+                "adapter_instance_created",
+                "adapter_method_called",
+                "bind_invoked",
+                "bind_receipt_created",
+                "trustlog_written",
+                "external_effect_used",
+                "check_scope_limitations"
+              ],
+              "properties": {
+                "readiness_check_id": {
+                  "type": "string"
+                },
+                "ordinal": {
+                  "type": "integer"
+                },
+                "check_name": {
+                  "type": "string"
+                },
+                "check_mode": {
+                  "const": "deterministic_local_readiness_only"
+                },
+                "passed": {
+                  "const": true
+                },
+                "evidence_ref": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "live_observation_used": {
+                  "const": false
+                },
+                "network_used": {
+                  "const": false
+                },
+                "filesystem_used": {
+                  "const": false
+                },
+                "credential_accessed": {
+                  "const": false
+                },
+                "adapter_instance_created": {
+                  "const": false
+                },
+                "adapter_method_called": {
+                  "const": false
+                },
+                "bind_invoked": {
+                  "const": false
+                },
+                "bind_receipt_created": {
+                  "const": false
+                },
+                "trustlog_written": {
+                  "const": false
+                },
+                "external_effect_used": {
+                  "const": false
+                },
+                "check_scope_limitations": {
+                  "type": "array",
+                  "prefixItems": [
+                    {
+                      "const": "NOT_LIVE_ADAPTER_RESULT"
+                    },
+                    {
+                      "const": "NOT_LIVE_STATE"
+                    },
+                    {
+                      "const": "NOT_LIVE_AUTHORITY_REVALIDATION"
+                    },
+                    {
+                      "const": "NOT_LIVE_CONSTRAINT_REVALIDATION"
+                    },
+                    {
+                      "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+                    },
+                    {
+                      "const": "NOT_BIND_AUTHORIZATION"
+                    },
+                    {
+                      "const": "NOT_BIND_RECEIPT"
+                    },
+                    {
+                      "const": "NOT_TRUSTLOG_WRITE"
+                    },
+                    {
+                      "const": "NOT_OPERATION_COMMIT"
+                    }
+                  ],
+                  "items": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 2
+                },
+                "check_name": {
+                  "const": "execution_intent_identity_verified"
+                },
+                "readiness_check_id": {
+                  "const": "live-adapter-dry-run-readiness-check:v1:2:execution-intent-identity-verified"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "type": "object",
+              "required": [
+                "readiness_check_id",
+                "ordinal",
+                "check_name",
+                "check_mode",
+                "passed",
+                "evidence_ref",
+                "live_observation_used",
+                "network_used",
+                "filesystem_used",
+                "credential_accessed",
+                "adapter_instance_created",
+                "adapter_method_called",
+                "bind_invoked",
+                "bind_receipt_created",
+                "trustlog_written",
+                "external_effect_used",
+                "check_scope_limitations"
+              ],
+              "properties": {
+                "readiness_check_id": {
+                  "type": "string"
+                },
+                "ordinal": {
+                  "type": "integer"
+                },
+                "check_name": {
+                  "type": "string"
+                },
+                "check_mode": {
+                  "const": "deterministic_local_readiness_only"
+                },
+                "passed": {
+                  "const": true
+                },
+                "evidence_ref": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "live_observation_used": {
+                  "const": false
+                },
+                "network_used": {
+                  "const": false
+                },
+                "filesystem_used": {
+                  "const": false
+                },
+                "credential_accessed": {
+                  "const": false
+                },
+                "adapter_instance_created": {
+                  "const": false
+                },
+                "adapter_method_called": {
+                  "const": false
+                },
+                "bind_invoked": {
+                  "const": false
+                },
+                "bind_receipt_created": {
+                  "const": false
+                },
+                "trustlog_written": {
+                  "const": false
+                },
+                "external_effect_used": {
+                  "const": false
+                },
+                "check_scope_limitations": {
+                  "type": "array",
+                  "prefixItems": [
+                    {
+                      "const": "NOT_LIVE_ADAPTER_RESULT"
+                    },
+                    {
+                      "const": "NOT_LIVE_STATE"
+                    },
+                    {
+                      "const": "NOT_LIVE_AUTHORITY_REVALIDATION"
+                    },
+                    {
+                      "const": "NOT_LIVE_CONSTRAINT_REVALIDATION"
+                    },
+                    {
+                      "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+                    },
+                    {
+                      "const": "NOT_BIND_AUTHORIZATION"
+                    },
+                    {
+                      "const": "NOT_BIND_RECEIPT"
+                    },
+                    {
+                      "const": "NOT_TRUSTLOG_WRITE"
+                    },
+                    {
+                      "const": "NOT_OPERATION_COMMIT"
+                    }
+                  ],
+                  "items": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 3
+                },
+                "check_name": {
+                  "const": "adapter_contract_descriptor_preserved"
+                },
+                "readiness_check_id": {
+                  "const": "live-adapter-dry-run-readiness-check:v1:3:adapter-contract-descriptor-preserved"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "type": "object",
+              "required": [
+                "readiness_check_id",
+                "ordinal",
+                "check_name",
+                "check_mode",
+                "passed",
+                "evidence_ref",
+                "live_observation_used",
+                "network_used",
+                "filesystem_used",
+                "credential_accessed",
+                "adapter_instance_created",
+                "adapter_method_called",
+                "bind_invoked",
+                "bind_receipt_created",
+                "trustlog_written",
+                "external_effect_used",
+                "check_scope_limitations"
+              ],
+              "properties": {
+                "readiness_check_id": {
+                  "type": "string"
+                },
+                "ordinal": {
+                  "type": "integer"
+                },
+                "check_name": {
+                  "type": "string"
+                },
+                "check_mode": {
+                  "const": "deterministic_local_readiness_only"
+                },
+                "passed": {
+                  "const": true
+                },
+                "evidence_ref": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "live_observation_used": {
+                  "const": false
+                },
+                "network_used": {
+                  "const": false
+                },
+                "filesystem_used": {
+                  "const": false
+                },
+                "credential_accessed": {
+                  "const": false
+                },
+                "adapter_instance_created": {
+                  "const": false
+                },
+                "adapter_method_called": {
+                  "const": false
+                },
+                "bind_invoked": {
+                  "const": false
+                },
+                "bind_receipt_created": {
+                  "const": false
+                },
+                "trustlog_written": {
+                  "const": false
+                },
+                "external_effect_used": {
+                  "const": false
+                },
+                "check_scope_limitations": {
+                  "type": "array",
+                  "prefixItems": [
+                    {
+                      "const": "NOT_LIVE_ADAPTER_RESULT"
+                    },
+                    {
+                      "const": "NOT_LIVE_STATE"
+                    },
+                    {
+                      "const": "NOT_LIVE_AUTHORITY_REVALIDATION"
+                    },
+                    {
+                      "const": "NOT_LIVE_CONSTRAINT_REVALIDATION"
+                    },
+                    {
+                      "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+                    },
+                    {
+                      "const": "NOT_BIND_AUTHORIZATION"
+                    },
+                    {
+                      "const": "NOT_BIND_RECEIPT"
+                    },
+                    {
+                      "const": "NOT_TRUSTLOG_WRITE"
+                    },
+                    {
+                      "const": "NOT_OPERATION_COMMIT"
+                    }
+                  ],
+                  "items": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 4
+                },
+                "check_name": {
+                  "const": "planned_steps_preserved"
+                },
+                "readiness_check_id": {
+                  "const": "live-adapter-dry-run-readiness-check:v1:4:planned-steps-preserved"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "type": "object",
+              "required": [
+                "readiness_check_id",
+                "ordinal",
+                "check_name",
+                "check_mode",
+                "passed",
+                "evidence_ref",
+                "live_observation_used",
+                "network_used",
+                "filesystem_used",
+                "credential_accessed",
+                "adapter_instance_created",
+                "adapter_method_called",
+                "bind_invoked",
+                "bind_receipt_created",
+                "trustlog_written",
+                "external_effect_used",
+                "check_scope_limitations"
+              ],
+              "properties": {
+                "readiness_check_id": {
+                  "type": "string"
+                },
+                "ordinal": {
+                  "type": "integer"
+                },
+                "check_name": {
+                  "type": "string"
+                },
+                "check_mode": {
+                  "const": "deterministic_local_readiness_only"
+                },
+                "passed": {
+                  "const": true
+                },
+                "evidence_ref": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "live_observation_used": {
+                  "const": false
+                },
+                "network_used": {
+                  "const": false
+                },
+                "filesystem_used": {
+                  "const": false
+                },
+                "credential_accessed": {
+                  "const": false
+                },
+                "adapter_instance_created": {
+                  "const": false
+                },
+                "adapter_method_called": {
+                  "const": false
+                },
+                "bind_invoked": {
+                  "const": false
+                },
+                "bind_receipt_created": {
+                  "const": false
+                },
+                "trustlog_written": {
+                  "const": false
+                },
+                "external_effect_used": {
+                  "const": false
+                },
+                "check_scope_limitations": {
+                  "type": "array",
+                  "prefixItems": [
+                    {
+                      "const": "NOT_LIVE_ADAPTER_RESULT"
+                    },
+                    {
+                      "const": "NOT_LIVE_STATE"
+                    },
+                    {
+                      "const": "NOT_LIVE_AUTHORITY_REVALIDATION"
+                    },
+                    {
+                      "const": "NOT_LIVE_CONSTRAINT_REVALIDATION"
+                    },
+                    {
+                      "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+                    },
+                    {
+                      "const": "NOT_BIND_AUTHORIZATION"
+                    },
+                    {
+                      "const": "NOT_BIND_RECEIPT"
+                    },
+                    {
+                      "const": "NOT_TRUSTLOG_WRITE"
+                    },
+                    {
+                      "const": "NOT_OPERATION_COMMIT"
+                    }
+                  ],
+                  "items": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 5
+                },
+                "check_name": {
+                  "const": "fixture_results_preserved"
+                },
+                "readiness_check_id": {
+                  "const": "live-adapter-dry-run-readiness-check:v1:5:fixture-results-preserved"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "type": "object",
+              "required": [
+                "readiness_check_id",
+                "ordinal",
+                "check_name",
+                "check_mode",
+                "passed",
+                "evidence_ref",
+                "live_observation_used",
+                "network_used",
+                "filesystem_used",
+                "credential_accessed",
+                "adapter_instance_created",
+                "adapter_method_called",
+                "bind_invoked",
+                "bind_receipt_created",
+                "trustlog_written",
+                "external_effect_used",
+                "check_scope_limitations"
+              ],
+              "properties": {
+                "readiness_check_id": {
+                  "type": "string"
+                },
+                "ordinal": {
+                  "type": "integer"
+                },
+                "check_name": {
+                  "type": "string"
+                },
+                "check_mode": {
+                  "const": "deterministic_local_readiness_only"
+                },
+                "passed": {
+                  "const": true
+                },
+                "evidence_ref": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "live_observation_used": {
+                  "const": false
+                },
+                "network_used": {
+                  "const": false
+                },
+                "filesystem_used": {
+                  "const": false
+                },
+                "credential_accessed": {
+                  "const": false
+                },
+                "adapter_instance_created": {
+                  "const": false
+                },
+                "adapter_method_called": {
+                  "const": false
+                },
+                "bind_invoked": {
+                  "const": false
+                },
+                "bind_receipt_created": {
+                  "const": false
+                },
+                "trustlog_written": {
+                  "const": false
+                },
+                "external_effect_used": {
+                  "const": false
+                },
+                "check_scope_limitations": {
+                  "type": "array",
+                  "prefixItems": [
+                    {
+                      "const": "NOT_LIVE_ADAPTER_RESULT"
+                    },
+                    {
+                      "const": "NOT_LIVE_STATE"
+                    },
+                    {
+                      "const": "NOT_LIVE_AUTHORITY_REVALIDATION"
+                    },
+                    {
+                      "const": "NOT_LIVE_CONSTRAINT_REVALIDATION"
+                    },
+                    {
+                      "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+                    },
+                    {
+                      "const": "NOT_BIND_AUTHORIZATION"
+                    },
+                    {
+                      "const": "NOT_BIND_RECEIPT"
+                    },
+                    {
+                      "const": "NOT_TRUSTLOG_WRITE"
+                    },
+                    {
+                      "const": "NOT_OPERATION_COMMIT"
+                    }
+                  ],
+                  "items": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 6
+                },
+                "check_name": {
+                  "const": "reference_rehearsal_results_preserved"
+                },
+                "readiness_check_id": {
+                  "const": "live-adapter-dry-run-readiness-check:v1:6:reference-rehearsal-results-preserved"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "type": "object",
+              "required": [
+                "readiness_check_id",
+                "ordinal",
+                "check_name",
+                "check_mode",
+                "passed",
+                "evidence_ref",
+                "live_observation_used",
+                "network_used",
+                "filesystem_used",
+                "credential_accessed",
+                "adapter_instance_created",
+                "adapter_method_called",
+                "bind_invoked",
+                "bind_receipt_created",
+                "trustlog_written",
+                "external_effect_used",
+                "check_scope_limitations"
+              ],
+              "properties": {
+                "readiness_check_id": {
+                  "type": "string"
+                },
+                "ordinal": {
+                  "type": "integer"
+                },
+                "check_name": {
+                  "type": "string"
+                },
+                "check_mode": {
+                  "const": "deterministic_local_readiness_only"
+                },
+                "passed": {
+                  "const": true
+                },
+                "evidence_ref": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "live_observation_used": {
+                  "const": false
+                },
+                "network_used": {
+                  "const": false
+                },
+                "filesystem_used": {
+                  "const": false
+                },
+                "credential_accessed": {
+                  "const": false
+                },
+                "adapter_instance_created": {
+                  "const": false
+                },
+                "adapter_method_called": {
+                  "const": false
+                },
+                "bind_invoked": {
+                  "const": false
+                },
+                "bind_receipt_created": {
+                  "const": false
+                },
+                "trustlog_written": {
+                  "const": false
+                },
+                "external_effect_used": {
+                  "const": false
+                },
+                "check_scope_limitations": {
+                  "type": "array",
+                  "prefixItems": [
+                    {
+                      "const": "NOT_LIVE_ADAPTER_RESULT"
+                    },
+                    {
+                      "const": "NOT_LIVE_STATE"
+                    },
+                    {
+                      "const": "NOT_LIVE_AUTHORITY_REVALIDATION"
+                    },
+                    {
+                      "const": "NOT_LIVE_CONSTRAINT_REVALIDATION"
+                    },
+                    {
+                      "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+                    },
+                    {
+                      "const": "NOT_BIND_AUTHORIZATION"
+                    },
+                    {
+                      "const": "NOT_BIND_RECEIPT"
+                    },
+                    {
+                      "const": "NOT_TRUSTLOG_WRITE"
+                    },
+                    {
+                      "const": "NOT_OPERATION_COMMIT"
+                    }
+                  ],
+                  "items": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 7
+                },
+                "check_name": {
+                  "const": "no_live_adapter_already_called"
+                },
+                "readiness_check_id": {
+                  "const": "live-adapter-dry-run-readiness-check:v1:7:no-live-adapter-already-called"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "type": "object",
+              "required": [
+                "readiness_check_id",
+                "ordinal",
+                "check_name",
+                "check_mode",
+                "passed",
+                "evidence_ref",
+                "live_observation_used",
+                "network_used",
+                "filesystem_used",
+                "credential_accessed",
+                "adapter_instance_created",
+                "adapter_method_called",
+                "bind_invoked",
+                "bind_receipt_created",
+                "trustlog_written",
+                "external_effect_used",
+                "check_scope_limitations"
+              ],
+              "properties": {
+                "readiness_check_id": {
+                  "type": "string"
+                },
+                "ordinal": {
+                  "type": "integer"
+                },
+                "check_name": {
+                  "type": "string"
+                },
+                "check_mode": {
+                  "const": "deterministic_local_readiness_only"
+                },
+                "passed": {
+                  "const": true
+                },
+                "evidence_ref": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "live_observation_used": {
+                  "const": false
+                },
+                "network_used": {
+                  "const": false
+                },
+                "filesystem_used": {
+                  "const": false
+                },
+                "credential_accessed": {
+                  "const": false
+                },
+                "adapter_instance_created": {
+                  "const": false
+                },
+                "adapter_method_called": {
+                  "const": false
+                },
+                "bind_invoked": {
+                  "const": false
+                },
+                "bind_receipt_created": {
+                  "const": false
+                },
+                "trustlog_written": {
+                  "const": false
+                },
+                "external_effect_used": {
+                  "const": false
+                },
+                "check_scope_limitations": {
+                  "type": "array",
+                  "prefixItems": [
+                    {
+                      "const": "NOT_LIVE_ADAPTER_RESULT"
+                    },
+                    {
+                      "const": "NOT_LIVE_STATE"
+                    },
+                    {
+                      "const": "NOT_LIVE_AUTHORITY_REVALIDATION"
+                    },
+                    {
+                      "const": "NOT_LIVE_CONSTRAINT_REVALIDATION"
+                    },
+                    {
+                      "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+                    },
+                    {
+                      "const": "NOT_BIND_AUTHORIZATION"
+                    },
+                    {
+                      "const": "NOT_BIND_RECEIPT"
+                    },
+                    {
+                      "const": "NOT_TRUSTLOG_WRITE"
+                    },
+                    {
+                      "const": "NOT_OPERATION_COMMIT"
+                    }
+                  ],
+                  "items": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 8
+                },
+                "check_name": {
+                  "const": "no_webhook_already_called"
+                },
+                "readiness_check_id": {
+                  "const": "live-adapter-dry-run-readiness-check:v1:8:no-webhook-already-called"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "type": "object",
+              "required": [
+                "readiness_check_id",
+                "ordinal",
+                "check_name",
+                "check_mode",
+                "passed",
+                "evidence_ref",
+                "live_observation_used",
+                "network_used",
+                "filesystem_used",
+                "credential_accessed",
+                "adapter_instance_created",
+                "adapter_method_called",
+                "bind_invoked",
+                "bind_receipt_created",
+                "trustlog_written",
+                "external_effect_used",
+                "check_scope_limitations"
+              ],
+              "properties": {
+                "readiness_check_id": {
+                  "type": "string"
+                },
+                "ordinal": {
+                  "type": "integer"
+                },
+                "check_name": {
+                  "type": "string"
+                },
+                "check_mode": {
+                  "const": "deterministic_local_readiness_only"
+                },
+                "passed": {
+                  "const": true
+                },
+                "evidence_ref": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "live_observation_used": {
+                  "const": false
+                },
+                "network_used": {
+                  "const": false
+                },
+                "filesystem_used": {
+                  "const": false
+                },
+                "credential_accessed": {
+                  "const": false
+                },
+                "adapter_instance_created": {
+                  "const": false
+                },
+                "adapter_method_called": {
+                  "const": false
+                },
+                "bind_invoked": {
+                  "const": false
+                },
+                "bind_receipt_created": {
+                  "const": false
+                },
+                "trustlog_written": {
+                  "const": false
+                },
+                "external_effect_used": {
+                  "const": false
+                },
+                "check_scope_limitations": {
+                  "type": "array",
+                  "prefixItems": [
+                    {
+                      "const": "NOT_LIVE_ADAPTER_RESULT"
+                    },
+                    {
+                      "const": "NOT_LIVE_STATE"
+                    },
+                    {
+                      "const": "NOT_LIVE_AUTHORITY_REVALIDATION"
+                    },
+                    {
+                      "const": "NOT_LIVE_CONSTRAINT_REVALIDATION"
+                    },
+                    {
+                      "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+                    },
+                    {
+                      "const": "NOT_BIND_AUTHORIZATION"
+                    },
+                    {
+                      "const": "NOT_BIND_RECEIPT"
+                    },
+                    {
+                      "const": "NOT_TRUSTLOG_WRITE"
+                    },
+                    {
+                      "const": "NOT_OPERATION_COMMIT"
+                    }
+                  ],
+                  "items": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 9
+                },
+                "check_name": {
+                  "const": "no_bind_already_invoked"
+                },
+                "readiness_check_id": {
+                  "const": "live-adapter-dry-run-readiness-check:v1:9:no-bind-already-invoked"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "type": "object",
+              "required": [
+                "readiness_check_id",
+                "ordinal",
+                "check_name",
+                "check_mode",
+                "passed",
+                "evidence_ref",
+                "live_observation_used",
+                "network_used",
+                "filesystem_used",
+                "credential_accessed",
+                "adapter_instance_created",
+                "adapter_method_called",
+                "bind_invoked",
+                "bind_receipt_created",
+                "trustlog_written",
+                "external_effect_used",
+                "check_scope_limitations"
+              ],
+              "properties": {
+                "readiness_check_id": {
+                  "type": "string"
+                },
+                "ordinal": {
+                  "type": "integer"
+                },
+                "check_name": {
+                  "type": "string"
+                },
+                "check_mode": {
+                  "const": "deterministic_local_readiness_only"
+                },
+                "passed": {
+                  "const": true
+                },
+                "evidence_ref": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "live_observation_used": {
+                  "const": false
+                },
+                "network_used": {
+                  "const": false
+                },
+                "filesystem_used": {
+                  "const": false
+                },
+                "credential_accessed": {
+                  "const": false
+                },
+                "adapter_instance_created": {
+                  "const": false
+                },
+                "adapter_method_called": {
+                  "const": false
+                },
+                "bind_invoked": {
+                  "const": false
+                },
+                "bind_receipt_created": {
+                  "const": false
+                },
+                "trustlog_written": {
+                  "const": false
+                },
+                "external_effect_used": {
+                  "const": false
+                },
+                "check_scope_limitations": {
+                  "type": "array",
+                  "prefixItems": [
+                    {
+                      "const": "NOT_LIVE_ADAPTER_RESULT"
+                    },
+                    {
+                      "const": "NOT_LIVE_STATE"
+                    },
+                    {
+                      "const": "NOT_LIVE_AUTHORITY_REVALIDATION"
+                    },
+                    {
+                      "const": "NOT_LIVE_CONSTRAINT_REVALIDATION"
+                    },
+                    {
+                      "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+                    },
+                    {
+                      "const": "NOT_BIND_AUTHORIZATION"
+                    },
+                    {
+                      "const": "NOT_BIND_RECEIPT"
+                    },
+                    {
+                      "const": "NOT_TRUSTLOG_WRITE"
+                    },
+                    {
+                      "const": "NOT_OPERATION_COMMIT"
+                    }
+                  ],
+                  "items": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 10
+                },
+                "check_name": {
+                  "const": "no_bind_receipt_created"
+                },
+                "readiness_check_id": {
+                  "const": "live-adapter-dry-run-readiness-check:v1:10:no-bind-receipt-created"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "type": "object",
+              "required": [
+                "readiness_check_id",
+                "ordinal",
+                "check_name",
+                "check_mode",
+                "passed",
+                "evidence_ref",
+                "live_observation_used",
+                "network_used",
+                "filesystem_used",
+                "credential_accessed",
+                "adapter_instance_created",
+                "adapter_method_called",
+                "bind_invoked",
+                "bind_receipt_created",
+                "trustlog_written",
+                "external_effect_used",
+                "check_scope_limitations"
+              ],
+              "properties": {
+                "readiness_check_id": {
+                  "type": "string"
+                },
+                "ordinal": {
+                  "type": "integer"
+                },
+                "check_name": {
+                  "type": "string"
+                },
+                "check_mode": {
+                  "const": "deterministic_local_readiness_only"
+                },
+                "passed": {
+                  "const": true
+                },
+                "evidence_ref": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "live_observation_used": {
+                  "const": false
+                },
+                "network_used": {
+                  "const": false
+                },
+                "filesystem_used": {
+                  "const": false
+                },
+                "credential_accessed": {
+                  "const": false
+                },
+                "adapter_instance_created": {
+                  "const": false
+                },
+                "adapter_method_called": {
+                  "const": false
+                },
+                "bind_invoked": {
+                  "const": false
+                },
+                "bind_receipt_created": {
+                  "const": false
+                },
+                "trustlog_written": {
+                  "const": false
+                },
+                "external_effect_used": {
+                  "const": false
+                },
+                "check_scope_limitations": {
+                  "type": "array",
+                  "prefixItems": [
+                    {
+                      "const": "NOT_LIVE_ADAPTER_RESULT"
+                    },
+                    {
+                      "const": "NOT_LIVE_STATE"
+                    },
+                    {
+                      "const": "NOT_LIVE_AUTHORITY_REVALIDATION"
+                    },
+                    {
+                      "const": "NOT_LIVE_CONSTRAINT_REVALIDATION"
+                    },
+                    {
+                      "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+                    },
+                    {
+                      "const": "NOT_BIND_AUTHORIZATION"
+                    },
+                    {
+                      "const": "NOT_BIND_RECEIPT"
+                    },
+                    {
+                      "const": "NOT_TRUSTLOG_WRITE"
+                    },
+                    {
+                      "const": "NOT_OPERATION_COMMIT"
+                    }
+                  ],
+                  "items": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 11
+                },
+                "check_name": {
+                  "const": "no_trustlog_written"
+                },
+                "readiness_check_id": {
+                  "const": "live-adapter-dry-run-readiness-check:v1:11:no-trustlog-written"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "type": "object",
+              "required": [
+                "readiness_check_id",
+                "ordinal",
+                "check_name",
+                "check_mode",
+                "passed",
+                "evidence_ref",
+                "live_observation_used",
+                "network_used",
+                "filesystem_used",
+                "credential_accessed",
+                "adapter_instance_created",
+                "adapter_method_called",
+                "bind_invoked",
+                "bind_receipt_created",
+                "trustlog_written",
+                "external_effect_used",
+                "check_scope_limitations"
+              ],
+              "properties": {
+                "readiness_check_id": {
+                  "type": "string"
+                },
+                "ordinal": {
+                  "type": "integer"
+                },
+                "check_name": {
+                  "type": "string"
+                },
+                "check_mode": {
+                  "const": "deterministic_local_readiness_only"
+                },
+                "passed": {
+                  "const": true
+                },
+                "evidence_ref": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "live_observation_used": {
+                  "const": false
+                },
+                "network_used": {
+                  "const": false
+                },
+                "filesystem_used": {
+                  "const": false
+                },
+                "credential_accessed": {
+                  "const": false
+                },
+                "adapter_instance_created": {
+                  "const": false
+                },
+                "adapter_method_called": {
+                  "const": false
+                },
+                "bind_invoked": {
+                  "const": false
+                },
+                "bind_receipt_created": {
+                  "const": false
+                },
+                "trustlog_written": {
+                  "const": false
+                },
+                "external_effect_used": {
+                  "const": false
+                },
+                "check_scope_limitations": {
+                  "type": "array",
+                  "prefixItems": [
+                    {
+                      "const": "NOT_LIVE_ADAPTER_RESULT"
+                    },
+                    {
+                      "const": "NOT_LIVE_STATE"
+                    },
+                    {
+                      "const": "NOT_LIVE_AUTHORITY_REVALIDATION"
+                    },
+                    {
+                      "const": "NOT_LIVE_CONSTRAINT_REVALIDATION"
+                    },
+                    {
+                      "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+                    },
+                    {
+                      "const": "NOT_BIND_AUTHORIZATION"
+                    },
+                    {
+                      "const": "NOT_BIND_RECEIPT"
+                    },
+                    {
+                      "const": "NOT_TRUSTLOG_WRITE"
+                    },
+                    {
+                      "const": "NOT_OPERATION_COMMIT"
+                    }
+                  ],
+                  "items": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 12
+                },
+                "check_name": {
+                  "const": "no_external_effect_observed"
+                },
+                "readiness_check_id": {
+                  "const": "live-adapter-dry-run-readiness-check:v1:12:no-external-effect-observed"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "type": "object",
+              "required": [
+                "readiness_check_id",
+                "ordinal",
+                "check_name",
+                "check_mode",
+                "passed",
+                "evidence_ref",
+                "live_observation_used",
+                "network_used",
+                "filesystem_used",
+                "credential_accessed",
+                "adapter_instance_created",
+                "adapter_method_called",
+                "bind_invoked",
+                "bind_receipt_created",
+                "trustlog_written",
+                "external_effect_used",
+                "check_scope_limitations"
+              ],
+              "properties": {
+                "readiness_check_id": {
+                  "type": "string"
+                },
+                "ordinal": {
+                  "type": "integer"
+                },
+                "check_name": {
+                  "type": "string"
+                },
+                "check_mode": {
+                  "const": "deterministic_local_readiness_only"
+                },
+                "passed": {
+                  "const": true
+                },
+                "evidence_ref": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "live_observation_used": {
+                  "const": false
+                },
+                "network_used": {
+                  "const": false
+                },
+                "filesystem_used": {
+                  "const": false
+                },
+                "credential_accessed": {
+                  "const": false
+                },
+                "adapter_instance_created": {
+                  "const": false
+                },
+                "adapter_method_called": {
+                  "const": false
+                },
+                "bind_invoked": {
+                  "const": false
+                },
+                "bind_receipt_created": {
+                  "const": false
+                },
+                "trustlog_written": {
+                  "const": false
+                },
+                "external_effect_used": {
+                  "const": false
+                },
+                "check_scope_limitations": {
+                  "type": "array",
+                  "prefixItems": [
+                    {
+                      "const": "NOT_LIVE_ADAPTER_RESULT"
+                    },
+                    {
+                      "const": "NOT_LIVE_STATE"
+                    },
+                    {
+                      "const": "NOT_LIVE_AUTHORITY_REVALIDATION"
+                    },
+                    {
+                      "const": "NOT_LIVE_CONSTRAINT_REVALIDATION"
+                    },
+                    {
+                      "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+                    },
+                    {
+                      "const": "NOT_BIND_AUTHORIZATION"
+                    },
+                    {
+                      "const": "NOT_BIND_RECEIPT"
+                    },
+                    {
+                      "const": "NOT_TRUSTLOG_WRITE"
+                    },
+                    {
+                      "const": "NOT_OPERATION_COMMIT"
+                    }
+                  ],
+                  "items": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 13
+                },
+                "check_name": {
+                  "const": "live_dry_run_request_not_yet_created"
+                },
+                "readiness_check_id": {
+                  "const": "live-adapter-dry-run-readiness-check:v1:13:live-dry-run-request-not-yet-created"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "type": "object",
+              "required": [
+                "readiness_check_id",
+                "ordinal",
+                "check_name",
+                "check_mode",
+                "passed",
+                "evidence_ref",
+                "live_observation_used",
+                "network_used",
+                "filesystem_used",
+                "credential_accessed",
+                "adapter_instance_created",
+                "adapter_method_called",
+                "bind_invoked",
+                "bind_receipt_created",
+                "trustlog_written",
+                "external_effect_used",
+                "check_scope_limitations"
+              ],
+              "properties": {
+                "readiness_check_id": {
+                  "type": "string"
+                },
+                "ordinal": {
+                  "type": "integer"
+                },
+                "check_name": {
+                  "type": "string"
+                },
+                "check_mode": {
+                  "const": "deterministic_local_readiness_only"
+                },
+                "passed": {
+                  "const": true
+                },
+                "evidence_ref": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "live_observation_used": {
+                  "const": false
+                },
+                "network_used": {
+                  "const": false
+                },
+                "filesystem_used": {
+                  "const": false
+                },
+                "credential_accessed": {
+                  "const": false
+                },
+                "adapter_instance_created": {
+                  "const": false
+                },
+                "adapter_method_called": {
+                  "const": false
+                },
+                "bind_invoked": {
+                  "const": false
+                },
+                "bind_receipt_created": {
+                  "const": false
+                },
+                "trustlog_written": {
+                  "const": false
+                },
+                "external_effect_used": {
+                  "const": false
+                },
+                "check_scope_limitations": {
+                  "type": "array",
+                  "prefixItems": [
+                    {
+                      "const": "NOT_LIVE_ADAPTER_RESULT"
+                    },
+                    {
+                      "const": "NOT_LIVE_STATE"
+                    },
+                    {
+                      "const": "NOT_LIVE_AUTHORITY_REVALIDATION"
+                    },
+                    {
+                      "const": "NOT_LIVE_CONSTRAINT_REVALIDATION"
+                    },
+                    {
+                      "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+                    },
+                    {
+                      "const": "NOT_BIND_AUTHORIZATION"
+                    },
+                    {
+                      "const": "NOT_BIND_RECEIPT"
+                    },
+                    {
+                      "const": "NOT_TRUSTLOG_WRITE"
+                    },
+                    {
+                      "const": "NOT_OPERATION_COMMIT"
+                    }
+                  ],
+                  "items": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 14
+                },
+                "check_name": {
+                  "const": "apply_still_forbidden"
+                },
+                "readiness_check_id": {
+                  "const": "live-adapter-dry-run-readiness-check:v1:14:apply-still-forbidden"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "type": "object",
+              "required": [
+                "readiness_check_id",
+                "ordinal",
+                "check_name",
+                "check_mode",
+                "passed",
+                "evidence_ref",
+                "live_observation_used",
+                "network_used",
+                "filesystem_used",
+                "credential_accessed",
+                "adapter_instance_created",
+                "adapter_method_called",
+                "bind_invoked",
+                "bind_receipt_created",
+                "trustlog_written",
+                "external_effect_used",
+                "check_scope_limitations"
+              ],
+              "properties": {
+                "readiness_check_id": {
+                  "type": "string"
+                },
+                "ordinal": {
+                  "type": "integer"
+                },
+                "check_name": {
+                  "type": "string"
+                },
+                "check_mode": {
+                  "const": "deterministic_local_readiness_only"
+                },
+                "passed": {
+                  "const": true
+                },
+                "evidence_ref": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "live_observation_used": {
+                  "const": false
+                },
+                "network_used": {
+                  "const": false
+                },
+                "filesystem_used": {
+                  "const": false
+                },
+                "credential_accessed": {
+                  "const": false
+                },
+                "adapter_instance_created": {
+                  "const": false
+                },
+                "adapter_method_called": {
+                  "const": false
+                },
+                "bind_invoked": {
+                  "const": false
+                },
+                "bind_receipt_created": {
+                  "const": false
+                },
+                "trustlog_written": {
+                  "const": false
+                },
+                "external_effect_used": {
+                  "const": false
+                },
+                "check_scope_limitations": {
+                  "type": "array",
+                  "prefixItems": [
+                    {
+                      "const": "NOT_LIVE_ADAPTER_RESULT"
+                    },
+                    {
+                      "const": "NOT_LIVE_STATE"
+                    },
+                    {
+                      "const": "NOT_LIVE_AUTHORITY_REVALIDATION"
+                    },
+                    {
+                      "const": "NOT_LIVE_CONSTRAINT_REVALIDATION"
+                    },
+                    {
+                      "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+                    },
+                    {
+                      "const": "NOT_BIND_AUTHORIZATION"
+                    },
+                    {
+                      "const": "NOT_BIND_RECEIPT"
+                    },
+                    {
+                      "const": "NOT_TRUSTLOG_WRITE"
+                    },
+                    {
+                      "const": "NOT_OPERATION_COMMIT"
+                    }
+                  ],
+                  "items": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 15
+                },
+                "check_name": {
+                  "const": "postconditions_still_deferred"
+                },
+                "readiness_check_id": {
+                  "const": "live-adapter-dry-run-readiness-check:v1:15:postconditions-still-deferred"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "type": "object",
+              "required": [
+                "readiness_check_id",
+                "ordinal",
+                "check_name",
+                "check_mode",
+                "passed",
+                "evidence_ref",
+                "live_observation_used",
+                "network_used",
+                "filesystem_used",
+                "credential_accessed",
+                "adapter_instance_created",
+                "adapter_method_called",
+                "bind_invoked",
+                "bind_receipt_created",
+                "trustlog_written",
+                "external_effect_used",
+                "check_scope_limitations"
+              ],
+              "properties": {
+                "readiness_check_id": {
+                  "type": "string"
+                },
+                "ordinal": {
+                  "type": "integer"
+                },
+                "check_name": {
+                  "type": "string"
+                },
+                "check_mode": {
+                  "const": "deterministic_local_readiness_only"
+                },
+                "passed": {
+                  "const": true
+                },
+                "evidence_ref": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "live_observation_used": {
+                  "const": false
+                },
+                "network_used": {
+                  "const": false
+                },
+                "filesystem_used": {
+                  "const": false
+                },
+                "credential_accessed": {
+                  "const": false
+                },
+                "adapter_instance_created": {
+                  "const": false
+                },
+                "adapter_method_called": {
+                  "const": false
+                },
+                "bind_invoked": {
+                  "const": false
+                },
+                "bind_receipt_created": {
+                  "const": false
+                },
+                "trustlog_written": {
+                  "const": false
+                },
+                "external_effect_used": {
+                  "const": false
+                },
+                "check_scope_limitations": {
+                  "type": "array",
+                  "prefixItems": [
+                    {
+                      "const": "NOT_LIVE_ADAPTER_RESULT"
+                    },
+                    {
+                      "const": "NOT_LIVE_STATE"
+                    },
+                    {
+                      "const": "NOT_LIVE_AUTHORITY_REVALIDATION"
+                    },
+                    {
+                      "const": "NOT_LIVE_CONSTRAINT_REVALIDATION"
+                    },
+                    {
+                      "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+                    },
+                    {
+                      "const": "NOT_BIND_AUTHORIZATION"
+                    },
+                    {
+                      "const": "NOT_BIND_RECEIPT"
+                    },
+                    {
+                      "const": "NOT_TRUSTLOG_WRITE"
+                    },
+                    {
+                      "const": "NOT_OPERATION_COMMIT"
+                    }
+                  ],
+                  "items": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 16
+                },
+                "check_name": {
+                  "const": "rollback_still_deferred"
+                },
+                "readiness_check_id": {
+                  "const": "live-adapter-dry-run-readiness-check:v1:16:rollback-still-deferred"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "items": false
+    },
+    "readiness_check_digest": {
+      "type": "string"
+    },
+    "local_readiness_checks": {
+      "type": "object",
+      "required": [
+        "source_reference_rehearsal_verified",
+        "execution_intent_hash_verified",
+        "execution_intent_id_verified",
+        "adapter_descriptor_preserved",
+        "planned_steps_preserved",
+        "fixture_results_preserved",
+        "reference_rehearsal_results_preserved",
+        "planned_step_digest_verified",
+        "fixture_result_digest_verified",
+        "reference_rehearsal_result_digest_verified",
+        "readiness_checks_ordered",
+        "readiness_checks_digest_verified",
+        "evaluated_after_reference_rehearsal",
+        "no_live_adapter_instance",
+        "no_live_adapter_invocation",
+        "no_webhook_invocation",
+        "no_live_dry_run_request_created",
+        "no_bind_invocation",
+        "no_bind_receipt_created",
+        "no_trustlog_write",
+        "no_network",
+        "no_filesystem",
+        "no_credential_access",
+        "no_external_effect",
+        "no_apply",
+        "no_postcondition_verification",
+        "no_revert",
+        "semantic_match_not_authority"
+      ],
+      "properties": {
+        "source_reference_rehearsal_verified": {
+          "const": true
+        },
+        "execution_intent_hash_verified": {
+          "const": true
+        },
+        "execution_intent_id_verified": {
+          "const": true
+        },
+        "adapter_descriptor_preserved": {
+          "const": true
+        },
+        "planned_steps_preserved": {
+          "const": true
+        },
+        "fixture_results_preserved": {
+          "const": true
+        },
+        "reference_rehearsal_results_preserved": {
+          "const": true
+        },
+        "planned_step_digest_verified": {
+          "const": true
+        },
+        "fixture_result_digest_verified": {
+          "const": true
+        },
+        "reference_rehearsal_result_digest_verified": {
+          "const": true
+        },
+        "readiness_checks_ordered": {
+          "const": true
+        },
+        "readiness_checks_digest_verified": {
+          "const": true
+        },
+        "evaluated_after_reference_rehearsal": {
+          "const": true
+        },
+        "no_live_adapter_instance": {
+          "const": true
+        },
+        "no_live_adapter_invocation": {
+          "const": true
+        },
+        "no_webhook_invocation": {
+          "const": true
+        },
+        "no_live_dry_run_request_created": {
+          "const": true
+        },
+        "no_bind_invocation": {
+          "const": true
+        },
+        "no_bind_receipt_created": {
+          "const": true
+        },
+        "no_trustlog_write": {
+          "const": true
+        },
+        "no_network": {
+          "const": true
+        },
+        "no_filesystem": {
+          "const": true
+        },
+        "no_credential_access": {
+          "const": true
+        },
+        "no_external_effect": {
+          "const": true
+        },
+        "no_apply": {
+          "const": true
+        },
+        "no_postcondition_verification": {
+          "const": true
+        },
+        "no_revert": {
+          "const": true
+        },
+        "semantic_match_not_authority": {
+          "const": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "future_live_adapter_dry_run_request_packet_requirements": {
+      "type": "object",
+      "required": [
+        "explicit_live_dry_run_request_packet_required",
+        "live_adapter_descriptor_required",
+        "live_adapter_endpoint_allowlist_required",
+        "live_adapter_read_only_scope_required",
+        "live_adapter_credentials_review_required",
+        "live_adapter_timeout_required",
+        "live_adapter_rate_limit_required",
+        "live_adapter_idempotency_key_required",
+        "live_adapter_no_apply_policy_required",
+        "live_adapter_no_commit_policy_required",
+        "live_adapter_no_trustlog_write_before_policy_required",
+        "bind_receipt_still_deferred",
+        "human_approval_still_required_when_policy_requires",
+        "authority_evidence_still_required",
+        "apply_still_forbidden",
+        "verify_postconditions_still_deferred",
+        "rollback_or_revert_still_deferred"
+      ],
+      "properties": {
+        "explicit_live_dry_run_request_packet_required": {
+          "const": true
+        },
+        "live_adapter_descriptor_required": {
+          "const": true
+        },
+        "live_adapter_endpoint_allowlist_required": {
+          "const": true
+        },
+        "live_adapter_read_only_scope_required": {
+          "const": true
+        },
+        "live_adapter_credentials_review_required": {
+          "const": true
+        },
+        "live_adapter_timeout_required": {
+          "const": true
+        },
+        "live_adapter_rate_limit_required": {
+          "const": true
+        },
+        "live_adapter_idempotency_key_required": {
+          "const": true
+        },
+        "live_adapter_no_apply_policy_required": {
+          "const": true
+        },
+        "live_adapter_no_commit_policy_required": {
+          "const": true
+        },
+        "live_adapter_no_trustlog_write_before_policy_required": {
+          "const": true
+        },
+        "bind_receipt_still_deferred": {
+          "const": true
+        },
+        "human_approval_still_required_when_policy_requires": {
+          "const": true
+        },
+        "authority_evidence_still_required": {
+          "const": true
+        },
+        "apply_still_forbidden": {
+          "const": true
+        },
+        "verify_postconditions_still_deferred": {
+          "const": true
+        },
+        "rollback_or_revert_still_deferred": {
+          "const": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "source_to_execution_intent_mapping": {
+      "type": "object",
+      "patternProperties": {
+        "^.*$": {}
+      },
+      "additionalProperties": false
+    },
+    "field_mapping_proof": {
+      "type": "object",
+      "patternProperties": {
+        "^.*$": {}
+      },
+      "additionalProperties": false
+    },
+    "required_field_presence": {
+      "type": "object",
+      "patternProperties": {
+        "^.*$": {}
+      },
+      "additionalProperties": false
+    },
+    "source_decision_identity": {
+      "type": "object",
+      "patternProperties": {
+        "^.*$": {}
+      },
+      "additionalProperties": false
+    },
+    "candidate_identity": {
+      "type": "object",
+      "patternProperties": {
+        "^.*$": {}
+      },
+      "additionalProperties": false
+    },
+    "evidence_lineage": {
+      "type": "object",
+      "patternProperties": {
+        "^.*$": {}
+      },
+      "additionalProperties": false
+    },
+    "replay_summary": {
+      "type": "object",
+      "patternProperties": {
+        "^.*$": {}
+      },
+      "additionalProperties": false
+    },
+    "scope_limitations": {
+      "type": "array",
+      "prefixItems": [
+        {
+          "const": "NOT_EXECUTION_AUTHORITY"
+        },
+        {
+          "const": "NOT_BIND_AUTHORIZATION"
+        },
+        {
+          "const": "NOT_BIND_RECEIPT"
+        },
+        {
+          "const": "NOT_BIND_INVOCATION"
+        },
+        {
+          "const": "NOT_LIVE_ADAPTER_INSTANCE"
+        },
+        {
+          "const": "NOT_LIVE_ADAPTER_INVOCATION"
+        },
+        {
+          "const": "NOT_LIVE_ADAPTER_RESULT"
+        },
+        {
+          "const": "NOT_LIVE_DRY_RUN_REQUEST"
+        },
+        {
+          "const": "NOT_WEBHOOK_INVOCATION"
+        },
+        {
+          "const": "NOT_EXTERNAL_EFFECT"
+        },
+        {
+          "const": "NOT_OPERATION_COMMIT"
+        },
+        {
+          "const": "NOT_TRUSTLOG_WRITE"
+        },
+        {
+          "const": "NOT_LIVE_STATE_CHECK"
+        },
+        {
+          "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+        },
+        {
+          "const": "NOT_LIVE_AUTHORITY_REVALIDATION"
+        },
+        {
+          "const": "NOT_LIVE_CONSTRAINT_REVALIDATION"
+        },
+        {
+          "const": "NOT_POSTCONDITION_VERIFICATION"
+        },
+        {
+          "const": "NOT_ROLLBACK_PROOF"
+        },
+        {
+          "const": "NOT_AUTHORITY_EVIDENCE"
+        },
+        {
+          "const": "NOT_HUMAN_APPROVAL"
+        }
+      ],
+      "items": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/veritas_os/policy/live_adapter_dry_run_readiness.py
+++ b/veritas_os/policy/live_adapter_dry_run_readiness.py
@@ -1,0 +1,390 @@
+"""Deterministic readiness boundary before any live-adapter request.
+
+The helpers in this module only verify and copy a canonical reference rehearsal.
+They deliberately have no adapter, execution, persistence, or I/O capability.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from veritas_os.policy.adapter_dry_run_plan import STEPS_DOMAIN, _digest as source_digest
+from veritas_os.policy.adapter_dry_run_result import RESULTS_DOMAIN as FIXTURE_DOMAIN
+from veritas_os.policy.bind_artifacts import (
+    ExecutionIntent,
+    canonical_execution_intent_json,
+    hash_execution_intent,
+)
+from veritas_os.policy.reference_adapter_rehearsal import (
+    RESULTS_DOMAIN as REHEARSAL_DOMAIN,
+    CanonicalReferenceAdapterInMemoryRehearsalPacket,
+    ReferenceAdapterRehearsalError,
+    verify_reference_adapter_in_memory_rehearsal_packet,
+)
+
+FORMAT_VERSION = "canonical-live-adapter-dry-run-request-readiness/v1"
+READINESS_MECHANISM = (
+    "evaluate_live_adapter_dry_run_request_readiness_without_request/v1"
+)
+CHECKS_DOMAIN = "veritas.live-adapter-dry-run-readiness.checks/v1"
+LOCAL_CHECKS_DOMAIN = "veritas.live-adapter-dry-run-readiness.local-checks/v1"
+FUTURE_REQUIREMENTS_DOMAIN = (
+    "veritas.live-adapter-dry-run-readiness.future-requirements/v1"
+)
+PACKET_DOMAIN = "veritas.live-adapter-dry-run-readiness.packet/v1"
+
+CHECK_NAMES = (
+    "source_reference_rehearsal_verified",
+    "execution_intent_identity_verified",
+    "adapter_contract_descriptor_preserved",
+    "planned_steps_preserved",
+    "fixture_results_preserved",
+    "reference_rehearsal_results_preserved",
+    "no_live_adapter_already_called",
+    "no_webhook_already_called",
+    "no_bind_already_invoked",
+    "no_bind_receipt_created",
+    "no_trustlog_written",
+    "no_external_effect_observed",
+    "live_dry_run_request_not_yet_created",
+    "apply_still_forbidden",
+    "postconditions_still_deferred",
+    "rollback_still_deferred",
+)
+CHECK_LIMITATIONS = (
+    "NOT_LIVE_ADAPTER_RESULT",
+    "NOT_LIVE_STATE",
+    "NOT_LIVE_AUTHORITY_REVALIDATION",
+    "NOT_LIVE_CONSTRAINT_REVALIDATION",
+    "NOT_RUNTIME_RISK_ACCEPTANCE",
+    "NOT_BIND_AUTHORIZATION",
+    "NOT_BIND_RECEIPT",
+    "NOT_TRUSTLOG_WRITE",
+    "NOT_OPERATION_COMMIT",
+)
+LOCAL_READINESS_CHECKS = {
+    key: True
+    for key in (
+        "source_reference_rehearsal_verified", "execution_intent_hash_verified",
+        "execution_intent_id_verified", "adapter_descriptor_preserved",
+        "planned_steps_preserved", "fixture_results_preserved",
+        "reference_rehearsal_results_preserved", "planned_step_digest_verified",
+        "fixture_result_digest_verified", "reference_rehearsal_result_digest_verified",
+        "readiness_checks_ordered", "readiness_checks_digest_verified",
+        "evaluated_after_reference_rehearsal", "no_live_adapter_instance",
+        "no_live_adapter_invocation", "no_webhook_invocation",
+        "no_live_dry_run_request_created", "no_bind_invocation",
+        "no_bind_receipt_created", "no_trustlog_write", "no_network",
+        "no_filesystem", "no_credential_access", "no_external_effect", "no_apply",
+        "no_postcondition_verification", "no_revert", "semantic_match_not_authority",
+    )
+}
+FUTURE_REQUIREMENTS = {
+    key: True
+    for key in (
+        "explicit_live_dry_run_request_packet_required", "live_adapter_descriptor_required",
+        "live_adapter_endpoint_allowlist_required", "live_adapter_read_only_scope_required",
+        "live_adapter_credentials_review_required", "live_adapter_timeout_required",
+        "live_adapter_rate_limit_required", "live_adapter_idempotency_key_required",
+        "live_adapter_no_apply_policy_required", "live_adapter_no_commit_policy_required",
+        "live_adapter_no_trustlog_write_before_policy_required",
+        "bind_receipt_still_deferred", "human_approval_still_required_when_policy_requires",
+        "authority_evidence_still_required", "apply_still_forbidden",
+        "verify_postconditions_still_deferred", "rollback_or_revert_still_deferred",
+    )
+}
+SCOPE_LIMITATIONS = (
+    "NOT_EXECUTION_AUTHORITY", "NOT_BIND_AUTHORIZATION", "NOT_BIND_RECEIPT",
+    "NOT_BIND_INVOCATION", "NOT_LIVE_ADAPTER_INSTANCE", "NOT_LIVE_ADAPTER_INVOCATION",
+    "NOT_LIVE_ADAPTER_RESULT", "NOT_LIVE_DRY_RUN_REQUEST", "NOT_WEBHOOK_INVOCATION",
+    "NOT_EXTERNAL_EFFECT", "NOT_OPERATION_COMMIT", "NOT_TRUSTLOG_WRITE",
+    "NOT_LIVE_STATE_CHECK", "NOT_RUNTIME_RISK_ACCEPTANCE",
+    "NOT_LIVE_AUTHORITY_REVALIDATION", "NOT_LIVE_CONSTRAINT_REVALIDATION",
+    "NOT_POSTCONDITION_VERIFICATION", "NOT_ROLLBACK_PROOF", "NOT_AUTHORITY_EVIDENCE",
+    "NOT_HUMAN_APPROVAL",
+)
+SOURCE_SUMMARY_KEYS = (
+    "reference_rehearsal_id", "reference_rehearsal_hash", "format_version",
+    "rehearsal_mechanism", "rehearsed_at", "execution_intent_id",
+    "execution_intent_hash", "reference_rehearsal_status",
+    "ready_for_live_adapter_dry_run_request",
+)
+COPIED_FIELDS = (
+    "adapter_contract_descriptor", "adapter_contract_id", "adapter_contract_hash",
+    "adapter_contract_version", "execution_intent", "execution_intent_id",
+    "execution_intent_hash", "source_adapter_dry_run_fixture_result_hash",
+    "source_adapter_dry_run_plan_hash", "source_adapter_contract_selection_hash",
+    "source_bind_preflight_adjudication_hash", "source_formation_hash",
+    "source_readiness_hash", "source_eligibility_hash", "source_handoff_hash",
+    "trusted_validation_context_hash", "validation_result_hash", "mapping_value_digest",
+    "execution_intent_contract_version", "source_to_execution_intent_mapping",
+    "field_mapping_proof", "required_field_presence", "source_decision_identity",
+    "candidate_identity", "evidence_lineage", "replay_summary",
+)
+
+
+class LiveAdapterDryRunReadinessError(ValueError):
+    """Stable fail-closed refusal for readiness packet processing."""
+
+
+class LiveAdapterDryRunReadinessCheck(BaseModel):
+    """Immutable evidence descriptor for one local readiness assertion."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    readiness_check_id: str = Field(pattern=r"^live-adapter-dry-run-readiness-check:v1:[1-9][0-9]*:[a-z0-9-]+$")
+    ordinal: int = Field(ge=1, le=16)
+    check_name: Literal[*CHECK_NAMES]
+    check_mode: Literal["deterministic_local_readiness_only"]
+    passed: Literal[True]
+    evidence_ref: str = Field(min_length=1)
+    live_observation_used: Literal[False]
+    network_used: Literal[False]
+    filesystem_used: Literal[False]
+    credential_accessed: Literal[False]
+    adapter_instance_created: Literal[False]
+    adapter_method_called: Literal[False]
+    bind_invoked: Literal[False]
+    bind_receipt_created: Literal[False]
+    trustlog_written: Literal[False]
+    external_effect_used: Literal[False]
+    check_scope_limitations: tuple[str, ...]
+
+
+class CanonicalLiveAdapterDryRunRequestReadinessPacket(BaseModel):
+    """Strict immutable content-addressed readiness-only packet."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    format_version: Literal[FORMAT_VERSION]
+    live_adapter_dry_run_readiness_id: str = Field(pattern=r"^ladr:v1:sha256:[0-9a-f]{64}$")
+    live_adapter_dry_run_readiness_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    readiness_mechanism: Literal[READINESS_MECHANISM]
+    readiness_evaluated_at: str
+    source_reference_rehearsal: dict[str, Any]
+    source_reference_rehearsal_hash: str
+    source_reference_rehearsal_packet: dict[str, Any]
+    adapter_contract_descriptor: dict[str, Any]
+    adapter_contract_id: str
+    adapter_contract_hash: str
+    adapter_contract_version: str
+    execution_intent: dict[str, Any]
+    execution_intent_id: str
+    execution_intent_hash: str
+    source_adapter_dry_run_fixture_result_hash: str
+    source_adapter_dry_run_plan_hash: str
+    source_adapter_contract_selection_hash: str
+    source_bind_preflight_adjudication_hash: str
+    source_formation_hash: str
+    source_readiness_hash: str
+    source_eligibility_hash: str
+    source_handoff_hash: str
+    trusted_validation_context_hash: str
+    validation_result_hash: str
+    mapping_value_digest: str
+    execution_intent_contract_version: str
+    live_adapter_dry_run_request_readiness_status: Literal["LIVE_ADAPTER_DRY_RUN_REQUEST_READY_BUT_NOT_REQUESTED"]
+    ready_for_live_adapter_dry_run_request_packet: Literal[True]
+    fail_closed: Literal[False]
+    planned_steps: tuple[dict[str, Any], ...]
+    planned_step_digest: str
+    fixture_step_results: tuple[dict[str, Any], ...]
+    fixture_result_digest: str
+    reference_rehearsal_results: tuple[dict[str, Any], ...]
+    reference_rehearsal_result_digest: str
+    readiness_checks: tuple[LiveAdapterDryRunReadinessCheck, ...]
+    readiness_check_digest: str
+    local_readiness_checks: dict[str, bool]
+    future_live_adapter_dry_run_request_packet_requirements: dict[str, bool]
+    source_to_execution_intent_mapping: dict[str, Any]
+    field_mapping_proof: dict[str, Any]
+    required_field_presence: dict[str, str]
+    source_decision_identity: dict[str, Any]
+    candidate_identity: dict[str, Any]
+    evidence_lineage: dict[str, Any]
+    replay_summary: dict[str, Any]
+    scope_limitations: tuple[str, ...]
+
+
+def _json_value(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        value = value.model_dump(mode="python")
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        if value != value or value in (float("inf"), float("-inf")):
+            raise LiveAdapterDryRunReadinessError("LADR_PACKET_INVALID")
+        return value
+    if isinstance(value, datetime):
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise LiveAdapterDryRunReadinessError("LADR_EVALUATED_AT_INVALID")
+        return value.isoformat()
+    if isinstance(value, (list, tuple)):
+        return [_json_value(item) for item in value]
+    if isinstance(value, dict) and all(isinstance(key, str) for key in value):
+        return {key: _json_value(item) for key, item in value.items()}
+    raise LiveAdapterDryRunReadinessError("LADR_PACKET_INVALID")
+
+
+def _aware(value: Any, code: str) -> datetime:
+    try:
+        parsed = value if isinstance(value, datetime) else datetime.fromisoformat(value)
+    except (TypeError, ValueError) as exc:
+        raise LiveAdapterDryRunReadinessError(code) from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise LiveAdapterDryRunReadinessError(code)
+    return parsed
+
+
+def _digest(domain: str, value: Any) -> str:
+    encoded = json.dumps(
+        {"domain": domain, "value": _json_value(value)}, allow_nan=False,
+        ensure_ascii=False, separators=(",", ":"), sort_keys=True,
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _packet_hash(raw: dict[str, Any]) -> str:
+    return _digest(PACKET_DOMAIN, {key: value for key, value in raw.items() if key not in {"live_adapter_dry_run_readiness_id", "live_adapter_dry_run_readiness_hash"}})
+
+
+def _source(value: Any) -> CanonicalReferenceAdapterInMemoryRehearsalPacket:
+    try:
+        return verify_reference_adapter_in_memory_rehearsal_packet(value)
+    except (ReferenceAdapterRehearsalError, TypeError, ValueError) as exc:
+        raise LiveAdapterDryRunReadinessError("LADR_REFERENCE_REHEARSAL_INVALID") from exc
+
+
+def _intent(raw: dict[str, Any]) -> ExecutionIntent:
+    try:
+        intent = ExecutionIntent(**raw)
+        canonical_execution_intent_json(intent)
+    except (TypeError, ValueError) as exc:
+        raise LiveAdapterDryRunReadinessError("LADR_PACKET_INVALID") from exc
+    if intent.to_dict() != raw:
+        raise LiveAdapterDryRunReadinessError("LADR_PACKET_INVALID")
+    return intent
+
+
+def _checks(source_hash: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "readiness_check_id": f"live-adapter-dry-run-readiness-check:v1:{ordinal}:{name.replace('_', '-')}",
+            "ordinal": ordinal, "check_name": name,
+            "check_mode": "deterministic_local_readiness_only", "passed": True,
+            "evidence_ref": f"reference_rehearsal_hash:{source_hash}:{name}",
+            "live_observation_used": False, "network_used": False,
+            "filesystem_used": False, "credential_accessed": False,
+            "adapter_instance_created": False, "adapter_method_called": False,
+            "bind_invoked": False, "bind_receipt_created": False,
+            "trustlog_written": False, "external_effect_used": False,
+            "check_scope_limitations": CHECK_LIMITATIONS,
+        }
+        for ordinal, name in enumerate(CHECK_NAMES, 1)
+    ]
+
+
+def _validate_source(source: CanonicalReferenceAdapterInMemoryRehearsalPacket) -> ExecutionIntent:
+    intent = _intent(source.execution_intent)
+    if intent.execution_intent_id != source.execution_intent_id:
+        raise LiveAdapterDryRunReadinessError("LADR_EXECUTION_INTENT_ID_MISMATCH")
+    if hash_execution_intent(intent) != source.execution_intent_hash:
+        raise LiveAdapterDryRunReadinessError("LADR_EXECUTION_INTENT_HASH_MISMATCH")
+    descriptor = source.adapter_contract_descriptor
+    if descriptor.get("target_system") != intent.target_system or descriptor.get("target_resource_scope") != intent.target_resource:
+        raise LiveAdapterDryRunReadinessError("LADR_DESCRIPTOR_MISMATCH")
+    for result in source.reference_rehearsal_results:
+        if any((result.live_adapter_instance_created, result.live_adapter_method_called,
+                result.network_used, result.filesystem_used, result.external_effect_used,
+                result.bind_invoked, result.bind_receipt_created, result.trustlog_written)):
+            raise LiveAdapterDryRunReadinessError("LADR_EXTERNAL_EFFECT_FORBIDDEN")
+    return intent
+
+
+def build_live_adapter_dry_run_request_readiness_packet(
+    reference_rehearsal_packet: Any,
+    readiness_evaluated_at: datetime,
+) -> CanonicalLiveAdapterDryRunRequestReadinessPacket:
+    """Build readiness evidence while stopping before any live request."""
+    evaluated = _aware(readiness_evaluated_at, "LADR_EVALUATED_AT_INVALID")
+    source = _source(_json_value(reference_rehearsal_packet))
+    _validate_source(source)
+    if evaluated < _aware(source.rehearsed_at, "LADR_REFERENCE_REHEARSAL_INVALID"):
+        raise LiveAdapterDryRunReadinessError("LADR_EVALUATED_BEFORE_REHEARSAL")
+    source_raw = source.model_dump(mode="json")
+    steps = _json_value(source.planned_steps)
+    fixtures = _json_value(source.fixture_step_results)
+    results = _json_value(source.reference_rehearsal_results)
+    checks = _checks(source.reference_rehearsal_hash)
+    raw = {
+        "format_version": FORMAT_VERSION, "readiness_mechanism": READINESS_MECHANISM,
+        "readiness_evaluated_at": evaluated.isoformat(),
+        "source_reference_rehearsal": {key: source_raw[key] for key in SOURCE_SUMMARY_KEYS},
+        "source_reference_rehearsal_hash": source.reference_rehearsal_hash,
+        "source_reference_rehearsal_packet": source_raw,
+        **{key: source_raw[key] for key in COPIED_FIELDS},
+        "live_adapter_dry_run_request_readiness_status": "LIVE_ADAPTER_DRY_RUN_REQUEST_READY_BUT_NOT_REQUESTED",
+        "ready_for_live_adapter_dry_run_request_packet": True, "fail_closed": False,
+        "planned_steps": steps, "planned_step_digest": source.planned_step_digest,
+        "fixture_step_results": fixtures, "fixture_result_digest": source.fixture_result_digest,
+        "reference_rehearsal_results": results,
+        "reference_rehearsal_result_digest": source.reference_rehearsal_result_digest,
+        "readiness_checks": checks, "readiness_check_digest": _digest(CHECKS_DOMAIN, checks),
+        "local_readiness_checks": LOCAL_READINESS_CHECKS,
+        "future_live_adapter_dry_run_request_packet_requirements": FUTURE_REQUIREMENTS,
+        "scope_limitations": SCOPE_LIMITATIONS,
+    }
+    digest = _packet_hash(raw)
+    raw.update(live_adapter_dry_run_readiness_hash=digest,
+               live_adapter_dry_run_readiness_id=f"ladr:v1:sha256:{digest}")
+    return verify_live_adapter_dry_run_request_readiness_packet(raw)
+
+
+def verify_live_adapter_dry_run_request_readiness_packet(
+    packet: Any,
+) -> CanonicalLiveAdapterDryRunRequestReadinessPacket:
+    """Independently reverify every readiness and source binding."""
+    try:
+        value = packet.model_dump(mode="json") if isinstance(packet, BaseModel) else _json_value(packet)
+        candidate = CanonicalLiveAdapterDryRunRequestReadinessPacket.model_validate(value)
+    except (ValidationError, LiveAdapterDryRunReadinessError, TypeError) as exc:
+        raise LiveAdapterDryRunReadinessError("LADR_PACKET_INVALID") from exc
+    raw = candidate.model_dump(mode="json")
+    source = _source(candidate.source_reference_rehearsal_packet)
+    source_raw = source.model_dump(mode="json")
+    _validate_source(source)
+    if set(candidate.source_reference_rehearsal) != set(SOURCE_SUMMARY_KEYS) or candidate.source_reference_rehearsal != {key: source_raw[key] for key in SOURCE_SUMMARY_KEYS} or candidate.source_reference_rehearsal_hash != source.reference_rehearsal_hash:
+        raise LiveAdapterDryRunReadinessError("LADR_SOURCE_SUMMARY_MISMATCH")
+    if _aware(candidate.readiness_evaluated_at, "LADR_EVALUATED_AT_INVALID") < _aware(source.rehearsed_at, "LADR_REFERENCE_REHEARSAL_INVALID"):
+        raise LiveAdapterDryRunReadinessError("LADR_EVALUATED_BEFORE_REHEARSAL")
+    if any(_json_value(getattr(candidate, key)) != _json_value(getattr(source, key)) for key in COPIED_FIELDS):
+        raise LiveAdapterDryRunReadinessError("LADR_SOURCE_SUMMARY_MISMATCH")
+    steps, fixtures, results = (_json_value(source.planned_steps), _json_value(source.fixture_step_results), _json_value(source.reference_rehearsal_results))
+    if _json_value(candidate.planned_steps) != steps or candidate.planned_step_digest != source.planned_step_digest or candidate.planned_step_digest != source_digest(STEPS_DOMAIN, steps):
+        raise LiveAdapterDryRunReadinessError("LADR_PLANNED_STEPS_MISMATCH")
+    if _json_value(candidate.fixture_step_results) != fixtures or candidate.fixture_result_digest != source.fixture_result_digest or candidate.fixture_result_digest != _digest(FIXTURE_DOMAIN, fixtures):
+        raise LiveAdapterDryRunReadinessError("LADR_FIXTURE_RESULTS_MISMATCH")
+    if _json_value(candidate.reference_rehearsal_results) != results or candidate.reference_rehearsal_result_digest != source.reference_rehearsal_result_digest or candidate.reference_rehearsal_result_digest != _digest(REHEARSAL_DOMAIN, results):
+        raise LiveAdapterDryRunReadinessError("LADR_REFERENCE_REHEARSAL_RESULTS_MISMATCH")
+    checks = _json_value(_checks(source.reference_rehearsal_hash))
+    if _json_value(candidate.readiness_checks) != checks:
+        raise LiveAdapterDryRunReadinessError("LADR_READINESS_CHECKS_INVALID")
+    if candidate.readiness_check_digest != _digest(CHECKS_DOMAIN, checks):
+        raise LiveAdapterDryRunReadinessError("LADR_READINESS_CHECK_DIGEST_MISMATCH")
+    if candidate.local_readiness_checks != LOCAL_READINESS_CHECKS:
+        raise LiveAdapterDryRunReadinessError("LADR_LOCAL_CHECKS_MISMATCH")
+    if candidate.future_live_adapter_dry_run_request_packet_requirements != FUTURE_REQUIREMENTS:
+        raise LiveAdapterDryRunReadinessError("LADR_FUTURE_REQUIREMENTS_MISMATCH")
+    _digest(LOCAL_CHECKS_DOMAIN, candidate.local_readiness_checks)
+    _digest(FUTURE_REQUIREMENTS_DOMAIN, candidate.future_live_adapter_dry_run_request_packet_requirements)
+    if candidate.scope_limitations != SCOPE_LIMITATIONS:
+        raise LiveAdapterDryRunReadinessError("LADR_SCOPE_LIMITATIONS_MISSING")
+    digest = _packet_hash(raw)
+    if candidate.live_adapter_dry_run_readiness_hash != digest:
+        raise LiveAdapterDryRunReadinessError("LADR_PACKET_HASH_MISMATCH")
+    if candidate.live_adapter_dry_run_readiness_id != f"ladr:v1:sha256:{digest}":
+        raise LiveAdapterDryRunReadinessError("LADR_PACKET_ID_MISMATCH")
+    return candidate

--- a/veritas_os/tests/test_live_adapter_dry_run_readiness.py
+++ b/veritas_os/tests/test_live_adapter_dry_run_readiness.py
@@ -1,0 +1,244 @@
+"""Security and integrity tests for live-adapter request readiness v1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from copy import deepcopy
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator, RefResolver, ValidationError
+
+from veritas_os.policy.live_adapter_dry_run_readiness import (
+    CHECK_NAMES,
+    CHECKS_DOMAIN,
+    PACKET_DOMAIN,
+    LiveAdapterDryRunReadinessError,
+    _digest,
+    _packet_hash,
+    build_live_adapter_dry_run_request_readiness_packet,
+    verify_live_adapter_dry_run_request_readiness_packet,
+)
+from veritas_os.tests.test_reference_adapter_rehearsal import (
+    REHEARSED_AT,
+    _packet as rehearsal_packet,
+)
+
+EVALUATED_AT = REHEARSED_AT + timedelta(seconds=1)
+MODULE = Path("veritas_os/policy/live_adapter_dry_run_readiness.py")
+SCHEMA = Path("schemas/live-adapter-dry-run-readiness-v1.schema.json")
+
+
+def _packet(*, semantic_match: bool = True):
+    return build_live_adapter_dry_run_request_readiness_packet(
+        rehearsal_packet(semantic_match=semantic_match), EVALUATED_AT
+    )
+
+
+def _rehash(raw):
+    digest = _packet_hash(raw)
+    raw["live_adapter_dry_run_readiness_hash"] = digest
+    raw["live_adapter_dry_run_readiness_id"] = f"ladr:v1:sha256:{digest}"
+
+
+def test_build_and_verify_preserve_source_without_effects(monkeypatch) -> None:
+    import veritas_os.policy.live_adapter_dry_run_readiness as module
+
+    actual = module.verify_reference_adapter_in_memory_rehearsal_packet
+    calls = []
+
+    def recording(value):
+        calls.append(value)
+        return actual(value)
+
+    monkeypatch.setattr(
+        module, "verify_reference_adapter_in_memory_rehearsal_packet", recording
+    )
+    source = rehearsal_packet(semantic_match=False)
+    packet = module.build_live_adapter_dry_run_request_readiness_packet(
+        source, EVALUATED_AT
+    )
+    assert len(calls) == 2
+    assert module.verify_live_adapter_dry_run_request_readiness_packet(packet) == packet
+    assert len(calls) == 3
+    assert packet.live_adapter_dry_run_readiness_id == (
+        f"ladr:v1:sha256:{packet.live_adapter_dry_run_readiness_hash}"
+    )
+    assert packet.live_adapter_dry_run_readiness_hash == _packet_hash(
+        packet.model_dump(mode="json")
+    )
+    assert packet.source_reference_rehearsal_packet == source.model_dump(mode="json")
+    for field in (
+        "adapter_contract_descriptor", "execution_intent", "planned_steps",
+        "fixture_step_results", "reference_rehearsal_results",
+        "source_to_execution_intent_mapping", "field_mapping_proof",
+        "source_decision_identity", "candidate_identity", "evidence_lineage",
+        "replay_summary",
+    ):
+        assert packet.model_dump(mode="json")[field] == source.model_dump(mode="json")[
+            field
+        ]
+    assert packet.replay_summary["semantic_match"] is False
+    assert [check.check_name for check in packet.readiness_checks] == list(CHECK_NAMES)
+    assert packet.readiness_check_digest == _digest(
+        CHECKS_DOMAIN,
+        [check.model_dump(mode="json") for check in packet.readiness_checks],
+    )
+    for check in packet.readiness_checks:
+        assert not any(
+            (
+                check.live_observation_used, check.network_used,
+                check.filesystem_used, check.credential_accessed,
+                check.adapter_instance_created, check.adapter_method_called,
+                check.bind_invoked, check.bind_receipt_created,
+                check.trustlog_written, check.external_effect_used,
+            )
+        )
+
+
+@pytest.mark.parametrize("semantic_match", [True, False])
+def test_semantic_match_is_preserved(semantic_match) -> None:
+    packet = _packet(semantic_match=semantic_match)
+    assert packet.replay_summary["semantic_match"] is semantic_match
+    assert verify_live_adapter_dry_run_request_readiness_packet(packet) == packet
+
+
+def test_invalid_source_and_timeline_refuse() -> None:
+    source = rehearsal_packet().model_dump(mode="json")
+    source["reference_rehearsal_hash"] = "0" * 64
+    with pytest.raises(LiveAdapterDryRunReadinessError, match="LADR_REFERENCE"):
+        build_live_adapter_dry_run_request_readiness_packet(source, EVALUATED_AT)
+    with pytest.raises(LiveAdapterDryRunReadinessError, match="LADR_EVALUATED_AT"):
+        build_live_adapter_dry_run_request_readiness_packet(
+            rehearsal_packet(), EVALUATED_AT.replace(tzinfo=None)
+        )
+    with pytest.raises(LiveAdapterDryRunReadinessError, match="LADR_EVALUATED_BEFORE"):
+        build_live_adapter_dry_run_request_readiness_packet(
+            rehearsal_packet(), REHEARSED_AT - timedelta(seconds=1)
+        )
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "missing", "extra", "reordered", "name", "check_digest", "live",
+        "network", "filesystem", "credential", "effect", "adapter_instance",
+        "adapter_method", "bind", "receipt", "trustlog", "source", "intent",
+        "descriptor", "planned", "fixture", "result", "local", "future",
+        "scope", "hash", "id", "request_completed", "apply_performed",
+    ],
+)
+def test_tampering_is_refused_even_when_rehashed(mutation) -> None:
+    raw = _packet().model_dump(mode="json")
+    checks = raw["readiness_checks"]
+    if mutation == "missing":
+        checks.pop()
+    elif mutation == "extra":
+        checks.append(deepcopy(checks[-1]))
+    elif mutation == "reordered":
+        checks[0], checks[1] = checks[1], checks[0]
+    elif mutation == "name":
+        checks[0]["check_name"] = CHECK_NAMES[1]
+    elif mutation == "check_digest":
+        raw["readiness_check_digest"] = "0" * 64
+    elif mutation in {"live", "network", "filesystem", "credential", "effect",
+                      "adapter_instance", "adapter_method", "bind", "receipt", "trustlog"}:
+        key = {
+            "live": "live_observation_used", "credential": "credential_accessed",
+            "effect": "external_effect_used", "adapter_instance": "adapter_instance_created",
+            "adapter_method": "adapter_method_called", "bind": "bind_invoked",
+            "receipt": "bind_receipt_created", "trustlog": "trustlog_written",
+        }.get(mutation, f"{mutation}_used")
+        checks[0][key] = True
+    elif mutation == "source":
+        raw["source_reference_rehearsal_packet"]["reference_rehearsal_hash"] = "0" * 64
+    elif mutation == "intent":
+        raw["execution_intent"]["target_resource"] = "changed"
+    elif mutation == "descriptor":
+        raw["adapter_contract_descriptor"]["target_system"] = "changed"
+    elif mutation == "planned":
+        raw["planned_steps"][0]["expected_output_ref"] = "changed"
+    elif mutation == "fixture":
+        raw["fixture_step_results"][0]["fixture_input_ref"] = "changed"
+    elif mutation == "result":
+        raw["reference_rehearsal_results"][0]["matched_expected_output_ref"] = "changed"
+    elif mutation == "local":
+        raw["local_readiness_checks"]["no_network"] = False
+    elif mutation == "future":
+        raw["future_live_adapter_dry_run_request_packet_requirements"]["apply_still_forbidden"] = False
+    elif mutation == "scope":
+        raw["scope_limitations"].pop()
+    elif mutation == "hash":
+        raw["live_adapter_dry_run_readiness_hash"] = "0" * 64
+    elif mutation == "id":
+        raw["live_adapter_dry_run_readiness_id"] = "ladr:v1:sha256:" + "0" * 64
+    elif mutation == "request_completed":
+        raw["live_dry_run_request_completed"] = True
+    elif mutation == "apply_performed":
+        raw["apply_performed"] = True
+    if mutation not in {"hash", "id"}:
+        _rehash(raw)
+    with pytest.raises(LiveAdapterDryRunReadinessError):
+        verify_live_adapter_dry_run_request_readiness_packet(raw)
+
+
+def test_model_validation_bypasses_are_refused() -> None:
+    packet = _packet()
+    candidates = (
+        packet.model_copy(update={"live_adapter_dry_run_readiness_hash": "0" * 64}),
+        type(packet).model_construct(**{**packet.model_dump(mode="python"), "fail_closed": True}),
+    )
+    for candidate in candidates:
+        with pytest.raises(LiveAdapterDryRunReadinessError):
+            verify_live_adapter_dry_run_request_readiness_packet(candidate)
+
+
+def test_closed_schema_accepts_valid_and_rejects_invalid_packet() -> None:
+    schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+    store = {}
+    for path in Path("schemas").glob("*.json"):
+        document = json.loads(path.read_text(encoding="utf-8"))
+        if "$id" in document:
+            store[document["$id"]] = document
+        store[f"https://veritas-os.org/schemas/{path.name}"] = document
+        store[f"https://veritas-os.example/schemas/{path.name}"] = document
+    validator = Draft202012Validator(
+        schema,
+        resolver=RefResolver(SCHEMA.resolve().as_uri(), schema, store=store),
+    )
+    raw = _packet().model_dump(mode="json")
+    validator.validate(raw)
+    raw["unexpected"] = True
+    with pytest.raises(ValidationError):
+        validator.validate(raw)
+
+
+def test_static_execution_boundary() -> None:
+    tree = ast.parse(MODULE.read_text(encoding="utf-8"))
+    forbidden = {
+        "BindReceipt", "hash_bind_receipt", "append_bind_receipt_trustlog",
+        "append_execution_intent_trustlog", "build_execution_intent_trustlog_entry",
+        "execute_bind_boundary", "execute_bind_adjudication", "BindAdapterContract",
+        "BindBoundaryAdapter", "ReferenceBindAdapter", "WebhookBindAdapter", "requests",
+        "httpx", "subprocess", "socket", "uuid4", "now", "apply", "revert",
+        "verify_postconditions", "create_bind_receipt", "write_trustlog",
+        "append_trustlog", "call_live_adapter", "call_webhook", "request_live_dry_run",
+    }
+    imported = {
+        alias.name.split(".")[0]
+        for node in ast.walk(tree) if isinstance(node, (ast.Import, ast.ImportFrom))
+        for alias in node.names
+    }
+    called = {
+        node.func.attr if isinstance(node.func, ast.Attribute) else node.func.id
+        for node in ast.walk(tree) if isinstance(node, ast.Call)
+        and isinstance(node.func, (ast.Name, ast.Attribute))
+    }
+    defined = {
+        node.name for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    assert forbidden.isdisjoint(imported | called | defined)
+    assert PACKET_DOMAIN != CHECKS_DOMAIN


### PR DESCRIPTION
### Motivation

Add a deterministic, local, side-effect-free readiness boundary between the verified Canonical Reference Adapter In-Memory Rehearsal Packet and any future live adapter dry-run request.

This allows VERITAS to assess readiness for a future live adapter dry-run request without instantiating or calling live adapters, Webhook adapters, Bind, TrustLog, credential stores, or any external systems.

### Description

- Add `veritas_os/policy/live_adapter_dry_run_readiness.py` implementing `CanonicalLiveAdapterDryRunRequestReadinessPacket`, `LiveAdapterDryRunReadinessCheck`, the builder `build_live_adapter_dry_run_request_readiness_packet`, and the verifier `verify_live_adapter_dry_run_request_readiness_packet`.
- Re-run `verify_reference_adapter_in_memory_rehearsal_packet(...)` in the builder and again in the verifier against the full embedded source packet.
- Reconstruct and rehash the `ExecutionIntent` using `hash_execution_intent(...)`.
- Preserve ExecutionIntent identity/hash, adapter descriptor identity/hash/version, planned steps, fixture step results, reference rehearsal results, source identities, evidence lineage, field mapping proof, required field presence, and replay summary.
- Construct exactly sixteen ordered readiness checks under `deterministic_local_readiness_only` mode.
- Emit a content-addressed identity using `ladr:v1:sha256:<hash>`.
- Recompute all digests with dedicated check/local/future/packet domains.
- Preserve replay `semantic_match` exactly and do not convert semantic divergence into Authority Evidence, Human Approval, Bind authorization, or execution authority.
- Add closed JSON Schema `schemas/live-adapter-dry-run-readiness-v1.schema.json`.
- Add docs `docs/en/architecture/live-adapter-dry-run-readiness-v1.md`.
- Add focused tests `veritas_os/tests/test_live_adapter_dry_run_readiness.py` covering positive flows, refusal/tamper cases, typed-instance bypass, schema validation, and static import-boundary checks.

### Security / non-claims

- Live Adapter Dry-Run Request Readiness does not authorize execution.
- Live Adapter Dry-Run Request Readiness does not create a live adapter dry-run request.
- Live Adapter Dry-Run Request Readiness does not instantiate or call live adapters.
- Live Adapter Dry-Run Request Readiness does not call Webhook adapter.
- Live Adapter Dry-Run Request Readiness does not invoke Bind.
- Live Adapter Dry-Run Request Readiness does not create BindReceipt.
- Live Adapter Dry-Run Request Readiness does not write TrustLog.
- Live Adapter Dry-Run Request Readiness does not perform network, filesystem, credential, provider, webhook, subprocess, database, or external-system effects.
- Live Adapter Dry-Run Request Readiness does not call `apply`, `verify_postconditions`, or `revert`.
- Live Adapter Dry-Run Request Readiness does not perform live state verification, live authority revalidation, live constraint validation, or live runtime risk acceptance.
- Live Adapter Dry-Run Request Readiness does not satisfy Authority Evidence or Human Approval.
- Live Adapter Dry-Run Request Readiness does not turn replay `semantic_match` into authorization.

### Testing

- Latest head SHA: `c22db35da2b5d1b2c8db7b966514d848311dfd3f`.
- Local focused unit test: `pytest -q veritas_os/tests/test_live_adapter_dry_run_readiness.py` passed with 35 tests.
- `ruff` checks passed for changed files.
- `python -m py_compile veritas_os/policy/live_adapter_dry_run_readiness.py` passed.
- `python -m json.tool schemas/live-adapter-dry-run-readiness-v1.schema.json` passed.
- GitHub CI #5075 completed successfully for this head.
- `test (py3.11)`: success.
- `test (py3.12)`: success.
- `test-postgresql (py3.12)`: success.
- `test-slow (py3.12)`: success.
- `lint`: success.
- `dependency-audit`: success.
- `future-dependency-compat`: success.
- `[Tier 1] governance-backend-fast`: success.
- `[Tier 1] governance-smoke`: success.
- `frontend-lint`: success.
- `frontend-test`: success.
- `frontend-e2e`: success.
- `Security Gates`: success.
- `CodeQL (custom)`: success.
- `Runtime Proof Evidence`: success.
- `Runtime Pickle Guard (Required)`: success.
- `Reviewer Evidence Packet Validation`: success.

### Final invariant

Canonical Live Adapter Dry-Run Request Readiness v1 now evaluates a verified Canonical Reference Adapter In-Memory Rehearsal Packet for future live adapter dry-run request readiness without creating a live adapter request, without live adapter access, without Webhook adapter access, without invoking Bind, without creating a BindReceipt, without writing TrustLog, without network/filesystem/credential/external effects, and without converting replay `semantic_match` into Authority Evidence, Human Approval, or execution authority.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a831b2367148326837a8160ea027d36)