### PR TITLE
feat(bind): add live adapter dry-run endpoint allowlist evaluation v1

### DIFF
--- a/docs/en/architecture/live-adapter-dry-run-endpoint-allowlist-v1.md
+++ b/docs/en/architecture/live-adapter-dry-run-endpoint-allowlist-v1.md
@@ -1,0 +1,52 @@
+# Canonical Live Adapter Dry-Run Endpoint Allowlist Evaluation v1
+
+## Purpose
+
+This packet is a deterministic, content-addressed **endpoint allowlist evaluation
+artifact**. It answers whether a declared endpoint candidate exactly matched an
+active entry in a caller-supplied local allowlist snapshot after the source
+non-dispatched dispatch-readiness packet was verified.
+
+Comparison is exact and local. It does not use fuzzy matching, redirects, CNAMEs,
+or semantic similarity. `semantic_match` from the source lineage is preserved,
+but is not used by the comparison and is not promoted to Authority Evidence,
+Human Approval, or execution authority. A mismatch is recorded with
+`fail_closed: true` rather than authorizing any action.
+
+## Security and non-effect boundary
+
+The implementation only validates caller-provided data and computes canonical
+JSON SHA-256 digests. It:
+
+- does not resolve endpoints or perform DNS lookup;
+- does not call a network endpoint or Webhook;
+- does not resolve, access, or embed credentials, tokens, cookies, secrets, or
+  authorization headers;
+- does not instantiate or call a live adapter;
+- does not invoke Bind or create a BindReceipt;
+- does not write TrustLog, a filesystem, or a database;
+- does not dispatch or commit an operation; and
+- does not authorize dispatch, satisfy Authority Evidence, or satisfy Human
+  Approval.
+
+An allowlist match proves only an exact comparison against the supplied snapshot.
+It is not a claim that an endpoint exists, is safe, is controlled by an intended
+party, or is suitable for production, customer, or regulatory use.
+
+## Determinism and integrity
+
+Candidate, snapshot, result, identity binding, ordered checks, future credential
+requirements, and the packet use separate hash domains. JSON encoding uses sorted
+keys and compact separators, and timestamps are normalized to UTC. The snapshot
+hash covers every snapshot field except its own hash. The verifier re-verifies the
+embedded dispatch-readiness packet and recomputes all derived values, hashes, and
+the `ladrea:v1:sha256:` identifier.
+
+## Deferred credential gate
+
+Future credential resolution requires a separate explicit artifact. That future
+artifact must address resolution authorization, source identity, scope binding,
+non-embedding, authorization-header construction and redaction boundaries,
+operator/human credential review, Bind pre-dispatch review, and the separate
+network dispatch boundary. This packet records those requirements but satisfies
+none of them.

