### PR TITLE
feat(bind): add live adapter dry-run request packet v1

### DIFF
--- a/docs/en/architecture/live-adapter-dry-run-request-v1.md
+++ b/docs/en/architecture/live-adapter-dry-run-request-v1.md
@@ -1,0 +1,43 @@
+# Canonical Live Adapter Dry-Run Request Packet v1
+
+## Boundary
+
+The packet is deterministic, content-addressed evidence that an already verified
+Live Adapter Dry-Run Request Readiness packet was transformed into pure request
+data. **It is not a dispatched request.** Readiness and request construction are
+distinct boundaries, and neither is live-adapter execution, Webhook invocation,
+Bind authorization, a BindReceipt, or a TrustLog write. Request construction is
+not Authority Evidence; `semantic_match` is not Human Approval.
+
+The implementation embeds no credentials, API tokens, authorization headers,
+provider secrets, or resolved endpoints. It performs no adapter construction,
+adapter method call, network, filesystem, credential-store, provider, database,
+subprocess, or external-effect operation. The descriptor remains dry-run-only,
+read-only, no-apply, no-commit, and non-mutating. Semantic divergence and
+`fields_changed` are preserved rather than promoted into an authorization gate.
+
+## Artifact sequence
+
+1. CDA
+2. Trust Link
+3. Replay Source/Evidence
+4. Replay Handoff Binding
+5. CanonicalDecisionHandoff validation
+6. Guarded Promotion Eligibility Packet
+7. ExecutionIntent Formation Readiness Packet
+8. Canonical ExecutionIntent Formation Packet
+9. ExecutionIntent Pre-Bind Validation Packet
+10. Canonical Bind Preflight Adjudication Packet
+11. Canonical Bind Adapter Contract Selection Packet
+12. Canonical Adapter Dry-Run Plan Packet
+13. Canonical Adapter Dry-Run Fixture Result Packet
+14. Canonical Reference Adapter In-Memory Rehearsal Packet
+15. Canonical Live Adapter Dry-Run Request Readiness Packet
+16. Canonical Live Adapter Dry-Run Request Packet
+17. **STOP**
+
+Actual dispatch readiness, endpoint allowlist resolution, credential resolution,
+a live adapter instance, Webhook adapter, network call, live result, Bind
+adjudication, BindReceipt creation, TrustLog write, apply, postconditions,
+rollback, and commit are intentionally deferred to future explicit changes.
+This artifact makes no production, customer, or regulatory certification claim.

