### PR TITLE
feat(bind): add live adapter dry-run operator dispatch review v1

### DIFF
--- a/docs/en/architecture/live-adapter-dry-run-operator-dispatch-review-v1.md
+++ b/docs/en/architecture/live-adapter-dry-run-operator-dispatch-review-v1.md
@@ -1,0 +1,87 @@
+# Canonical Live Adapter Dry-Run Operator Dispatch Review v1
+
+## Purpose
+
+The Canonical Live Adapter Dry-Run Operator Dispatch Review Packet is a
+deterministic, content-addressed **operator dispatch review artifact**. It
+answers whether an identified operator explicitly reviewed a verified,
+credential-authorized, non-dispatched candidate, including its endpoint
+allowlist evidence, credential authorization evidence, scope limitations, and
+non-effect guarantees.
+
+An approved packet permits progression only to a **separate future Bind
+pre-dispatch review artifact**. It does not authorize execution or Bind by
+itself. `REJECT` and `HOLD_FOR_MORE_EVIDENCE` decisions remain fail-closed.
+Human maintainer approval remains required for this governance-sensitive
+boundary.
+
+## Inputs and deterministic verification
+
+The builder accepts a Canonical Live Adapter Dry-Run Credential Authorization
+Evaluation Packet v1, an explicit closed-schema operator decision, and a
+caller-supplied recording timestamp. Both the builder and verifier reverify the
+embedded credential authorization packet. They require an authorized source
+whose state and status remain non-dispatched, and exact matches for the
+endpoint, credential reference, adapter contract, target system, and target
+resource scope identities.
+
+Canonical JSON uses sorted keys and compact separators. Domain-separated
+SHA-256 digests bind the decision, review binding, ordered checks, future
+requirements, and complete packet. Timestamps are normalized to UTC. No UUID,
+random value, current time, environment state, filesystem state, or external
+provider contributes to verification.
+
+`semantic_match` is copied exactly through the source evidence lineage. It is
+not promoted to Authority Evidence, Human Approval, Bind authorization, or
+execution authority. Either semantic-match value can be recorded locally when
+the canonical source packet otherwise verifies.
+
+## Security and non-effect boundary
+
+This artifact:
+
+- does **not** dispatch the request;
+- does **not** invoke Bind;
+- does **not** create a BindReceipt;
+- does **not** write TrustLog;
+- does **not** resolve an endpoint or perform DNS resolution;
+- does **not** resolve or access credential material;
+- does **not** embed credentials, tokens, or secrets;
+- does **not** construct authorization headers;
+- does **not** call the network or Webhook;
+- does **not** instantiate or call a live adapter;
+- does **not** commit an operation; and
+- does **not** authorize execution by itself.
+
+Every ordered check repeats false effect flags. The packet-level state is
+`NOT_DISPATCHED`, and all effect booleans are fixed to `false`. Mutation of the
+source, decision, bindings, checks, future requirements, lineage, scope
+limitations, packet hash, or content-addressed ID is rejected.
+
+> **Security warning:** Approval here is only permission to advance evidence
+> to another review boundary. Treating this artifact as dispatch or Bind
+> authority would violate its fail-closed contract.
+
+## Future Bind pre-dispatch review
+
+This packet records, but does not satisfy, requirements for a separate future
+artifact. Before any future dispatch, that artifact must prove:
+
+1. Bind pre-dispatch policy review;
+2. Authority Evidence recheck;
+3. Human Approval boundary verification, when applicable;
+4. endpoint identity recheck;
+5. credential authorization recheck;
+6. credential-material resolution boundary;
+7. authorization-header construction boundary;
+8. network dispatch boundary;
+9. request dispatch receipt boundary;
+10. TrustLog write boundary after proper authorization;
+11. BindReceipt boundary only after Bind; and
+12. rollback and postcondition requirements for a later apply path.
+
+Each requirement states both `separate_future_artifact_required: true` and
+`satisfied_by_this_packet: false`. Consequently, even an
+`APPROVE_FOR_BIND_PRE_DISPATCH_REVIEW` decision can set `fail_closed` to false
+only for progression to that future review; it cannot cross any execution or
+external-effect boundary.