--- a/schemas/live-adapter-dry-run-endpoint-allowlist-v1.schema.json
+++ b/schemas/live-adapter-dry-run-endpoint-allowlist-v1.schema.json
@@ -1,0 +1,665 @@
+{
+  "$defs": {
+    "AllowlistEntry": {
+      "additionalProperties": false,
+      "properties": {
+        "allowed_adapter_contract_ids": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "allowed_purposes": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "allowed_target_resource_scopes": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "allowed_target_systems": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "endpoint_environment": {
+          "type": "string"
+        },
+        "endpoint_host": {
+          "type": "string"
+        },
+        "endpoint_kind": {
+          "type": "string"
+        },
+        "endpoint_path_prefix": {
+          "type": "string"
+        },
+        "endpoint_port": {
+          "type": "integer"
+        },
+        "endpoint_scheme": {
+          "type": "string"
+        },
+        "entry_id": {
+          "type": "string"
+        },
+        "entry_status": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "entry_id",
+        "endpoint_kind",
+        "endpoint_scheme",
+        "endpoint_host",
+        "endpoint_port",
+        "endpoint_path_prefix",
+        "endpoint_environment",
+        "allowed_adapter_contract_ids",
+        "allowed_target_systems",
+        "allowed_target_resource_scopes",
+        "allowed_purposes",
+        "entry_status"
+      ],
+      "type": "object"
+    },
+    "AllowlistEvaluationResult": {
+      "additionalProperties": false,
+      "properties": {
+        "comparison_mode": {
+          "const": "exact_local_allowlist_comparison_only"
+        },
+        "exact_fields_compared": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "match_reason": {
+          "type": "string"
+        },
+        "matched": {
+          "type": "boolean"
+        },
+        "matched_entry_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "mismatch_reasons": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "semantic_match_used": {
+          "const": false
+        }
+      },
+      "required": [
+        "matched",
+        "matched_entry_id",
+        "match_reason",
+        "mismatch_reasons",
+        "comparison_mode",
+        "exact_fields_compared",
+        "semantic_match_used"
+      ],
+      "type": "object"
+    },
+    "EndpointAllowlistCheck": {
+      "additionalProperties": false,
+      "properties": {
+        "authorization_header_embedded": {
+          "const": false
+        },
+        "bind_invoked": {
+          "const": false
+        },
+        "bind_receipt_created": {
+          "const": false
+        },
+        "check_id": {
+          "type": "string"
+        },
+        "credential_material_accessed": {
+          "const": false
+        },
+        "credential_material_embedded": {
+          "const": false
+        },
+        "database_used": {
+          "const": false
+        },
+        "dns_used": {
+          "const": false
+        },
+        "endpoint_resolved": {
+          "const": false
+        },
+        "evidence_ref": {
+          "type": "string"
+        },
+        "external_effect_used": {
+          "const": false
+        },
+        "filesystem_used": {
+          "const": false
+        },
+        "live_adapter_instantiated": {
+          "const": false
+        },
+        "live_adapter_method_called": {
+          "const": false
+        },
+        "mode": {
+          "const": "deterministic_local_endpoint_allowlist_evaluation_only"
+        },
+        "name": {
+          "enum": [
+            "source_dispatch_readiness_verified",
+            "source_request_not_dispatched",
+            "endpoint_candidate_closed_schema_valid",
+            "endpoint_candidate_contains_no_credentials",
+            "endpoint_candidate_contains_no_authorization_headers",
+            "endpoint_candidate_contains_no_tokens",
+            "endpoint_candidate_contains_no_secrets",
+            "allowlist_snapshot_closed_schema_valid",
+            "allowlist_snapshot_hash_verified",
+            "allowlist_entry_active_status_required",
+            "endpoint_scheme_exact_match",
+            "endpoint_host_exact_match",
+            "endpoint_port_exact_match",
+            "endpoint_path_prefix_exact_match",
+            "endpoint_environment_exact_match",
+            "adapter_contract_id_allowed",
+            "target_system_allowed",
+            "target_resource_scope_allowed",
+            "endpoint_purpose_allowed",
+            "endpoint_identity_binding_constructed",
+            "endpoint_not_resolved",
+            "dns_not_used",
+            "network_not_used",
+            "credential_not_accessed",
+            "webhook_not_called",
+            "live_adapter_not_instantiated",
+            "bind_not_invoked",
+            "bind_receipt_not_created",
+            "trustlog_not_written",
+            "future_credential_gate_required"
+          ]
+        },
+        "network_used": {
+          "const": false
+        },
+        "operation_committed": {
+          "const": false
+        },
+        "ordinal": {
+          "type": "integer"
+        },
+        "passed": {
+          "type": "boolean"
+        },
+        "provider_used": {
+          "const": false
+        },
+        "request_dispatched": {
+          "const": false
+        },
+        "secret_embedded": {
+          "const": false
+        },
+        "subprocess_used": {
+          "const": false
+        },
+        "token_embedded": {
+          "const": false
+        },
+        "trustlog_written": {
+          "const": false
+        },
+        "webhook_called": {
+          "const": false
+        }
+      },
+      "required": [
+        "check_id",
+        "ordinal",
+        "name",
+        "mode",
+        "passed",
+        "evidence_ref",
+        "endpoint_resolved",
+        "dns_used",
+        "network_used",
+        "credential_material_accessed",
+        "credential_material_embedded",
+        "authorization_header_embedded",
+        "token_embedded",
+        "secret_embedded",
+        "webhook_called",
+        "live_adapter_instantiated",
+        "live_adapter_method_called",
+        "request_dispatched",
+        "bind_invoked",
+        "bind_receipt_created",
+        "trustlog_written",
+        "external_effect_used",
+        "filesystem_used",
+        "database_used",
+        "provider_used",
+        "subprocess_used",
+        "operation_committed"
+      ],
+      "type": "object"
+    },
+    "EndpointAllowlistSnapshot": {
+      "additionalProperties": false,
+      "properties": {
+        "allowlist_entries": {
+          "items": {
+            "$ref": "#/$defs/AllowlistEntry"
+          },
+          "type": "array"
+        },
+        "allowlist_generated_at": {
+          "type": "string"
+        },
+        "allowlist_scope_limitations": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "allowlist_snapshot_hash": {
+          "type": "string"
+        },
+        "allowlist_snapshot_id": {
+          "type": "string"
+        },
+        "allowlist_source": {
+          "type": "string"
+        },
+        "allowlist_version": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "allowlist_snapshot_id",
+        "allowlist_snapshot_hash",
+        "allowlist_version",
+        "allowlist_source",
+        "allowlist_generated_at",
+        "allowlist_entries",
+        "allowlist_scope_limitations"
+      ],
+      "type": "object"
+    },
+    "EndpointCandidate": {
+      "additionalProperties": false,
+      "properties": {
+        "adapter_contract_id": {
+          "type": "string"
+        },
+        "declared_at": {
+          "type": "string"
+        },
+        "declared_by": {
+          "type": "string"
+        },
+        "endpoint_candidate_id": {
+          "type": "string"
+        },
+        "endpoint_environment": {
+          "type": "string"
+        },
+        "endpoint_host": {
+          "type": "string"
+        },
+        "endpoint_kind": {
+          "type": "string"
+        },
+        "endpoint_path_prefix": {
+          "type": "string"
+        },
+        "endpoint_port": {
+          "type": "integer"
+        },
+        "endpoint_purpose": {
+          "type": "string"
+        },
+        "endpoint_scheme": {
+          "type": "string"
+        },
+        "target_resource_scope": {
+          "type": "string"
+        },
+        "target_system": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "endpoint_candidate_id",
+        "endpoint_kind",
+        "endpoint_scheme",
+        "endpoint_host",
+        "endpoint_port",
+        "endpoint_path_prefix",
+        "endpoint_environment",
+        "endpoint_purpose",
+        "adapter_contract_id",
+        "target_system",
+        "target_resource_scope",
+        "declared_by",
+        "declared_at"
+      ],
+      "type": "object"
+    },
+    "FutureCredentialRequirement": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "ordinal": {
+          "type": "integer"
+        },
+        "satisfied_by_this_packet": {
+          "const": false
+        },
+        "separate_future_artifact_required": {
+          "const": true
+        }
+      },
+      "required": [
+        "ordinal",
+        "name",
+        "separate_future_artifact_required",
+        "satisfied_by_this_packet"
+      ],
+      "type": "object"
+    }
+  },
+  "$id": "https://veritas-os.example/schemas/live-adapter-dry-run-endpoint-allowlist-v1.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "adapter_contract_descriptor": {
+      "type": "object"
+    },
+    "adapter_contract_hash": {
+      "type": "string"
+    },
+    "adapter_contract_id": {
+      "type": "string"
+    },
+    "adapter_contract_version": {
+      "type": "string"
+    },
+    "allowlist_evaluation_digest": {
+      "type": "string"
+    },
+    "allowlist_evaluation_result": {
+      "$ref": "#/$defs/AllowlistEvaluationResult"
+    },
+    "allowlist_snapshot": {
+      "$ref": "#/$defs/EndpointAllowlistSnapshot"
+    },
+    "allowlist_snapshot_hash": {
+      "type": "string"
+    },
+    "bind_invoked": {
+      "const": false
+    },
+    "bind_receipt_created": {
+      "const": false
+    },
+    "candidate_identity": {
+      "type": "object"
+    },
+    "credential_material_accessed": {
+      "const": false
+    },
+    "endpoint_allowlist_check_digest": {
+      "type": "string"
+    },
+    "endpoint_allowlist_checks": {
+      "items": {
+        "$ref": "#/$defs/EndpointAllowlistCheck"
+      },
+      "type": "array"
+    },
+    "endpoint_allowlist_evaluated_at": {
+      "type": "string"
+    },
+    "endpoint_allowlist_evaluation_mechanism": {
+      "const": "evaluate_live_adapter_dry_run_endpoint_allowlist_without_resolution/v1"
+    },
+    "endpoint_allowlist_status": {
+      "const": "LIVE_ADAPTER_DRY_RUN_ENDPOINT_ALLOWLIST_EVALUATED_NOT_DISPATCHED"
+    },
+    "endpoint_candidate": {
+      "$ref": "#/$defs/EndpointCandidate"
+    },
+    "endpoint_candidate_digest": {
+      "type": "string"
+    },
+    "endpoint_identity_binding": {
+      "type": "object"
+    },
+    "endpoint_identity_binding_digest": {
+      "type": "string"
+    },
+    "endpoint_resolved": {
+      "const": false
+    },
+    "evidence_lineage": {
+      "type": "object"
+    },
+    "execution_intent": {
+      "type": "object"
+    },
+    "execution_intent_hash": {
+      "type": "string"
+    },
+    "execution_intent_id": {
+      "type": "string"
+    },
+    "fail_closed": {
+      "type": "boolean"
+    },
+    "field_mapping_proof": {
+      "type": "object"
+    },
+    "format_version": {
+      "const": "canonical-live-adapter-dry-run-endpoint-allowlist-evaluation/v1"
+    },
+    "future_credential_requirement_digest": {
+      "type": "string"
+    },
+    "future_credential_requirements": {
+      "items": {
+        "$ref": "#/$defs/FutureCredentialRequirement"
+      },
+      "type": "array"
+    },
+    "live_adapter_dry_run_endpoint_allowlist_evaluation_hash": {
+      "type": "string"
+    },
+    "live_adapter_dry_run_endpoint_allowlist_evaluation_id": {
+      "type": "string"
+    },
+    "live_adapter_instantiated": {
+      "const": false
+    },
+    "network_used": {
+      "const": false
+    },
+    "replay_summary": {
+      "type": "object"
+    },
+    "request_descriptor": {
+      "type": "object"
+    },
+    "request_dispatch_state": {
+      "const": "NOT_DISPATCHED"
+    },
+    "required_field_presence": {
+      "type": "object"
+    },
+    "scope_limitations": {
+      "items": false,
+      "maxItems": 20,
+      "minItems": 20,
+      "prefixItems": [
+        {
+          "const": "NOT_DISPATCHED"
+        },
+        {
+          "const": "NOT_ENDPOINT_RESOLUTION"
+        },
+        {
+          "const": "NOT_DNS_RESOLUTION"
+        },
+        {
+          "const": "NOT_NETWORK_CALL"
+        },
+        {
+          "const": "NOT_WEBHOOK_CALL"
+        },
+        {
+          "const": "NOT_CREDENTIAL_RESOLUTION"
+        },
+        {
+          "const": "NOT_CREDENTIAL_ACCESS"
+        },
+        {
+          "const": "NOT_CREDENTIAL_EMBEDDING"
+        },
+        {
+          "const": "NOT_AUTHORIZATION_HEADER"
+        },
+        {
+          "const": "NOT_TOKEN"
+        },
+        {
+          "const": "NOT_SECRET"
+        },
+        {
+          "const": "NOT_LIVE_ADAPTER_INSTANCE"
+        },
+        {
+          "const": "NOT_LIVE_ADAPTER_RESULT"
+        },
+        {
+          "const": "NOT_BIND_AUTHORIZATION"
+        },
+        {
+          "const": "NOT_BIND_RECEIPT"
+        },
+        {
+          "const": "NOT_TRUSTLOG_WRITE"
+        },
+        {
+          "const": "NOT_OPERATION_COMMIT"
+        },
+        {
+          "const": "NOT_PRODUCTION_CLAIM"
+        },
+        {
+          "const": "NOT_CUSTOMER_CLAIM"
+        },
+        {
+          "const": "NOT_REGULATORY_CERTIFICATION"
+        }
+      ],
+      "type": "array"
+    },
+    "source_decision_identity": {
+      "type": "object"
+    },
+    "source_dispatch_readiness_hash": {
+      "type": "string"
+    },
+    "source_dispatch_readiness_id": {
+      "type": "string"
+    },
+    "source_dispatch_readiness_packet": {
+      "type": "object"
+    },
+    "source_live_adapter_dry_run_request_hash": {
+      "type": "string"
+    },
+    "source_live_adapter_dry_run_request_id": {
+      "type": "string"
+    },
+    "source_to_execution_intent_mapping": {
+      "type": "object"
+    },
+    "trustlog_written": {
+      "const": false
+    },
+    "webhook_called": {
+      "const": false
+    }
+  },
+  "required": [
+    "format_version",
+    "live_adapter_dry_run_endpoint_allowlist_evaluation_id",
+    "live_adapter_dry_run_endpoint_allowlist_evaluation_hash",
+    "endpoint_allowlist_evaluation_mechanism",
+    "endpoint_allowlist_evaluated_at",
+    "source_dispatch_readiness_id",
+    "source_dispatch_readiness_hash",
+    "source_dispatch_readiness_packet",
+    "source_live_adapter_dry_run_request_id",
+    "source_live_adapter_dry_run_request_hash",
+    "request_descriptor",
+    "execution_intent",
+    "execution_intent_id",
+    "execution_intent_hash",
+    "adapter_contract_descriptor",
+    "adapter_contract_id",
+    "adapter_contract_hash",
+    "adapter_contract_version",
+    "endpoint_candidate",
+    "endpoint_candidate_digest",
+    "allowlist_snapshot",
+    "allowlist_snapshot_hash",
+    "allowlist_evaluation_result",
+    "allowlist_evaluation_digest",
+    "endpoint_identity_binding",
+    "endpoint_identity_binding_digest",
+    "endpoint_allowlist_checks",
+    "endpoint_allowlist_check_digest",
+    "future_credential_requirements",
+    "future_credential_requirement_digest",
+    "source_to_execution_intent_mapping",
+    "field_mapping_proof",
+    "required_field_presence",
+    "source_decision_identity",
+    "candidate_identity",
+    "evidence_lineage",
+    "replay_summary",
+    "endpoint_allowlist_status",
+    "request_dispatch_state",
+    "endpoint_resolved",
+    "network_used",
+    "credential_material_accessed",
+    "live_adapter_instantiated",
+    "webhook_called",
+    "bind_invoked",
+    "bind_receipt_created",
+    "trustlog_written",
+    "fail_closed",
+    "scope_limitations"
+  ],
+  "type": "object"
+}