--- a/schemas/live-adapter-dry-run-request-v1.schema.json
+++ b/schemas/live-adapter-dry-run-request-v1.schema.json
@@ -1,0 +1,2878 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://veritas-os.org/schemas/live-adapter-dry-run-request-v1.schema.json",
+  "title": "Canonical Live Adapter Dry-Run Request Packet v1",
+  "type": "object",
+  "required": [
+    "format_version",
+    "live_adapter_dry_run_request_id",
+    "live_adapter_dry_run_request_hash",
+    "request_mechanism",
+    "requested_at",
+    "source_live_adapter_dry_run_readiness",
+    "source_live_adapter_dry_run_readiness_hash",
+    "source_live_adapter_dry_run_readiness_packet",
+    "request_descriptor",
+    "adapter_contract_descriptor",
+    "adapter_contract_id",
+    "adapter_contract_hash",
+    "adapter_contract_version",
+    "execution_intent",
+    "execution_intent_id",
+    "execution_intent_hash",
+    "source_reference_rehearsal_hash",
+    "source_adapter_dry_run_fixture_result_hash",
+    "source_adapter_dry_run_plan_hash",
+    "source_adapter_contract_selection_hash",
+    "source_bind_preflight_adjudication_hash",
+    "source_formation_hash",
+    "source_readiness_hash",
+    "source_eligibility_hash",
+    "source_handoff_hash",
+    "trusted_validation_context_hash",
+    "validation_result_hash",
+    "mapping_value_digest",
+    "execution_intent_contract_version",
+    "live_adapter_dry_run_request_status",
+    "request_dispatch_state",
+    "ready_for_live_adapter_dry_run_dispatch_readiness",
+    "fail_closed",
+    "planned_steps",
+    "planned_step_digest",
+    "fixture_step_results",
+    "fixture_result_digest",
+    "reference_rehearsal_results",
+    "reference_rehearsal_result_digest",
+    "readiness_checks",
+    "readiness_check_digest",
+    "dispatch_preconditions",
+    "dispatch_precondition_digest",
+    "request_construction_checks",
+    "future_live_adapter_dry_run_dispatch_requirements",
+    "source_to_execution_intent_mapping",
+    "field_mapping_proof",
+    "required_field_presence",
+    "source_decision_identity",
+    "candidate_identity",
+    "evidence_lineage",
+    "replay_summary",
+    "scope_limitations"
+  ],
+  "properties": {
+    "format_version": {
+      "const": "canonical-live-adapter-dry-run-request/v1"
+    },
+    "live_adapter_dry_run_request_id": {
+      "type": "string",
+      "pattern": "^ladrq:v1:sha256:[0-9a-f]{64}$"
+    },
+    "live_adapter_dry_run_request_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "request_mechanism": {
+      "const": "construct_live_adapter_dry_run_request_without_dispatch/v1"
+    },
+    "requested_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "source_live_adapter_dry_run_readiness": {
+      "type": "object",
+      "required": [
+        "live_adapter_dry_run_readiness_id",
+        "live_adapter_dry_run_readiness_hash",
+        "format_version",
+        "readiness_mechanism",
+        "readiness_evaluated_at",
+        "execution_intent_id",
+        "execution_intent_hash",
+        "live_adapter_dry_run_request_readiness_status",
+        "ready_for_live_adapter_dry_run_request_packet"
+      ],
+      "properties": {
+        "live_adapter_dry_run_readiness_id": {
+          "$ref": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json#/properties/live_adapter_dry_run_readiness_id"
+        },
+        "live_adapter_dry_run_readiness_hash": {
+          "$ref": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json#/properties/live_adapter_dry_run_readiness_hash"
+        },
+        "format_version": {
+          "$ref": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json#/properties/format_version"
+        },
+        "readiness_mechanism": {
+          "$ref": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json#/properties/readiness_mechanism"
+        },
+        "readiness_evaluated_at": {
+          "$ref": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json#/properties/readiness_evaluated_at"
+        },
+        "execution_intent_id": {
+          "$ref": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json#/properties/execution_intent_id"
+        },
+        "execution_intent_hash": {
+          "$ref": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json#/properties/execution_intent_hash"
+        },
+        "live_adapter_dry_run_request_readiness_status": {
+          "$ref": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json#/properties/live_adapter_dry_run_request_readiness_status"
+        },
+        "ready_for_live_adapter_dry_run_request_packet": {
+          "$ref": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json#/properties/ready_for_live_adapter_dry_run_request_packet"
+        }
+      },
+      "additionalProperties": false
+    },
+    "source_live_adapter_dry_run_readiness_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "source_live_adapter_dry_run_readiness_packet": {
+      "$ref": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json"
+    },
+    "request_descriptor": {
+      "type": "object",
+      "required": [
+        "request_descriptor_id",
+        "request_kind",
+        "dispatch_mode",
+        "adapter_contract_id",
+        "adapter_contract_hash",
+        "adapter_contract_version",
+        "target_system",
+        "target_resource_scope",
+        "action_name",
+        "dry_run_only",
+        "read_only_scope_required",
+        "no_apply",
+        "no_commit",
+        "no_state_mutation",
+        "no_trustlog_write_before_policy",
+        "no_bind_receipt_before_bind",
+        "credential_material_included",
+        "credential_accessed",
+        "endpoint_material_included",
+        "endpoint_contacted",
+        "webhook_contacted",
+        "network_used",
+        "external_effect_used",
+        "descriptor_scope_limitations"
+      ],
+      "properties": {
+        "request_descriptor_id": {
+          "type": "string",
+          "pattern": "^live-adapter-dry-run-request-descriptor:v1:[a-z0-9-]+$"
+        },
+        "request_kind": {
+          "const": "live_adapter_dry_run"
+        },
+        "dispatch_mode": {
+          "const": "not_dispatched"
+        },
+        "adapter_contract_id": {
+          "type": "string"
+        },
+        "adapter_contract_hash": {
+          "type": "string"
+        },
+        "adapter_contract_version": {
+          "type": "string"
+        },
+        "target_system": {
+          "type": "string"
+        },
+        "target_resource_scope": {
+          "type": "string"
+        },
+        "action_name": {
+          "type": "string"
+        },
+        "dry_run_only": {
+          "const": true
+        },
+        "read_only_scope_required": {
+          "const": true
+        },
+        "no_apply": {
+          "const": true
+        },
+        "no_commit": {
+          "const": true
+        },
+        "no_state_mutation": {
+          "const": true
+        },
+        "no_trustlog_write_before_policy": {
+          "const": true
+        },
+        "no_bind_receipt_before_bind": {
+          "const": true
+        },
+        "credential_material_included": {
+          "const": false
+        },
+        "credential_accessed": {
+          "const": false
+        },
+        "endpoint_material_included": {
+          "const": false
+        },
+        "endpoint_contacted": {
+          "const": false
+        },
+        "webhook_contacted": {
+          "const": false
+        },
+        "network_used": {
+          "const": false
+        },
+        "external_effect_used": {
+          "const": false
+        },
+        "descriptor_scope_limitations": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "const": "NOT_DISPATCHED"
+            },
+            {
+              "const": "NOT_LIVE_ADAPTER_INVOCATION"
+            },
+            {
+              "const": "NOT_WEBHOOK_INVOCATION"
+            },
+            {
+              "const": "NOT_NETWORK_CALL"
+            },
+            {
+              "const": "NOT_CREDENTIAL_ACCESS"
+            },
+            {
+              "const": "NOT_LIVE_STATE"
+            },
+            {
+              "const": "NOT_BIND_AUTHORIZATION"
+            },
+            {
+              "const": "NOT_BIND_RECEIPT"
+            },
+            {
+              "const": "NOT_TRUSTLOG_WRITE"
+            },
+            {
+              "const": "NOT_OPERATION_COMMIT"
+            }
+          ],
+          "items": false,
+          "minItems": 10,
+          "maxItems": 10
+        }
+      },
+      "additionalProperties": false
+    },
+    "adapter_contract_descriptor": {
+      "$ref": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json#/properties/adapter_contract_descriptor"
+    },
+    "adapter_contract_id": {
+      "$ref": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json#/properties/adapter_contract_id"
+    },
+    "adapter_contract_hash": {
+      "$ref": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json#/properties/adapter_contract_hash"
+    },
+    "adapter_contract_version": {
+      "$ref": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json#/properties/adapter_contract_version"
+    },
+    "execution_intent": {
+      "$ref": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json#/properties/execution_intent"
+    },
+    "execution_intent_id": {
+      "$ref": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json#/properties/execution_intent_id"
+    },
+    "execution_intent_hash": {
+      "$ref": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json#/properties/execution_intent_hash"
+    },
+    "source_adapter_dry_run_fixture_result_hash": {
+      "$ref": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json#/properties/source_adapter_dry_run_fixture_result_hash"
+    },
+    "source_adapter_dry_run_plan_hash": {
+      "$ref": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json#/properties/source_adapter_dry_run_plan_hash"
+    },
+    "source_adapter_contract_selection_hash": {
+      "$ref": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json#/properties/source_adapter_contract_selection_hash"
+    },
+    "source_bind_preflight_adjudication_hash": {
+      "$ref": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json#/properties/source_bind_preflight_adjudication_hash"
+    },
+    "source_formation_hash": {
+      "$ref": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json#/properties/source_formation_hash"
+    },
+    "source_readiness_hash": {
+      "$ref": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json#/properties/source_readiness_hash"
+    },
+    "source_eligibility_hash": {
+      "$ref": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json#/properties/source_eligibility_hash"
+    },
+    "source_handoff_hash": {
+      "$ref": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json#/properties/source_handoff_hash"
+    },
+    "trusted_validation_context_hash": {
+      "$ref": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json#/properties/trusted_validation_context_hash"
+    },
+    "validation_result_hash": {
+      "$ref": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json#/properties/validation_result_hash"
+    },
+    "mapping_value_digest": {
+      "$ref": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json#/properties/mapping_value_digest"
+    },
+    "execution_intent_contract_version": {
+      "$ref": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json#/properties/execution_intent_contract_version"
+    },
+    "planned_steps": {
+      "$ref": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json#/properties/planned_steps"
+    },
+    "planned_step_digest": {
+      "$ref": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json#/properties/planned_step_digest"
+    },
+    "fixture_step_results": {
+      "$ref": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json#/properties/fixture_step_results"
+    },
+    "fixture_result_digest": {
+      "$ref": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json#/properties/fixture_result_digest"
+    },
+    "reference_rehearsal_results": {
+      "$ref": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json#/properties/reference_rehearsal_results"
+    },
+    "reference_rehearsal_result_digest": {
+      "$ref": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json#/properties/reference_rehearsal_result_digest"
+    },
+    "readiness_checks": {
+      "$ref": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json#/properties/readiness_checks"
+    },
+    "readiness_check_digest": {
+      "$ref": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json#/properties/readiness_check_digest"
+    },
+    "source_to_execution_intent_mapping": {
+      "$ref": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json#/properties/source_to_execution_intent_mapping"
+    },
+    "field_mapping_proof": {
+      "$ref": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json#/properties/field_mapping_proof"
+    },
+    "required_field_presence": {
+      "$ref": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json#/properties/required_field_presence"
+    },
+    "source_decision_identity": {
+      "$ref": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json#/properties/source_decision_identity"
+    },
+    "candidate_identity": {
+      "$ref": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json#/properties/candidate_identity"
+    },
+    "evidence_lineage": {
+      "$ref": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json#/properties/evidence_lineage"
+    },
+    "replay_summary": {
+      "$ref": "https://veritas-os.org/schemas/live-adapter-dry-run-readiness-v1.schema.json#/properties/replay_summary"
+    },
+    "source_reference_rehearsal_hash": {
+      "type": "string"
+    },
+    "live_adapter_dry_run_request_status": {
+      "const": "LIVE_ADAPTER_DRY_RUN_REQUEST_CREATED_NOT_DISPATCHED"
+    },
+    "request_dispatch_state": {
+      "const": "NOT_DISPATCHED"
+    },
+    "ready_for_live_adapter_dry_run_dispatch_readiness": {
+      "const": true
+    },
+    "fail_closed": {
+      "const": false
+    },
+    "dispatch_preconditions": {
+      "type": "array",
+      "prefixItems": [
+        {
+          "type": "object",
+          "required": [
+            "precondition_id",
+            "ordinal",
+            "precondition_name",
+            "precondition_mode",
+            "passed",
+            "evidence_ref",
+            "live_observation_used",
+            "network_used",
+            "filesystem_used",
+            "credential_accessed",
+            "adapter_instance_created",
+            "adapter_method_called",
+            "request_dispatched",
+            "webhook_called",
+            "bind_invoked",
+            "bind_receipt_created",
+            "trustlog_written",
+            "external_effect_used",
+            "precondition_scope_limitations"
+          ],
+          "properties": {
+            "live_observation_used": {
+              "const": false
+            },
+            "network_used": {
+              "const": false
+            },
+            "filesystem_used": {
+              "const": false
+            },
+            "credential_accessed": {
+              "const": false
+            },
+            "adapter_instance_created": {
+              "const": false
+            },
+            "adapter_method_called": {
+              "const": false
+            },
+            "request_dispatched": {
+              "const": false
+            },
+            "webhook_called": {
+              "const": false
+            },
+            "bind_invoked": {
+              "const": false
+            },
+            "bind_receipt_created": {
+              "const": false
+            },
+            "trustlog_written": {
+              "const": false
+            },
+            "external_effect_used": {
+              "const": false
+            },
+            "precondition_id": {
+              "type": "string",
+              "pattern": "^live-adapter-dry-run-dispatch-precondition:v1:1:[a-z0-9-]+$"
+            },
+            "ordinal": {
+              "const": 1
+            },
+            "precondition_name": {
+              "const": "readiness_packet_verified"
+            },
+            "precondition_mode": {
+              "const": "deterministic_local_request_construction_only"
+            },
+            "passed": {
+              "const": true
+            },
+            "evidence_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "precondition_scope_limitations": {
+              "type": "array",
+              "prefixItems": [
+                {
+                  "const": "NOT_DISPATCHED"
+                },
+                {
+                  "const": "NOT_LIVE_ADAPTER_RESULT"
+                },
+                {
+                  "const": "NOT_LIVE_STATE"
+                },
+                {
+                  "const": "NOT_LIVE_AUTHORITY_REVALIDATION"
+                },
+                {
+                  "const": "NOT_LIVE_CONSTRAINT_REVALIDATION"
+                },
+                {
+                  "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+                },
+                {
+                  "const": "NOT_BIND_AUTHORIZATION"
+                },
+                {
+                  "const": "NOT_BIND_RECEIPT"
+                },
+                {
+                  "const": "NOT_TRUSTLOG_WRITE"
+                },
+                {
+                  "const": "NOT_OPERATION_COMMIT"
+                }
+              ],
+              "items": false,
+              "minItems": 10,
+              "maxItems": 10
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "precondition_id",
+            "ordinal",
+            "precondition_name",
+            "precondition_mode",
+            "passed",
+            "evidence_ref",
+            "live_observation_used",
+            "network_used",
+            "filesystem_used",
+            "credential_accessed",
+            "adapter_instance_created",
+            "adapter_method_called",
+            "request_dispatched",
+            "webhook_called",
+            "bind_invoked",
+            "bind_receipt_created",
+            "trustlog_written",
+            "external_effect_used",
+            "precondition_scope_limitations"
+          ],
+          "properties": {
+            "live_observation_used": {
+              "const": false
+            },
+            "network_used": {
+              "const": false
+            },
+            "filesystem_used": {
+              "const": false
+            },
+            "credential_accessed": {
+              "const": false
+            },
+            "adapter_instance_created": {
+              "const": false
+            },
+            "adapter_method_called": {
+              "const": false
+            },
+            "request_dispatched": {
+              "const": false
+            },
+            "webhook_called": {
+              "const": false
+            },
+            "bind_invoked": {
+              "const": false
+            },
+            "bind_receipt_created": {
+              "const": false
+            },
+            "trustlog_written": {
+              "const": false
+            },
+            "external_effect_used": {
+              "const": false
+            },
+            "precondition_id": {
+              "type": "string",
+              "pattern": "^live-adapter-dry-run-dispatch-precondition:v1:2:[a-z0-9-]+$"
+            },
+            "ordinal": {
+              "const": 2
+            },
+            "precondition_name": {
+              "const": "execution_intent_identity_verified"
+            },
+            "precondition_mode": {
+              "const": "deterministic_local_request_construction_only"
+            },
+            "passed": {
+              "const": true
+            },
+            "evidence_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "precondition_scope_limitations": {
+              "type": "array",
+              "prefixItems": [
+                {
+                  "const": "NOT_DISPATCHED"
+                },
+                {
+                  "const": "NOT_LIVE_ADAPTER_RESULT"
+                },
+                {
+                  "const": "NOT_LIVE_STATE"
+                },
+                {
+                  "const": "NOT_LIVE_AUTHORITY_REVALIDATION"
+                },
+                {
+                  "const": "NOT_LIVE_CONSTRAINT_REVALIDATION"
+                },
+                {
+                  "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+                },
+                {
+                  "const": "NOT_BIND_AUTHORIZATION"
+                },
+                {
+                  "const": "NOT_BIND_RECEIPT"
+                },
+                {
+                  "const": "NOT_TRUSTLOG_WRITE"
+                },
+                {
+                  "const": "NOT_OPERATION_COMMIT"
+                }
+              ],
+              "items": false,
+              "minItems": 10,
+              "maxItems": 10
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "precondition_id",
+            "ordinal",
+            "precondition_name",
+            "precondition_mode",
+            "passed",
+            "evidence_ref",
+            "live_observation_used",
+            "network_used",
+            "filesystem_used",
+            "credential_accessed",
+            "adapter_instance_created",
+            "adapter_method_called",
+            "request_dispatched",
+            "webhook_called",
+            "bind_invoked",
+            "bind_receipt_created",
+            "trustlog_written",
+            "external_effect_used",
+            "precondition_scope_limitations"
+          ],
+          "properties": {
+            "live_observation_used": {
+              "const": false
+            },
+            "network_used": {
+              "const": false
+            },
+            "filesystem_used": {
+              "const": false
+            },
+            "credential_accessed": {
+              "const": false
+            },
+            "adapter_instance_created": {
+              "const": false
+            },
+            "adapter_method_called": {
+              "const": false
+            },
+            "request_dispatched": {
+              "const": false
+            },
+            "webhook_called": {
+              "const": false
+            },
+            "bind_invoked": {
+              "const": false
+            },
+            "bind_receipt_created": {
+              "const": false
+            },
+            "trustlog_written": {
+              "const": false
+            },
+            "external_effect_used": {
+              "const": false
+            },
+            "precondition_id": {
+              "type": "string",
+              "pattern": "^live-adapter-dry-run-dispatch-precondition:v1:3:[a-z0-9-]+$"
+            },
+            "ordinal": {
+              "const": 3
+            },
+            "precondition_name": {
+              "const": "adapter_descriptor_preserved"
+            },
+            "precondition_mode": {
+              "const": "deterministic_local_request_construction_only"
+            },
+            "passed": {
+              "const": true
+            },
+            "evidence_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "precondition_scope_limitations": {
+              "type": "array",
+              "prefixItems": [
+                {
+                  "const": "NOT_DISPATCHED"
+                },
+                {
+                  "const": "NOT_LIVE_ADAPTER_RESULT"
+                },
+                {
+                  "const": "NOT_LIVE_STATE"
+                },
+                {
+                  "const": "NOT_LIVE_AUTHORITY_REVALIDATION"
+                },
+                {
+                  "const": "NOT_LIVE_CONSTRAINT_REVALIDATION"
+                },
+                {
+                  "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+                },
+                {
+                  "const": "NOT_BIND_AUTHORIZATION"
+                },
+                {
+                  "const": "NOT_BIND_RECEIPT"
+                },
+                {
+                  "const": "NOT_TRUSTLOG_WRITE"
+                },
+                {
+                  "const": "NOT_OPERATION_COMMIT"
+                }
+              ],
+              "items": false,
+              "minItems": 10,
+              "maxItems": 10
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "precondition_id",
+            "ordinal",
+            "precondition_name",
+            "precondition_mode",
+            "passed",
+            "evidence_ref",
+            "live_observation_used",
+            "network_used",
+            "filesystem_used",
+            "credential_accessed",
+            "adapter_instance_created",
+            "adapter_method_called",
+            "request_dispatched",
+            "webhook_called",
+            "bind_invoked",
+            "bind_receipt_created",
+            "trustlog_written",
+            "external_effect_used",
+            "precondition_scope_limitations"
+          ],
+          "properties": {
+            "live_observation_used": {
+              "const": false
+            },
+            "network_used": {
+              "const": false
+            },
+            "filesystem_used": {
+              "const": false
+            },
+            "credential_accessed": {
+              "const": false
+            },
+            "adapter_instance_created": {
+              "const": false
+            },
+            "adapter_method_called": {
+              "const": false
+            },
+            "request_dispatched": {
+              "const": false
+            },
+            "webhook_called": {
+              "const": false
+            },
+            "bind_invoked": {
+              "const": false
+            },
+            "bind_receipt_created": {
+              "const": false
+            },
+            "trustlog_written": {
+              "const": false
+            },
+            "external_effect_used": {
+              "const": false
+            },
+            "precondition_id": {
+              "type": "string",
+              "pattern": "^live-adapter-dry-run-dispatch-precondition:v1:4:[a-z0-9-]+$"
+            },
+            "ordinal": {
+              "const": 4
+            },
+            "precondition_name": {
+              "const": "request_descriptor_constructed"
+            },
+            "precondition_mode": {
+              "const": "deterministic_local_request_construction_only"
+            },
+            "passed": {
+              "const": true
+            },
+            "evidence_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "precondition_scope_limitations": {
+              "type": "array",
+              "prefixItems": [
+                {
+                  "const": "NOT_DISPATCHED"
+                },
+                {
+                  "const": "NOT_LIVE_ADAPTER_RESULT"
+                },
+                {
+                  "const": "NOT_LIVE_STATE"
+                },
+                {
+                  "const": "NOT_LIVE_AUTHORITY_REVALIDATION"
+                },
+                {
+                  "const": "NOT_LIVE_CONSTRAINT_REVALIDATION"
+                },
+                {
+                  "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+                },
+                {
+                  "const": "NOT_BIND_AUTHORIZATION"
+                },
+                {
+                  "const": "NOT_BIND_RECEIPT"
+                },
+                {
+                  "const": "NOT_TRUSTLOG_WRITE"
+                },
+                {
+                  "const": "NOT_OPERATION_COMMIT"
+                }
+              ],
+              "items": false,
+              "minItems": 10,
+              "maxItems": 10
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "precondition_id",
+            "ordinal",
+            "precondition_name",
+            "precondition_mode",
+            "passed",
+            "evidence_ref",
+            "live_observation_used",
+            "network_used",
+            "filesystem_used",
+            "credential_accessed",
+            "adapter_instance_created",
+            "adapter_method_called",
+            "request_dispatched",
+            "webhook_called",
+            "bind_invoked",
+            "bind_receipt_created",
+            "trustlog_written",
+            "external_effect_used",
+            "precondition_scope_limitations"
+          ],
+          "properties": {
+            "live_observation_used": {
+              "const": false
+            },
+            "network_used": {
+              "const": false
+            },
+            "filesystem_used": {
+              "const": false
+            },
+            "credential_accessed": {
+              "const": false
+            },
+            "adapter_instance_created": {
+              "const": false
+            },
+            "adapter_method_called": {
+              "const": false
+            },
+            "request_dispatched": {
+              "const": false
+            },
+            "webhook_called": {
+              "const": false
+            },
+            "bind_invoked": {
+              "const": false
+            },
+            "bind_receipt_created": {
+              "const": false
+            },
+            "trustlog_written": {
+              "const": false
+            },
+            "external_effect_used": {
+              "const": false
+            },
+            "precondition_id": {
+              "type": "string",
+              "pattern": "^live-adapter-dry-run-dispatch-precondition:v1:5:[a-z0-9-]+$"
+            },
+            "ordinal": {
+              "const": 5
+            },
+            "precondition_name": {
+              "const": "dry_run_only_policy_declared"
+            },
+            "precondition_mode": {
+              "const": "deterministic_local_request_construction_only"
+            },
+            "passed": {
+              "const": true
+            },
+            "evidence_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "precondition_scope_limitations": {
+              "type": "array",
+              "prefixItems": [
+                {
+                  "const": "NOT_DISPATCHED"
+                },
+                {
+                  "const": "NOT_LIVE_ADAPTER_RESULT"
+                },
+                {
+                  "const": "NOT_LIVE_STATE"
+                },
+                {
+                  "const": "NOT_LIVE_AUTHORITY_REVALIDATION"
+                },
+                {
+                  "const": "NOT_LIVE_CONSTRAINT_REVALIDATION"
+                },
+                {
+                  "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+                },
+                {
+                  "const": "NOT_BIND_AUTHORIZATION"
+                },
+                {
+                  "const": "NOT_BIND_RECEIPT"
+                },
+                {
+                  "const": "NOT_TRUSTLOG_WRITE"
+                },
+                {
+                  "const": "NOT_OPERATION_COMMIT"
+                }
+              ],
+              "items": false,
+              "minItems": 10,
+              "maxItems": 10
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "precondition_id",
+            "ordinal",
+            "precondition_name",
+            "precondition_mode",
+            "passed",
+            "evidence_ref",
+            "live_observation_used",
+            "network_used",
+            "filesystem_used",
+            "credential_accessed",
+            "adapter_instance_created",
+            "adapter_method_called",
+            "request_dispatched",
+            "webhook_called",
+            "bind_invoked",
+            "bind_receipt_created",
+            "trustlog_written",
+            "external_effect_used",
+            "precondition_scope_limitations"
+          ],
+          "properties": {
+            "live_observation_used": {
+              "const": false
+            },
+            "network_used": {
+              "const": false
+            },
+            "filesystem_used": {
+              "const": false
+            },
+            "credential_accessed": {
+              "const": false
+            },
+            "adapter_instance_created": {
+              "const": false
+            },
+            "adapter_method_called": {
+              "const": false
+            },
+            "request_dispatched": {
+              "const": false
+            },
+            "webhook_called": {
+              "const": false
+            },
+            "bind_invoked": {
+              "const": false
+            },
+            "bind_receipt_created": {
+              "const": false
+            },
+            "trustlog_written": {
+              "const": false
+            },
+            "external_effect_used": {
+              "const": false
+            },
+            "precondition_id": {
+              "type": "string",
+              "pattern": "^live-adapter-dry-run-dispatch-precondition:v1:6:[a-z0-9-]+$"
+            },
+            "ordinal": {
+              "const": 6
+            },
+            "precondition_name": {
+              "const": "read_only_scope_declared"
+            },
+            "precondition_mode": {
+              "const": "deterministic_local_request_construction_only"
+            },
+            "passed": {
+              "const": true
+            },
+            "evidence_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "precondition_scope_limitations": {
+              "type": "array",
+              "prefixItems": [
+                {
+                  "const": "NOT_DISPATCHED"
+                },
+                {
+                  "const": "NOT_LIVE_ADAPTER_RESULT"
+                },
+                {
+                  "const": "NOT_LIVE_STATE"
+                },
+                {
+                  "const": "NOT_LIVE_AUTHORITY_REVALIDATION"
+                },
+                {
+                  "const": "NOT_LIVE_CONSTRAINT_REVALIDATION"
+                },
+                {
+                  "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+                },
+                {
+                  "const": "NOT_BIND_AUTHORIZATION"
+                },
+                {
+                  "const": "NOT_BIND_RECEIPT"
+                },
+                {
+                  "const": "NOT_TRUSTLOG_WRITE"
+                },
+                {
+                  "const": "NOT_OPERATION_COMMIT"
+                }
+              ],
+              "items": false,
+              "minItems": 10,
+              "maxItems": 10
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "precondition_id",
+            "ordinal",
+            "precondition_name",
+            "precondition_mode",
+            "passed",
+            "evidence_ref",
+            "live_observation_used",
+            "network_used",
+            "filesystem_used",
+            "credential_accessed",
+            "adapter_instance_created",
+            "adapter_method_called",
+            "request_dispatched",
+            "webhook_called",
+            "bind_invoked",
+            "bind_receipt_created",
+            "trustlog_written",
+            "external_effect_used",
+            "precondition_scope_limitations"
+          ],
+          "properties": {
+            "live_observation_used": {
+              "const": false
+            },
+            "network_used": {
+              "const": false
+            },
+            "filesystem_used": {
+              "const": false
+            },
+            "credential_accessed": {
+              "const": false
+            },
+            "adapter_instance_created": {
+              "const": false
+            },
+            "adapter_method_called": {
+              "const": false
+            },
+            "request_dispatched": {
+              "const": false
+            },
+            "webhook_called": {
+              "const": false
+            },
+            "bind_invoked": {
+              "const": false
+            },
+            "bind_receipt_created": {
+              "const": false
+            },
+            "trustlog_written": {
+              "const": false
+            },
+            "external_effect_used": {
+              "const": false
+            },
+            "precondition_id": {
+              "type": "string",
+              "pattern": "^live-adapter-dry-run-dispatch-precondition:v1:7:[a-z0-9-]+$"
+            },
+            "ordinal": {
+              "const": 7
+            },
+            "precondition_name": {
+              "const": "no_apply_policy_declared"
+            },
+            "precondition_mode": {
+              "const": "deterministic_local_request_construction_only"
+            },
+            "passed": {
+              "const": true
+            },
+            "evidence_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "precondition_scope_limitations": {
+              "type": "array",
+              "prefixItems": [
+                {
+                  "const": "NOT_DISPATCHED"
+                },
+                {
+                  "const": "NOT_LIVE_ADAPTER_RESULT"
+                },
+                {
+                  "const": "NOT_LIVE_STATE"
+                },
+                {
+                  "const": "NOT_LIVE_AUTHORITY_REVALIDATION"
+                },
+                {
+                  "const": "NOT_LIVE_CONSTRAINT_REVALIDATION"
+                },
+                {
+                  "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+                },
+                {
+                  "const": "NOT_BIND_AUTHORIZATION"
+                },
+                {
+                  "const": "NOT_BIND_RECEIPT"
+                },
+                {
+                  "const": "NOT_TRUSTLOG_WRITE"
+                },
+                {
+                  "const": "NOT_OPERATION_COMMIT"
+                }
+              ],
+              "items": false,
+              "minItems": 10,
+              "maxItems": 10
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "precondition_id",
+            "ordinal",
+            "precondition_name",
+            "precondition_mode",
+            "passed",
+            "evidence_ref",
+            "live_observation_used",
+            "network_used",
+            "filesystem_used",
+            "credential_accessed",
+            "adapter_instance_created",
+            "adapter_method_called",
+            "request_dispatched",
+            "webhook_called",
+            "bind_invoked",
+            "bind_receipt_created",
+            "trustlog_written",
+            "external_effect_used",
+            "precondition_scope_limitations"
+          ],
+          "properties": {
+            "live_observation_used": {
+              "const": false
+            },
+            "network_used": {
+              "const": false
+            },
+            "filesystem_used": {
+              "const": false
+            },
+            "credential_accessed": {
+              "const": false
+            },
+            "adapter_instance_created": {
+              "const": false
+            },
+            "adapter_method_called": {
+              "const": false
+            },
+            "request_dispatched": {
+              "const": false
+            },
+            "webhook_called": {
+              "const": false
+            },
+            "bind_invoked": {
+              "const": false
+            },
+            "bind_receipt_created": {
+              "const": false
+            },
+            "trustlog_written": {
+              "const": false
+            },
+            "external_effect_used": {
+              "const": false
+            },
+            "precondition_id": {
+              "type": "string",
+              "pattern": "^live-adapter-dry-run-dispatch-precondition:v1:8:[a-z0-9-]+$"
+            },
+            "ordinal": {
+              "const": 8
+            },
+            "precondition_name": {
+              "const": "no_commit_policy_declared"
+            },
+            "precondition_mode": {
+              "const": "deterministic_local_request_construction_only"
+            },
+            "passed": {
+              "const": true
+            },
+            "evidence_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "precondition_scope_limitations": {
+              "type": "array",
+              "prefixItems": [
+                {
+                  "const": "NOT_DISPATCHED"
+                },
+                {
+                  "const": "NOT_LIVE_ADAPTER_RESULT"
+                },
+                {
+                  "const": "NOT_LIVE_STATE"
+                },
+                {
+                  "const": "NOT_LIVE_AUTHORITY_REVALIDATION"
+                },
+                {
+                  "const": "NOT_LIVE_CONSTRAINT_REVALIDATION"
+                },
+                {
+                  "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+                },
+                {
+                  "const": "NOT_BIND_AUTHORIZATION"
+                },
+                {
+                  "const": "NOT_BIND_RECEIPT"
+                },
+                {
+                  "const": "NOT_TRUSTLOG_WRITE"
+                },
+                {
+                  "const": "NOT_OPERATION_COMMIT"
+                }
+              ],
+              "items": false,
+              "minItems": 10,
+              "maxItems": 10
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "precondition_id",
+            "ordinal",
+            "precondition_name",
+            "precondition_mode",
+            "passed",
+            "evidence_ref",
+            "live_observation_used",
+            "network_used",
+            "filesystem_used",
+            "credential_accessed",
+            "adapter_instance_created",
+            "adapter_method_called",
+            "request_dispatched",
+            "webhook_called",
+            "bind_invoked",
+            "bind_receipt_created",
+            "trustlog_written",
+            "external_effect_used",
+            "precondition_scope_limitations"
+          ],
+          "properties": {
+            "live_observation_used": {
+              "const": false
+            },
+            "network_used": {
+              "const": false
+            },
+            "filesystem_used": {
+              "const": false
+            },
+            "credential_accessed": {
+              "const": false
+            },
+            "adapter_instance_created": {
+              "const": false
+            },
+            "adapter_method_called": {
+              "const": false
+            },
+            "request_dispatched": {
+              "const": false
+            },
+            "webhook_called": {
+              "const": false
+            },
+            "bind_invoked": {
+              "const": false
+            },
+            "bind_receipt_created": {
+              "const": false
+            },
+            "trustlog_written": {
+              "const": false
+            },
+            "external_effect_used": {
+              "const": false
+            },
+            "precondition_id": {
+              "type": "string",
+              "pattern": "^live-adapter-dry-run-dispatch-precondition:v1:9:[a-z0-9-]+$"
+            },
+            "ordinal": {
+              "const": 9
+            },
+            "precondition_name": {
+              "const": "no_credential_material_embedded"
+            },
+            "precondition_mode": {
+              "const": "deterministic_local_request_construction_only"
+            },
+            "passed": {
+              "const": true
+            },
+            "evidence_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "precondition_scope_limitations": {
+              "type": "array",
+              "prefixItems": [
+                {
+                  "const": "NOT_DISPATCHED"
+                },
+                {
+                  "const": "NOT_LIVE_ADAPTER_RESULT"
+                },
+                {
+                  "const": "NOT_LIVE_STATE"
+                },
+                {
+                  "const": "NOT_LIVE_AUTHORITY_REVALIDATION"
+                },
+                {
+                  "const": "NOT_LIVE_CONSTRAINT_REVALIDATION"
+                },
+                {
+                  "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+                },
+                {
+                  "const": "NOT_BIND_AUTHORIZATION"
+                },
+                {
+                  "const": "NOT_BIND_RECEIPT"
+                },
+                {
+                  "const": "NOT_TRUSTLOG_WRITE"
+                },
+                {
+                  "const": "NOT_OPERATION_COMMIT"
+                }
+              ],
+              "items": false,
+              "minItems": 10,
+              "maxItems": 10
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "precondition_id",
+            "ordinal",
+            "precondition_name",
+            "precondition_mode",
+            "passed",
+            "evidence_ref",
+            "live_observation_used",
+            "network_used",
+            "filesystem_used",
+            "credential_accessed",
+            "adapter_instance_created",
+            "adapter_method_called",
+            "request_dispatched",
+            "webhook_called",
+            "bind_invoked",
+            "bind_receipt_created",
+            "trustlog_written",
+            "external_effect_used",
+            "precondition_scope_limitations"
+          ],
+          "properties": {
+            "live_observation_used": {
+              "const": false
+            },
+            "network_used": {
+              "const": false
+            },
+            "filesystem_used": {
+              "const": false
+            },
+            "credential_accessed": {
+              "const": false
+            },
+            "adapter_instance_created": {
+              "const": false
+            },
+            "adapter_method_called": {
+              "const": false
+            },
+            "request_dispatched": {
+              "const": false
+            },
+            "webhook_called": {
+              "const": false
+            },
+            "bind_invoked": {
+              "const": false
+            },
+            "bind_receipt_created": {
+              "const": false
+            },
+            "trustlog_written": {
+              "const": false
+            },
+            "external_effect_used": {
+              "const": false
+            },
+            "precondition_id": {
+              "type": "string",
+              "pattern": "^live-adapter-dry-run-dispatch-precondition:v1:10:[a-z0-9-]+$"
+            },
+            "ordinal": {
+              "const": 10
+            },
+            "precondition_name": {
+              "const": "no_endpoint_material_embedded"
+            },
+            "precondition_mode": {
+              "const": "deterministic_local_request_construction_only"
+            },
+            "passed": {
+              "const": true
+            },
+            "evidence_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "precondition_scope_limitations": {
+              "type": "array",
+              "prefixItems": [
+                {
+                  "const": "NOT_DISPATCHED"
+                },
+                {
+                  "const": "NOT_LIVE_ADAPTER_RESULT"
+                },
+                {
+                  "const": "NOT_LIVE_STATE"
+                },
+                {
+                  "const": "NOT_LIVE_AUTHORITY_REVALIDATION"
+                },
+                {
+                  "const": "NOT_LIVE_CONSTRAINT_REVALIDATION"
+                },
+                {
+                  "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+                },
+                {
+                  "const": "NOT_BIND_AUTHORIZATION"
+                },
+                {
+                  "const": "NOT_BIND_RECEIPT"
+                },
+                {
+                  "const": "NOT_TRUSTLOG_WRITE"
+                },
+                {
+                  "const": "NOT_OPERATION_COMMIT"
+                }
+              ],
+              "items": false,
+              "minItems": 10,
+              "maxItems": 10
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "precondition_id",
+            "ordinal",
+            "precondition_name",
+            "precondition_mode",
+            "passed",
+            "evidence_ref",
+            "live_observation_used",
+            "network_used",
+            "filesystem_used",
+            "credential_accessed",
+            "adapter_instance_created",
+            "adapter_method_called",
+            "request_dispatched",
+            "webhook_called",
+            "bind_invoked",
+            "bind_receipt_created",
+            "trustlog_written",
+            "external_effect_used",
+            "precondition_scope_limitations"
+          ],
+          "properties": {
+            "live_observation_used": {
+              "const": false
+            },
+            "network_used": {
+              "const": false
+            },
+            "filesystem_used": {
+              "const": false
+            },
+            "credential_accessed": {
+              "const": false
+            },
+            "adapter_instance_created": {
+              "const": false
+            },
+            "adapter_method_called": {
+              "const": false
+            },
+            "request_dispatched": {
+              "const": false
+            },
+            "webhook_called": {
+              "const": false
+            },
+            "bind_invoked": {
+              "const": false
+            },
+            "bind_receipt_created": {
+              "const": false
+            },
+            "trustlog_written": {
+              "const": false
+            },
+            "external_effect_used": {
+              "const": false
+            },
+            "precondition_id": {
+              "type": "string",
+              "pattern": "^live-adapter-dry-run-dispatch-precondition:v1:11:[a-z0-9-]+$"
+            },
+            "ordinal": {
+              "const": 11
+            },
+            "precondition_name": {
+              "const": "dispatch_not_performed"
+            },
+            "precondition_mode": {
+              "const": "deterministic_local_request_construction_only"
+            },
+            "passed": {
+              "const": true
+            },
+            "evidence_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "precondition_scope_limitations": {
+              "type": "array",
+              "prefixItems": [
+                {
+                  "const": "NOT_DISPATCHED"
+                },
+                {
+                  "const": "NOT_LIVE_ADAPTER_RESULT"
+                },
+                {
+                  "const": "NOT_LIVE_STATE"
+                },
+                {
+                  "const": "NOT_LIVE_AUTHORITY_REVALIDATION"
+                },
+                {
+                  "const": "NOT_LIVE_CONSTRAINT_REVALIDATION"
+                },
+                {
+                  "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+                },
+                {
+                  "const": "NOT_BIND_AUTHORIZATION"
+                },
+                {
+                  "const": "NOT_BIND_RECEIPT"
+                },
+                {
+                  "const": "NOT_TRUSTLOG_WRITE"
+                },
+                {
+                  "const": "NOT_OPERATION_COMMIT"
+                }
+              ],
+              "items": false,
+              "minItems": 10,
+              "maxItems": 10
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "precondition_id",
+            "ordinal",
+            "precondition_name",
+            "precondition_mode",
+            "passed",
+            "evidence_ref",
+            "live_observation_used",
+            "network_used",
+            "filesystem_used",
+            "credential_accessed",
+            "adapter_instance_created",
+            "adapter_method_called",
+            "request_dispatched",
+            "webhook_called",
+            "bind_invoked",
+            "bind_receipt_created",
+            "trustlog_written",
+            "external_effect_used",
+            "precondition_scope_limitations"
+          ],
+          "properties": {
+            "live_observation_used": {
+              "const": false
+            },
+            "network_used": {
+              "const": false
+            },
+            "filesystem_used": {
+              "const": false
+            },
+            "credential_accessed": {
+              "const": false
+            },
+            "adapter_instance_created": {
+              "const": false
+            },
+            "adapter_method_called": {
+              "const": false
+            },
+            "request_dispatched": {
+              "const": false
+            },
+            "webhook_called": {
+              "const": false
+            },
+            "bind_invoked": {
+              "const": false
+            },
+            "bind_receipt_created": {
+              "const": false
+            },
+            "trustlog_written": {
+              "const": false
+            },
+            "external_effect_used": {
+              "const": false
+            },
+            "precondition_id": {
+              "type": "string",
+              "pattern": "^live-adapter-dry-run-dispatch-precondition:v1:12:[a-z0-9-]+$"
+            },
+            "ordinal": {
+              "const": 12
+            },
+            "precondition_name": {
+              "const": "webhook_not_called"
+            },
+            "precondition_mode": {
+              "const": "deterministic_local_request_construction_only"
+            },
+            "passed": {
+              "const": true
+            },
+            "evidence_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "precondition_scope_limitations": {
+              "type": "array",
+              "prefixItems": [
+                {
+                  "const": "NOT_DISPATCHED"
+                },
+                {
+                  "const": "NOT_LIVE_ADAPTER_RESULT"
+                },
+                {
+                  "const": "NOT_LIVE_STATE"
+                },
+                {
+                  "const": "NOT_LIVE_AUTHORITY_REVALIDATION"
+                },
+                {
+                  "const": "NOT_LIVE_CONSTRAINT_REVALIDATION"
+                },
+                {
+                  "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+                },
+                {
+                  "const": "NOT_BIND_AUTHORIZATION"
+                },
+                {
+                  "const": "NOT_BIND_RECEIPT"
+                },
+                {
+                  "const": "NOT_TRUSTLOG_WRITE"
+                },
+                {
+                  "const": "NOT_OPERATION_COMMIT"
+                }
+              ],
+              "items": false,
+              "minItems": 10,
+              "maxItems": 10
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "precondition_id",
+            "ordinal",
+            "precondition_name",
+            "precondition_mode",
+            "passed",
+            "evidence_ref",
+            "live_observation_used",
+            "network_used",
+            "filesystem_used",
+            "credential_accessed",
+            "adapter_instance_created",
+            "adapter_method_called",
+            "request_dispatched",
+            "webhook_called",
+            "bind_invoked",
+            "bind_receipt_created",
+            "trustlog_written",
+            "external_effect_used",
+            "precondition_scope_limitations"
+          ],
+          "properties": {
+            "live_observation_used": {
+              "const": false
+            },
+            "network_used": {
+              "const": false
+            },
+            "filesystem_used": {
+              "const": false
+            },
+            "credential_accessed": {
+              "const": false
+            },
+            "adapter_instance_created": {
+              "const": false
+            },
+            "adapter_method_called": {
+              "const": false
+            },
+            "request_dispatched": {
+              "const": false
+            },
+            "webhook_called": {
+              "const": false
+            },
+            "bind_invoked": {
+              "const": false
+            },
+            "bind_receipt_created": {
+              "const": false
+            },
+            "trustlog_written": {
+              "const": false
+            },
+            "external_effect_used": {
+              "const": false
+            },
+            "precondition_id": {
+              "type": "string",
+              "pattern": "^live-adapter-dry-run-dispatch-precondition:v1:13:[a-z0-9-]+$"
+            },
+            "ordinal": {
+              "const": 13
+            },
+            "precondition_name": {
+              "const": "live_adapter_not_instantiated"
+            },
+            "precondition_mode": {
+              "const": "deterministic_local_request_construction_only"
+            },
+            "passed": {
+              "const": true
+            },
+            "evidence_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "precondition_scope_limitations": {
+              "type": "array",
+              "prefixItems": [
+                {
+                  "const": "NOT_DISPATCHED"
+                },
+                {
+                  "const": "NOT_LIVE_ADAPTER_RESULT"
+                },
+                {
+                  "const": "NOT_LIVE_STATE"
+                },
+                {
+                  "const": "NOT_LIVE_AUTHORITY_REVALIDATION"
+                },
+                {
+                  "const": "NOT_LIVE_CONSTRAINT_REVALIDATION"
+                },
+                {
+                  "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+                },
+                {
+                  "const": "NOT_BIND_AUTHORIZATION"
+                },
+                {
+                  "const": "NOT_BIND_RECEIPT"
+                },
+                {
+                  "const": "NOT_TRUSTLOG_WRITE"
+                },
+                {
+                  "const": "NOT_OPERATION_COMMIT"
+                }
+              ],
+              "items": false,
+              "minItems": 10,
+              "maxItems": 10
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "precondition_id",
+            "ordinal",
+            "precondition_name",
+            "precondition_mode",
+            "passed",
+            "evidence_ref",
+            "live_observation_used",
+            "network_used",
+            "filesystem_used",
+            "credential_accessed",
+            "adapter_instance_created",
+            "adapter_method_called",
+            "request_dispatched",
+            "webhook_called",
+            "bind_invoked",
+            "bind_receipt_created",
+            "trustlog_written",
+            "external_effect_used",
+            "precondition_scope_limitations"
+          ],
+          "properties": {
+            "live_observation_used": {
+              "const": false
+            },
+            "network_used": {
+              "const": false
+            },
+            "filesystem_used": {
+              "const": false
+            },
+            "credential_accessed": {
+              "const": false
+            },
+            "adapter_instance_created": {
+              "const": false
+            },
+            "adapter_method_called": {
+              "const": false
+            },
+            "request_dispatched": {
+              "const": false
+            },
+            "webhook_called": {
+              "const": false
+            },
+            "bind_invoked": {
+              "const": false
+            },
+            "bind_receipt_created": {
+              "const": false
+            },
+            "trustlog_written": {
+              "const": false
+            },
+            "external_effect_used": {
+              "const": false
+            },
+            "precondition_id": {
+              "type": "string",
+              "pattern": "^live-adapter-dry-run-dispatch-precondition:v1:14:[a-z0-9-]+$"
+            },
+            "ordinal": {
+              "const": 14
+            },
+            "precondition_name": {
+              "const": "bind_not_invoked"
+            },
+            "precondition_mode": {
+              "const": "deterministic_local_request_construction_only"
+            },
+            "passed": {
+              "const": true
+            },
+            "evidence_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "precondition_scope_limitations": {
+              "type": "array",
+              "prefixItems": [
+                {
+                  "const": "NOT_DISPATCHED"
+                },
+                {
+                  "const": "NOT_LIVE_ADAPTER_RESULT"
+                },
+                {
+                  "const": "NOT_LIVE_STATE"
+                },
+                {
+                  "const": "NOT_LIVE_AUTHORITY_REVALIDATION"
+                },
+                {
+                  "const": "NOT_LIVE_CONSTRAINT_REVALIDATION"
+                },
+                {
+                  "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+                },
+                {
+                  "const": "NOT_BIND_AUTHORIZATION"
+                },
+                {
+                  "const": "NOT_BIND_RECEIPT"
+                },
+                {
+                  "const": "NOT_TRUSTLOG_WRITE"
+                },
+                {
+                  "const": "NOT_OPERATION_COMMIT"
+                }
+              ],
+              "items": false,
+              "minItems": 10,
+              "maxItems": 10
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "precondition_id",
+            "ordinal",
+            "precondition_name",
+            "precondition_mode",
+            "passed",
+            "evidence_ref",
+            "live_observation_used",
+            "network_used",
+            "filesystem_used",
+            "credential_accessed",
+            "adapter_instance_created",
+            "adapter_method_called",
+            "request_dispatched",
+            "webhook_called",
+            "bind_invoked",
+            "bind_receipt_created",
+            "trustlog_written",
+            "external_effect_used",
+            "precondition_scope_limitations"
+          ],
+          "properties": {
+            "live_observation_used": {
+              "const": false
+            },
+            "network_used": {
+              "const": false
+            },
+            "filesystem_used": {
+              "const": false
+            },
+            "credential_accessed": {
+              "const": false
+            },
+            "adapter_instance_created": {
+              "const": false
+            },
+            "adapter_method_called": {
+              "const": false
+            },
+            "request_dispatched": {
+              "const": false
+            },
+            "webhook_called": {
+              "const": false
+            },
+            "bind_invoked": {
+              "const": false
+            },
+            "bind_receipt_created": {
+              "const": false
+            },
+            "trustlog_written": {
+              "const": false
+            },
+            "external_effect_used": {
+              "const": false
+            },
+            "precondition_id": {
+              "type": "string",
+              "pattern": "^live-adapter-dry-run-dispatch-precondition:v1:15:[a-z0-9-]+$"
+            },
+            "ordinal": {
+              "const": 15
+            },
+            "precondition_name": {
+              "const": "bind_receipt_not_created"
+            },
+            "precondition_mode": {
+              "const": "deterministic_local_request_construction_only"
+            },
+            "passed": {
+              "const": true
+            },
+            "evidence_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "precondition_scope_limitations": {
+              "type": "array",
+              "prefixItems": [
+                {
+                  "const": "NOT_DISPATCHED"
+                },
+                {
+                  "const": "NOT_LIVE_ADAPTER_RESULT"
+                },
+                {
+                  "const": "NOT_LIVE_STATE"
+                },
+                {
+                  "const": "NOT_LIVE_AUTHORITY_REVALIDATION"
+                },
+                {
+                  "const": "NOT_LIVE_CONSTRAINT_REVALIDATION"
+                },
+                {
+                  "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+                },
+                {
+                  "const": "NOT_BIND_AUTHORIZATION"
+                },
+                {
+                  "const": "NOT_BIND_RECEIPT"
+                },
+                {
+                  "const": "NOT_TRUSTLOG_WRITE"
+                },
+                {
+                  "const": "NOT_OPERATION_COMMIT"
+                }
+              ],
+              "items": false,
+              "minItems": 10,
+              "maxItems": 10
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "precondition_id",
+            "ordinal",
+            "precondition_name",
+            "precondition_mode",
+            "passed",
+            "evidence_ref",
+            "live_observation_used",
+            "network_used",
+            "filesystem_used",
+            "credential_accessed",
+            "adapter_instance_created",
+            "adapter_method_called",
+            "request_dispatched",
+            "webhook_called",
+            "bind_invoked",
+            "bind_receipt_created",
+            "trustlog_written",
+            "external_effect_used",
+            "precondition_scope_limitations"
+          ],
+          "properties": {
+            "live_observation_used": {
+              "const": false
+            },
+            "network_used": {
+              "const": false
+            },
+            "filesystem_used": {
+              "const": false
+            },
+            "credential_accessed": {
+              "const": false
+            },
+            "adapter_instance_created": {
+              "const": false
+            },
+            "adapter_method_called": {
+              "const": false
+            },
+            "request_dispatched": {
+              "const": false
+            },
+            "webhook_called": {
+              "const": false
+            },
+            "bind_invoked": {
+              "const": false
+            },
+            "bind_receipt_created": {
+              "const": false
+            },
+            "trustlog_written": {
+              "const": false
+            },
+            "external_effect_used": {
+              "const": false
+            },
+            "precondition_id": {
+              "type": "string",
+              "pattern": "^live-adapter-dry-run-dispatch-precondition:v1:16:[a-z0-9-]+$"
+            },
+            "ordinal": {
+              "const": 16
+            },
+            "precondition_name": {
+              "const": "trustlog_not_written"
+            },
+            "precondition_mode": {
+              "const": "deterministic_local_request_construction_only"
+            },
+            "passed": {
+              "const": true
+            },
+            "evidence_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "precondition_scope_limitations": {
+              "type": "array",
+              "prefixItems": [
+                {
+                  "const": "NOT_DISPATCHED"
+                },
+                {
+                  "const": "NOT_LIVE_ADAPTER_RESULT"
+                },
+                {
+                  "const": "NOT_LIVE_STATE"
+                },
+                {
+                  "const": "NOT_LIVE_AUTHORITY_REVALIDATION"
+                },
+                {
+                  "const": "NOT_LIVE_CONSTRAINT_REVALIDATION"
+                },
+                {
+                  "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+                },
+                {
+                  "const": "NOT_BIND_AUTHORIZATION"
+                },
+                {
+                  "const": "NOT_BIND_RECEIPT"
+                },
+                {
+                  "const": "NOT_TRUSTLOG_WRITE"
+                },
+                {
+                  "const": "NOT_OPERATION_COMMIT"
+                }
+              ],
+              "items": false,
+              "minItems": 10,
+              "maxItems": 10
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "precondition_id",
+            "ordinal",
+            "precondition_name",
+            "precondition_mode",
+            "passed",
+            "evidence_ref",
+            "live_observation_used",
+            "network_used",
+            "filesystem_used",
+            "credential_accessed",
+            "adapter_instance_created",
+            "adapter_method_called",
+            "request_dispatched",
+            "webhook_called",
+            "bind_invoked",
+            "bind_receipt_created",
+            "trustlog_written",
+            "external_effect_used",
+            "precondition_scope_limitations"
+          ],
+          "properties": {
+            "live_observation_used": {
+              "const": false
+            },
+            "network_used": {
+              "const": false
+            },
+            "filesystem_used": {
+              "const": false
+            },
+            "credential_accessed": {
+              "const": false
+            },
+            "adapter_instance_created": {
+              "const": false
+            },
+            "adapter_method_called": {
+              "const": false
+            },
+            "request_dispatched": {
+              "const": false
+            },
+            "webhook_called": {
+              "const": false
+            },
+            "bind_invoked": {
+              "const": false
+            },
+            "bind_receipt_created": {
+              "const": false
+            },
+            "trustlog_written": {
+              "const": false
+            },
+            "external_effect_used": {
+              "const": false
+            },
+            "precondition_id": {
+              "type": "string",
+              "pattern": "^live-adapter-dry-run-dispatch-precondition:v1:17:[a-z0-9-]+$"
+            },
+            "ordinal": {
+              "const": 17
+            },
+            "precondition_name": {
+              "const": "external_effect_not_used"
+            },
+            "precondition_mode": {
+              "const": "deterministic_local_request_construction_only"
+            },
+            "passed": {
+              "const": true
+            },
+            "evidence_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "precondition_scope_limitations": {
+              "type": "array",
+              "prefixItems": [
+                {
+                  "const": "NOT_DISPATCHED"
+                },
+                {
+                  "const": "NOT_LIVE_ADAPTER_RESULT"
+                },
+                {
+                  "const": "NOT_LIVE_STATE"
+                },
+                {
+                  "const": "NOT_LIVE_AUTHORITY_REVALIDATION"
+                },
+                {
+                  "const": "NOT_LIVE_CONSTRAINT_REVALIDATION"
+                },
+                {
+                  "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+                },
+                {
+                  "const": "NOT_BIND_AUTHORIZATION"
+                },
+                {
+                  "const": "NOT_BIND_RECEIPT"
+                },
+                {
+                  "const": "NOT_TRUSTLOG_WRITE"
+                },
+                {
+                  "const": "NOT_OPERATION_COMMIT"
+                }
+              ],
+              "items": false,
+              "minItems": 10,
+              "maxItems": 10
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "precondition_id",
+            "ordinal",
+            "precondition_name",
+            "precondition_mode",
+            "passed",
+            "evidence_ref",
+            "live_observation_used",
+            "network_used",
+            "filesystem_used",
+            "credential_accessed",
+            "adapter_instance_created",
+            "adapter_method_called",
+            "request_dispatched",
+            "webhook_called",
+            "bind_invoked",
+            "bind_receipt_created",
+            "trustlog_written",
+            "external_effect_used",
+            "precondition_scope_limitations"
+          ],
+          "properties": {
+            "live_observation_used": {
+              "const": false
+            },
+            "network_used": {
+              "const": false
+            },
+            "filesystem_used": {
+              "const": false
+            },
+            "credential_accessed": {
+              "const": false
+            },
+            "adapter_instance_created": {
+              "const": false
+            },
+            "adapter_method_called": {
+              "const": false
+            },
+            "request_dispatched": {
+              "const": false
+            },
+            "webhook_called": {
+              "const": false
+            },
+            "bind_invoked": {
+              "const": false
+            },
+            "bind_receipt_created": {
+              "const": false
+            },
+            "trustlog_written": {
+              "const": false
+            },
+            "external_effect_used": {
+              "const": false
+            },
+            "precondition_id": {
+              "type": "string",
+              "pattern": "^live-adapter-dry-run-dispatch-precondition:v1:18:[a-z0-9-]+$"
+            },
+            "ordinal": {
+              "const": 18
+            },
+            "precondition_name": {
+              "const": "future_dispatch_gate_required"
+            },
+            "precondition_mode": {
+              "const": "deterministic_local_request_construction_only"
+            },
+            "passed": {
+              "const": true
+            },
+            "evidence_ref": {
+              "type": "string",
+              "minLength": 1
+            },
+            "precondition_scope_limitations": {
+              "type": "array",
+              "prefixItems": [
+                {
+                  "const": "NOT_DISPATCHED"
+                },
+                {
+                  "const": "NOT_LIVE_ADAPTER_RESULT"
+                },
+                {
+                  "const": "NOT_LIVE_STATE"
+                },
+                {
+                  "const": "NOT_LIVE_AUTHORITY_REVALIDATION"
+                },
+                {
+                  "const": "NOT_LIVE_CONSTRAINT_REVALIDATION"
+                },
+                {
+                  "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+                },
+                {
+                  "const": "NOT_BIND_AUTHORIZATION"
+                },
+                {
+                  "const": "NOT_BIND_RECEIPT"
+                },
+                {
+                  "const": "NOT_TRUSTLOG_WRITE"
+                },
+                {
+                  "const": "NOT_OPERATION_COMMIT"
+                }
+              ],
+              "items": false,
+              "minItems": 10,
+              "maxItems": 10
+            }
+          },
+          "additionalProperties": false
+        }
+      ],
+      "items": false,
+      "minItems": 18,
+      "maxItems": 18
+    },
+    "dispatch_precondition_digest": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "request_construction_checks": {
+      "type": "object",
+      "required": [
+        "readiness_packet_verified",
+        "execution_intent_hash_verified",
+        "execution_intent_id_verified",
+        "adapter_descriptor_preserved",
+        "planned_steps_preserved",
+        "fixture_results_preserved",
+        "reference_rehearsal_results_preserved",
+        "readiness_checks_preserved",
+        "planned_step_digest_verified",
+        "fixture_result_digest_verified",
+        "reference_rehearsal_result_digest_verified",
+        "readiness_check_digest_verified",
+        "request_descriptor_constructed",
+        "dispatch_preconditions_ordered",
+        "dispatch_precondition_digest_verified",
+        "requested_after_readiness_evaluation",
+        "no_live_adapter_instance",
+        "no_live_adapter_invocation",
+        "no_webhook_invocation",
+        "no_live_dry_run_dispatch",
+        "no_bind_invocation",
+        "no_bind_receipt_created",
+        "no_trustlog_write",
+        "no_network",
+        "no_filesystem",
+        "no_credential_access",
+        "no_endpoint_contact",
+        "no_external_effect",
+        "no_apply",
+        "no_postcondition_verification",
+        "no_revert",
+        "semantic_match_not_authority"
+      ],
+      "properties": {
+        "readiness_packet_verified": {
+          "const": true
+        },
+        "execution_intent_hash_verified": {
+          "const": true
+        },
+        "execution_intent_id_verified": {
+          "const": true
+        },
+        "adapter_descriptor_preserved": {
+          "const": true
+        },
+        "planned_steps_preserved": {
+          "const": true
+        },
+        "fixture_results_preserved": {
+          "const": true
+        },
+        "reference_rehearsal_results_preserved": {
+          "const": true
+        },
+        "readiness_checks_preserved": {
+          "const": true
+        },
+        "planned_step_digest_verified": {
+          "const": true
+        },
+        "fixture_result_digest_verified": {
+          "const": true
+        },
+        "reference_rehearsal_result_digest_verified": {
+          "const": true
+        },
+        "readiness_check_digest_verified": {
+          "const": true
+        },
+        "request_descriptor_constructed": {
+          "const": true
+        },
+        "dispatch_preconditions_ordered": {
+          "const": true
+        },
+        "dispatch_precondition_digest_verified": {
+          "const": true
+        },
+        "requested_after_readiness_evaluation": {
+          "const": true
+        },
+        "no_live_adapter_instance": {
+          "const": true
+        },
+        "no_live_adapter_invocation": {
+          "const": true
+        },
+        "no_webhook_invocation": {
+          "const": true
+        },
+        "no_live_dry_run_dispatch": {
+          "const": true
+        },
+        "no_bind_invocation": {
+          "const": true
+        },
+        "no_bind_receipt_created": {
+          "const": true
+        },
+        "no_trustlog_write": {
+          "const": true
+        },
+        "no_network": {
+          "const": true
+        },
+        "no_filesystem": {
+          "const": true
+        },
+        "no_credential_access": {
+          "const": true
+        },
+        "no_endpoint_contact": {
+          "const": true
+        },
+        "no_external_effect": {
+          "const": true
+        },
+        "no_apply": {
+          "const": true
+        },
+        "no_postcondition_verification": {
+          "const": true
+        },
+        "no_revert": {
+          "const": true
+        },
+        "semantic_match_not_authority": {
+          "const": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "future_live_adapter_dry_run_dispatch_requirements": {
+      "type": "object",
+      "required": [
+        "dispatch_readiness_packet_required",
+        "endpoint_allowlist_resolution_required",
+        "credential_resolution_required",
+        "credential_scope_review_required",
+        "live_adapter_instance_policy_required",
+        "live_adapter_timeout_required",
+        "live_adapter_rate_limit_required",
+        "live_adapter_idempotency_key_required",
+        "dry_run_only_enforcement_required",
+        "no_apply_runtime_guard_required",
+        "no_commit_runtime_guard_required",
+        "network_egress_policy_required",
+        "webhook_dispatch_policy_required",
+        "live_result_packet_required",
+        "bind_receipt_still_deferred",
+        "human_approval_still_required_when_policy_requires",
+        "authority_evidence_still_required",
+        "apply_still_forbidden",
+        "verify_postconditions_still_deferred",
+        "rollback_or_revert_still_deferred"
+      ],
+      "properties": {
+        "dispatch_readiness_packet_required": {
+          "const": true
+        },
+        "endpoint_allowlist_resolution_required": {
+          "const": true
+        },
+        "credential_resolution_required": {
+          "const": true
+        },
+        "credential_scope_review_required": {
+          "const": true
+        },
+        "live_adapter_instance_policy_required": {
+          "const": true
+        },
+        "live_adapter_timeout_required": {
+          "const": true
+        },
+        "live_adapter_rate_limit_required": {
+          "const": true
+        },
+        "live_adapter_idempotency_key_required": {
+          "const": true
+        },
+        "dry_run_only_enforcement_required": {
+          "const": true
+        },
+        "no_apply_runtime_guard_required": {
+          "const": true
+        },
+        "no_commit_runtime_guard_required": {
+          "const": true
+        },
+        "network_egress_policy_required": {
+          "const": true
+        },
+        "webhook_dispatch_policy_required": {
+          "const": true
+        },
+        "live_result_packet_required": {
+          "const": true
+        },
+        "bind_receipt_still_deferred": {
+          "const": true
+        },
+        "human_approval_still_required_when_policy_requires": {
+          "const": true
+        },
+        "authority_evidence_still_required": {
+          "const": true
+        },
+        "apply_still_forbidden": {
+          "const": true
+        },
+        "verify_postconditions_still_deferred": {
+          "const": true
+        },
+        "rollback_or_revert_still_deferred": {
+          "const": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "scope_limitations": {
+      "type": "array",
+      "prefixItems": [
+        {
+          "const": "NOT_EXECUTION_AUTHORITY"
+        },
+        {
+          "const": "NOT_BIND_AUTHORIZATION"
+        },
+        {
+          "const": "NOT_BIND_RECEIPT"
+        },
+        {
+          "const": "NOT_BIND_INVOCATION"
+        },
+        {
+          "const": "NOT_LIVE_ADAPTER_INSTANCE"
+        },
+        {
+          "const": "NOT_LIVE_ADAPTER_INVOCATION"
+        },
+        {
+          "const": "NOT_LIVE_ADAPTER_RESULT"
+        },
+        {
+          "const": "NOT_LIVE_DRY_RUN_DISPATCH"
+        },
+        {
+          "const": "NOT_WEBHOOK_INVOCATION"
+        },
+        {
+          "const": "NOT_NETWORK_CALL"
+        },
+        {
+          "const": "NOT_CREDENTIAL_ACCESS"
+        },
+        {
+          "const": "NOT_EXTERNAL_EFFECT"
+        },
+        {
+          "const": "NOT_OPERATION_COMMIT"
+        },
+        {
+          "const": "NOT_TRUSTLOG_WRITE"
+        },
+        {
+          "const": "NOT_LIVE_STATE_CHECK"
+        },
+        {
+          "const": "NOT_RUNTIME_RISK_ACCEPTANCE"
+        },
+        {
+          "const": "NOT_LIVE_AUTHORITY_REVALIDATION"
+        },
+        {
+          "const": "NOT_LIVE_CONSTRAINT_REVALIDATION"
+        },
+        {
+          "const": "NOT_POSTCONDITION_VERIFICATION"
+        },
+        {
+          "const": "NOT_ROLLBACK_PROOF"
+        },
+        {
+          "const": "NOT_AUTHORITY_EVIDENCE"
+        },
+        {
+          "const": "NOT_HUMAN_APPROVAL"
+        }
+      ],
+      "items": false,
+      "minItems": 22,
+      "maxItems": 22
+    }
+  },
+  "additionalProperties": false
+}

--- a/veritas_os/policy/live_adapter_dry_run_request.py
+++ b/veritas_os/policy/live_adapter_dry_run_request.py
@@ -319,7 +319,14 @@ def _intent(raw: dict[str, Any]) -> ExecutionIntent:
     return intent
 
 
-def _descriptor(source: CanonicalLiveAdapterDryRunRequestReadinessPacket) -> dict[str, Any]:
+def _build_expected_request_descriptor(
+    source: CanonicalLiveAdapterDryRunRequestReadinessPacket,
+) -> dict[str, Any]:
+    """Return the canonical descriptor derived only from verified readiness.
+
+    Normalizing the complete descriptor here ensures the builder and verifier
+    compare the same JSON representation, including list-valued limitations.
+    """
     intent = _intent(source.execution_intent)
     slug = re.sub(r"[^a-z0-9]+", "-", source.adapter_contract_id.lower()).strip("-")
     raw = {
@@ -341,8 +348,9 @@ def _descriptor(source: CanonicalLiveAdapterDryRunRequestReadinessPacket) -> dic
         "external_effect_used": False,
         "descriptor_scope_limitations": DESCRIPTOR_LIMITATIONS,
     }
-    _digest(DESCRIPTOR_DOMAIN, raw)
-    return raw
+    canonical = _json_value(raw)
+    _digest(DESCRIPTOR_DOMAIN, canonical)
+    return canonical
 
 
 def _preconditions(source_hash: str) -> list[dict[str, Any]]:
@@ -396,7 +404,7 @@ def build_live_adapter_dry_run_request_packet(
         },
         "source_live_adapter_dry_run_readiness_hash": source.live_adapter_dry_run_readiness_hash,
         "source_live_adapter_dry_run_readiness_packet": source_raw,
-        "request_descriptor": _descriptor(source),
+        "request_descriptor": _build_expected_request_descriptor(source),
         "adapter_contract_descriptor": source_raw["adapter_contract_descriptor"],
         "adapter_contract_id": source.adapter_contract_id,
         "adapter_contract_hash": source.adapter_contract_hash,
@@ -466,7 +474,9 @@ def verify_live_adapter_dry_run_request_packet(
     if (hash_execution_intent(intent) != candidate.execution_intent_hash or
             candidate.execution_intent_hash != source.execution_intent_hash):
         raise LiveAdapterDryRunRequestError("LADRQ_EXECUTION_INTENT_HASH_MISMATCH")
-    if _json_value(candidate.request_descriptor) != _descriptor(source):
+    actual_descriptor = _json_value(candidate.request_descriptor)
+    expected_descriptor = _build_expected_request_descriptor(source)
+    if actual_descriptor != expected_descriptor:
         raise LiveAdapterDryRunRequestError("LADRQ_REQUEST_DESCRIPTOR_INVALID")
     for key in ("adapter_contract_descriptor", "adapter_contract_id",
                 "adapter_contract_hash", "adapter_contract_version", *COPIED_FIELDS):

--- a/veritas_os/policy/live_adapter_dry_run_request.py
+++ b/veritas_os/policy/live_adapter_dry_run_request.py
@@ -1,0 +1,510 @@
+"""Construct a deterministic live-adapter dry-run request without dispatch.
+
+This module is an intentionally local, pure-data boundary.  It verifies the
+readiness artifact and constructs content-addressed evidence for a *future*
+dispatch; it has no capability to instantiate or call an adapter.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from veritas_os.policy.adapter_dry_run_plan import STEPS_DOMAIN, _digest as source_digest
+from veritas_os.policy.adapter_dry_run_result import RESULTS_DOMAIN as FIXTURE_DOMAIN
+from veritas_os.policy.bind_artifacts import (
+    ExecutionIntent,
+    canonical_execution_intent_json,
+    hash_execution_intent,
+)
+from veritas_os.policy.live_adapter_dry_run_readiness import (
+    CHECKS_DOMAIN as READINESS_CHECKS_DOMAIN,
+    CanonicalLiveAdapterDryRunRequestReadinessPacket,
+    LiveAdapterDryRunReadinessError,
+    _digest as readiness_digest,
+    verify_live_adapter_dry_run_request_readiness_packet,
+)
+from veritas_os.policy.reference_adapter_rehearsal import (
+    RESULTS_DOMAIN as REHEARSAL_DOMAIN,
+)
+
+FORMAT_VERSION = "canonical-live-adapter-dry-run-request/v1"
+REQUEST_MECHANISM = "construct_live_adapter_dry_run_request_without_dispatch/v1"
+DESCRIPTOR_DOMAIN = "veritas.live-adapter-dry-run-request.descriptor/v1"
+DISPATCH_PRECONDITIONS_DOMAIN = (
+    "veritas.live-adapter-dry-run-request.dispatch-preconditions/v1"
+)
+CONSTRUCTION_CHECKS_DOMAIN = (
+    "veritas.live-adapter-dry-run-request.construction-checks/v1"
+)
+FUTURE_REQUIREMENTS_DOMAIN = (
+    "veritas.live-adapter-dry-run-request.future-requirements/v1"
+)
+PACKET_DOMAIN = "veritas.live-adapter-dry-run-request.packet/v1"
+
+PRECONDITION_NAMES = (
+    "readiness_packet_verified", "execution_intent_identity_verified",
+    "adapter_descriptor_preserved", "request_descriptor_constructed",
+    "dry_run_only_policy_declared", "read_only_scope_declared",
+    "no_apply_policy_declared", "no_commit_policy_declared",
+    "no_credential_material_embedded", "no_endpoint_material_embedded",
+    "dispatch_not_performed", "webhook_not_called",
+    "live_adapter_not_instantiated", "bind_not_invoked",
+    "bind_receipt_not_created", "trustlog_not_written",
+    "external_effect_not_used", "future_dispatch_gate_required",
+)
+PRECONDITION_LIMITATIONS = (
+    "NOT_DISPATCHED", "NOT_LIVE_ADAPTER_RESULT", "NOT_LIVE_STATE",
+    "NOT_LIVE_AUTHORITY_REVALIDATION", "NOT_LIVE_CONSTRAINT_REVALIDATION",
+    "NOT_RUNTIME_RISK_ACCEPTANCE", "NOT_BIND_AUTHORIZATION",
+    "NOT_BIND_RECEIPT", "NOT_TRUSTLOG_WRITE", "NOT_OPERATION_COMMIT",
+)
+DESCRIPTOR_LIMITATIONS = (
+    "NOT_DISPATCHED", "NOT_LIVE_ADAPTER_INVOCATION",
+    "NOT_WEBHOOK_INVOCATION", "NOT_NETWORK_CALL", "NOT_CREDENTIAL_ACCESS",
+    "NOT_LIVE_STATE", "NOT_BIND_AUTHORIZATION", "NOT_BIND_RECEIPT",
+    "NOT_TRUSTLOG_WRITE", "NOT_OPERATION_COMMIT",
+)
+SCOPE_LIMITATIONS = (
+    "NOT_EXECUTION_AUTHORITY", "NOT_BIND_AUTHORIZATION", "NOT_BIND_RECEIPT",
+    "NOT_BIND_INVOCATION", "NOT_LIVE_ADAPTER_INSTANCE",
+    "NOT_LIVE_ADAPTER_INVOCATION", "NOT_LIVE_ADAPTER_RESULT",
+    "NOT_LIVE_DRY_RUN_DISPATCH", "NOT_WEBHOOK_INVOCATION",
+    "NOT_NETWORK_CALL", "NOT_CREDENTIAL_ACCESS", "NOT_EXTERNAL_EFFECT",
+    "NOT_OPERATION_COMMIT", "NOT_TRUSTLOG_WRITE", "NOT_LIVE_STATE_CHECK",
+    "NOT_RUNTIME_RISK_ACCEPTANCE", "NOT_LIVE_AUTHORITY_REVALIDATION",
+    "NOT_LIVE_CONSTRAINT_REVALIDATION", "NOT_POSTCONDITION_VERIFICATION",
+    "NOT_ROLLBACK_PROOF", "NOT_AUTHORITY_EVIDENCE", "NOT_HUMAN_APPROVAL",
+)
+SOURCE_SUMMARY_KEYS = (
+    "live_adapter_dry_run_readiness_id", "live_adapter_dry_run_readiness_hash",
+    "format_version", "readiness_mechanism", "readiness_evaluated_at",
+    "execution_intent_id", "execution_intent_hash",
+    "live_adapter_dry_run_request_readiness_status",
+    "ready_for_live_adapter_dry_run_request_packet",
+)
+COPIED_FIELDS = (
+    "source_reference_rehearsal_hash",
+    "source_adapter_dry_run_fixture_result_hash", "source_adapter_dry_run_plan_hash",
+    "source_adapter_contract_selection_hash",
+    "source_bind_preflight_adjudication_hash", "source_formation_hash",
+    "source_readiness_hash", "source_eligibility_hash", "source_handoff_hash",
+    "trusted_validation_context_hash", "validation_result_hash",
+    "mapping_value_digest", "execution_intent_contract_version",
+    "source_to_execution_intent_mapping", "field_mapping_proof",
+    "required_field_presence", "source_decision_identity", "candidate_identity",
+    "evidence_lineage", "replay_summary",
+)
+CONSTRUCTION_CHECKS = {key: True for key in (
+    "readiness_packet_verified", "execution_intent_hash_verified",
+    "execution_intent_id_verified", "adapter_descriptor_preserved",
+    "planned_steps_preserved", "fixture_results_preserved",
+    "reference_rehearsal_results_preserved", "readiness_checks_preserved",
+    "planned_step_digest_verified", "fixture_result_digest_verified",
+    "reference_rehearsal_result_digest_verified", "readiness_check_digest_verified",
+    "request_descriptor_constructed", "dispatch_preconditions_ordered",
+    "dispatch_precondition_digest_verified", "requested_after_readiness_evaluation",
+    "no_live_adapter_instance", "no_live_adapter_invocation",
+    "no_webhook_invocation", "no_live_dry_run_dispatch", "no_bind_invocation",
+    "no_bind_receipt_created", "no_trustlog_write", "no_network",
+    "no_filesystem", "no_credential_access", "no_endpoint_contact",
+    "no_external_effect", "no_apply", "no_postcondition_verification",
+    "no_revert", "semantic_match_not_authority",
+)}
+FUTURE_REQUIREMENTS = {key: True for key in (
+    "dispatch_readiness_packet_required", "endpoint_allowlist_resolution_required",
+    "credential_resolution_required", "credential_scope_review_required",
+    "live_adapter_instance_policy_required", "live_adapter_timeout_required",
+    "live_adapter_rate_limit_required", "live_adapter_idempotency_key_required",
+    "dry_run_only_enforcement_required", "no_apply_runtime_guard_required",
+    "no_commit_runtime_guard_required", "network_egress_policy_required",
+    "webhook_dispatch_policy_required", "live_result_packet_required",
+    "bind_receipt_still_deferred", "human_approval_still_required_when_policy_requires",
+    "authority_evidence_still_required", "apply_still_forbidden",
+    "verify_postconditions_still_deferred", "rollback_or_revert_still_deferred",
+)}
+
+
+class LiveAdapterDryRunRequestError(ValueError):
+    """Stable fail-closed refusal for request packet processing."""
+
+
+class LiveAdapterDryRunRequestDescriptor(BaseModel):
+    """Immutable non-secret description of a future dry-run request."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    request_descriptor_id: str = Field(
+        pattern=r"^live-adapter-dry-run-request-descriptor:v1:[a-z0-9-]+$"
+    )
+    request_kind: Literal["live_adapter_dry_run"]
+    dispatch_mode: Literal["not_dispatched"]
+    adapter_contract_id: str
+    adapter_contract_hash: str
+    adapter_contract_version: str
+    target_system: str
+    target_resource_scope: str
+    action_name: str
+    dry_run_only: Literal[True]
+    read_only_scope_required: Literal[True]
+    no_apply: Literal[True]
+    no_commit: Literal[True]
+    no_state_mutation: Literal[True]
+    no_trustlog_write_before_policy: Literal[True]
+    no_bind_receipt_before_bind: Literal[True]
+    credential_material_included: Literal[False]
+    credential_accessed: Literal[False]
+    endpoint_material_included: Literal[False]
+    endpoint_contacted: Literal[False]
+    webhook_contacted: Literal[False]
+    network_used: Literal[False]
+    external_effect_used: Literal[False]
+    descriptor_scope_limitations: tuple[str, ...]
+
+
+class LiveAdapterDryRunDispatchPrecondition(BaseModel):
+    """Immutable local assertion that precedes any future dispatch gate."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    precondition_id: str = Field(
+        pattern=(
+            r"^live-adapter-dry-run-dispatch-precondition:v1:"
+            r"[1-9][0-9]*:[a-z0-9-]+$"
+        )
+    )
+    ordinal: int = Field(ge=1, le=18)
+    precondition_name: Literal[*PRECONDITION_NAMES]
+    precondition_mode: Literal["deterministic_local_request_construction_only"]
+    passed: Literal[True]
+    evidence_ref: str = Field(min_length=1)
+    live_observation_used: Literal[False]
+    network_used: Literal[False]
+    filesystem_used: Literal[False]
+    credential_accessed: Literal[False]
+    adapter_instance_created: Literal[False]
+    adapter_method_called: Literal[False]
+    request_dispatched: Literal[False]
+    webhook_called: Literal[False]
+    bind_invoked: Literal[False]
+    bind_receipt_created: Literal[False]
+    trustlog_written: Literal[False]
+    external_effect_used: Literal[False]
+    precondition_scope_limitations: tuple[str, ...]
+
+
+class CanonicalLiveAdapterDryRunRequestPacket(BaseModel):
+    """Strict immutable content-addressed, non-dispatched request packet."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    format_version: Literal[FORMAT_VERSION]
+    live_adapter_dry_run_request_id: str = Field(pattern=r"^ladrq:v1:sha256:[0-9a-f]{64}$")
+    live_adapter_dry_run_request_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    request_mechanism: Literal[REQUEST_MECHANISM]
+    requested_at: str
+    source_live_adapter_dry_run_readiness: dict[str, Any]
+    source_live_adapter_dry_run_readiness_hash: str
+    source_live_adapter_dry_run_readiness_packet: dict[str, Any]
+    request_descriptor: LiveAdapterDryRunRequestDescriptor
+    adapter_contract_descriptor: dict[str, Any]
+    adapter_contract_id: str
+    adapter_contract_hash: str
+    adapter_contract_version: str
+    execution_intent: dict[str, Any]
+    execution_intent_id: str
+    execution_intent_hash: str
+    source_reference_rehearsal_hash: str
+    source_adapter_dry_run_fixture_result_hash: str
+    source_adapter_dry_run_plan_hash: str
+    source_adapter_contract_selection_hash: str
+    source_bind_preflight_adjudication_hash: str
+    source_formation_hash: str
+    source_readiness_hash: str
+    source_eligibility_hash: str
+    source_handoff_hash: str
+    trusted_validation_context_hash: str
+    validation_result_hash: str
+    mapping_value_digest: str
+    execution_intent_contract_version: str
+    live_adapter_dry_run_request_status: Literal[
+        "LIVE_ADAPTER_DRY_RUN_REQUEST_CREATED_NOT_DISPATCHED"
+    ]
+    request_dispatch_state: Literal["NOT_DISPATCHED"]
+    ready_for_live_adapter_dry_run_dispatch_readiness: Literal[True]
+    fail_closed: Literal[False]
+    planned_steps: tuple[dict[str, Any], ...]
+    planned_step_digest: str
+    fixture_step_results: tuple[dict[str, Any], ...]
+    fixture_result_digest: str
+    reference_rehearsal_results: tuple[dict[str, Any], ...]
+    reference_rehearsal_result_digest: str
+    readiness_checks: tuple[dict[str, Any], ...]
+    readiness_check_digest: str
+    dispatch_preconditions: tuple[LiveAdapterDryRunDispatchPrecondition, ...]
+    dispatch_precondition_digest: str
+    request_construction_checks: dict[str, bool]
+    future_live_adapter_dry_run_dispatch_requirements: dict[str, bool]
+    source_to_execution_intent_mapping: dict[str, Any]
+    field_mapping_proof: dict[str, Any]
+    required_field_presence: dict[str, str]
+    source_decision_identity: dict[str, Any]
+    candidate_identity: dict[str, Any]
+    evidence_lineage: dict[str, Any]
+    replay_summary: dict[str, Any]
+    scope_limitations: tuple[str, ...]
+
+
+def _json_value(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        value = value.model_dump(mode="python")
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        if value != value or value in (float("inf"), float("-inf")):
+            raise LiveAdapterDryRunRequestError("LADRQ_PACKET_INVALID")
+        return value
+    if isinstance(value, datetime):
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise LiveAdapterDryRunRequestError("LADRQ_REQUESTED_AT_INVALID")
+        return value.isoformat()
+    if isinstance(value, (list, tuple)):
+        return [_json_value(item) for item in value]
+    if isinstance(value, dict) and all(isinstance(key, str) for key in value):
+        return {key: _json_value(item) for key, item in value.items()}
+    raise LiveAdapterDryRunRequestError("LADRQ_PACKET_INVALID")
+
+
+def _aware(value: Any, code: str) -> datetime:
+    try:
+        parsed = value if isinstance(value, datetime) else datetime.fromisoformat(value)
+    except (TypeError, ValueError) as exc:
+        raise LiveAdapterDryRunRequestError(code) from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise LiveAdapterDryRunRequestError(code)
+    return parsed
+
+
+def _digest(domain: str, value: Any) -> str:
+    encoded = json.dumps(
+        {"domain": domain, "value": _json_value(value)}, allow_nan=False,
+        ensure_ascii=False, separators=(",", ":"), sort_keys=True,
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _packet_hash(raw: dict[str, Any]) -> str:
+    return _digest(PACKET_DOMAIN, {key: value for key, value in raw.items() if key not in {
+        "live_adapter_dry_run_request_id", "live_adapter_dry_run_request_hash",
+    }})
+
+
+def _source(value: Any) -> CanonicalLiveAdapterDryRunRequestReadinessPacket:
+    try:
+        return verify_live_adapter_dry_run_request_readiness_packet(value)
+    except (LiveAdapterDryRunReadinessError, TypeError, ValueError) as exc:
+        raise LiveAdapterDryRunRequestError("LADRQ_READINESS_PACKET_INVALID") from exc
+
+
+def _intent(raw: dict[str, Any]) -> ExecutionIntent:
+    try:
+        intent = ExecutionIntent(**raw)
+        canonical_execution_intent_json(intent)
+    except (TypeError, ValueError) as exc:
+        raise LiveAdapterDryRunRequestError("LADRQ_PACKET_INVALID") from exc
+    if intent.to_dict() != raw:
+        raise LiveAdapterDryRunRequestError("LADRQ_PACKET_INVALID")
+    return intent
+
+
+def _descriptor(source: CanonicalLiveAdapterDryRunRequestReadinessPacket) -> dict[str, Any]:
+    intent = _intent(source.execution_intent)
+    slug = re.sub(r"[^a-z0-9]+", "-", source.adapter_contract_id.lower()).strip("-")
+    raw = {
+        "request_descriptor_id": f"live-adapter-dry-run-request-descriptor:v1:{slug}",
+        "request_kind": "live_adapter_dry_run", "dispatch_mode": "not_dispatched",
+        "adapter_contract_id": source.adapter_contract_id,
+        "adapter_contract_hash": source.adapter_contract_hash,
+        "adapter_contract_version": source.adapter_contract_version,
+        "target_system": intent.target_system,
+        "target_resource_scope": intent.target_resource,
+        "action_name": intent.intended_action,
+        "dry_run_only": True, "read_only_scope_required": True,
+        "no_apply": True, "no_commit": True, "no_state_mutation": True,
+        "no_trustlog_write_before_policy": True,
+        "no_bind_receipt_before_bind": True,
+        "credential_material_included": False, "credential_accessed": False,
+        "endpoint_material_included": False, "endpoint_contacted": False,
+        "webhook_contacted": False, "network_used": False,
+        "external_effect_used": False,
+        "descriptor_scope_limitations": DESCRIPTOR_LIMITATIONS,
+    }
+    _digest(DESCRIPTOR_DOMAIN, raw)
+    return raw
+
+
+def _preconditions(source_hash: str) -> list[dict[str, Any]]:
+    return [{
+        "precondition_id": (
+            "live-adapter-dry-run-dispatch-precondition:"
+            f"v1:{ordinal}:{name.replace('_', '-')}"
+        ),
+        "ordinal": ordinal, "precondition_name": name,
+        "precondition_mode": "deterministic_local_request_construction_only",
+        "passed": True, "evidence_ref": f"readiness_hash:{source_hash}:{name}",
+        "live_observation_used": False, "network_used": False,
+        "filesystem_used": False, "credential_accessed": False,
+        "adapter_instance_created": False, "adapter_method_called": False,
+        "request_dispatched": False, "webhook_called": False,
+        "bind_invoked": False, "bind_receipt_created": False,
+        "trustlog_written": False, "external_effect_used": False,
+        "precondition_scope_limitations": PRECONDITION_LIMITATIONS,
+    } for ordinal, name in enumerate(PRECONDITION_NAMES, 1)]
+
+
+def _validate_source(source: CanonicalLiveAdapterDryRunRequestReadinessPacket) -> None:
+    intent = _intent(source.execution_intent)
+    if intent.execution_intent_id != source.execution_intent_id:
+        raise LiveAdapterDryRunRequestError("LADRQ_EXECUTION_INTENT_ID_MISMATCH")
+    if hash_execution_intent(intent) != source.execution_intent_hash:
+        raise LiveAdapterDryRunRequestError("LADRQ_EXECUTION_INTENT_HASH_MISMATCH")
+    descriptor = source.adapter_contract_descriptor
+    if (descriptor.get("target_system") != intent.target_system or
+            descriptor.get("target_resource_scope") != intent.target_resource):
+        raise LiveAdapterDryRunRequestError("LADRQ_DESCRIPTOR_MISMATCH")
+
+
+def build_live_adapter_dry_run_request_packet(
+    live_adapter_dry_run_readiness_packet: Any,
+    requested_at: datetime,
+) -> CanonicalLiveAdapterDryRunRequestPacket:
+    """Verify readiness and construct a request packet without dispatching it."""
+    requested = _aware(requested_at, "LADRQ_REQUESTED_AT_INVALID")
+    source = _source(_json_value(live_adapter_dry_run_readiness_packet))
+    _validate_source(source)
+    if requested < _aware(source.readiness_evaluated_at, "LADRQ_READINESS_PACKET_INVALID"):
+        raise LiveAdapterDryRunRequestError("LADRQ_REQUESTED_BEFORE_READINESS")
+    source_raw = source.model_dump(mode="json")
+    preconditions = _preconditions(source.live_adapter_dry_run_readiness_hash)
+    raw = {
+        "format_version": FORMAT_VERSION, "request_mechanism": REQUEST_MECHANISM,
+        "requested_at": requested.isoformat(),
+        "source_live_adapter_dry_run_readiness": {
+            key: source_raw[key] for key in SOURCE_SUMMARY_KEYS
+        },
+        "source_live_adapter_dry_run_readiness_hash": source.live_adapter_dry_run_readiness_hash,
+        "source_live_adapter_dry_run_readiness_packet": source_raw,
+        "request_descriptor": _descriptor(source),
+        "adapter_contract_descriptor": source_raw["adapter_contract_descriptor"],
+        "adapter_contract_id": source.adapter_contract_id,
+        "adapter_contract_hash": source.adapter_contract_hash,
+        "adapter_contract_version": source.adapter_contract_version,
+        "execution_intent": source_raw["execution_intent"],
+        "execution_intent_id": source.execution_intent_id,
+        "execution_intent_hash": source.execution_intent_hash,
+        **{key: source_raw[key] for key in COPIED_FIELDS},
+        "live_adapter_dry_run_request_status": (
+            "LIVE_ADAPTER_DRY_RUN_REQUEST_CREATED_NOT_DISPATCHED"
+        ),
+        "request_dispatch_state": "NOT_DISPATCHED",
+        "ready_for_live_adapter_dry_run_dispatch_readiness": True,
+        "fail_closed": False,
+        "planned_steps": source_raw["planned_steps"],
+        "planned_step_digest": source.planned_step_digest,
+        "fixture_step_results": source_raw["fixture_step_results"],
+        "fixture_result_digest": source.fixture_result_digest,
+        "reference_rehearsal_results": source_raw["reference_rehearsal_results"],
+        "reference_rehearsal_result_digest": source.reference_rehearsal_result_digest,
+        "readiness_checks": source_raw["readiness_checks"],
+        "readiness_check_digest": source.readiness_check_digest,
+        "dispatch_preconditions": preconditions,
+        "dispatch_precondition_digest": _digest(DISPATCH_PRECONDITIONS_DOMAIN, preconditions),
+        "request_construction_checks": CONSTRUCTION_CHECKS,
+        "future_live_adapter_dry_run_dispatch_requirements": FUTURE_REQUIREMENTS,
+        "scope_limitations": SCOPE_LIMITATIONS,
+    }
+    digest = _packet_hash(raw)
+    raw.update(live_adapter_dry_run_request_hash=digest,
+               live_adapter_dry_run_request_id=f"ladrq:v1:sha256:{digest}")
+    return verify_live_adapter_dry_run_request_packet(raw)
+
+
+def verify_live_adapter_dry_run_request_packet(
+    packet: Any,
+) -> CanonicalLiveAdapterDryRunRequestPacket:
+    """Independently reverify source, preserved data, claims, and identity."""
+    try:
+        value = (
+            packet.model_dump(mode="json")
+            if isinstance(packet, BaseModel)
+            else _json_value(packet)
+        )
+        candidate = CanonicalLiveAdapterDryRunRequestPacket.model_validate(value)
+    except (ValidationError, LiveAdapterDryRunRequestError, TypeError) as exc:
+        raise LiveAdapterDryRunRequestError("LADRQ_PACKET_INVALID") from exc
+    raw = candidate.model_dump(mode="json")
+    source = _source(candidate.source_live_adapter_dry_run_readiness_packet)
+    source_raw = source.model_dump(mode="json")
+    _validate_source(source)
+    expected_summary = {key: source_raw[key] for key in SOURCE_SUMMARY_KEYS}
+    if (set(candidate.source_live_adapter_dry_run_readiness) != set(SOURCE_SUMMARY_KEYS)
+            or candidate.source_live_adapter_dry_run_readiness != expected_summary
+            or candidate.source_live_adapter_dry_run_readiness_hash
+            != source.live_adapter_dry_run_readiness_hash):
+        raise LiveAdapterDryRunRequestError("LADRQ_SOURCE_SUMMARY_MISMATCH")
+    if _aware(candidate.requested_at, "LADRQ_REQUESTED_AT_INVALID") < _aware(
+            source.readiness_evaluated_at, "LADRQ_READINESS_PACKET_INVALID"):
+        raise LiveAdapterDryRunRequestError("LADRQ_REQUESTED_BEFORE_READINESS")
+    intent = _intent(candidate.execution_intent)
+    if candidate.execution_intent != source.execution_intent:
+        raise LiveAdapterDryRunRequestError("LADRQ_EXECUTION_INTENT_HASH_MISMATCH")
+    if (intent.execution_intent_id != candidate.execution_intent_id or
+            candidate.execution_intent_id != source.execution_intent_id):
+        raise LiveAdapterDryRunRequestError("LADRQ_EXECUTION_INTENT_ID_MISMATCH")
+    if (hash_execution_intent(intent) != candidate.execution_intent_hash or
+            candidate.execution_intent_hash != source.execution_intent_hash):
+        raise LiveAdapterDryRunRequestError("LADRQ_EXECUTION_INTENT_HASH_MISMATCH")
+    if _json_value(candidate.request_descriptor) != _descriptor(source):
+        raise LiveAdapterDryRunRequestError("LADRQ_REQUEST_DESCRIPTOR_INVALID")
+    for key in ("adapter_contract_descriptor", "adapter_contract_id",
+                "adapter_contract_hash", "adapter_contract_version", *COPIED_FIELDS):
+        if _json_value(getattr(candidate, key)) != _json_value(getattr(source, key)):
+            raise LiveAdapterDryRunRequestError("LADRQ_DESCRIPTOR_MISMATCH")
+    collections = (
+        ("planned_steps", "planned_step_digest", STEPS_DOMAIN, source_digest,
+         "LADRQ_PLANNED_STEPS_MISMATCH"),
+        ("fixture_step_results", "fixture_result_digest", FIXTURE_DOMAIN, _digest,
+         "LADRQ_FIXTURE_RESULTS_MISMATCH"),
+        ("reference_rehearsal_results", "reference_rehearsal_result_digest",
+         REHEARSAL_DOMAIN, _digest, "LADRQ_REFERENCE_REHEARSAL_RESULTS_MISMATCH"),
+        ("readiness_checks", "readiness_check_digest", READINESS_CHECKS_DOMAIN,
+         readiness_digest, "LADRQ_READINESS_CHECKS_MISMATCH"),
+    )
+    for field, digest_field, domain, digest_fn, code in collections:
+        value = _json_value(getattr(candidate, field))
+        if (value != _json_value(getattr(source, field)) or
+                getattr(candidate, digest_field) != getattr(source, digest_field) or
+                getattr(candidate, digest_field) != digest_fn(domain, value)):
+            raise LiveAdapterDryRunRequestError(code)
+    preconditions = _preconditions(source.live_adapter_dry_run_readiness_hash)
+    if _json_value(candidate.dispatch_preconditions) != preconditions:
+        raise LiveAdapterDryRunRequestError("LADRQ_DISPATCH_PRECONDITIONS_INVALID")
+    if candidate.dispatch_precondition_digest != _digest(
+            DISPATCH_PRECONDITIONS_DOMAIN, preconditions):
+        raise LiveAdapterDryRunRequestError("LADRQ_DISPATCH_PRECONDITION_DIGEST_MISMATCH")
+    if candidate.request_construction_checks != CONSTRUCTION_CHECKS:
+        raise LiveAdapterDryRunRequestError("LADRQ_CONSTRUCTION_CHECKS_MISMATCH")
+    if candidate.future_live_adapter_dry_run_dispatch_requirements != FUTURE_REQUIREMENTS:
+        raise LiveAdapterDryRunRequestError("LADRQ_FUTURE_REQUIREMENTS_MISMATCH")
+    _digest(CONSTRUCTION_CHECKS_DOMAIN, candidate.request_construction_checks)
+    _digest(FUTURE_REQUIREMENTS_DOMAIN, candidate.future_live_adapter_dry_run_dispatch_requirements)
+    if candidate.scope_limitations != SCOPE_LIMITATIONS:
+        raise LiveAdapterDryRunRequestError("LADRQ_SCOPE_LIMITATIONS_MISSING")
+    digest = _packet_hash(raw)
+    if candidate.live_adapter_dry_run_request_hash != digest:
+        raise LiveAdapterDryRunRequestError("LADRQ_PACKET_HASH_MISMATCH")
+    if candidate.live_adapter_dry_run_request_id != f"ladrq:v1:sha256:{digest}":
+        raise LiveAdapterDryRunRequestError("LADRQ_PACKET_ID_MISMATCH")
+    return candidate

--- a/veritas_os/tests/test_live_adapter_dry_run_request.py
+++ b/veritas_os/tests/test_live_adapter_dry_run_request.py
@@ -1,0 +1,221 @@
+"""Security and integrity tests for live-adapter dry-run request packet v1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from copy import deepcopy
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator, RefResolver, ValidationError
+
+from veritas_os.policy.live_adapter_dry_run_request import (
+    DISPATCH_PRECONDITIONS_DOMAIN,
+    PACKET_DOMAIN,
+    PRECONDITION_NAMES,
+    LiveAdapterDryRunRequestError,
+    _digest,
+    _packet_hash,
+    build_live_adapter_dry_run_request_packet,
+    verify_live_adapter_dry_run_request_packet,
+)
+from veritas_os.tests.test_live_adapter_dry_run_readiness import (
+    EVALUATED_AT,
+    _packet as readiness_packet,
+)
+
+REQUESTED_AT = EVALUATED_AT + timedelta(seconds=1)
+MODULE = Path("veritas_os/policy/live_adapter_dry_run_request.py")
+SCHEMA = Path("schemas/live-adapter-dry-run-request-v1.schema.json")
+
+
+def _packet(*, semantic_match: bool = True):
+    return build_live_adapter_dry_run_request_packet(
+        readiness_packet(semantic_match=semantic_match), REQUESTED_AT
+    )
+
+
+def _rehash(raw):
+    digest = _packet_hash(raw)
+    raw["live_adapter_dry_run_request_hash"] = digest
+    raw["live_adapter_dry_run_request_id"] = f"ladrq:v1:sha256:{digest}"
+
+
+def test_build_verify_preserves_source_without_dispatch(monkeypatch) -> None:
+    import veritas_os.policy.live_adapter_dry_run_request as module
+
+    actual = module.verify_live_adapter_dry_run_request_readiness_packet
+    calls = []
+
+    def recording(value):
+        calls.append(value)
+        return actual(value)
+
+    monkeypatch.setattr(
+        module, "verify_live_adapter_dry_run_request_readiness_packet", recording
+    )
+    source = readiness_packet(semantic_match=False)
+    packet = module.build_live_adapter_dry_run_request_packet(source, REQUESTED_AT)
+    assert len(calls) == 2
+    assert module.verify_live_adapter_dry_run_request_packet(packet) == packet
+    assert len(calls) == 3
+    assert packet.live_adapter_dry_run_request_id == (
+        f"ladrq:v1:sha256:{packet.live_adapter_dry_run_request_hash}"
+    )
+    assert packet.live_adapter_dry_run_request_hash == _packet_hash(
+        packet.model_dump(mode="json")
+    )
+    assert packet.source_live_adapter_dry_run_readiness_packet == source.model_dump(
+        mode="json"
+    )
+    for field in (
+        "adapter_contract_descriptor", "planned_steps", "fixture_step_results",
+        "reference_rehearsal_results", "readiness_checks",
+        "source_to_execution_intent_mapping", "field_mapping_proof",
+        "required_field_presence", "source_decision_identity", "candidate_identity",
+        "evidence_lineage", "replay_summary",
+    ):
+        assert packet.model_dump(mode="json")[field] == source.model_dump(mode="json")[field]
+    assert packet.replay_summary["semantic_match"] is False
+    assert packet.request_dispatch_state == "NOT_DISPATCHED"
+    assert packet.request_descriptor.dispatch_mode == "not_dispatched"
+    assert packet.request_descriptor.credential_material_included is False
+    assert packet.request_descriptor.endpoint_material_included is False
+    assert [item.precondition_name for item in packet.dispatch_preconditions] == list(
+        PRECONDITION_NAMES
+    )
+    assert packet.dispatch_precondition_digest == _digest(
+        DISPATCH_PRECONDITIONS_DOMAIN,
+        [item.model_dump(mode="json") for item in packet.dispatch_preconditions],
+    )
+    for item in packet.dispatch_preconditions:
+        assert not any((
+            item.live_observation_used, item.network_used, item.filesystem_used,
+            item.credential_accessed, item.adapter_instance_created,
+            item.adapter_method_called, item.request_dispatched, item.webhook_called,
+            item.bind_invoked, item.bind_receipt_created, item.trustlog_written,
+            item.external_effect_used,
+        ))
+
+
+@pytest.mark.parametrize("semantic_match", [True, False])
+def test_semantic_match_is_preserved(semantic_match) -> None:
+    packet = _packet(semantic_match=semantic_match)
+    assert packet.replay_summary["semantic_match"] is semantic_match
+    assert verify_live_adapter_dry_run_request_packet(packet) == packet
+
+
+def test_invalid_source_and_timeline_refuse() -> None:
+    source = readiness_packet().model_dump(mode="json")
+    source["live_adapter_dry_run_readiness_hash"] = "0" * 64
+    with pytest.raises(LiveAdapterDryRunRequestError, match="LADRQ_READINESS"):
+        build_live_adapter_dry_run_request_packet(source, REQUESTED_AT)
+    with pytest.raises(LiveAdapterDryRunRequestError, match="LADRQ_REQUESTED_AT"):
+        build_live_adapter_dry_run_request_packet(
+            readiness_packet(), REQUESTED_AT.replace(tzinfo=None)
+        )
+    with pytest.raises(LiveAdapterDryRunRequestError, match="LADRQ_REQUESTED_BEFORE"):
+        build_live_adapter_dry_run_request_packet(
+            readiness_packet(), EVALUATED_AT - timedelta(seconds=1)
+        )
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "missing", "extra", "reordered", "name", "digest", "live", "network",
+        "filesystem", "credential", "effect", "adapter_instance", "adapter_method",
+        "dispatch", "webhook", "bind", "receipt", "trustlog", "source", "intent",
+        "descriptor", "adapter", "planned", "fixture", "rehearsal", "readiness",
+        "construction", "future", "scope", "hash", "id", "apply_performed",
+    ],
+)
+def test_tampering_is_refused_even_when_rehashed(mutation) -> None:
+    raw = _packet().model_dump(mode="json")
+    items = raw["dispatch_preconditions"]
+    if mutation == "missing": items.pop()
+    elif mutation == "extra": items.append(deepcopy(items[-1]))
+    elif mutation == "reordered": items[0], items[1] = items[1], items[0]
+    elif mutation == "name": items[0]["precondition_name"] = PRECONDITION_NAMES[1]
+    elif mutation == "digest": raw["dispatch_precondition_digest"] = "0" * 64
+    elif mutation in {"live", "network", "filesystem", "credential", "effect",
+                      "adapter_instance", "adapter_method", "dispatch", "webhook",
+                      "bind", "receipt", "trustlog"}:
+        key = {
+            "live": "live_observation_used", "credential": "credential_accessed",
+            "effect": "external_effect_used", "adapter_instance": "adapter_instance_created",
+            "adapter_method": "adapter_method_called", "dispatch": "request_dispatched",
+            "webhook": "webhook_called", "bind": "bind_invoked",
+            "receipt": "bind_receipt_created", "trustlog": "trustlog_written",
+        }.get(mutation, f"{mutation}_used")
+        items[0][key] = True
+    elif mutation == "source":
+        raw["source_live_adapter_dry_run_readiness_packet"]["live_adapter_dry_run_readiness_hash"] = "0" * 64
+    elif mutation == "intent": raw["execution_intent"]["target_resource"] = "changed"
+    elif mutation == "descriptor": raw["request_descriptor"]["target_system"] = "changed"
+    elif mutation == "adapter": raw["adapter_contract_descriptor"]["target_system"] = "changed"
+    elif mutation == "planned": raw["planned_steps"][0]["expected_output_ref"] = "changed"
+    elif mutation == "fixture": raw["fixture_step_results"][0]["fixture_input_ref"] = "changed"
+    elif mutation == "rehearsal": raw["reference_rehearsal_results"][0]["matched_expected_output_ref"] = "changed"
+    elif mutation == "readiness": raw["readiness_checks"][0]["evidence_ref"] = "changed"
+    elif mutation == "construction": raw["request_construction_checks"]["no_network"] = False
+    elif mutation == "future": raw["future_live_adapter_dry_run_dispatch_requirements"]["apply_still_forbidden"] = False
+    elif mutation == "scope": raw["scope_limitations"].pop()
+    elif mutation == "hash": raw["live_adapter_dry_run_request_hash"] = "0" * 64
+    elif mutation == "id": raw["live_adapter_dry_run_request_id"] = "ladrq:v1:sha256:" + "0" * 64
+    elif mutation == "apply_performed": raw["apply_performed"] = True
+    if mutation not in {"hash", "id"}: _rehash(raw)
+    with pytest.raises(LiveAdapterDryRunRequestError):
+        verify_live_adapter_dry_run_request_packet(raw)
+
+
+def test_model_validation_bypasses_are_refused() -> None:
+    packet = _packet()
+    candidates = (
+        packet.model_copy(update={"live_adapter_dry_run_request_hash": "0" * 64}),
+        type(packet).model_construct(**{**packet.model_dump(mode="python"), "fail_closed": True}),
+    )
+    for candidate in candidates:
+        with pytest.raises(LiveAdapterDryRunRequestError):
+            verify_live_adapter_dry_run_request_packet(candidate)
+
+
+def test_closed_schema_accepts_valid_and_rejects_invalid_packet() -> None:
+    schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+    store = {}
+    for path in Path("schemas").glob("*.json"):
+        document = json.loads(path.read_text(encoding="utf-8"))
+        if "$id" in document: store[document["$id"]] = document
+        store[f"https://veritas-os.org/schemas/{path.name}"] = document
+    validator = Draft202012Validator(
+        schema, resolver=RefResolver(SCHEMA.resolve().as_uri(), schema, store=store)
+    )
+    raw = _packet().model_dump(mode="json")
+    validator.validate(raw)
+    raw["unexpected"] = True
+    with pytest.raises(ValidationError): validator.validate(raw)
+
+
+def test_static_execution_boundary() -> None:
+    tree = ast.parse(MODULE.read_text(encoding="utf-8"))
+    forbidden = {
+        "BindReceipt", "hash_bind_receipt", "append_bind_receipt_trustlog",
+        "append_execution_intent_trustlog", "build_execution_intent_trustlog_entry",
+        "execute_bind_boundary", "execute_bind_adjudication", "BindAdapterContract",
+        "BindBoundaryAdapter", "ReferenceBindAdapter", "WebhookBindAdapter", "requests",
+        "httpx", "subprocess", "socket", "uuid4", "now", "apply", "revert",
+        "verify_postconditions", "create_bind_receipt", "write_trustlog",
+        "append_trustlog", "call_live_adapter", "call_webhook", "dispatch_request",
+        "send_request", "perform_http", "request_live_dry_run",
+    }
+    imported = {alias.name.split(".")[0] for node in ast.walk(tree)
+                if isinstance(node, (ast.Import, ast.ImportFrom)) for alias in node.names}
+    called = {node.func.attr if isinstance(node.func, ast.Attribute) else node.func.id
+              for node in ast.walk(tree) if isinstance(node, ast.Call)
+              and isinstance(node.func, (ast.Name, ast.Attribute))}
+    defined = {node.name for node in ast.walk(tree)
+               if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))}
+    assert forbidden.isdisjoint(imported | called | defined)
+    assert PACKET_DOMAIN != DISPATCH_PRECONDITIONS_DOMAIN

--- a/veritas_os/tests/test_live_adapter_dry_run_request.py
+++ b/veritas_os/tests/test_live_adapter_dry_run_request.py
@@ -16,6 +16,7 @@ from veritas_os.policy.live_adapter_dry_run_request import (
     PACKET_DOMAIN,
     PRECONDITION_NAMES,
     LiveAdapterDryRunRequestError,
+    _build_expected_request_descriptor,
     _digest,
     _packet_hash,
     build_live_adapter_dry_run_request_packet,
@@ -71,18 +72,31 @@ def test_build_verify_preserves_source_without_dispatch(monkeypatch) -> None:
         mode="json"
     )
     for field in (
-        "adapter_contract_descriptor", "planned_steps", "fixture_step_results",
-        "reference_rehearsal_results", "readiness_checks",
-        "source_to_execution_intent_mapping", "field_mapping_proof",
-        "required_field_presence", "source_decision_identity", "candidate_identity",
-        "evidence_lineage", "replay_summary",
+        "adapter_contract_descriptor",
+        "planned_steps",
+        "fixture_step_results",
+        "reference_rehearsal_results",
+        "readiness_checks",
+        "source_to_execution_intent_mapping",
+        "field_mapping_proof",
+        "required_field_presence",
+        "source_decision_identity",
+        "candidate_identity",
+        "evidence_lineage",
+        "replay_summary",
     ):
-        assert packet.model_dump(mode="json")[field] == source.model_dump(mode="json")[field]
+        assert (
+            packet.model_dump(mode="json")[field]
+            == source.model_dump(mode="json")[field]
+        )
     assert packet.replay_summary["semantic_match"] is False
     assert packet.request_dispatch_state == "NOT_DISPATCHED"
     assert packet.request_descriptor.dispatch_mode == "not_dispatched"
     assert packet.request_descriptor.credential_material_included is False
     assert packet.request_descriptor.endpoint_material_included is False
+    assert packet.request_descriptor.model_dump(mode="json") == (
+        _build_expected_request_descriptor(source)
+    )
     assert [item.precondition_name for item in packet.dispatch_preconditions] == list(
         PRECONDITION_NAMES
     )
@@ -91,13 +105,22 @@ def test_build_verify_preserves_source_without_dispatch(monkeypatch) -> None:
         [item.model_dump(mode="json") for item in packet.dispatch_preconditions],
     )
     for item in packet.dispatch_preconditions:
-        assert not any((
-            item.live_observation_used, item.network_used, item.filesystem_used,
-            item.credential_accessed, item.adapter_instance_created,
-            item.adapter_method_called, item.request_dispatched, item.webhook_called,
-            item.bind_invoked, item.bind_receipt_created, item.trustlog_written,
-            item.external_effect_used,
-        ))
+        assert not any(
+            (
+                item.live_observation_used,
+                item.network_used,
+                item.filesystem_used,
+                item.credential_accessed,
+                item.adapter_instance_created,
+                item.adapter_method_called,
+                item.request_dispatched,
+                item.webhook_called,
+                item.bind_invoked,
+                item.bind_receipt_created,
+                item.trustlog_written,
+                item.external_effect_used,
+            )
+        )
 
 
 @pytest.mark.parametrize("semantic_match", [True, False])
@@ -105,6 +128,19 @@ def test_semantic_match_is_preserved(semantic_match) -> None:
     packet = _packet(semantic_match=semantic_match)
     assert packet.replay_summary["semantic_match"] is semantic_match
     assert verify_live_adapter_dry_run_request_packet(packet) == packet
+
+
+def test_request_descriptor_limitation_order_is_enforced() -> None:
+    """Reject a reordered descriptor even when packet identity is recomputed."""
+    raw = _packet().model_dump(mode="json")
+    limitations = raw["request_descriptor"]["descriptor_scope_limitations"]
+    limitations[0], limitations[1] = limitations[1], limitations[0]
+    _rehash(raw)
+    with pytest.raises(
+        LiveAdapterDryRunRequestError,
+        match="LADRQ_REQUEST_DESCRIPTOR_INVALID",
+    ):
+        verify_live_adapter_dry_run_request_packet(raw)
 
 
 def test_invalid_source_and_timeline_refuse() -> None:
@@ -125,48 +161,113 @@ def test_invalid_source_and_timeline_refuse() -> None:
 @pytest.mark.parametrize(
     "mutation",
     [
-        "missing", "extra", "reordered", "name", "digest", "live", "network",
-        "filesystem", "credential", "effect", "adapter_instance", "adapter_method",
-        "dispatch", "webhook", "bind", "receipt", "trustlog", "source", "intent",
-        "descriptor", "adapter", "planned", "fixture", "rehearsal", "readiness",
-        "construction", "future", "scope", "hash", "id", "apply_performed",
+        "missing",
+        "extra",
+        "reordered",
+        "name",
+        "digest",
+        "live",
+        "network",
+        "filesystem",
+        "credential",
+        "effect",
+        "adapter_instance",
+        "adapter_method",
+        "dispatch",
+        "webhook",
+        "bind",
+        "receipt",
+        "trustlog",
+        "source",
+        "intent",
+        "descriptor",
+        "adapter",
+        "planned",
+        "fixture",
+        "rehearsal",
+        "readiness",
+        "construction",
+        "future",
+        "scope",
+        "hash",
+        "id",
+        "apply_performed",
     ],
 )
 def test_tampering_is_refused_even_when_rehashed(mutation) -> None:
     raw = _packet().model_dump(mode="json")
     items = raw["dispatch_preconditions"]
-    if mutation == "missing": items.pop()
-    elif mutation == "extra": items.append(deepcopy(items[-1]))
-    elif mutation == "reordered": items[0], items[1] = items[1], items[0]
-    elif mutation == "name": items[0]["precondition_name"] = PRECONDITION_NAMES[1]
-    elif mutation == "digest": raw["dispatch_precondition_digest"] = "0" * 64
-    elif mutation in {"live", "network", "filesystem", "credential", "effect",
-                      "adapter_instance", "adapter_method", "dispatch", "webhook",
-                      "bind", "receipt", "trustlog"}:
+    if mutation == "missing":
+        items.pop()
+    elif mutation == "extra":
+        items.append(deepcopy(items[-1]))
+    elif mutation == "reordered":
+        items[0], items[1] = items[1], items[0]
+    elif mutation == "name":
+        items[0]["precondition_name"] = PRECONDITION_NAMES[1]
+    elif mutation == "digest":
+        raw["dispatch_precondition_digest"] = "0" * 64
+    elif mutation in {
+        "live",
+        "network",
+        "filesystem",
+        "credential",
+        "effect",
+        "adapter_instance",
+        "adapter_method",
+        "dispatch",
+        "webhook",
+        "bind",
+        "receipt",
+        "trustlog",
+    }:
         key = {
-            "live": "live_observation_used", "credential": "credential_accessed",
-            "effect": "external_effect_used", "adapter_instance": "adapter_instance_created",
-            "adapter_method": "adapter_method_called", "dispatch": "request_dispatched",
-            "webhook": "webhook_called", "bind": "bind_invoked",
-            "receipt": "bind_receipt_created", "trustlog": "trustlog_written",
+            "live": "live_observation_used",
+            "credential": "credential_accessed",
+            "effect": "external_effect_used",
+            "adapter_instance": "adapter_instance_created",
+            "adapter_method": "adapter_method_called",
+            "dispatch": "request_dispatched",
+            "webhook": "webhook_called",
+            "bind": "bind_invoked",
+            "receipt": "bind_receipt_created",
+            "trustlog": "trustlog_written",
         }.get(mutation, f"{mutation}_used")
         items[0][key] = True
     elif mutation == "source":
-        raw["source_live_adapter_dry_run_readiness_packet"]["live_adapter_dry_run_readiness_hash"] = "0" * 64
-    elif mutation == "intent": raw["execution_intent"]["target_resource"] = "changed"
-    elif mutation == "descriptor": raw["request_descriptor"]["target_system"] = "changed"
-    elif mutation == "adapter": raw["adapter_contract_descriptor"]["target_system"] = "changed"
-    elif mutation == "planned": raw["planned_steps"][0]["expected_output_ref"] = "changed"
-    elif mutation == "fixture": raw["fixture_step_results"][0]["fixture_input_ref"] = "changed"
-    elif mutation == "rehearsal": raw["reference_rehearsal_results"][0]["matched_expected_output_ref"] = "changed"
-    elif mutation == "readiness": raw["readiness_checks"][0]["evidence_ref"] = "changed"
-    elif mutation == "construction": raw["request_construction_checks"]["no_network"] = False
-    elif mutation == "future": raw["future_live_adapter_dry_run_dispatch_requirements"]["apply_still_forbidden"] = False
-    elif mutation == "scope": raw["scope_limitations"].pop()
-    elif mutation == "hash": raw["live_adapter_dry_run_request_hash"] = "0" * 64
-    elif mutation == "id": raw["live_adapter_dry_run_request_id"] = "ladrq:v1:sha256:" + "0" * 64
-    elif mutation == "apply_performed": raw["apply_performed"] = True
-    if mutation not in {"hash", "id"}: _rehash(raw)
+        raw["source_live_adapter_dry_run_readiness_packet"][
+            "live_adapter_dry_run_readiness_hash"
+        ] = "0" * 64
+    elif mutation == "intent":
+        raw["execution_intent"]["target_resource"] = "changed"
+    elif mutation == "descriptor":
+        raw["request_descriptor"]["target_system"] = "changed"
+    elif mutation == "adapter":
+        raw["adapter_contract_descriptor"]["target_system"] = "changed"
+    elif mutation == "planned":
+        raw["planned_steps"][0]["expected_output_ref"] = "changed"
+    elif mutation == "fixture":
+        raw["fixture_step_results"][0]["fixture_input_ref"] = "changed"
+    elif mutation == "rehearsal":
+        raw["reference_rehearsal_results"][0]["matched_expected_output_ref"] = "changed"
+    elif mutation == "readiness":
+        raw["readiness_checks"][0]["evidence_ref"] = "changed"
+    elif mutation == "construction":
+        raw["request_construction_checks"]["no_network"] = False
+    elif mutation == "future":
+        raw["future_live_adapter_dry_run_dispatch_requirements"][
+            "apply_still_forbidden"
+        ] = False
+    elif mutation == "scope":
+        raw["scope_limitations"].pop()
+    elif mutation == "hash":
+        raw["live_adapter_dry_run_request_hash"] = "0" * 64
+    elif mutation == "id":
+        raw["live_adapter_dry_run_request_id"] = "ladrq:v1:sha256:" + "0" * 64
+    elif mutation == "apply_performed":
+        raw["apply_performed"] = True
+    if mutation not in {"hash", "id"}:
+        _rehash(raw)
     with pytest.raises(LiveAdapterDryRunRequestError):
         verify_live_adapter_dry_run_request_packet(raw)
 
@@ -175,7 +276,9 @@ def test_model_validation_bypasses_are_refused() -> None:
     packet = _packet()
     candidates = (
         packet.model_copy(update={"live_adapter_dry_run_request_hash": "0" * 64}),
-        type(packet).model_construct(**{**packet.model_dump(mode="python"), "fail_closed": True}),
+        type(packet).model_construct(
+            **{**packet.model_dump(mode="python"), "fail_closed": True}
+        ),
     )
     for candidate in candidates:
         with pytest.raises(LiveAdapterDryRunRequestError):
@@ -187,7 +290,8 @@ def test_closed_schema_accepts_valid_and_rejects_invalid_packet() -> None:
     store = {}
     for path in Path("schemas").glob("*.json"):
         document = json.loads(path.read_text(encoding="utf-8"))
-        if "$id" in document: store[document["$id"]] = document
+        if "$id" in document:
+            store[document["$id"]] = document
         store[f"https://veritas-os.org/schemas/{path.name}"] = document
     validator = Draft202012Validator(
         schema, resolver=RefResolver(SCHEMA.resolve().as_uri(), schema, store=store)
@@ -195,27 +299,59 @@ def test_closed_schema_accepts_valid_and_rejects_invalid_packet() -> None:
     raw = _packet().model_dump(mode="json")
     validator.validate(raw)
     raw["unexpected"] = True
-    with pytest.raises(ValidationError): validator.validate(raw)
+    with pytest.raises(ValidationError):
+        validator.validate(raw)
 
 
 def test_static_execution_boundary() -> None:
     tree = ast.parse(MODULE.read_text(encoding="utf-8"))
     forbidden = {
-        "BindReceipt", "hash_bind_receipt", "append_bind_receipt_trustlog",
-        "append_execution_intent_trustlog", "build_execution_intent_trustlog_entry",
-        "execute_bind_boundary", "execute_bind_adjudication", "BindAdapterContract",
-        "BindBoundaryAdapter", "ReferenceBindAdapter", "WebhookBindAdapter", "requests",
-        "httpx", "subprocess", "socket", "uuid4", "now", "apply", "revert",
-        "verify_postconditions", "create_bind_receipt", "write_trustlog",
-        "append_trustlog", "call_live_adapter", "call_webhook", "dispatch_request",
-        "send_request", "perform_http", "request_live_dry_run",
+        "BindReceipt",
+        "hash_bind_receipt",
+        "append_bind_receipt_trustlog",
+        "append_execution_intent_trustlog",
+        "build_execution_intent_trustlog_entry",
+        "execute_bind_boundary",
+        "execute_bind_adjudication",
+        "BindAdapterContract",
+        "BindBoundaryAdapter",
+        "ReferenceBindAdapter",
+        "WebhookBindAdapter",
+        "requests",
+        "httpx",
+        "subprocess",
+        "socket",
+        "uuid4",
+        "now",
+        "apply",
+        "revert",
+        "verify_postconditions",
+        "create_bind_receipt",
+        "write_trustlog",
+        "append_trustlog",
+        "call_live_adapter",
+        "call_webhook",
+        "dispatch_request",
+        "send_request",
+        "perform_http",
+        "request_live_dry_run",
     }
-    imported = {alias.name.split(".")[0] for node in ast.walk(tree)
-                if isinstance(node, (ast.Import, ast.ImportFrom)) for alias in node.names}
-    called = {node.func.attr if isinstance(node.func, ast.Attribute) else node.func.id
-              for node in ast.walk(tree) if isinstance(node, ast.Call)
-              and isinstance(node.func, (ast.Name, ast.Attribute))}
-    defined = {node.name for node in ast.walk(tree)
-               if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))}
+    imported = {
+        alias.name.split(".")[0]
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.Import, ast.ImportFrom))
+        for alias in node.names
+    }
+    called = {
+        node.func.attr if isinstance(node.func, ast.Attribute) else node.func.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, (ast.Name, ast.Attribute))
+    }
+    defined = {
+        node.name
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
     assert forbidden.isdisjoint(imported | called | defined)
     assert PACKET_DOMAIN != DISPATCH_PRECONDITIONS_DOMAIN


### PR DESCRIPTION
### Motivation
- Provide a deterministic, content-addressed Canonical Live Adapter Dry-Run Request Packet v1 that sits after the verified readiness packet and stops before any dispatch, live adapter instantiation, Webhook/provider calls, Bind adjudication, BindReceipt creation, or TrustLog writes.
- Enforce a strict local-only request construction boundary so request construction cannot create authority, invoke adapters, access credentials, or produce external effects.
- This change touches the Bind policy artifact chain and therefore is high-risk and requires human maintainer review/approval before merging.

### Description
- Add `veritas_os/policy/live_adapter_dry_run_request.py` with strict, frozen Pydantic models: `CanonicalLiveAdapterDryRunRequestPacket`, `LiveAdapterDryRunRequestDescriptor`, and `LiveAdapterDryRunDispatchPrecondition` and supporting JSON-normalization and hashing helpers.
- Implement builder `build_live_adapter_dry_run_request_packet(live_adapter_dry_run_readiness_packet, requested_at)` which calls `verify_live_adapter_dry_run_request_readiness_packet(...)`, reconstructs `ExecutionIntent`, preserves and verifies source fields (planned steps, fixture results, reference rehearsal results, readiness checks), builds a deterministic `request_descriptor`, constructs exactly the eighteen dispatch preconditions in order, computes dispatch and packet digests, sets `request_dispatch_state == "NOT_DISPATCHED"`, and returns a validated `CanonicalLiveAdapterDryRunRequestPacket`.
- Implement verifier `verify_live_adapter_dry_run_request_packet(packet)` which independently revalidates the full packet, re-verifies the embedded readiness packet, recomputes all digests (collections, dispatch preconditions, construction checks, future requirements, and packet), and rejects any tampering or bypass patterns.
- Add a closed JSON Schema `schemas/live-adapter-dry-run-request-v1.schema.json`, documentation `docs/en/architecture/live-adapter-dry-run-request-v1.md`, and comprehensive tests `veritas_os/tests/test_live_adapter_dry_run_request.py` covering positive constructions, many negative/fuzz/refusal cases, static import boundary checks, and preservation of semantic_match and source identity.

### Testing
- Static checks performed: `python -m py_compile veritas_os/policy/live_adapter_dry_run_request.py` and `python -m json.tool schemas/live-adapter-dry-run-request-v1.schema.json`, and `git diff --check` all succeeded locally.
- Focused pytest run was attempted but collection/execution was blocked because the test environment lacked required runtime dependencies (`pydantic`), so the unit tests added were not executed to completion in this environment; they are included and will run under CI or a developer environment with dependencies installed.
- Attempted dependency installation to run tests was blocked by the environment network/proxy, so installation of `pydantic`/`jsonschema`/`pytest`/`ruff` could not complete here.
- The change includes unit tests and schema validation; please run the focused test matrix and full CI (Python 3.11/3.12, lint, and governance checks) in CI before merging, and obtain human maintainer approval due to the Bind/policy sensitivity.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a832bb16ce48326a11e7e54c1b01910)