--- a/schemas/live-adapter-dry-run-operator-dispatch-review-v1.schema.json
+++ b/schemas/live-adapter-dry-run-operator-dispatch-review-v1.schema.json
@@ -1,0 +1,1583 @@
+{
+  "$defs": {
+    "FutureBindPreDispatchReviewRequirement": {
+      "additionalProperties": false,
+      "description": "One future boundary that this review explicitly does not satisfy.",
+      "properties": {
+        "name": {
+          "enum": [
+            "bind_pre_dispatch_policy_review",
+            "authority_evidence_recheck",
+            "human_approval_boundary_verification_if_applicable",
+            "endpoint_identity_recheck",
+            "credential_authorization_recheck",
+            "credential_material_resolution_boundary",
+            "authorization_header_construction_boundary",
+            "network_dispatch_boundary",
+            "request_dispatch_receipt_boundary",
+            "trustlog_write_boundary_after_proper_authorization",
+            "bind_receipt_boundary_only_after_bind",
+            "rollback_postcondition_requirements_for_later_apply_path"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "ordinal": {
+          "maximum": 12,
+          "minimum": 1,
+          "title": "Ordinal",
+          "type": "integer"
+        },
+        "satisfied_by_this_packet": {
+          "const": false,
+          "title": "Satisfied By This Packet",
+          "type": "boolean"
+        },
+        "separate_future_artifact_required": {
+          "const": true,
+          "title": "Separate Future Artifact Required",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "ordinal",
+        "name",
+        "separate_future_artifact_required",
+        "satisfied_by_this_packet"
+      ],
+      "title": "FutureBindPreDispatchReviewRequirement",
+      "type": "object"
+    },
+    "OperatorDispatchReviewCheck": {
+      "additionalProperties": false,
+      "description": "One deterministic local check carrying explicit non-effect facts.",
+      "properties": {
+        "authorization_header_constructed": {
+          "const": false,
+          "title": "Authorization Header Constructed",
+          "type": "boolean"
+        },
+        "bind_invoked": {
+          "const": false,
+          "title": "Bind Invoked",
+          "type": "boolean"
+        },
+        "bind_receipt_created": {
+          "const": false,
+          "title": "Bind Receipt Created",
+          "type": "boolean"
+        },
+        "check_id": {
+          "title": "Check Id",
+          "type": "string"
+        },
+        "credential_material_accessed": {
+          "const": false,
+          "title": "Credential Material Accessed",
+          "type": "boolean"
+        },
+        "credential_material_embedded": {
+          "const": false,
+          "title": "Credential Material Embedded",
+          "type": "boolean"
+        },
+        "credential_resolved": {
+          "const": false,
+          "title": "Credential Resolved",
+          "type": "boolean"
+        },
+        "database_used": {
+          "const": false,
+          "title": "Database Used",
+          "type": "boolean"
+        },
+        "dns_used": {
+          "const": false,
+          "title": "Dns Used",
+          "type": "boolean"
+        },
+        "endpoint_resolved": {
+          "const": false,
+          "title": "Endpoint Resolved",
+          "type": "boolean"
+        },
+        "evidence_ref": {
+          "title": "Evidence Ref",
+          "type": "string"
+        },
+        "external_effect_used": {
+          "const": false,
+          "title": "External Effect Used",
+          "type": "boolean"
+        },
+        "filesystem_used": {
+          "const": false,
+          "title": "Filesystem Used",
+          "type": "boolean"
+        },
+        "live_adapter_instantiated": {
+          "const": false,
+          "title": "Live Adapter Instantiated",
+          "type": "boolean"
+        },
+        "live_adapter_method_called": {
+          "const": false,
+          "title": "Live Adapter Method Called",
+          "type": "boolean"
+        },
+        "mode": {
+          "const": "deterministic_local_operator_dispatch_review_record_only",
+          "title": "Mode",
+          "type": "string"
+        },
+        "name": {
+          "enum": [
+            "source_credential_authorization_evaluation_verified",
+            "source_request_not_dispatched",
+            "source_credential_authorized",
+            "operator_review_decision_closed_schema_valid",
+            "reviewer_identity_present",
+            "reviewer_role_present",
+            "review_decision_allowed_value",
+            "reviewed_endpoint_candidate_identity_matches_source",
+            "reviewed_credential_reference_identity_matches_source",
+            "reviewed_adapter_contract_identity_matches_source",
+            "reviewed_target_system_matches_source",
+            "reviewed_target_resource_scope_matches_source",
+            "scope_limitations_acknowledged",
+            "non_effect_guarantees_acknowledged",
+            "future_bind_pre_dispatch_review_acknowledged",
+            "no_dispatch_acknowledged",
+            "no_credential_access_acknowledged",
+            "no_network_acknowledged",
+            "no_bind_acknowledged",
+            "no_bind_receipt_acknowledged",
+            "no_trustlog_write_acknowledged",
+            "operator_review_binding_constructed",
+            "credential_not_resolved",
+            "credential_material_not_accessed",
+            "authorization_header_not_constructed",
+            "network_not_used",
+            "webhook_not_called",
+            "live_adapter_not_instantiated",
+            "bind_not_invoked",
+            "bind_receipt_not_created",
+            "trustlog_not_written",
+            "request_not_dispatched",
+            "future_bind_pre_dispatch_review_required"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "network_used": {
+          "const": false,
+          "title": "Network Used",
+          "type": "boolean"
+        },
+        "operation_committed": {
+          "const": false,
+          "title": "Operation Committed",
+          "type": "boolean"
+        },
+        "ordinal": {
+          "maximum": 33,
+          "minimum": 1,
+          "title": "Ordinal",
+          "type": "integer"
+        },
+        "passed": {
+          "title": "Passed",
+          "type": "boolean"
+        },
+        "provider_used": {
+          "const": false,
+          "title": "Provider Used",
+          "type": "boolean"
+        },
+        "request_dispatched": {
+          "const": false,
+          "title": "Request Dispatched",
+          "type": "boolean"
+        },
+        "secret_embedded": {
+          "const": false,
+          "title": "Secret Embedded",
+          "type": "boolean"
+        },
+        "subprocess_used": {
+          "const": false,
+          "title": "Subprocess Used",
+          "type": "boolean"
+        },
+        "token_embedded": {
+          "const": false,
+          "title": "Token Embedded",
+          "type": "boolean"
+        },
+        "trustlog_written": {
+          "const": false,
+          "title": "Trustlog Written",
+          "type": "boolean"
+        },
+        "webhook_called": {
+          "const": false,
+          "title": "Webhook Called",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "check_id",
+        "ordinal",
+        "name",
+        "mode",
+        "passed",
+        "evidence_ref",
+        "credential_resolved",
+        "credential_material_accessed",
+        "credential_material_embedded",
+        "authorization_header_constructed",
+        "token_embedded",
+        "secret_embedded",
+        "endpoint_resolved",
+        "dns_used",
+        "network_used",
+        "webhook_called",
+        "live_adapter_instantiated",
+        "live_adapter_method_called",
+        "request_dispatched",
+        "bind_invoked",
+        "bind_receipt_created",
+        "trustlog_written",
+        "external_effect_used",
+        "filesystem_used",
+        "database_used",
+        "provider_used",
+        "subprocess_used",
+        "operation_committed"
+      ],
+      "title": "OperatorDispatchReviewCheck",
+      "type": "object"
+    },
+    "OperatorReviewDecision": {
+      "additionalProperties": false,
+      "description": "Closed explicit operator decision and mandatory acknowledgements.",
+      "properties": {
+        "acknowledged_future_bind_pre_dispatch_review_required": {
+          "const": true,
+          "title": "Acknowledged Future Bind Pre Dispatch Review Required",
+          "type": "boolean"
+        },
+        "acknowledged_no_bind": {
+          "const": true,
+          "title": "Acknowledged No Bind",
+          "type": "boolean"
+        },
+        "acknowledged_no_bind_receipt": {
+          "const": true,
+          "title": "Acknowledged No Bind Receipt",
+          "type": "boolean"
+        },
+        "acknowledged_no_credential_access": {
+          "const": true,
+          "title": "Acknowledged No Credential Access",
+          "type": "boolean"
+        },
+        "acknowledged_no_dispatch": {
+          "const": true,
+          "title": "Acknowledged No Dispatch",
+          "type": "boolean"
+        },
+        "acknowledged_no_network": {
+          "const": true,
+          "title": "Acknowledged No Network",
+          "type": "boolean"
+        },
+        "acknowledged_no_trustlog_write": {
+          "const": true,
+          "title": "Acknowledged No Trustlog Write",
+          "type": "boolean"
+        },
+        "acknowledged_non_effect_guarantees": {
+          "const": true,
+          "title": "Acknowledged Non Effect Guarantees",
+          "type": "boolean"
+        },
+        "acknowledged_scope_limitations": {
+          "const": true,
+          "title": "Acknowledged Scope Limitations",
+          "type": "boolean"
+        },
+        "operator_review_id": {
+          "minLength": 1,
+          "title": "Operator Review Id",
+          "type": "string"
+        },
+        "review_decision": {
+          "enum": [
+            "APPROVE_FOR_BIND_PRE_DISPATCH_REVIEW",
+            "REJECT",
+            "HOLD_FOR_MORE_EVIDENCE"
+          ],
+          "title": "Review Decision",
+          "type": "string"
+        },
+        "review_reason": {
+          "minLength": 1,
+          "title": "Review Reason",
+          "type": "string"
+        },
+        "reviewed_adapter_contract_id": {
+          "minLength": 1,
+          "title": "Reviewed Adapter Contract Id",
+          "type": "string"
+        },
+        "reviewed_at": {
+          "title": "Reviewed At",
+          "type": "string"
+        },
+        "reviewed_credential_reference_id": {
+          "minLength": 1,
+          "title": "Reviewed Credential Reference Id",
+          "type": "string"
+        },
+        "reviewed_endpoint_candidate_id": {
+          "minLength": 1,
+          "title": "Reviewed Endpoint Candidate Id",
+          "type": "string"
+        },
+        "reviewed_target_resource_scope": {
+          "minLength": 1,
+          "title": "Reviewed Target Resource Scope",
+          "type": "string"
+        },
+        "reviewed_target_system": {
+          "minLength": 1,
+          "title": "Reviewed Target System",
+          "type": "string"
+        },
+        "reviewer_id": {
+          "minLength": 1,
+          "title": "Reviewer Id",
+          "type": "string"
+        },
+        "reviewer_organization": {
+          "minLength": 1,
+          "title": "Reviewer Organization",
+          "type": "string"
+        },
+        "reviewer_role": {
+          "minLength": 1,
+          "title": "Reviewer Role",
+          "type": "string"
+        }
+      },
+      "required": [
+        "operator_review_id",
+        "reviewer_id",
+        "reviewer_role",
+        "reviewer_organization",
+        "reviewed_at",
+        "review_decision",
+        "review_reason",
+        "reviewed_endpoint_candidate_id",
+        "reviewed_credential_reference_id",
+        "reviewed_adapter_contract_id",
+        "reviewed_target_system",
+        "reviewed_target_resource_scope",
+        "acknowledged_scope_limitations",
+        "acknowledged_non_effect_guarantees",
+        "acknowledged_future_bind_pre_dispatch_review_required",
+        "acknowledged_no_dispatch",
+        "acknowledged_no_credential_access",
+        "acknowledged_no_network",
+        "acknowledged_no_bind",
+        "acknowledged_no_bind_receipt",
+        "acknowledged_no_trustlog_write"
+      ],
+      "title": "OperatorReviewDecision",
+      "type": "object"
+    }
+  },
+  "$id": "https://veritas-os.example/schemas/live-adapter-dry-run-operator-dispatch-review-v1.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Closed content-addressed operator dispatch review packet.",
+  "properties": {
+    "adapter_contract_descriptor": {
+      "additionalProperties": true,
+      "title": "Adapter Contract Descriptor",
+      "type": "object"
+    },
+    "adapter_contract_hash": {
+      "title": "Adapter Contract Hash",
+      "type": "string"
+    },
+    "adapter_contract_id": {
+      "title": "Adapter Contract Id",
+      "type": "string"
+    },
+    "adapter_contract_version": {
+      "title": "Adapter Contract Version",
+      "type": "string"
+    },
+    "authorization_header_constructed": {
+      "const": false,
+      "title": "Authorization Header Constructed",
+      "type": "boolean"
+    },
+    "bind_invoked": {
+      "const": false,
+      "title": "Bind Invoked",
+      "type": "boolean"
+    },
+    "bind_receipt_created": {
+      "const": false,
+      "title": "Bind Receipt Created",
+      "type": "boolean"
+    },
+    "candidate_identity": {
+      "additionalProperties": true,
+      "title": "Candidate Identity",
+      "type": "object"
+    },
+    "credential_material_accessed": {
+      "const": false,
+      "title": "Credential Material Accessed",
+      "type": "boolean"
+    },
+    "credential_material_embedded": {
+      "const": false,
+      "title": "Credential Material Embedded",
+      "type": "boolean"
+    },
+    "credential_reference": {
+      "additionalProperties": true,
+      "title": "Credential Reference",
+      "type": "object"
+    },
+    "credential_reference_digest": {
+      "title": "Credential Reference Digest",
+      "type": "string"
+    },
+    "credential_resolved": {
+      "const": false,
+      "title": "Credential Resolved",
+      "type": "boolean"
+    },
+    "credential_scope_binding": {
+      "additionalProperties": true,
+      "title": "Credential Scope Binding",
+      "type": "object"
+    },
+    "credential_scope_binding_digest": {
+      "title": "Credential Scope Binding Digest",
+      "type": "string"
+    },
+    "endpoint_candidate": {
+      "additionalProperties": true,
+      "title": "Endpoint Candidate",
+      "type": "object"
+    },
+    "endpoint_candidate_digest": {
+      "title": "Endpoint Candidate Digest",
+      "type": "string"
+    },
+    "endpoint_identity_binding": {
+      "additionalProperties": true,
+      "title": "Endpoint Identity Binding",
+      "type": "object"
+    },
+    "endpoint_identity_binding_digest": {
+      "title": "Endpoint Identity Binding Digest",
+      "type": "string"
+    },
+    "endpoint_resolved": {
+      "const": false,
+      "title": "Endpoint Resolved",
+      "type": "boolean"
+    },
+    "evidence_lineage": {
+      "additionalProperties": true,
+      "title": "Evidence Lineage",
+      "type": "object"
+    },
+    "execution_intent": {
+      "additionalProperties": true,
+      "title": "Execution Intent",
+      "type": "object"
+    },
+    "execution_intent_hash": {
+      "title": "Execution Intent Hash",
+      "type": "string"
+    },
+    "execution_intent_id": {
+      "title": "Execution Intent Id",
+      "type": "string"
+    },
+    "fail_closed": {
+      "title": "Fail Closed",
+      "type": "boolean"
+    },
+    "field_mapping_proof": {
+      "additionalProperties": true,
+      "title": "Field Mapping Proof",
+      "type": "object"
+    },
+    "format_version": {
+      "const": "canonical-live-adapter-dry-run-operator-dispatch-review/v1",
+      "title": "Format Version",
+      "type": "string"
+    },
+    "future_bind_pre_dispatch_review_requirement_digest": {
+      "title": "Future Bind Pre Dispatch Review Requirement Digest",
+      "type": "string"
+    },
+    "future_bind_pre_dispatch_review_requirements": {
+      "maxItems": 12,
+      "minItems": 12,
+      "prefixItems": [
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FutureBindPreDispatchReviewRequirement"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "bind_pre_dispatch_policy_review"
+                },
+                "ordinal": {
+                  "const": 1
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FutureBindPreDispatchReviewRequirement"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "authority_evidence_recheck"
+                },
+                "ordinal": {
+                  "const": 2
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FutureBindPreDispatchReviewRequirement"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "human_approval_boundary_verification_if_applicable"
+                },
+                "ordinal": {
+                  "const": 3
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FutureBindPreDispatchReviewRequirement"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "endpoint_identity_recheck"
+                },
+                "ordinal": {
+                  "const": 4
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FutureBindPreDispatchReviewRequirement"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "credential_authorization_recheck"
+                },
+                "ordinal": {
+                  "const": 5
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FutureBindPreDispatchReviewRequirement"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "credential_material_resolution_boundary"
+                },
+                "ordinal": {
+                  "const": 6
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FutureBindPreDispatchReviewRequirement"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "authorization_header_construction_boundary"
+                },
+                "ordinal": {
+                  "const": 7
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FutureBindPreDispatchReviewRequirement"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "network_dispatch_boundary"
+                },
+                "ordinal": {
+                  "const": 8
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FutureBindPreDispatchReviewRequirement"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "request_dispatch_receipt_boundary"
+                },
+                "ordinal": {
+                  "const": 9
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FutureBindPreDispatchReviewRequirement"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "trustlog_write_boundary_after_proper_authorization"
+                },
+                "ordinal": {
+                  "const": 10
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FutureBindPreDispatchReviewRequirement"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "bind_receipt_boundary_only_after_bind"
+                },
+                "ordinal": {
+                  "const": 11
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FutureBindPreDispatchReviewRequirement"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "rollback_postcondition_requirements_for_later_apply_path"
+                },
+                "ordinal": {
+                  "const": 12
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "title": "Future Bind Pre Dispatch Review Requirements",
+      "type": "array"
+    },
+    "live_adapter_dry_run_operator_dispatch_review_hash": {
+      "title": "Live Adapter Dry Run Operator Dispatch Review Hash",
+      "type": "string"
+    },
+    "live_adapter_dry_run_operator_dispatch_review_id": {
+      "title": "Live Adapter Dry Run Operator Dispatch Review Id",
+      "type": "string"
+    },
+    "live_adapter_instantiated": {
+      "const": false,
+      "title": "Live Adapter Instantiated",
+      "type": "boolean"
+    },
+    "network_used": {
+      "const": false,
+      "title": "Network Used",
+      "type": "boolean"
+    },
+    "operator_dispatch_review_check_digest": {
+      "title": "Operator Dispatch Review Check Digest",
+      "type": "string"
+    },
+    "operator_dispatch_review_checks": {
+      "maxItems": 33,
+      "minItems": 33,
+      "prefixItems": [
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/OperatorDispatchReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "source_credential_authorization_evaluation_verified"
+                },
+                "ordinal": {
+                  "const": 1
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/OperatorDispatchReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "source_request_not_dispatched"
+                },
+                "ordinal": {
+                  "const": 2
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/OperatorDispatchReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "source_credential_authorized"
+                },
+                "ordinal": {
+                  "const": 3
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/OperatorDispatchReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "operator_review_decision_closed_schema_valid"
+                },
+                "ordinal": {
+                  "const": 4
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/OperatorDispatchReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "reviewer_identity_present"
+                },
+                "ordinal": {
+                  "const": 5
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/OperatorDispatchReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "reviewer_role_present"
+                },
+                "ordinal": {
+                  "const": 6
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/OperatorDispatchReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "review_decision_allowed_value"
+                },
+                "ordinal": {
+                  "const": 7
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/OperatorDispatchReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "reviewed_endpoint_candidate_identity_matches_source"
+                },
+                "ordinal": {
+                  "const": 8
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/OperatorDispatchReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "reviewed_credential_reference_identity_matches_source"
+                },
+                "ordinal": {
+                  "const": 9
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/OperatorDispatchReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "reviewed_adapter_contract_identity_matches_source"
+                },
+                "ordinal": {
+                  "const": 10
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/OperatorDispatchReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "reviewed_target_system_matches_source"
+                },
+                "ordinal": {
+                  "const": 11
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/OperatorDispatchReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "reviewed_target_resource_scope_matches_source"
+                },
+                "ordinal": {
+                  "const": 12
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/OperatorDispatchReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "scope_limitations_acknowledged"
+                },
+                "ordinal": {
+                  "const": 13
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/OperatorDispatchReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "non_effect_guarantees_acknowledged"
+                },
+                "ordinal": {
+                  "const": 14
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/OperatorDispatchReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "future_bind_pre_dispatch_review_acknowledged"
+                },
+                "ordinal": {
+                  "const": 15
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/OperatorDispatchReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "no_dispatch_acknowledged"
+                },
+                "ordinal": {
+                  "const": 16
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/OperatorDispatchReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "no_credential_access_acknowledged"
+                },
+                "ordinal": {
+                  "const": 17
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/OperatorDispatchReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "no_network_acknowledged"
+                },
+                "ordinal": {
+                  "const": 18
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/OperatorDispatchReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "no_bind_acknowledged"
+                },
+                "ordinal": {
+                  "const": 19
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/OperatorDispatchReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "no_bind_receipt_acknowledged"
+                },
+                "ordinal": {
+                  "const": 20
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/OperatorDispatchReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "no_trustlog_write_acknowledged"
+                },
+                "ordinal": {
+                  "const": 21
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/OperatorDispatchReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "operator_review_binding_constructed"
+                },
+                "ordinal": {
+                  "const": 22
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/OperatorDispatchReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "credential_not_resolved"
+                },
+                "ordinal": {
+                  "const": 23
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/OperatorDispatchReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "credential_material_not_accessed"
+                },
+                "ordinal": {
+                  "const": 24
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/OperatorDispatchReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "authorization_header_not_constructed"
+                },
+                "ordinal": {
+                  "const": 25
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/OperatorDispatchReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "network_not_used"
+                },
+                "ordinal": {
+                  "const": 26
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/OperatorDispatchReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "webhook_not_called"
+                },
+                "ordinal": {
+                  "const": 27
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/OperatorDispatchReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "live_adapter_not_instantiated"
+                },
+                "ordinal": {
+                  "const": 28
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/OperatorDispatchReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "bind_not_invoked"
+                },
+                "ordinal": {
+                  "const": 29
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/OperatorDispatchReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "bind_receipt_not_created"
+                },
+                "ordinal": {
+                  "const": 30
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/OperatorDispatchReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "trustlog_not_written"
+                },
+                "ordinal": {
+                  "const": 31
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/OperatorDispatchReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "request_not_dispatched"
+                },
+                "ordinal": {
+                  "const": 32
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/OperatorDispatchReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "future_bind_pre_dispatch_review_required"
+                },
+                "ordinal": {
+                  "const": 33
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "title": "Operator Dispatch Review Checks",
+      "type": "array"
+    },
+    "operator_dispatch_review_mechanism": {
+      "const": "record_live_adapter_dry_run_operator_dispatch_review_without_dispatch/v1",
+      "title": "Operator Dispatch Review Mechanism",
+      "type": "string"
+    },
+    "operator_dispatch_review_recorded_at": {
+      "title": "Operator Dispatch Review Recorded At",
+      "type": "string"
+    },
+    "operator_dispatch_review_status": {
+      "const": "LIVE_ADAPTER_DRY_RUN_OPERATOR_DISPATCH_REVIEW_RECORDED_NOT_DISPATCHED",
+      "title": "Operator Dispatch Review Status",
+      "type": "string"
+    },
+    "operator_review_binding": {
+      "additionalProperties": true,
+      "title": "Operator Review Binding",
+      "type": "object"
+    },
+    "operator_review_binding_digest": {
+      "title": "Operator Review Binding Digest",
+      "type": "string"
+    },
+    "operator_review_decision": {
+      "$ref": "#/$defs/OperatorReviewDecision"
+    },
+    "operator_review_decision_digest": {
+      "title": "Operator Review Decision Digest",
+      "type": "string"
+    },
+    "replay_summary": {
+      "additionalProperties": true,
+      "title": "Replay Summary",
+      "type": "object"
+    },
+    "request_descriptor": {
+      "additionalProperties": true,
+      "title": "Request Descriptor",
+      "type": "object"
+    },
+    "request_dispatch_state": {
+      "const": "NOT_DISPATCHED",
+      "title": "Request Dispatch State",
+      "type": "string"
+    },
+    "request_dispatched": {
+      "const": false,
+      "title": "Request Dispatched",
+      "type": "boolean"
+    },
+    "required_field_presence": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "title": "Required Field Presence",
+      "type": "object"
+    },
+    "scope_limitations": {
+      "maxItems": 20,
+      "minItems": 20,
+      "prefixItems": [
+        {
+          "const": "NOT_DISPATCHED"
+        },
+        {
+          "const": "NOT_BIND_AUTHORIZATION"
+        },
+        {
+          "const": "NOT_BIND_RECEIPT"
+        },
+        {
+          "const": "NOT_TRUSTLOG_WRITE"
+        },
+        {
+          "const": "NOT_CREDENTIAL_RESOLUTION"
+        },
+        {
+          "const": "NOT_CREDENTIAL_ACCESS"
+        },
+        {
+          "const": "NOT_CREDENTIAL_EMBEDDING"
+        },
+        {
+          "const": "NOT_AUTHORIZATION_HEADER"
+        },
+        {
+          "const": "NOT_TOKEN"
+        },
+        {
+          "const": "NOT_SECRET"
+        },
+        {
+          "const": "NOT_ENDPOINT_RESOLUTION"
+        },
+        {
+          "const": "NOT_DNS_RESOLUTION"
+        },
+        {
+          "const": "NOT_NETWORK_CALL"
+        },
+        {
+          "const": "NOT_WEBHOOK_CALL"
+        },
+        {
+          "const": "NOT_LIVE_ADAPTER_INSTANCE"
+        },
+        {
+          "const": "NOT_LIVE_ADAPTER_RESULT"
+        },
+        {
+          "const": "NOT_OPERATION_COMMIT"
+        },
+        {
+          "const": "NOT_PRODUCTION_CLAIM"
+        },
+        {
+          "const": "NOT_CUSTOMER_CLAIM"
+        },
+        {
+          "const": "NOT_REGULATORY_CERTIFICATION"
+        }
+      ],
+      "title": "Scope Limitations",
+      "type": "array"
+    },
+    "secret_embedded": {
+      "const": false,
+      "title": "Secret Embedded",
+      "type": "boolean"
+    },
+    "source_credential_authorization_evaluation_hash": {
+      "title": "Source Credential Authorization Evaluation Hash",
+      "type": "string"
+    },
+    "source_credential_authorization_evaluation_id": {
+      "title": "Source Credential Authorization Evaluation Id",
+      "type": "string"
+    },
+    "source_credential_authorization_evaluation_packet": {
+      "additionalProperties": true,
+      "title": "Source Credential Authorization Evaluation Packet",
+      "type": "object"
+    },
+    "source_decision_identity": {
+      "additionalProperties": true,
+      "title": "Source Decision Identity",
+      "type": "object"
+    },
+    "source_dispatch_readiness_hash": {
+      "title": "Source Dispatch Readiness Hash",
+      "type": "string"
+    },
+    "source_endpoint_allowlist_evaluation_hash": {
+      "title": "Source Endpoint Allowlist Evaluation Hash",
+      "type": "string"
+    },
+    "source_live_adapter_dry_run_request_hash": {
+      "title": "Source Live Adapter Dry Run Request Hash",
+      "type": "string"
+    },
+    "source_to_execution_intent_mapping": {
+      "additionalProperties": true,
+      "title": "Source To Execution Intent Mapping",
+      "type": "object"
+    },
+    "token_embedded": {
+      "const": false,
+      "title": "Token Embedded",
+      "type": "boolean"
+    },
+    "trustlog_written": {
+      "const": false,
+      "title": "Trustlog Written",
+      "type": "boolean"
+    },
+    "webhook_called": {
+      "const": false,
+      "title": "Webhook Called",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "format_version",
+    "live_adapter_dry_run_operator_dispatch_review_id",
+    "live_adapter_dry_run_operator_dispatch_review_hash",
+    "operator_dispatch_review_mechanism",
+    "operator_dispatch_review_recorded_at",
+    "source_credential_authorization_evaluation_id",
+    "source_credential_authorization_evaluation_hash",
+    "source_credential_authorization_evaluation_packet",
+    "source_endpoint_allowlist_evaluation_hash",
+    "source_dispatch_readiness_hash",
+    "source_live_adapter_dry_run_request_hash",
+    "request_descriptor",
+    "execution_intent",
+    "execution_intent_id",
+    "execution_intent_hash",
+    "adapter_contract_descriptor",
+    "adapter_contract_id",
+    "adapter_contract_hash",
+    "adapter_contract_version",
+    "endpoint_candidate",
+    "endpoint_candidate_digest",
+    "endpoint_identity_binding",
+    "endpoint_identity_binding_digest",
+    "credential_reference",
+    "credential_reference_digest",
+    "credential_scope_binding",
+    "credential_scope_binding_digest",
+    "operator_review_decision",
+    "operator_review_decision_digest",
+    "operator_review_binding",
+    "operator_review_binding_digest",
+    "operator_dispatch_review_checks",
+    "operator_dispatch_review_check_digest",
+    "future_bind_pre_dispatch_review_requirements",
+    "future_bind_pre_dispatch_review_requirement_digest",
+    "source_to_execution_intent_mapping",
+    "field_mapping_proof",
+    "required_field_presence",
+    "source_decision_identity",
+    "candidate_identity",
+    "evidence_lineage",
+    "replay_summary",
+    "operator_dispatch_review_status",
+    "request_dispatch_state",
+    "credential_resolved",
+    "credential_material_accessed",
+    "credential_material_embedded",
+    "authorization_header_constructed",
+    "token_embedded",
+    "secret_embedded",
+    "endpoint_resolved",
+    "network_used",
+    "live_adapter_instantiated",
+    "webhook_called",
+    "bind_invoked",
+    "bind_receipt_created",
+    "trustlog_written",
+    "request_dispatched",
+    "fail_closed",
+    "scope_limitations"
+  ],
+  "title": "Canonical Live Adapter Dry-Run Operator Dispatch Review Packet v1",
+  "type": "object"
+}

--- a/veritas_os/policy/live_adapter_dry_run_operator_dispatch_review.py
+++ b/veritas_os/policy/live_adapter_dry_run_operator_dispatch_review.py
@@ -1,0 +1,618 @@
+"""Record an operator dispatch review without dispatching or external effects.
+
+The packet produced here is metadata-only evidence.  It is not execution
+authority, Bind authorization, a receipt, or an audit-log write.  All inputs
+are caller supplied and every derived value is deterministic and reverified.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from veritas_os.policy.live_adapter_dry_run_credential_authorization import (
+    CanonicalLiveAdapterDryRunCredentialAuthorizationEvaluationPacket,
+    LiveAdapterDryRunCredentialAuthorizationError,
+    verify_live_adapter_dry_run_credential_authorization_evaluation_packet,
+)
+
+FORMAT_VERSION = "canonical-live-adapter-dry-run-operator-dispatch-review/v1"
+REVIEW_MECHANISM = (
+    "record_live_adapter_dry_run_operator_dispatch_review_without_dispatch/v1"
+)
+STATUS = "LIVE_ADAPTER_DRY_RUN_OPERATOR_DISPATCH_REVIEW_RECORDED_NOT_DISPATCHED"
+SOURCE_STATUS = (
+    "LIVE_ADAPTER_DRY_RUN_CREDENTIAL_AUTHORIZATION_EVALUATED_NOT_DISPATCHED"
+)
+CHECK_MODE = "deterministic_local_operator_dispatch_review_record_only"
+DECISION_DOMAIN = "veritas.live-adapter-dry-run-operator-dispatch-review.decision/v1"
+BINDING_DOMAIN = "veritas.live-adapter-dry-run-operator-dispatch-review.binding/v1"
+CHECKS_DOMAIN = "veritas.live-adapter-dry-run-operator-dispatch-review.checks/v1"
+REQUIREMENTS_DOMAIN = (
+    "veritas.live-adapter-dry-run-operator-dispatch-review."
+    "future-bind-pre-dispatch-requirements/v1"
+)
+PACKET_DOMAIN = "veritas.live-adapter-dry-run-operator-dispatch-review.packet/v1"
+
+REVIEW_DECISIONS = (
+    "APPROVE_FOR_BIND_PRE_DISPATCH_REVIEW",
+    "REJECT",
+    "HOLD_FOR_MORE_EVIDENCE",
+)
+CHECK_NAMES = (
+    "source_credential_authorization_evaluation_verified",
+    "source_request_not_dispatched",
+    "source_credential_authorized",
+    "operator_review_decision_closed_schema_valid",
+    "reviewer_identity_present",
+    "reviewer_role_present",
+    "review_decision_allowed_value",
+    "reviewed_endpoint_candidate_identity_matches_source",
+    "reviewed_credential_reference_identity_matches_source",
+    "reviewed_adapter_contract_identity_matches_source",
+    "reviewed_target_system_matches_source",
+    "reviewed_target_resource_scope_matches_source",
+    "scope_limitations_acknowledged",
+    "non_effect_guarantees_acknowledged",
+    "future_bind_pre_dispatch_review_acknowledged",
+    "no_dispatch_acknowledged",
+    "no_credential_access_acknowledged",
+    "no_network_acknowledged",
+    "no_bind_acknowledged",
+    "no_bind_receipt_acknowledged",
+    "no_trustlog_write_acknowledged",
+    "operator_review_binding_constructed",
+    "credential_not_resolved",
+    "credential_material_not_accessed",
+    "authorization_header_not_constructed",
+    "network_not_used",
+    "webhook_not_called",
+    "live_adapter_not_instantiated",
+    "bind_not_invoked",
+    "bind_receipt_not_created",
+    "trustlog_not_written",
+    "request_not_dispatched",
+    "future_bind_pre_dispatch_review_required",
+)
+EFFECT_FIELDS = (
+    "credential_resolved", "credential_material_accessed",
+    "credential_material_embedded", "authorization_header_constructed",
+    "token_embedded", "secret_embedded", "endpoint_resolved", "dns_used",
+    "network_used", "webhook_called", "live_adapter_instantiated",
+    "live_adapter_method_called", "request_dispatched", "bind_invoked",
+    "bind_receipt_created", "trustlog_written", "external_effect_used",
+    "filesystem_used", "database_used", "provider_used", "subprocess_used",
+    "operation_committed",
+)
+SCOPE_LIMITATIONS = (
+    "NOT_DISPATCHED", "NOT_BIND_AUTHORIZATION", "NOT_BIND_RECEIPT",
+    "NOT_TRUSTLOG_WRITE", "NOT_CREDENTIAL_RESOLUTION",
+    "NOT_CREDENTIAL_ACCESS", "NOT_CREDENTIAL_EMBEDDING",
+    "NOT_AUTHORIZATION_HEADER", "NOT_TOKEN", "NOT_SECRET",
+    "NOT_ENDPOINT_RESOLUTION", "NOT_DNS_RESOLUTION", "NOT_NETWORK_CALL",
+    "NOT_WEBHOOK_CALL", "NOT_LIVE_ADAPTER_INSTANCE",
+    "NOT_LIVE_ADAPTER_RESULT", "NOT_OPERATION_COMMIT",
+    "NOT_PRODUCTION_CLAIM", "NOT_CUSTOMER_CLAIM",
+    "NOT_REGULATORY_CERTIFICATION",
+)
+FUTURE_REQUIREMENT_NAMES = (
+    "bind_pre_dispatch_policy_review",
+    "authority_evidence_recheck",
+    "human_approval_boundary_verification_if_applicable",
+    "endpoint_identity_recheck",
+    "credential_authorization_recheck",
+    "credential_material_resolution_boundary",
+    "authorization_header_construction_boundary",
+    "network_dispatch_boundary",
+    "request_dispatch_receipt_boundary",
+    "trustlog_write_boundary_after_proper_authorization",
+    "bind_receipt_boundary_only_after_bind",
+    "rollback_postcondition_requirements_for_later_apply_path",
+)
+COPIED_FIELDS = (
+    "request_descriptor", "execution_intent", "execution_intent_id",
+    "execution_intent_hash", "adapter_contract_descriptor",
+    "adapter_contract_id", "adapter_contract_hash", "adapter_contract_version",
+    "endpoint_candidate", "endpoint_candidate_digest",
+    "endpoint_identity_binding", "endpoint_identity_binding_digest",
+    "credential_reference", "credential_reference_digest",
+    "credential_scope_binding", "credential_scope_binding_digest",
+    "source_to_execution_intent_mapping", "field_mapping_proof",
+    "required_field_presence", "source_decision_identity",
+    "candidate_identity", "evidence_lineage", "replay_summary",
+)
+
+
+class LiveAdapterDryRunOperatorDispatchReviewError(ValueError):
+    """Stable fail-closed refusal for invalid operator review evidence."""
+
+
+class OperatorReviewDecision(BaseModel):
+    """Closed explicit operator decision and mandatory acknowledgements."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    operator_review_id: str = Field(min_length=1)
+    reviewer_id: str = Field(min_length=1)
+    reviewer_role: str = Field(min_length=1)
+    reviewer_organization: str = Field(min_length=1)
+    reviewed_at: str
+    review_decision: Literal[*REVIEW_DECISIONS]
+    review_reason: str = Field(min_length=1)
+    reviewed_endpoint_candidate_id: str = Field(min_length=1)
+    reviewed_credential_reference_id: str = Field(min_length=1)
+    reviewed_adapter_contract_id: str = Field(min_length=1)
+    reviewed_target_system: str = Field(min_length=1)
+    reviewed_target_resource_scope: str = Field(min_length=1)
+    acknowledged_scope_limitations: Literal[True]
+    acknowledged_non_effect_guarantees: Literal[True]
+    acknowledged_future_bind_pre_dispatch_review_required: Literal[True]
+    acknowledged_no_dispatch: Literal[True]
+    acknowledged_no_credential_access: Literal[True]
+    acknowledged_no_network: Literal[True]
+    acknowledged_no_bind: Literal[True]
+    acknowledged_no_bind_receipt: Literal[True]
+    acknowledged_no_trustlog_write: Literal[True]
+
+
+class OperatorDispatchReviewCheck(BaseModel):
+    """One deterministic local check carrying explicit non-effect facts."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    check_id: str
+    ordinal: int = Field(ge=1, le=33)
+    name: Literal[*CHECK_NAMES]
+    mode: Literal[CHECK_MODE]
+    passed: bool
+    evidence_ref: str
+    credential_resolved: Literal[False]
+    credential_material_accessed: Literal[False]
+    credential_material_embedded: Literal[False]
+    authorization_header_constructed: Literal[False]
+    token_embedded: Literal[False]
+    secret_embedded: Literal[False]
+    endpoint_resolved: Literal[False]
+    dns_used: Literal[False]
+    network_used: Literal[False]
+    webhook_called: Literal[False]
+    live_adapter_instantiated: Literal[False]
+    live_adapter_method_called: Literal[False]
+    request_dispatched: Literal[False]
+    bind_invoked: Literal[False]
+    bind_receipt_created: Literal[False]
+    trustlog_written: Literal[False]
+    external_effect_used: Literal[False]
+    filesystem_used: Literal[False]
+    database_used: Literal[False]
+    provider_used: Literal[False]
+    subprocess_used: Literal[False]
+    operation_committed: Literal[False]
+
+
+class FutureBindPreDispatchReviewRequirement(BaseModel):
+    """One future boundary that this review explicitly does not satisfy."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    ordinal: int = Field(ge=1, le=12)
+    name: Literal[*FUTURE_REQUIREMENT_NAMES]
+    separate_future_artifact_required: Literal[True]
+    satisfied_by_this_packet: Literal[False]
+
+
+class CanonicalLiveAdapterDryRunOperatorDispatchReviewPacket(BaseModel):
+    """Closed content-addressed operator dispatch review packet."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    format_version: Literal[FORMAT_VERSION]
+    live_adapter_dry_run_operator_dispatch_review_id: str
+    live_adapter_dry_run_operator_dispatch_review_hash: str
+    operator_dispatch_review_mechanism: Literal[REVIEW_MECHANISM]
+    operator_dispatch_review_recorded_at: str
+    source_credential_authorization_evaluation_id: str
+    source_credential_authorization_evaluation_hash: str
+    source_credential_authorization_evaluation_packet: dict[str, Any]
+    source_endpoint_allowlist_evaluation_hash: str
+    source_dispatch_readiness_hash: str
+    source_live_adapter_dry_run_request_hash: str
+    request_descriptor: dict[str, Any]
+    execution_intent: dict[str, Any]
+    execution_intent_id: str
+    execution_intent_hash: str
+    adapter_contract_descriptor: dict[str, Any]
+    adapter_contract_id: str
+    adapter_contract_hash: str
+    adapter_contract_version: str
+    endpoint_candidate: dict[str, Any]
+    endpoint_candidate_digest: str
+    endpoint_identity_binding: dict[str, Any]
+    endpoint_identity_binding_digest: str
+    credential_reference: dict[str, Any]
+    credential_reference_digest: str
+    credential_scope_binding: dict[str, Any]
+    credential_scope_binding_digest: str
+    operator_review_decision: OperatorReviewDecision
+    operator_review_decision_digest: str
+    operator_review_binding: dict[str, Any]
+    operator_review_binding_digest: str
+    operator_dispatch_review_checks: tuple[OperatorDispatchReviewCheck, ...]
+    operator_dispatch_review_check_digest: str
+    future_bind_pre_dispatch_review_requirements: tuple[
+        FutureBindPreDispatchReviewRequirement, ...
+    ]
+    future_bind_pre_dispatch_review_requirement_digest: str
+    source_to_execution_intent_mapping: dict[str, Any]
+    field_mapping_proof: dict[str, Any]
+    required_field_presence: dict[str, str]
+    source_decision_identity: dict[str, Any]
+    candidate_identity: dict[str, Any]
+    evidence_lineage: dict[str, Any]
+    replay_summary: dict[str, Any]
+    operator_dispatch_review_status: Literal[STATUS]
+    request_dispatch_state: Literal["NOT_DISPATCHED"]
+    credential_resolved: Literal[False]
+    credential_material_accessed: Literal[False]
+    credential_material_embedded: Literal[False]
+    authorization_header_constructed: Literal[False]
+    token_embedded: Literal[False]
+    secret_embedded: Literal[False]
+    endpoint_resolved: Literal[False]
+    network_used: Literal[False]
+    live_adapter_instantiated: Literal[False]
+    webhook_called: Literal[False]
+    bind_invoked: Literal[False]
+    bind_receipt_created: Literal[False]
+    trustlog_written: Literal[False]
+    request_dispatched: Literal[False]
+    fail_closed: bool
+    scope_limitations: tuple[Literal[*SCOPE_LIMITATIONS], ...]
+
+
+def _timestamp(value: Any) -> str:
+    try:
+        parsed = value if isinstance(value, datetime) else datetime.fromisoformat(value)
+    except (TypeError, ValueError) as exc:
+        raise LiveAdapterDryRunOperatorDispatchReviewError(
+            "LADROR_TIMESTAMP_INVALID"
+        ) from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise LiveAdapterDryRunOperatorDispatchReviewError(
+            "LADROR_TIMESTAMP_INVALID"
+        )
+    return parsed.astimezone(timezone.utc).isoformat()
+
+
+def _json_value(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        value = value.model_dump(mode="python")
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        if value != value or value in (float("inf"), float("-inf")):
+            raise LiveAdapterDryRunOperatorDispatchReviewError(
+                "LADROR_PACKET_INVALID"
+            )
+        return value
+    if isinstance(value, datetime):
+        return _timestamp(value)
+    if isinstance(value, (list, tuple)):
+        return [_json_value(item) for item in value]
+    if isinstance(value, dict) and all(isinstance(key, str) for key in value):
+        return {key: _json_value(item) for key, item in value.items()}
+    raise LiveAdapterDryRunOperatorDispatchReviewError("LADROR_PACKET_INVALID")
+
+
+def _digest(domain: str, value: Any) -> str:
+    encoded = json.dumps(
+        {"domain": domain, "value": _json_value(value)},
+        allow_nan=False, ensure_ascii=False, separators=(",", ":"), sort_keys=True,
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _packet_hash(raw: dict[str, Any]) -> str:
+    omitted = {
+        "live_adapter_dry_run_operator_dispatch_review_id",
+        "live_adapter_dry_run_operator_dispatch_review_hash",
+    }
+    return _digest(
+        PACKET_DOMAIN, {key: value for key, value in raw.items() if key not in omitted}
+    )
+
+
+def _source(
+    value: Any,
+) -> CanonicalLiveAdapterDryRunCredentialAuthorizationEvaluationPacket:
+    try:
+        return verify_live_adapter_dry_run_credential_authorization_evaluation_packet(
+            value
+        )
+    except (LiveAdapterDryRunCredentialAuthorizationError, TypeError, ValueError) as exc:
+        raise LiveAdapterDryRunOperatorDispatchReviewError(
+            "LADROR_SOURCE_INVALID"
+        ) from exc
+
+
+def _validate_source(
+    source: CanonicalLiveAdapterDryRunCredentialAuthorizationEvaluationPacket,
+) -> None:
+    if source.request_dispatch_state != "NOT_DISPATCHED":
+        raise LiveAdapterDryRunOperatorDispatchReviewError(
+            "LADROR_SOURCE_DISPATCHED"
+        )
+    if source.credential_authorization_status != SOURCE_STATUS:
+        raise LiveAdapterDryRunOperatorDispatchReviewError(
+            "LADROR_SOURCE_STATUS_INVALID"
+        )
+    if not source.credential_authorization_result.authorized:
+        raise LiveAdapterDryRunOperatorDispatchReviewError(
+            "LADROR_SOURCE_CREDENTIAL_UNAUTHORIZED"
+        )
+
+
+def _validate_decision(
+    source: CanonicalLiveAdapterDryRunCredentialAuthorizationEvaluationPacket,
+    decision: OperatorReviewDecision,
+) -> None:
+    expected = (
+        source.endpoint_candidate["endpoint_candidate_id"],
+        source.credential_reference.credential_reference_id,
+        source.adapter_contract_id,
+        source.credential_reference.target_system,
+        source.credential_reference.target_resource_scope,
+    )
+    actual = (
+        decision.reviewed_endpoint_candidate_id,
+        decision.reviewed_credential_reference_id,
+        decision.reviewed_adapter_contract_id,
+        decision.reviewed_target_system,
+        decision.reviewed_target_resource_scope,
+    )
+    if actual != expected:
+        raise LiveAdapterDryRunOperatorDispatchReviewError(
+            "LADROR_REVIEWED_IDENTITY_MISMATCH"
+        )
+
+
+def _binding(
+    source: CanonicalLiveAdapterDryRunCredentialAuthorizationEvaluationPacket,
+    decision: OperatorReviewDecision,
+) -> dict[str, Any]:
+    return {
+        "operator_review_id": decision.operator_review_id,
+        "reviewer_id": decision.reviewer_id,
+        "review_decision": decision.review_decision,
+        "source_credential_authorization_evaluation_id": (
+            source.live_adapter_dry_run_credential_authorization_evaluation_id
+        ),
+        "source_credential_authorization_evaluation_hash": (
+            source.live_adapter_dry_run_credential_authorization_evaluation_hash
+        ),
+        "endpoint_candidate_id": decision.reviewed_endpoint_candidate_id,
+        "credential_reference_id": decision.reviewed_credential_reference_id,
+        "adapter_contract_id": decision.reviewed_adapter_contract_id,
+        "target_system": decision.reviewed_target_system,
+        "target_resource_scope": decision.reviewed_target_resource_scope,
+        "bind_pre_dispatch_review_required": True,
+        "execution_authorized_by_this_packet": False,
+    }
+
+
+def _checks(source_hash: str, decision_digest: str) -> list[dict[str, Any]]:
+    return [{
+        "check_id": f"ladror-check:v1:{ordinal}:{name.replace('_', '-')}",
+        "ordinal": ordinal,
+        "name": name,
+        "mode": CHECK_MODE,
+        "passed": True,
+        "evidence_ref": f"source:{source_hash}:decision:{decision_digest}:{name}",
+        **{field: False for field in EFFECT_FIELDS},
+    } for ordinal, name in enumerate(CHECK_NAMES, 1)]
+
+
+def _requirements() -> list[dict[str, Any]]:
+    return [{
+        "ordinal": ordinal,
+        "name": name,
+        "separate_future_artifact_required": True,
+        "satisfied_by_this_packet": False,
+    } for ordinal, name in enumerate(FUTURE_REQUIREMENT_NAMES, 1)]
+
+
+def build_live_adapter_dry_run_operator_dispatch_review_packet(
+    source_credential_authorization_evaluation_packet: Any,
+    operator_review_decision: Any,
+    operator_dispatch_review_recorded_at: datetime,
+) -> CanonicalLiveAdapterDryRunOperatorDispatchReviewPacket:
+    """Build and self-verify a deterministic, non-dispatching review packet."""
+    source = _source(_json_value(source_credential_authorization_evaluation_packet))
+    _validate_source(source)
+    try:
+        decision = OperatorReviewDecision.model_validate(
+            _json_value(operator_review_decision)
+        )
+    except ValidationError as exc:
+        raise LiveAdapterDryRunOperatorDispatchReviewError(
+            "LADROR_DECISION_INVALID"
+        ) from exc
+    reviewed_at = _timestamp(decision.reviewed_at)
+    recorded_at = _timestamp(operator_dispatch_review_recorded_at)
+    if datetime.fromisoformat(recorded_at) < datetime.fromisoformat(reviewed_at):
+        raise LiveAdapterDryRunOperatorDispatchReviewError(
+            "LADROR_RECORDED_TOO_EARLY"
+        )
+    _validate_decision(source, decision)
+    source_raw = source.model_dump(mode="json")
+    decision_raw = decision.model_dump(mode="json")
+    decision_raw["reviewed_at"] = reviewed_at
+    decision_digest = _digest(DECISION_DOMAIN, decision_raw)
+    binding = _binding(source, decision)
+    checks = _checks(
+        source.live_adapter_dry_run_credential_authorization_evaluation_hash,
+        decision_digest,
+    )
+    requirements = _requirements()
+    raw = {
+        "format_version": FORMAT_VERSION,
+        "operator_dispatch_review_mechanism": REVIEW_MECHANISM,
+        "operator_dispatch_review_recorded_at": recorded_at,
+        "source_credential_authorization_evaluation_id": (
+            source.live_adapter_dry_run_credential_authorization_evaluation_id
+        ),
+        "source_credential_authorization_evaluation_hash": (
+            source.live_adapter_dry_run_credential_authorization_evaluation_hash
+        ),
+        "source_credential_authorization_evaluation_packet": source_raw,
+        "source_endpoint_allowlist_evaluation_hash": (
+            source.source_endpoint_allowlist_evaluation_hash
+        ),
+        "source_dispatch_readiness_hash": source.source_dispatch_readiness_hash,
+        "source_live_adapter_dry_run_request_hash": (
+            source.source_live_adapter_dry_run_request_hash
+        ),
+        **{field: source_raw[field] for field in COPIED_FIELDS},
+        "operator_review_decision": decision_raw,
+        "operator_review_decision_digest": decision_digest,
+        "operator_review_binding": binding,
+        "operator_review_binding_digest": _digest(BINDING_DOMAIN, binding),
+        "operator_dispatch_review_checks": checks,
+        "operator_dispatch_review_check_digest": _digest(CHECKS_DOMAIN, checks),
+        "future_bind_pre_dispatch_review_requirements": requirements,
+        "future_bind_pre_dispatch_review_requirement_digest": _digest(
+            REQUIREMENTS_DOMAIN, requirements
+        ),
+        "operator_dispatch_review_status": STATUS,
+        "request_dispatch_state": "NOT_DISPATCHED",
+        **{field: False for field in (
+            "credential_resolved", "credential_material_accessed",
+            "credential_material_embedded", "authorization_header_constructed",
+            "token_embedded", "secret_embedded", "endpoint_resolved",
+            "network_used", "live_adapter_instantiated", "webhook_called",
+            "bind_invoked", "bind_receipt_created", "trustlog_written",
+            "request_dispatched",
+        )},
+        "fail_closed": decision.review_decision != REVIEW_DECISIONS[0],
+        "scope_limitations": SCOPE_LIMITATIONS,
+    }
+    digest = _packet_hash(raw)
+    raw["live_adapter_dry_run_operator_dispatch_review_hash"] = digest
+    raw["live_adapter_dry_run_operator_dispatch_review_id"] = (
+        f"ladror:v1:sha256:{digest}"
+    )
+    return verify_live_adapter_dry_run_operator_dispatch_review_packet(raw)
+
+
+def verify_live_adapter_dry_run_operator_dispatch_review_packet(
+    raw: Any,
+) -> CanonicalLiveAdapterDryRunOperatorDispatchReviewPacket:
+    """Reverify source and recompute every binding, digest, hash, and ID."""
+    try:
+        value = raw.model_dump(mode="json") if isinstance(raw, BaseModel) else raw
+        packet = CanonicalLiveAdapterDryRunOperatorDispatchReviewPacket.model_validate(
+            _json_value(value)
+        )
+    except (ValidationError, TypeError,
+            LiveAdapterDryRunOperatorDispatchReviewError) as exc:
+        raise LiveAdapterDryRunOperatorDispatchReviewError(
+            "LADROR_PACKET_INVALID"
+        ) from exc
+    actual = packet.model_dump(mode="json")
+    source = _source(packet.source_credential_authorization_evaluation_packet)
+    _validate_source(source)
+    source_raw = source.model_dump(mode="json")
+    if (
+        packet.source_credential_authorization_evaluation_id
+        != source.live_adapter_dry_run_credential_authorization_evaluation_id
+        or packet.source_credential_authorization_evaluation_hash
+        != source.live_adapter_dry_run_credential_authorization_evaluation_hash
+    ):
+        raise LiveAdapterDryRunOperatorDispatchReviewError(
+            "LADROR_SOURCE_IDENTITY_MISMATCH"
+        )
+    lineage = (
+        packet.source_endpoint_allowlist_evaluation_hash,
+        packet.source_dispatch_readiness_hash,
+        packet.source_live_adapter_dry_run_request_hash,
+    )
+    if lineage != (
+        source.source_endpoint_allowlist_evaluation_hash,
+        source.source_dispatch_readiness_hash,
+        source.source_live_adapter_dry_run_request_hash,
+    ):
+        raise LiveAdapterDryRunOperatorDispatchReviewError(
+            "LADROR_LINEAGE_MISMATCH"
+        )
+    for field in COPIED_FIELDS:
+        if _json_value(getattr(packet, field)) != _json_value(source_raw[field]):
+            raise LiveAdapterDryRunOperatorDispatchReviewError(
+                "LADROR_SOURCE_FIELD_MISMATCH"
+            )
+    _validate_decision(source, packet.operator_review_decision)
+    reviewed_at = _timestamp(packet.operator_review_decision.reviewed_at)
+    recorded_at = _timestamp(packet.operator_dispatch_review_recorded_at)
+    if datetime.fromisoformat(recorded_at) < datetime.fromisoformat(reviewed_at):
+        raise LiveAdapterDryRunOperatorDispatchReviewError(
+            "LADROR_RECORDED_TOO_EARLY"
+        )
+    decision_raw = packet.operator_review_decision.model_dump(mode="json")
+    decision_raw["reviewed_at"] = reviewed_at
+    decision_digest = _digest(DECISION_DOMAIN, decision_raw)
+    if packet.operator_review_decision_digest != decision_digest:
+        raise LiveAdapterDryRunOperatorDispatchReviewError(
+            "LADROR_DECISION_DIGEST_MISMATCH"
+        )
+    binding = _binding(source, packet.operator_review_decision)
+    if (
+        packet.operator_review_binding != binding
+        or packet.operator_review_binding_digest != _digest(BINDING_DOMAIN, binding)
+    ):
+        raise LiveAdapterDryRunOperatorDispatchReviewError(
+            "LADROR_BINDING_MISMATCH"
+        )
+    checks = _checks(
+        source.live_adapter_dry_run_credential_authorization_evaluation_hash,
+        decision_digest,
+    )
+    if (
+        _json_value(packet.operator_dispatch_review_checks) != checks
+        or packet.operator_dispatch_review_check_digest
+        != _digest(CHECKS_DOMAIN, checks)
+    ):
+        raise LiveAdapterDryRunOperatorDispatchReviewError(
+            "LADROR_CHECKS_MISMATCH"
+        )
+    requirements = _requirements()
+    if (
+        _json_value(packet.future_bind_pre_dispatch_review_requirements)
+        != requirements
+        or packet.future_bind_pre_dispatch_review_requirement_digest
+        != _digest(REQUIREMENTS_DOMAIN, requirements)
+    ):
+        raise LiveAdapterDryRunOperatorDispatchReviewError(
+            "LADROR_REQUIREMENTS_MISMATCH"
+        )
+    expected_fail_closed = packet.operator_review_decision.review_decision != (
+        "APPROVE_FOR_BIND_PRE_DISPATCH_REVIEW"
+    ) or not all(check.passed for check in packet.operator_dispatch_review_checks)
+    if packet.fail_closed != expected_fail_closed:
+        raise LiveAdapterDryRunOperatorDispatchReviewError(
+            "LADROR_FAIL_CLOSED_MISMATCH"
+        )
+    if packet.scope_limitations != SCOPE_LIMITATIONS:
+        raise LiveAdapterDryRunOperatorDispatchReviewError(
+            "LADROR_SCOPE_LIMITATIONS_MISMATCH"
+        )
+    digest = _packet_hash(actual)
+    if packet.live_adapter_dry_run_operator_dispatch_review_hash != digest:
+        raise LiveAdapterDryRunOperatorDispatchReviewError(
+            "LADROR_PACKET_HASH_MISMATCH"
+        )
+    if packet.live_adapter_dry_run_operator_dispatch_review_id != (
+        f"ladror:v1:sha256:{digest}"
+    ):
+        raise LiveAdapterDryRunOperatorDispatchReviewError(
+            "LADROR_PACKET_ID_MISMATCH"
+        )
+    return packet

--- a/veritas_os/tests/test_live_adapter_dry_run_operator_dispatch_review.py
+++ b/veritas_os/tests/test_live_adapter_dry_run_operator_dispatch_review.py
@@ -1,0 +1,323 @@
+"""Integrity and non-effect tests for operator dispatch review v1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from copy import deepcopy
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator, ValidationError
+
+from veritas_os.policy.live_adapter_dry_run_operator_dispatch_review import (
+    CHECK_NAMES,
+    EFFECT_FIELDS,
+    FUTURE_REQUIREMENT_NAMES,
+    SCOPE_LIMITATIONS,
+    LiveAdapterDryRunOperatorDispatchReviewError,
+    _digest,
+    _packet_hash,
+    build_live_adapter_dry_run_operator_dispatch_review_packet,
+    verify_live_adapter_dry_run_operator_dispatch_review_packet,
+)
+from veritas_os.tests.test_live_adapter_dry_run_credential_authorization import (
+    EVALUATED_AT,
+    _packet as credential_packet,
+)
+
+RECORDED_AT = EVALUATED_AT + timedelta(seconds=1)
+MODULE = Path(
+    "veritas_os/policy/live_adapter_dry_run_operator_dispatch_review.py"
+)
+SCHEMA = Path(
+    "schemas/live-adapter-dry-run-operator-dispatch-review-v1.schema.json"
+)
+
+
+def _decision(source=None, review_decision="APPROVE_FOR_BIND_PRE_DISPATCH_REVIEW",
+              **changes):
+    source = source or credential_packet()
+    value = {
+        "operator_review_id": "operator-review:billing:v1",
+        "reviewer_id": "reviewer:alice",
+        "reviewer_role": "dispatch-reviewer",
+        "reviewer_organization": "veritas-local",
+        "reviewed_at": RECORDED_AT.isoformat(),
+        "review_decision": review_decision,
+        "review_reason": "Evidence reviewed; advance only to separate Bind review.",
+        "reviewed_endpoint_candidate_id": (
+            source.endpoint_candidate["endpoint_candidate_id"]
+        ),
+        "reviewed_credential_reference_id": (
+            source.credential_reference.credential_reference_id
+        ),
+        "reviewed_adapter_contract_id": source.adapter_contract_id,
+        "reviewed_target_system": source.credential_reference.target_system,
+        "reviewed_target_resource_scope": (
+            source.credential_reference.target_resource_scope
+        ),
+        "acknowledged_scope_limitations": True,
+        "acknowledged_non_effect_guarantees": True,
+        "acknowledged_future_bind_pre_dispatch_review_required": True,
+        "acknowledged_no_dispatch": True,
+        "acknowledged_no_credential_access": True,
+        "acknowledged_no_network": True,
+        "acknowledged_no_bind": True,
+        "acknowledged_no_bind_receipt": True,
+        "acknowledged_no_trustlog_write": True,
+    }
+    value.update(changes)
+    return value
+
+
+def _packet(*, source=None, decision=None, semantic_match=False):
+    source = source or credential_packet(semantic_match=semantic_match)
+    return build_live_adapter_dry_run_operator_dispatch_review_packet(
+        source, decision or _decision(source), RECORDED_AT
+    )
+
+
+def _rehash(raw):
+    digest = _packet_hash(raw)
+    raw["live_adapter_dry_run_operator_dispatch_review_hash"] = digest
+    raw["live_adapter_dry_run_operator_dispatch_review_id"] = (
+        f"ladror:v1:sha256:{digest}"
+    )
+
+
+def test_builder_creates_verified_approved_packet_and_reverifies_source(
+    monkeypatch,
+) -> None:
+    import veritas_os.policy.live_adapter_dry_run_operator_dispatch_review as module
+
+    actual = module.verify_live_adapter_dry_run_credential_authorization_evaluation_packet
+    calls = []
+
+    def recording(value):
+        calls.append(value)
+        return actual(value)
+
+    monkeypatch.setattr(
+        module,
+        "verify_live_adapter_dry_run_credential_authorization_evaluation_packet",
+        recording,
+    )
+    packet = module.build_live_adapter_dry_run_operator_dispatch_review_packet(
+        credential_packet(), _decision(), RECORDED_AT
+    )
+    assert len(calls) == 2
+    assert module.verify_live_adapter_dry_run_operator_dispatch_review_packet(
+        packet
+    ) == packet
+    assert len(calls) == 3
+    assert not packet.fail_closed
+    assert packet.request_dispatch_state == "NOT_DISPATCHED"
+    assert not any(getattr(packet, field) for field in (
+        "credential_resolved", "credential_material_accessed",
+        "credential_material_embedded", "authorization_header_constructed",
+        "token_embedded", "secret_embedded", "endpoint_resolved",
+        "network_used", "live_adapter_instantiated", "webhook_called",
+        "bind_invoked", "bind_receipt_created", "trustlog_written",
+        "request_dispatched",
+    ))
+
+
+@pytest.mark.parametrize("decision", ["REJECT", "HOLD_FOR_MORE_EVIDENCE"])
+def test_non_approval_decisions_remain_fail_closed(decision) -> None:
+    assert _packet(decision=_decision(review_decision=decision)).fail_closed
+
+
+@pytest.mark.parametrize("field", [
+    "reviewer_id", "reviewer_role", "reviewer_organization", "review_reason",
+])
+def test_required_operator_text_must_be_present(field) -> None:
+    with pytest.raises(LiveAdapterDryRunOperatorDispatchReviewError):
+        _packet(decision=_decision(**{field: ""}))
+
+
+def test_decision_is_closed_and_allowed() -> None:
+    with pytest.raises(LiveAdapterDryRunOperatorDispatchReviewError):
+        _packet(decision=_decision(unexpected=True))
+    with pytest.raises(LiveAdapterDryRunOperatorDispatchReviewError):
+        _packet(decision=_decision(review_decision="EXECUTE"))
+
+
+@pytest.mark.parametrize("field", [
+    "reviewed_endpoint_candidate_id", "reviewed_credential_reference_id",
+    "reviewed_adapter_contract_id", "reviewed_target_system",
+    "reviewed_target_resource_scope",
+])
+def test_reviewed_source_identities_must_match_exactly(field) -> None:
+    with pytest.raises(LiveAdapterDryRunOperatorDispatchReviewError):
+        _packet(decision=_decision(**{field: "forged"}))
+
+
+@pytest.mark.parametrize("field", [
+    "acknowledged_scope_limitations",
+    "acknowledged_non_effect_guarantees",
+    "acknowledged_future_bind_pre_dispatch_review_required",
+    "acknowledged_no_dispatch", "acknowledged_no_credential_access",
+    "acknowledged_no_network", "acknowledged_no_bind",
+    "acknowledged_no_bind_receipt", "acknowledged_no_trustlog_write",
+])
+def test_all_acknowledgements_are_mandatory(field) -> None:
+    with pytest.raises(LiveAdapterDryRunOperatorDispatchReviewError):
+        _packet(decision=_decision(**{field: False}))
+
+
+def test_source_fields_and_lineage_are_preserved_exactly() -> None:
+    source = credential_packet()
+    packet = _packet(source=source)
+    raw = source.model_dump(mode="json")
+    for field in (
+        "request_descriptor", "execution_intent", "adapter_contract_descriptor",
+        "adapter_contract_id", "adapter_contract_hash", "adapter_contract_version",
+        "endpoint_candidate", "endpoint_identity_binding", "credential_reference",
+        "credential_scope_binding", "source_to_execution_intent_mapping",
+        "field_mapping_proof", "required_field_presence",
+        "source_decision_identity", "candidate_identity", "evidence_lineage",
+        "replay_summary",
+    ):
+        actual = getattr(packet, field)
+        if hasattr(actual, "model_dump"):
+            actual = actual.model_dump(mode="json")
+        assert actual == raw[field]
+    assert packet.source_endpoint_allowlist_evaluation_hash == (
+        source.source_endpoint_allowlist_evaluation_hash
+    )
+    assert packet.source_dispatch_readiness_hash == source.source_dispatch_readiness_hash
+    assert packet.source_live_adapter_dry_run_request_hash == (
+        source.source_live_adapter_dry_run_request_hash
+    )
+
+
+def test_checks_and_future_requirements_are_exact_ordered_non_effect_evidence() -> None:
+    packet = _packet()
+    assert tuple(check.name for check in packet.operator_dispatch_review_checks) == (
+        CHECK_NAMES
+    )
+    for ordinal, check in enumerate(packet.operator_dispatch_review_checks, 1):
+        assert check.ordinal == ordinal and check.passed
+        assert not any(getattr(check, field) for field in EFFECT_FIELDS)
+    assert tuple(
+        item.name for item in packet.future_bind_pre_dispatch_review_requirements
+    ) == FUTURE_REQUIREMENT_NAMES
+    assert all(
+        item.separate_future_artifact_required
+        and not item.satisfied_by_this_packet
+        for item in packet.future_bind_pre_dispatch_review_requirements
+    )
+    assert packet.scope_limitations == SCOPE_LIMITATIONS
+
+
+@pytest.mark.parametrize("field", [
+    "operator_dispatch_review_checks",
+    "future_bind_pre_dispatch_review_requirements",
+    "scope_limitations", "operator_review_decision", "fail_closed",
+])
+def test_mutations_are_rejected_even_if_outer_packet_is_rehashed(field) -> None:
+    raw = _packet().model_dump(mode="json")
+    if field == "operator_dispatch_review_checks":
+        raw[field][0]["evidence_ref"] = "forged"
+    elif field == "future_bind_pre_dispatch_review_requirements":
+        raw[field][0]["satisfied_by_this_packet"] = True
+    elif field == "scope_limitations":
+        raw[field].reverse()
+    elif field == "operator_review_decision":
+        raw[field]["reviewer_id"] = "forged"
+    else:
+        raw[field] = True
+    _rehash(raw)
+    with pytest.raises(LiveAdapterDryRunOperatorDispatchReviewError):
+        verify_live_adapter_dry_run_operator_dispatch_review_packet(raw)
+
+
+@pytest.mark.parametrize("field", [
+    "live_adapter_dry_run_operator_dispatch_review_id",
+    "live_adapter_dry_run_operator_dispatch_review_hash",
+])
+def test_forged_content_address_is_rejected(field) -> None:
+    raw = _packet().model_dump(mode="json")
+    raw[field] = "forged"
+    with pytest.raises(LiveAdapterDryRunOperatorDispatchReviewError):
+        verify_live_adapter_dry_run_operator_dispatch_review_packet(raw)
+
+
+def test_digest_and_content_address_change_with_content() -> None:
+    first = _packet()
+    second = _packet(decision=_decision(review_reason="Different local reason."))
+    assert first.operator_review_decision_digest != second.operator_review_decision_digest
+    assert first.live_adapter_dry_run_operator_dispatch_review_hash != (
+        second.live_adapter_dry_run_operator_dispatch_review_hash
+    )
+    checks = first.model_dump(mode="json")["operator_dispatch_review_checks"]
+    old_digest = _digest(
+        "veritas.live-adapter-dry-run-operator-dispatch-review.checks/v1", checks
+    )
+    checks[0]["evidence_ref"] = "changed"
+    assert old_digest != _digest(
+        "veritas.live-adapter-dry-run-operator-dispatch-review.checks/v1", checks
+    )
+
+
+@pytest.mark.parametrize("semantic_match", [True, False])
+def test_semantic_match_is_preserved_without_authority(semantic_match) -> None:
+    packet = _packet(semantic_match=semantic_match)
+    assert packet.replay_summary["semantic_match"] is semantic_match
+    serialized = json.dumps(packet.model_dump(mode="json"))
+    assert "authority_evidence_recheck" in serialized
+    assert all(
+        not requirement.satisfied_by_this_packet
+        for requirement in packet.future_bind_pre_dispatch_review_requirements
+    )
+
+
+def test_source_mutation_is_rejected_by_reverification() -> None:
+    raw = _packet().model_dump(mode="json")
+    raw["source_credential_authorization_evaluation_packet"][
+        "credential_authorization_result"
+    ]["authorized"] = False
+    _rehash(raw)
+    with pytest.raises(LiveAdapterDryRunOperatorDispatchReviewError):
+        verify_live_adapter_dry_run_operator_dispatch_review_packet(raw)
+
+
+def test_schema_accepts_packet_and_rejects_mutations() -> None:
+    schema = json.loads(SCHEMA.read_text())
+    raw = _packet().model_dump(mode="json")
+    Draft202012Validator(schema).validate(raw)
+    extra = deepcopy(raw)
+    extra["unexpected"] = True
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(extra)
+    effect = deepcopy(raw)
+    effect["network_used"] = True
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(effect)
+
+
+def test_module_has_no_prohibited_imports_or_effect_calls() -> None:
+    tree = ast.parse(MODULE.read_text())
+    imports = {
+        alias.name.split(".")[0]
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.Import, ast.ImportFrom))
+        for alias in node.names
+    }
+    assert not imports & {
+        "requests", "httpx", "urllib", "socket", "dns", "subprocess", "os",
+        "pathlib",
+    }
+    source = MODULE.read_text()
+    called = {
+        node.func.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    assert not called & {
+        "open", "apply", "verify_postconditions", "revert",
+        "WebhookBindAdapter", "Bind", "BindReceipt", "TrustLog",
+    }
+    assert "os.environ" not in source


### PR DESCRIPTION
### Motivation

- Continue the dry-run milestone sequence by adding an explicit operator review artifact that records a deterministic, content-addressed decision for a verified non-dispatched credential-authorization evaluation.
- Provide a review-only governance boundary that permits progression to a future Bind pre-dispatch review without creating execution authority or causing external side effects.
- Enforce strict, closed validation and non-effect guarantees so operator reviews cannot accidentally dispatch, access secrets, or mutate provenance.

### Description

- Add `veritas_os/policy/live_adapter_dry_run_operator_dispatch_review.py` implementing Pydantic v2 models, a deterministic domain-separated hashing scheme, a builder `build_live_adapter_dry_run_operator_dispatch_review_packet(...)`, and a verifier `verify_live_adapter_dry_run_operator_dispatch_review_packet(...)` that re-verifies the embedded credential-authorization source and recomputes all digests, bindings, checks, and packet hash/ID.
- Introduce a closed `OperatorReviewDecision` schema, deterministic ordered `OperatorDispatchReviewCheck` list (33 checks with explicit non-effect flags), and `FutureBindPreDispatchReviewRequirement` list binding future requirements that this artifact does not satisfy.
- Add JSON Schema `schemas/live-adapter-dry-run-operator-dispatch-review-v1.schema.json` with `additionalProperties: false` and strict const/enums for format, mechanism, status, request state, check names, check mode, and scope limitations, plus exact ordered arrays for checks and future requirements.
- Add comprehensive unit tests `veritas_os/tests/test_live_adapter_dry_run_operator_dispatch_review.py` exercising builder/verifier behavior, identity/acknowledgement enforcement, mutation rejection, digest/ID sensitivity, semantic_match preservation (without promotion to authority), and prohibition of any network/filesystem/Bind/Webhook/TrustLog effects.
- Add documentation `docs/en/architecture/live-adapter-dry-run-operator-dispatch-review-v1.md` describing purpose, deterministic verification, non-effect guarantees, and future Bind pre-dispatch review requirements.
- Security / non-effect guarantees: the implementation and schema explicitly forbid dispatch, Bind invocation, BindReceipt creation, TrustLog writes, endpoint resolution, credential material access or embedding, authorization header construction, token/secret embedding, network/Webhook/DNS calls, live adapter instantiation, subprocess/filesystem/database/provider usage, and any operation commit; the packet is record-only and must not be treated as Bind authorization.

- Final invariant: Canonical Live Adapter Dry-Run Operator Dispatch Review v1 now records an explicit operator review decision for a verified non-dispatched credential-authorization evaluation packet without dispatching the request, without invoking Bind, without creating a BindReceipt, without writing TrustLog, without resolving endpoints, without accessing credential material, without constructing authorization headers, without network access, without instantiating a live adapter, without calling Webhook, without external effects, and without converting semantic_match into Authority Evidence, Human Approval, or execution authority.

### Testing

- Ran `pytest -q veritas_os/tests/test_live_adapter_dry_run_operator_dispatch_review.py` — 37 passed.
- Ran the requested 10-file regression suite including credential-authorization and related fixtures — 469 passed in the environment used for verification.
- Ran lint/type checks: `ruff check veritas_os/policy/live_adapter_dry_run_operator_dispatch_review.py veritas_os/tests/test_live_adapter_dry_run_operator_dispatch_review.py` — passed.
- Verified compile/serialization utilities: `python -m py_compile veritas_os/policy/live_adapter_dry_run_operator_dispatch_review.py` and `python -m json.tool schemas/live-adapter-dry-run-operator-dispatch-review-v1.schema.json` — both passed.
- Confirmed `git diff --check` and staged changes show no whitespace/check errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a841138174c8326aadf3a2abf665730)