--- a/veritas_os/policy/live_adapter_dry_run_endpoint_allowlist.py
+++ b/veritas_os/policy/live_adapter_dry_run_endpoint_allowlist.py
@@ -1,0 +1,519 @@
+"""Create deterministic endpoint-allowlist evidence without external effects.
+
+This module compares declared data only.  It intentionally has no endpoint
+resolution, credential, adapter, network, persistence, or dispatch capability.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from veritas_os.policy.live_adapter_dry_run_dispatch_readiness import (
+    CanonicalLiveAdapterDryRunDispatchReadinessPacket,
+    LiveAdapterDryRunDispatchReadinessError,
+    verify_live_adapter_dry_run_dispatch_readiness_packet,
+)
+
+FORMAT_VERSION = "canonical-live-adapter-dry-run-endpoint-allowlist-evaluation/v1"
+EVALUATION_MECHANISM = (
+    "evaluate_live_adapter_dry_run_endpoint_allowlist_without_resolution/v1"
+)
+STATUS = "LIVE_ADAPTER_DRY_RUN_ENDPOINT_ALLOWLIST_EVALUATED_NOT_DISPATCHED"
+CHECK_MODE = "deterministic_local_endpoint_allowlist_evaluation_only"
+CANDIDATE_DOMAIN = "veritas.live-adapter-dry-run-endpoint-allowlist.candidate/v1"
+SNAPSHOT_DOMAIN = "veritas.live-adapter-dry-run-endpoint-allowlist.snapshot/v1"
+EVALUATION_DOMAIN = "veritas.live-adapter-dry-run-endpoint-allowlist.evaluation/v1"
+IDENTITY_DOMAIN = "veritas.live-adapter-dry-run-endpoint-allowlist.identity-binding/v1"
+CHECKS_DOMAIN = "veritas.live-adapter-dry-run-endpoint-allowlist.checks/v1"
+FUTURE_CREDENTIAL_REQUIREMENTS_DOMAIN = (
+    "veritas.live-adapter-dry-run-endpoint-allowlist.future-credential-requirements/v1"
+)
+PACKET_DOMAIN = "veritas.live-adapter-dry-run-endpoint-allowlist.packet/v1"
+
+CHECK_NAMES = (
+    "source_dispatch_readiness_verified", "source_request_not_dispatched",
+    "endpoint_candidate_closed_schema_valid",
+    "endpoint_candidate_contains_no_credentials",
+    "endpoint_candidate_contains_no_authorization_headers",
+    "endpoint_candidate_contains_no_tokens", "endpoint_candidate_contains_no_secrets",
+    "allowlist_snapshot_closed_schema_valid", "allowlist_snapshot_hash_verified",
+    "allowlist_entry_active_status_required", "endpoint_scheme_exact_match",
+    "endpoint_host_exact_match", "endpoint_port_exact_match",
+    "endpoint_path_prefix_exact_match", "endpoint_environment_exact_match",
+    "adapter_contract_id_allowed", "target_system_allowed",
+    "target_resource_scope_allowed", "endpoint_purpose_allowed",
+    "endpoint_identity_binding_constructed", "endpoint_not_resolved",
+    "dns_not_used", "network_not_used", "credential_not_accessed",
+    "webhook_not_called", "live_adapter_not_instantiated", "bind_not_invoked",
+    "bind_receipt_not_created", "trustlog_not_written",
+    "future_credential_gate_required",
+)
+EFFECT_FIELDS = (
+    "endpoint_resolved", "dns_used", "network_used", "credential_material_accessed",
+    "credential_material_embedded", "authorization_header_embedded", "token_embedded",
+    "secret_embedded", "webhook_called", "live_adapter_instantiated",
+    "live_adapter_method_called", "request_dispatched", "bind_invoked",
+    "bind_receipt_created", "trustlog_written", "external_effect_used",
+    "filesystem_used", "database_used", "provider_used", "subprocess_used",
+    "operation_committed",
+)
+SCOPE_LIMITATIONS = (
+    "NOT_DISPATCHED", "NOT_ENDPOINT_RESOLUTION", "NOT_DNS_RESOLUTION",
+    "NOT_NETWORK_CALL", "NOT_WEBHOOK_CALL", "NOT_CREDENTIAL_RESOLUTION",
+    "NOT_CREDENTIAL_ACCESS", "NOT_CREDENTIAL_EMBEDDING",
+    "NOT_AUTHORIZATION_HEADER", "NOT_TOKEN", "NOT_SECRET",
+    "NOT_LIVE_ADAPTER_INSTANCE", "NOT_LIVE_ADAPTER_RESULT",
+    "NOT_BIND_AUTHORIZATION", "NOT_BIND_RECEIPT", "NOT_TRUSTLOG_WRITE",
+    "NOT_OPERATION_COMMIT", "NOT_PRODUCTION_CLAIM", "NOT_CUSTOMER_CLAIM",
+    "NOT_REGULATORY_CERTIFICATION",
+)
+FUTURE_REQUIREMENT_NAMES = (
+    "credential_resolution_authorization", "credential_source_identity",
+    "credential_scope_binding", "credential_material_non_embedding",
+    "authorization_header_construction_boundary", "credential_redaction_boundary",
+    "operator_human_credential_review", "bind_pre_dispatch_review",
+    "network_dispatch_boundary_remains_separate",
+)
+COPIED_FIELDS = (
+    "request_descriptor", "execution_intent", "execution_intent_id",
+    "execution_intent_hash", "adapter_contract_descriptor", "adapter_contract_id",
+    "adapter_contract_hash", "adapter_contract_version",
+    "source_to_execution_intent_mapping", "field_mapping_proof",
+    "required_field_presence", "source_decision_identity", "candidate_identity",
+    "evidence_lineage", "replay_summary",
+)
+EXACT_FIELDS = (
+    "endpoint_kind", "endpoint_scheme", "endpoint_host", "endpoint_port",
+    "endpoint_path_prefix", "endpoint_environment", "adapter_contract_id",
+    "target_system", "target_resource_scope", "endpoint_purpose",
+)
+PROHIBITED_KEYS = (
+    "authorization", "authorization_header", "token", "secret", "cookie",
+    "credential", "credentials", "request_body", "body",
+)
+
+
+class LiveAdapterDryRunEndpointAllowlistError(ValueError):
+    """Stable fail-closed refusal for invalid endpoint-allowlist evidence."""
+
+
+class EndpointCandidate(BaseModel):
+    """Closed, data-only endpoint declaration."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    endpoint_candidate_id: str = Field(min_length=1)
+    endpoint_kind: str = Field(min_length=1)
+    endpoint_scheme: str = Field(min_length=1)
+    endpoint_host: str = Field(min_length=1)
+    endpoint_port: int = Field(ge=1, le=65535)
+    endpoint_path_prefix: str
+    endpoint_environment: str = Field(min_length=1)
+    endpoint_purpose: str = Field(min_length=1)
+    adapter_contract_id: str = Field(min_length=1)
+    target_system: str = Field(min_length=1)
+    target_resource_scope: str = Field(min_length=1)
+    declared_by: str = Field(min_length=1)
+    declared_at: str
+
+
+class AllowlistEntry(BaseModel):
+    """One exact local allowlist entry."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    entry_id: str = Field(min_length=1)
+    endpoint_kind: str
+    endpoint_scheme: str
+    endpoint_host: str
+    endpoint_port: int = Field(ge=1, le=65535)
+    endpoint_path_prefix: str
+    endpoint_environment: str
+    allowed_adapter_contract_ids: tuple[str, ...]
+    allowed_target_systems: tuple[str, ...]
+    allowed_target_resource_scopes: tuple[str, ...]
+    allowed_purposes: tuple[str, ...]
+    entry_status: Literal["ACTIVE", "INACTIVE"]
+
+
+class EndpointAllowlistSnapshot(BaseModel):
+    """Closed deterministic snapshot supplied by the caller."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    allowlist_snapshot_id: str = Field(min_length=1)
+    allowlist_snapshot_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    allowlist_version: str = Field(min_length=1)
+    allowlist_source: str = Field(min_length=1)
+    allowlist_generated_at: str
+    allowlist_entries: tuple[AllowlistEntry, ...]
+    allowlist_scope_limitations: tuple[str, ...]
+
+
+class AllowlistEvaluationResult(BaseModel):
+    """Exact comparison outcome; never a semantic safety inference."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    matched: bool
+    matched_entry_id: str | None
+    match_reason: str
+    mismatch_reasons: tuple[str, ...]
+    comparison_mode: Literal["exact_local_allowlist_comparison_only"]
+    exact_fields_compared: tuple[str, ...]
+    semantic_match_used: Literal[False]
+
+
+class EndpointAllowlistCheck(BaseModel):
+    """One ordered local check with explicit non-effect claims."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    check_id: str
+    ordinal: int = Field(ge=1, le=30)
+    name: Literal[*CHECK_NAMES]
+    mode: Literal[CHECK_MODE]
+    passed: bool
+    evidence_ref: str
+    endpoint_resolved: Literal[False]
+    dns_used: Literal[False]
+    network_used: Literal[False]
+    credential_material_accessed: Literal[False]
+    credential_material_embedded: Literal[False]
+    authorization_header_embedded: Literal[False]
+    token_embedded: Literal[False]
+    secret_embedded: Literal[False]
+    webhook_called: Literal[False]
+    live_adapter_instantiated: Literal[False]
+    live_adapter_method_called: Literal[False]
+    request_dispatched: Literal[False]
+    bind_invoked: Literal[False]
+    bind_receipt_created: Literal[False]
+    trustlog_written: Literal[False]
+    external_effect_used: Literal[False]
+    filesystem_used: Literal[False]
+    database_used: Literal[False]
+    provider_used: Literal[False]
+    subprocess_used: Literal[False]
+    operation_committed: Literal[False]
+
+
+class FutureCredentialRequirement(BaseModel):
+    """A credential gate explicitly not satisfied by this packet."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    ordinal: int = Field(ge=1, le=9)
+    name: Literal[*FUTURE_REQUIREMENT_NAMES]
+    separate_future_artifact_required: Literal[True]
+    satisfied_by_this_packet: Literal[False]
+
+
+class CanonicalLiveAdapterDryRunEndpointAllowlistEvaluationPacket(BaseModel):
+    """Closed content-addressed endpoint allowlist evaluation packet."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    format_version: Literal[FORMAT_VERSION]
+    live_adapter_dry_run_endpoint_allowlist_evaluation_id: str
+    live_adapter_dry_run_endpoint_allowlist_evaluation_hash: str
+    endpoint_allowlist_evaluation_mechanism: Literal[EVALUATION_MECHANISM]
+    endpoint_allowlist_evaluated_at: str
+    source_dispatch_readiness_id: str
+    source_dispatch_readiness_hash: str
+    source_dispatch_readiness_packet: dict[str, Any]
+    source_live_adapter_dry_run_request_id: str
+    source_live_adapter_dry_run_request_hash: str
+    request_descriptor: dict[str, Any]
+    execution_intent: dict[str, Any]
+    execution_intent_id: str
+    execution_intent_hash: str
+    adapter_contract_descriptor: dict[str, Any]
+    adapter_contract_id: str
+    adapter_contract_hash: str
+    adapter_contract_version: str
+    endpoint_candidate: EndpointCandidate
+    endpoint_candidate_digest: str
+    allowlist_snapshot: EndpointAllowlistSnapshot
+    allowlist_snapshot_hash: str
+    allowlist_evaluation_result: AllowlistEvaluationResult
+    allowlist_evaluation_digest: str
+    endpoint_identity_binding: dict[str, Any]
+    endpoint_identity_binding_digest: str
+    endpoint_allowlist_checks: tuple[EndpointAllowlistCheck, ...]
+    endpoint_allowlist_check_digest: str
+    future_credential_requirements: tuple[FutureCredentialRequirement, ...]
+    future_credential_requirement_digest: str
+    source_to_execution_intent_mapping: dict[str, Any]
+    field_mapping_proof: dict[str, Any]
+    required_field_presence: dict[str, str]
+    source_decision_identity: dict[str, Any]
+    candidate_identity: dict[str, Any]
+    evidence_lineage: dict[str, Any]
+    replay_summary: dict[str, Any]
+    endpoint_allowlist_status: Literal[STATUS]
+    request_dispatch_state: Literal["NOT_DISPATCHED"]
+    endpoint_resolved: Literal[False]
+    network_used: Literal[False]
+    credential_material_accessed: Literal[False]
+    live_adapter_instantiated: Literal[False]
+    webhook_called: Literal[False]
+    bind_invoked: Literal[False]
+    bind_receipt_created: Literal[False]
+    trustlog_written: Literal[False]
+    fail_closed: bool
+    scope_limitations: tuple[Literal[*SCOPE_LIMITATIONS], ...]
+
+
+def _normalized_timestamp(value: Any) -> str:
+    try:
+        parsed = value if isinstance(value, datetime) else datetime.fromisoformat(value)
+    except (TypeError, ValueError) as exc:
+        raise LiveAdapterDryRunEndpointAllowlistError("LADREA_TIMESTAMP_INVALID") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise LiveAdapterDryRunEndpointAllowlistError("LADREA_TIMESTAMP_INVALID")
+    return parsed.astimezone(timezone.utc).isoformat()
+
+
+def _json_value(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        value = value.model_dump(mode="python")
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        if value != value or value in (float("inf"), float("-inf")):
+            raise LiveAdapterDryRunEndpointAllowlistError("LADREA_PACKET_INVALID")
+        return value
+    if isinstance(value, datetime):
+        return _normalized_timestamp(value)
+    if isinstance(value, (list, tuple)):
+        return [_json_value(item) for item in value]
+    if isinstance(value, dict) and all(isinstance(key, str) for key in value):
+        return {key: _json_value(item) for key, item in value.items()}
+    raise LiveAdapterDryRunEndpointAllowlistError("LADREA_PACKET_INVALID")
+
+
+def _digest(domain: str, value: Any) -> str:
+    encoded = json.dumps(
+        {"domain": domain, "value": _json_value(value)}, allow_nan=False,
+        ensure_ascii=False, separators=(",", ":"), sort_keys=True,
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _snapshot_hash(raw: dict[str, Any]) -> str:
+    return _digest(SNAPSHOT_DOMAIN, {
+        key: value for key, value in raw.items() if key != "allowlist_snapshot_hash"
+    })
+
+
+def _packet_hash(raw: dict[str, Any]) -> str:
+    omitted = {
+        "live_adapter_dry_run_endpoint_allowlist_evaluation_id",
+        "live_adapter_dry_run_endpoint_allowlist_evaluation_hash",
+    }
+    return _digest(PACKET_DOMAIN, {key: value for key, value in raw.items()
+                                   if key not in omitted})
+
+
+def _reject_sensitive_keys(value: Any) -> None:
+    if not isinstance(value, dict):
+        return
+    for key in value:
+        normalized = key.lower().replace("-", "_")
+        if normalized in PROHIBITED_KEYS:
+            raise LiveAdapterDryRunEndpointAllowlistError("LADREA_SENSITIVE_INPUT")
+
+
+def _evaluation(candidate: EndpointCandidate, snapshot: EndpointAllowlistSnapshot) -> dict[str, Any]:
+    field_failures: set[str] = set()
+    active_seen = False
+    for entry in snapshot.allowlist_entries:
+        if entry.entry_status != "ACTIVE":
+            continue
+        active_seen = True
+        comparisons = {
+            "endpoint_kind": candidate.endpoint_kind == entry.endpoint_kind,
+            "endpoint_scheme": candidate.endpoint_scheme == entry.endpoint_scheme,
+            "endpoint_host": candidate.endpoint_host == entry.endpoint_host,
+            "endpoint_port": candidate.endpoint_port == entry.endpoint_port,
+            "endpoint_path_prefix": candidate.endpoint_path_prefix == entry.endpoint_path_prefix,
+            "endpoint_environment": candidate.endpoint_environment == entry.endpoint_environment,
+            "adapter_contract_id": candidate.adapter_contract_id in entry.allowed_adapter_contract_ids,
+            "target_system": candidate.target_system in entry.allowed_target_systems,
+            "target_resource_scope": candidate.target_resource_scope in entry.allowed_target_resource_scopes,
+            "endpoint_purpose": candidate.endpoint_purpose in entry.allowed_purposes,
+        }
+        if all(comparisons.values()):
+            return {"matched": True, "matched_entry_id": entry.entry_id,
+                    "match_reason": "active_entry_exact_match", "mismatch_reasons": [],
+                    "comparison_mode": "exact_local_allowlist_comparison_only",
+                    "exact_fields_compared": list(EXACT_FIELDS), "semantic_match_used": False}
+        field_failures.update(name for name, passed in comparisons.items() if not passed)
+    reasons = (["no_active_allowlist_entry"] if not active_seen else
+               [f"{name}_mismatch" for name in EXACT_FIELDS if name in field_failures])
+    return {"matched": False, "matched_entry_id": None,
+            "match_reason": "no_active_exact_match", "mismatch_reasons": reasons,
+            "comparison_mode": "exact_local_allowlist_comparison_only",
+            "exact_fields_compared": list(EXACT_FIELDS), "semantic_match_used": False}
+
+
+def _identity(source: CanonicalLiveAdapterDryRunDispatchReadinessPacket,
+              candidate: EndpointCandidate, snapshot: EndpointAllowlistSnapshot) -> dict[str, Any]:
+    return {
+        "source_dispatch_readiness_id": source.live_adapter_dry_run_dispatch_readiness_id,
+        "endpoint_candidate_id": candidate.endpoint_candidate_id,
+        "adapter_contract_id": candidate.adapter_contract_id,
+        "allowlist_snapshot_id": snapshot.allowlist_snapshot_id,
+    }
+
+
+def _requirements() -> list[dict[str, Any]]:
+    return [{"ordinal": ordinal, "name": name,
+             "separate_future_artifact_required": True,
+             "satisfied_by_this_packet": False}
+            for ordinal, name in enumerate(FUTURE_REQUIREMENT_NAMES, 1)]
+
+
+def _checks(source_hash: str, result: dict[str, Any]) -> list[dict[str, Any]]:
+    match_checks = set(CHECK_NAMES[9:19])
+    return [{
+        "check_id": f"ladrea-check:v1:{ordinal}:{name.replace('_', '-')}",
+        "ordinal": ordinal, "name": name, "mode": CHECK_MODE,
+        "passed": result["matched"] if name in match_checks else True,
+        "evidence_ref": f"source_dispatch_readiness_hash:{source_hash}:{name}",
+        **{field: False for field in EFFECT_FIELDS},
+    } for ordinal, name in enumerate(CHECK_NAMES, 1)]
+
+
+def _source(value: Any) -> CanonicalLiveAdapterDryRunDispatchReadinessPacket:
+    try:
+        return verify_live_adapter_dry_run_dispatch_readiness_packet(value)
+    except (LiveAdapterDryRunDispatchReadinessError, TypeError, ValueError) as exc:
+        raise LiveAdapterDryRunEndpointAllowlistError("LADREA_SOURCE_INVALID") from exc
+
+
+def build_live_adapter_dry_run_endpoint_allowlist_evaluation_packet(
+    source_dispatch_readiness_packet: Any, endpoint_candidate: Any,
+    allowlist_snapshot: Any, endpoint_allowlist_evaluated_at: datetime,
+) -> CanonicalLiveAdapterDryRunEndpointAllowlistEvaluationPacket:
+    """Build and self-verify a purely local exact allowlist evaluation."""
+    evaluated_at = _normalized_timestamp(endpoint_allowlist_evaluated_at)
+    source = _source(_json_value(source_dispatch_readiness_packet))
+    if source.request_dispatch_state != "NOT_DISPATCHED":
+        raise LiveAdapterDryRunEndpointAllowlistError("LADREA_SOURCE_DISPATCHED")
+    if source.dispatch_readiness_status != (
+        "LIVE_ADAPTER_DRY_RUN_DISPATCH_READINESS_EVALUATED_NOT_DISPATCHED"
+    ):
+        raise LiveAdapterDryRunEndpointAllowlistError("LADREA_SOURCE_STATUS_INVALID")
+    candidate_input = _json_value(endpoint_candidate)
+    _reject_sensitive_keys(candidate_input)
+    try:
+        candidate = EndpointCandidate.model_validate(candidate_input)
+        snapshot = EndpointAllowlistSnapshot.model_validate(_json_value(allowlist_snapshot))
+    except ValidationError as exc:
+        raise LiveAdapterDryRunEndpointAllowlistError("LADREA_INPUT_INVALID") from exc
+    candidate_raw = candidate.model_dump(mode="json")
+    snapshot_raw = snapshot.model_dump(mode="json")
+    _normalized_timestamp(candidate.declared_at)
+    _normalized_timestamp(snapshot.allowlist_generated_at)
+    if snapshot.allowlist_snapshot_hash != _snapshot_hash(snapshot_raw):
+        raise LiveAdapterDryRunEndpointAllowlistError("LADREA_SNAPSHOT_HASH_INVALID")
+    if datetime.fromisoformat(evaluated_at) < datetime.fromisoformat(
+        _normalized_timestamp(source.dispatch_readiness_evaluated_at)
+    ):
+        raise LiveAdapterDryRunEndpointAllowlistError("LADREA_EVALUATED_TOO_EARLY")
+    result = _evaluation(candidate, snapshot)
+    identity = _identity(source, candidate, snapshot)
+    checks = _checks(source.live_adapter_dry_run_dispatch_readiness_hash, result)
+    requirements = _requirements()
+    source_raw = source.model_dump(mode="json")
+    raw = {
+        "format_version": FORMAT_VERSION,
+        "endpoint_allowlist_evaluation_mechanism": EVALUATION_MECHANISM,
+        "endpoint_allowlist_evaluated_at": evaluated_at,
+        "source_dispatch_readiness_id": source.live_adapter_dry_run_dispatch_readiness_id,
+        "source_dispatch_readiness_hash": source.live_adapter_dry_run_dispatch_readiness_hash,
+        "source_dispatch_readiness_packet": source_raw,
+        "source_live_adapter_dry_run_request_id": source.source_live_adapter_dry_run_request_id,
+        "source_live_adapter_dry_run_request_hash": source.source_live_adapter_dry_run_request_hash,
+        **{field: source_raw[field] for field in COPIED_FIELDS},
+        "endpoint_candidate": candidate_raw,
+        "endpoint_candidate_digest": _digest(CANDIDATE_DOMAIN, candidate_raw),
+        "allowlist_snapshot": snapshot_raw,
+        "allowlist_snapshot_hash": snapshot.allowlist_snapshot_hash,
+        "allowlist_evaluation_result": result,
+        "allowlist_evaluation_digest": _digest(EVALUATION_DOMAIN, result),
+        "endpoint_identity_binding": identity,
+        "endpoint_identity_binding_digest": _digest(IDENTITY_DOMAIN, identity),
+        "endpoint_allowlist_checks": checks,
+        "endpoint_allowlist_check_digest": _digest(CHECKS_DOMAIN, checks),
+        "future_credential_requirements": requirements,
+        "future_credential_requirement_digest": _digest(
+            FUTURE_CREDENTIAL_REQUIREMENTS_DOMAIN, requirements),
+        "endpoint_allowlist_status": STATUS, "request_dispatch_state": "NOT_DISPATCHED",
+        **{field: False for field in ("endpoint_resolved", "network_used",
+           "credential_material_accessed", "live_adapter_instantiated", "webhook_called",
+           "bind_invoked", "bind_receipt_created", "trustlog_written")},
+        "fail_closed": not result["matched"], "scope_limitations": SCOPE_LIMITATIONS,
+    }
+    digest = _packet_hash(raw)
+    raw["live_adapter_dry_run_endpoint_allowlist_evaluation_hash"] = digest
+    raw["live_adapter_dry_run_endpoint_allowlist_evaluation_id"] = f"ladrea:v1:sha256:{digest}"
+    return verify_live_adapter_dry_run_endpoint_allowlist_evaluation_packet(raw)
+
+
+def verify_live_adapter_dry_run_endpoint_allowlist_evaluation_packet(
+    raw: Any,
+) -> CanonicalLiveAdapterDryRunEndpointAllowlistEvaluationPacket:
+    """Recompute every source binding, outcome, check, digest, hash, and ID."""
+    try:
+        value = raw.model_dump(mode="json") if isinstance(raw, BaseModel) else _json_value(raw)
+        packet = CanonicalLiveAdapterDryRunEndpointAllowlistEvaluationPacket.model_validate(value)
+    except (ValidationError, TypeError, LiveAdapterDryRunEndpointAllowlistError) as exc:
+        raise LiveAdapterDryRunEndpointAllowlistError("LADREA_PACKET_INVALID") from exc
+    actual = packet.model_dump(mode="json")
+    source = _source(packet.source_dispatch_readiness_packet)
+    source_raw = source.model_dump(mode="json")
+    if packet.source_dispatch_readiness_id != source.live_adapter_dry_run_dispatch_readiness_id:
+        raise LiveAdapterDryRunEndpointAllowlistError("LADREA_SOURCE_ID_MISMATCH")
+    if packet.source_dispatch_readiness_hash != source.live_adapter_dry_run_dispatch_readiness_hash:
+        raise LiveAdapterDryRunEndpointAllowlistError("LADREA_SOURCE_HASH_MISMATCH")
+    if source.request_dispatch_state != "NOT_DISPATCHED" or packet.request_dispatch_state != "NOT_DISPATCHED":
+        raise LiveAdapterDryRunEndpointAllowlistError("LADREA_SOURCE_DISPATCHED")
+    if source.dispatch_readiness_status != "LIVE_ADAPTER_DRY_RUN_DISPATCH_READINESS_EVALUATED_NOT_DISPATCHED":
+        raise LiveAdapterDryRunEndpointAllowlistError("LADREA_SOURCE_STATUS_INVALID")
+    for field in COPIED_FIELDS:
+        if _json_value(getattr(packet, field)) != _json_value(source_raw[field]):
+            raise LiveAdapterDryRunEndpointAllowlistError("LADREA_SOURCE_FIELD_MISMATCH")
+    if packet.source_live_adapter_dry_run_request_id != source.source_live_adapter_dry_run_request_id or packet.source_live_adapter_dry_run_request_hash != source.source_live_adapter_dry_run_request_hash:
+        raise LiveAdapterDryRunEndpointAllowlistError("LADREA_LINEAGE_MISMATCH")
+    candidate_raw = packet.endpoint_candidate.model_dump(mode="json")
+    snapshot_raw = packet.allowlist_snapshot.model_dump(mode="json")
+    _normalized_timestamp(packet.endpoint_candidate.declared_at)
+    _normalized_timestamp(packet.allowlist_snapshot.allowlist_generated_at)
+    if packet.endpoint_candidate_digest != _digest(CANDIDATE_DOMAIN, candidate_raw):
+        raise LiveAdapterDryRunEndpointAllowlistError("LADREA_CANDIDATE_DIGEST_MISMATCH")
+    snapshot_hash = _snapshot_hash(snapshot_raw)
+    if packet.allowlist_snapshot_hash != snapshot_hash or packet.allowlist_snapshot.allowlist_snapshot_hash != snapshot_hash:
+        raise LiveAdapterDryRunEndpointAllowlistError("LADREA_SNAPSHOT_HASH_MISMATCH")
+    result = _evaluation(packet.endpoint_candidate, packet.allowlist_snapshot)
+    if _json_value(packet.allowlist_evaluation_result) != result or packet.allowlist_evaluation_digest != _digest(EVALUATION_DOMAIN, result):
+        raise LiveAdapterDryRunEndpointAllowlistError("LADREA_EVALUATION_MISMATCH")
+    identity = _identity(source, packet.endpoint_candidate, packet.allowlist_snapshot)
+    if packet.endpoint_identity_binding != identity or packet.endpoint_identity_binding_digest != _digest(IDENTITY_DOMAIN, identity):
+        raise LiveAdapterDryRunEndpointAllowlistError("LADREA_IDENTITY_MISMATCH")
+    checks = _checks(source.live_adapter_dry_run_dispatch_readiness_hash, result)
+    if _json_value(packet.endpoint_allowlist_checks) != checks or packet.endpoint_allowlist_check_digest != _digest(CHECKS_DOMAIN, checks):
+        raise LiveAdapterDryRunEndpointAllowlistError("LADREA_CHECKS_MISMATCH")
+    requirements = _requirements()
+    if _json_value(packet.future_credential_requirements) != requirements or packet.future_credential_requirement_digest != _digest(FUTURE_CREDENTIAL_REQUIREMENTS_DOMAIN, requirements):
+        raise LiveAdapterDryRunEndpointAllowlistError("LADREA_REQUIREMENTS_MISMATCH")
+    if packet.fail_closed is result["matched"] or packet.scope_limitations != SCOPE_LIMITATIONS:
+        raise LiveAdapterDryRunEndpointAllowlistError("LADREA_FAIL_CLOSED_MISMATCH")
+    if datetime.fromisoformat(_normalized_timestamp(packet.endpoint_allowlist_evaluated_at)) < datetime.fromisoformat(_normalized_timestamp(source.dispatch_readiness_evaluated_at)):
+        raise LiveAdapterDryRunEndpointAllowlistError("LADREA_EVALUATED_TOO_EARLY")
+    digest = _packet_hash(actual)
+    if packet.live_adapter_dry_run_endpoint_allowlist_evaluation_hash != digest:
+        raise LiveAdapterDryRunEndpointAllowlistError("LADREA_PACKET_HASH_MISMATCH")
+    if packet.live_adapter_dry_run_endpoint_allowlist_evaluation_id != f"ladrea:v1:sha256:{digest}":
+        raise LiveAdapterDryRunEndpointAllowlistError("LADREA_PACKET_ID_MISMATCH")
+    return packet

--- a/veritas_os/tests/test_live_adapter_dry_run_endpoint_allowlist.py
+++ b/veritas_os/tests/test_live_adapter_dry_run_endpoint_allowlist.py
@@ -1,0 +1,251 @@
+"""Integrity and non-effect tests for endpoint allowlist evaluation v1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from copy import deepcopy
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator, ValidationError
+
+from veritas_os.policy.live_adapter_dry_run_endpoint_allowlist import (
+    CHECK_NAMES,
+    EFFECT_FIELDS,
+    FUTURE_REQUIREMENT_NAMES,
+    SCOPE_LIMITATIONS,
+    LiveAdapterDryRunEndpointAllowlistError,
+    _packet_hash,
+    _snapshot_hash,
+    build_live_adapter_dry_run_endpoint_allowlist_evaluation_packet,
+    verify_live_adapter_dry_run_endpoint_allowlist_evaluation_packet,
+)
+from veritas_os.policy.live_adapter_dry_run_dispatch_readiness import (
+    build_live_adapter_dry_run_dispatch_readiness_packet,
+)
+from veritas_os.tests.test_live_adapter_dry_run_request import (
+    REQUESTED_AT,
+    _packet as request_packet,
+)
+
+EVALUATED_AT = REQUESTED_AT + timedelta(seconds=2)
+MODULE = Path("veritas_os/policy/live_adapter_dry_run_endpoint_allowlist.py")
+SCHEMA = Path("schemas/live-adapter-dry-run-endpoint-allowlist-v1.schema.json")
+
+
+def _source(*, semantic_match: bool = False):
+    return build_live_adapter_dry_run_dispatch_readiness_packet(
+        request_packet(semantic_match=semantic_match), REQUESTED_AT + timedelta(seconds=1)
+    )
+
+
+def _candidate(**changes):
+    value = {
+        "endpoint_candidate_id": "endpoint:billing:v1", "endpoint_kind": "HTTPS_API",
+        "endpoint_scheme": "https", "endpoint_host": "api.example.invalid",
+        "endpoint_port": 443, "endpoint_path_prefix": "/v1/billing",
+        "endpoint_environment": "staging", "endpoint_purpose": "dry-run",
+        "adapter_contract_id": _source().adapter_contract_id,
+        "target_system": "billing", "target_resource_scope": "invoices:read",
+        "declared_by": "operator:local", "declared_at": EVALUATED_AT.isoformat(),
+    }
+    value.update(changes)
+    return value
+
+
+def _snapshot(candidate=None, *, active=True, entries=True):
+    candidate = candidate or _candidate()
+    entry = {
+        "entry_id": "allow:billing:v1", "endpoint_kind": candidate["endpoint_kind"],
+        "endpoint_scheme": candidate["endpoint_scheme"],
+        "endpoint_host": candidate["endpoint_host"], "endpoint_port": candidate["endpoint_port"],
+        "endpoint_path_prefix": candidate["endpoint_path_prefix"],
+        "endpoint_environment": candidate["endpoint_environment"],
+        "allowed_adapter_contract_ids": [candidate["adapter_contract_id"]],
+        "allowed_target_systems": [candidate["target_system"]],
+        "allowed_target_resource_scopes": [candidate["target_resource_scope"]],
+        "allowed_purposes": [candidate["endpoint_purpose"]],
+        "entry_status": "ACTIVE" if active else "INACTIVE",
+    }
+    value = {
+        "allowlist_snapshot_id": "allowlist:local:v1", "allowlist_snapshot_hash": "0" * 64,
+        "allowlist_version": "1", "allowlist_source": "local-reviewed-fixture",
+        "allowlist_generated_at": EVALUATED_AT.isoformat(),
+        "allowlist_entries": [entry] if entries else [],
+        "allowlist_scope_limitations": ["LOCAL_DECLARATIONS_ONLY"],
+    }
+    value["allowlist_snapshot_hash"] = _snapshot_hash(value)
+    return value
+
+
+def _packet(candidate=None, snapshot=None, *, semantic_match=False):
+    candidate = candidate or _candidate()
+    return build_live_adapter_dry_run_endpoint_allowlist_evaluation_packet(
+        _source(semantic_match=semantic_match), candidate,
+        snapshot or _snapshot(candidate), EVALUATED_AT,
+    )
+
+
+def _rehash(raw):
+    digest = _packet_hash(raw)
+    raw["live_adapter_dry_run_endpoint_allowlist_evaluation_hash"] = digest
+    raw["live_adapter_dry_run_endpoint_allowlist_evaluation_id"] = f"ladrea:v1:sha256:{digest}"
+
+
+def test_builder_verifier_exact_match_and_preservation(monkeypatch) -> None:
+    import veritas_os.policy.live_adapter_dry_run_endpoint_allowlist as module
+
+    actual = module.verify_live_adapter_dry_run_dispatch_readiness_packet
+    calls = []
+
+    def recording(value):
+        calls.append(value)
+        return actual(value)
+
+    monkeypatch.setattr(module, "verify_live_adapter_dry_run_dispatch_readiness_packet", recording)
+    source = _source()
+    candidate = _candidate()
+    packet = module.build_live_adapter_dry_run_endpoint_allowlist_evaluation_packet(
+        source, candidate, _snapshot(candidate), EVALUATED_AT)
+    assert len(calls) == 2
+    assert module.verify_live_adapter_dry_run_endpoint_allowlist_evaluation_packet(packet) == packet
+    assert len(calls) == 3
+    assert packet.allowlist_evaluation_result.matched
+    assert not packet.fail_closed
+    for field in ("request_descriptor", "execution_intent", "execution_intent_id",
+                  "execution_intent_hash", "adapter_contract_descriptor",
+                  "adapter_contract_id", "adapter_contract_hash", "adapter_contract_version",
+                  "source_to_execution_intent_mapping", "field_mapping_proof",
+                  "required_field_presence", "source_decision_identity", "candidate_identity",
+                  "evidence_lineage", "replay_summary"):
+        assert getattr(packet, field) == getattr(source, field)
+
+
+@pytest.mark.parametrize(
+    ("candidate_field", "entry_field", "value"),
+    [("endpoint_host", "endpoint_host", "API.example.invalid"),
+     ("endpoint_scheme", "endpoint_scheme", "HTTPS"),
+     ("endpoint_port", "endpoint_port", 8443),
+     ("endpoint_path_prefix", "endpoint_path_prefix", "/v1/billing/"),
+     ("endpoint_environment", "endpoint_environment", "production"),
+     ("adapter_contract_id", "allowed_adapter_contract_ids", "other"),
+     ("target_system", "allowed_target_systems", "other"),
+     ("target_resource_scope", "allowed_target_resource_scopes", "other"),
+     ("endpoint_purpose", "allowed_purposes", "other")],
+)
+def test_every_comparison_is_exact_and_fail_closed(candidate_field, entry_field, value) -> None:
+    candidate = _candidate()
+    snapshot = _snapshot(candidate)
+    snapshot["allowlist_entries"][0][entry_field] = [value] if entry_field.startswith("allowed_") else value
+    snapshot["allowlist_snapshot_hash"] = _snapshot_hash(snapshot)
+    packet = _packet(candidate, snapshot)
+    assert not packet.allowlist_evaluation_result.matched
+    assert packet.allowlist_evaluation_result.semantic_match_used is False
+    assert packet.fail_closed
+
+
+@pytest.mark.parametrize("active,entries", [(False, True), (True, False)])
+def test_inactive_or_missing_entry_fails_closed(active, entries) -> None:
+    packet = _packet(snapshot=_snapshot(active=active, entries=entries))
+    assert packet.fail_closed and not packet.allowlist_evaluation_result.matched
+
+
+@pytest.mark.parametrize("key", ["authorization_header", "token", "secret", "cookie", "credential"])
+def test_sensitive_candidate_fields_are_rejected(key) -> None:
+    candidate = _candidate()
+    candidate[key] = "forbidden"
+    with pytest.raises(LiveAdapterDryRunEndpointAllowlistError):
+        _packet(candidate, _snapshot())
+
+
+def test_closed_inputs_and_snapshot_hash_are_enforced() -> None:
+    candidate = _candidate(unexpected=True)
+    snapshot = _snapshot()
+    snapshot["unexpected"] = True
+    for bad_candidate, bad_snapshot in ((candidate, _snapshot()), (_candidate(), snapshot)):
+        with pytest.raises(LiveAdapterDryRunEndpointAllowlistError):
+            _packet(bad_candidate, bad_snapshot)
+    bad_hash = _snapshot()
+    bad_hash["allowlist_snapshot_hash"] = "0" * 64
+    with pytest.raises(LiveAdapterDryRunEndpointAllowlistError):
+        _packet(snapshot=bad_hash)
+
+
+def test_checks_requirements_scope_and_effects_are_exact() -> None:
+    packet = _packet()
+    assert [item.name for item in packet.endpoint_allowlist_checks] == list(CHECK_NAMES)
+    assert [item.ordinal for item in packet.endpoint_allowlist_checks] == list(range(1, 31))
+    assert all(getattr(item, field) is False for item in packet.endpoint_allowlist_checks
+               for field in EFFECT_FIELDS)
+    assert [item.name for item in packet.future_credential_requirements] == list(FUTURE_REQUIREMENT_NAMES)
+    assert all(not item.satisfied_by_this_packet for item in packet.future_credential_requirements)
+    assert packet.scope_limitations == SCOPE_LIMITATIONS
+
+
+@pytest.mark.parametrize("semantic_match", [True, False])
+def test_semantic_match_is_preserved_but_never_used_as_authority(semantic_match) -> None:
+    packet = _packet(semantic_match=semantic_match)
+    assert packet.replay_summary["semantic_match"] is semantic_match
+    assert packet.allowlist_evaluation_result.semantic_match_used is False
+    assert "Authority Evidence" not in json.dumps(packet.model_dump(mode="json"))
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("live_adapter_dry_run_endpoint_allowlist_evaluation_hash", "0" * 64),
+     ("live_adapter_dry_run_endpoint_allowlist_evaluation_id", "ladrea:v1:sha256:" + "0" * 64),
+     ("fail_closed", True), ("scope_limitations", ["NOT_DISPATCHED"]),
+     ("request_descriptor", {}), ("execution_intent", {}),
+     ("source_dispatch_readiness_hash", "0" * 64)],
+)
+def test_top_level_tampering_is_rejected(field, value) -> None:
+    raw = _packet().model_dump(mode="json")
+    raw[field] = value
+    if "hash" not in field and "id" not in field:
+        _rehash(raw)
+    with pytest.raises(LiveAdapterDryRunEndpointAllowlistError):
+        verify_live_adapter_dry_run_endpoint_allowlist_evaluation_packet(raw)
+
+
+@pytest.mark.parametrize("target", ["allowlist_evaluation_result", "endpoint_allowlist_checks", "future_credential_requirements"])
+def test_nested_mutation_is_rejected(target) -> None:
+    raw = _packet().model_dump(mode="json")
+    if target == "allowlist_evaluation_result":
+        raw[target]["matched_entry_id"] = "forged"
+    else:
+        raw[target].reverse()
+    _rehash(raw)
+    with pytest.raises(LiveAdapterDryRunEndpointAllowlistError):
+        verify_live_adapter_dry_run_endpoint_allowlist_evaluation_packet(raw)
+
+
+def test_source_mutation_is_reverified() -> None:
+    raw = _packet().model_dump(mode="json")
+    raw["source_dispatch_readiness_packet"]["live_adapter_dry_run_dispatch_readiness_hash"] = "0" * 64
+    _rehash(raw)
+    with pytest.raises(LiveAdapterDryRunEndpointAllowlistError):
+        verify_live_adapter_dry_run_endpoint_allowlist_evaluation_packet(raw)
+
+
+def test_schema_accepts_packet_and_rejects_mutation() -> None:
+    schema = json.loads(SCHEMA.read_text())
+    raw = _packet().model_dump(mode="json")
+    Draft202012Validator(schema).validate(raw)
+    raw["unexpected"] = True
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(raw)
+
+
+def test_module_has_no_forbidden_imports_or_effect_calls() -> None:
+    tree = ast.parse(MODULE.read_text())
+    imports = {alias.name.split(".")[0] for node in ast.walk(tree)
+               if isinstance(node, (ast.Import, ast.ImportFrom))
+               for alias in node.names}
+    assert imports.isdisjoint({"requests", "httpx", "urllib", "socket", "dns",
+                               "subprocess", "os", "pathlib"})
+    source = MODULE.read_text()
+    for forbidden in ("WebhookBindAdapter", "BindReceipt", "TrustLog", "verify_postconditions",
+                      "credential_store", "provider_client"):
+        assert forbidden not in source


### PR DESCRIPTION
### Motivation

- Provide a deterministic, content-addressed artifact that proves a declared endpoint candidate was evaluated against a local allowlist snapshot before any live dispatch, building on the previously added dispatch-readiness packet.
- Ensure this evaluation is purely local, exact, auditable, and fail-closed when no exact active allowlist entry matches.

### Description

- Add closed Pydantic models, domain-separated hashing, and deterministic builders/verifiers in `veritas_os/policy/live_adapter_dry_run_endpoint_allowlist.py` implementing `build_live_adapter_dry_run_endpoint_allowlist_evaluation_packet(...)` and `verify_live_adapter_dry_run_endpoint_allowlist_evaluation_packet(...)` with re-verification of the source dispatch-readiness packet.
- Implement exact local allowlist comparison logic (no fuzzy/semantic matching) with deterministic identity binding, ordered non-effecting checks, and deterministic future credential requirements.
- Add comprehensive unit tests at `veritas_os/tests/test_live_adapter_dry_run_endpoint_allowlist.py` covering matching, fail-closed behavior, schema enforcement, tamper detection, forbidden sensitive fields, and forbidden imports/effects.
- Add closed JSON Schema `schemas/live-adapter-dry-run-endpoint-allowlist-v1.schema.json` and documentation `docs/en/architecture/live-adapter-dry-run-endpoint-allowlist-v1.md` describing semantics and non-effect guarantees.

### Security / non-effect guarantees

- This implementation does not perform endpoint resolution, DNS lookup, network access, or Webhook calls. It does not instantiate or call any live adapter, does not access credentials, does not invoke Bind, and does not create BindReceipt or write TrustLog.
- Input is treated as data-only with closed schemas and explicit rejection of authorization/credential material (authorization headers, tokens, secrets, cookies, request bodies, etc.).
- All derived values use canonical JSON, sorted keys, compact separators, and explicit domain-separated SHA-256 hashing; the verifier recomputes and rejects any mutation (fail-closed on mismatch).

### Testing

- Ran `ruff check` on the new policy and test module (passed under available interpreter invocation). (passed)
- Ran `python -m py_compile veritas_os/policy/live_adapter_dry_run_endpoint_allowlist.py` (passed).
- Generated and validated `schemas/live-adapter-dry-run-endpoint-allowlist-v1.schema.json` with `python -m json.tool` (passed).
- Attempted `pytest -q veritas_os/tests/test_live_adapter_dry_run_endpoint_allowlist.py`, but full pytest execution could not complete in this environment due to missing runtime test dependencies (notably `pydantic`/test environment and PyPI fetch errors); tests are present and exercise builder/verifier extensively but require the repository test environment to run. (blocked / not executed to completion)
- Per CI-quality gates, the module was checked for forbidden imports/effects in tests and code; checks in tests assert absence of network/DNS/credential/Bind/TrustLog usage.

Final invariant

- Canonical Live Adapter Dry-Run Endpoint Allowlist Evaluation v1 now evaluates a declared endpoint candidate against a deterministic local allowlist snapshot from a verified non-dispatched dispatch-readiness packet without resolving endpoints, without DNS lookup, without network access, without accessing credentials, without embedding secrets or authorization material, without instantiating a live adapter, without calling Webhook, without invoking Bind, without creating a BindReceipt, without writing TrustLog, without external effects, and without converting semantic_match into Authority Evidence, Human Approval, or execution authority.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8369d6a95c83268ea999ee603dd9a2)