### PR TITLE
feat(bind): add live adapter dry-run bind pre-dispatch review v1

### DIFF
--- a/docs/en/architecture/live-adapter-dry-run-bind-pre-dispatch-review-v1.md
+++ b/docs/en/architecture/live-adapter-dry-run-bind-pre-dispatch-review-v1.md
@@ -1,0 +1,62 @@
+# Canonical Live Adapter Dry-Run Bind Pre-Dispatch Review v1
+
+## Purpose
+
+This canonical packet is a deterministic, local, content-addressed **Bind
+pre-dispatch review artifact**. It answers whether a verified, operator-reviewed,
+non-dispatched dry-run path has been reviewed at the Bind boundary before a
+separate future Bind-dispatch gate review. The embedded operator packet is
+reverified, its identities and lineage are preserved exactly, and every derived
+value is protected by domain-separated canonical-JSON hashing.
+
+This is review evidence only. It does **not** authorize execution, satisfy
+Authority Evidence, satisfy Human Approval, create execution authority, or
+constitute Bind authorization. A preserved `semantic_match` value is provenance,
+not authority: the result's `semantic_match_used` remains false and semantic
+matching is never promoted to Authority Evidence, Human Approval, or execution
+authority.
+
+## Security and non-effect boundary
+
+Building or verifying this packet:
+
+- does not invoke Bind;
+- does not create a BindReceipt;
+- does not write TrustLog;
+- does not dispatch the request;
+- does not resolve endpoints or DNS;
+- does not access, resolve, or embed credentials;
+- does not construct authorization headers or tokens;
+- does not call a network or Webhook;
+- does not instantiate or call a live adapter; and
+- does not commit an operation or use any external effect.
+
+All timestamps are supplied by the caller and normalized to UTC. The verifier
+uses no clock, random value, UUID, filesystem, environment, provider, credential
+store, subprocess, or network access. Closed Pydantic models reject missing and
+extra fields. The embedded source is always reverified rather than trusted as a
+raw dictionary, and the verifier recomputes the decision, result, preconditions,
+ordered checks, future requirements, digests, packet hash, and packet ID.
+
+## Outcomes and fail-closed behavior
+
+The closed decision has only two outcomes:
+
+- `ACCEPTED_FOR_FUTURE_BIND_DISPATCH_GATE_REVIEW`
+- `REJECTED_FOR_FUTURE_BIND_DISPATCH_GATE_REVIEW`
+
+“Accepted” means only that this local evidence may proceed to a separate future
+gate review. It does not mean “authorized.” A rejected decision is recorded with
+`fail_closed: true`. An accepted packet can set `fail_closed: false` only after
+source acceptance, all mandatory acknowledgements, and all deterministic checks
+pass. Incomplete acknowledgements are rejected by the closed schema.
+
+## Future Bind invocation
+
+A future Bind invocation requires a **separate explicit artifact** proving valid
+Authority Evidence, Human Approval where required, final policy admissibility,
+endpoint and credential boundaries, authorization-header construction, runtime
+risk and idempotency binding, dispatch and Bind boundaries, BindReceipt creation,
+a post-Bind TrustLog boundary, and later apply-path postcondition and rollback
+requirements. This packet lists those requirements and marks every one as not
+satisfied by this packet.

--- a/schemas/live-adapter-dry-run-bind-pre-dispatch-review-v1.schema.json
+++ b/schemas/live-adapter-dry-run-bind-pre-dispatch-review-v1.schema.json
@@ -1,0 +1,1779 @@
+{
+  "$defs": {
+    "BindPreDispatchReviewCheck": {
+      "additionalProperties": false,
+      "description": "One ordered local check with explicit false effect flags.",
+      "properties": {
+        "check_id": {
+          "title": "Check Id",
+          "type": "string"
+        },
+        "ordinal": {
+          "maximum": 37,
+          "minimum": 1,
+          "title": "Ordinal",
+          "type": "integer"
+        },
+        "name": {
+          "enum": [
+            "source_operator_dispatch_review_verified",
+            "source_request_not_dispatched",
+            "source_bind_not_invoked",
+            "source_operator_review_accepted",
+            "bind_pre_dispatch_review_decision_closed_schema_valid",
+            "reviewer_identity_present",
+            "reviewer_role_present",
+            "reviewer_attestation_present",
+            "acknowledged_not_bind_authorization",
+            "acknowledged_no_bind_invocation",
+            "acknowledged_no_bind_receipt",
+            "acknowledged_no_trustlog_write",
+            "acknowledged_no_dispatch",
+            "acknowledged_no_credential_access",
+            "acknowledged_no_network_call",
+            "acknowledged_semantic_match_not_authority",
+            "request_descriptor_preserved",
+            "execution_intent_identity_preserved",
+            "adapter_contract_identity_preserved",
+            "endpoint_identity_binding_preserved",
+            "credential_scope_binding_preserved",
+            "operator_review_decision_preserved",
+            "bind_boundary_preconditions_constructed",
+            "bind_not_invoked",
+            "bind_receipt_not_created",
+            "trustlog_not_written",
+            "request_not_dispatched",
+            "endpoint_not_resolved",
+            "credential_material_not_accessed",
+            "authorization_header_not_constructed",
+            "network_not_used",
+            "webhook_not_called",
+            "live_adapter_not_instantiated",
+            "no_execution_authority_created",
+            "no_human_approval_created",
+            "no_authority_evidence_created",
+            "future_bind_invocation_gate_required"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "mode": {
+          "const": "deterministic_local_bind_pre_dispatch_review_only",
+          "title": "Mode",
+          "type": "string"
+        },
+        "passed": {
+          "title": "Passed",
+          "type": "boolean"
+        },
+        "evidence_ref": {
+          "title": "Evidence Ref",
+          "type": "string"
+        },
+        "bind_invoked": {
+          "const": false,
+          "title": "Bind Invoked",
+          "type": "boolean"
+        },
+        "bind_receipt_created": {
+          "const": false,
+          "title": "Bind Receipt Created",
+          "type": "boolean"
+        },
+        "trustlog_written": {
+          "const": false,
+          "title": "Trustlog Written",
+          "type": "boolean"
+        },
+        "request_dispatched": {
+          "const": false,
+          "title": "Request Dispatched",
+          "type": "boolean"
+        },
+        "endpoint_resolved": {
+          "const": false,
+          "title": "Endpoint Resolved",
+          "type": "boolean"
+        },
+        "credential_material_accessed": {
+          "const": false,
+          "title": "Credential Material Accessed",
+          "type": "boolean"
+        },
+        "credential_material_embedded": {
+          "const": false,
+          "title": "Credential Material Embedded",
+          "type": "boolean"
+        },
+        "authorization_header_constructed": {
+          "const": false,
+          "title": "Authorization Header Constructed",
+          "type": "boolean"
+        },
+        "token_embedded": {
+          "const": false,
+          "title": "Token Embedded",
+          "type": "boolean"
+        },
+        "secret_embedded": {
+          "const": false,
+          "title": "Secret Embedded",
+          "type": "boolean"
+        },
+        "network_used": {
+          "const": false,
+          "title": "Network Used",
+          "type": "boolean"
+        },
+        "dns_used": {
+          "const": false,
+          "title": "Dns Used",
+          "type": "boolean"
+        },
+        "webhook_called": {
+          "const": false,
+          "title": "Webhook Called",
+          "type": "boolean"
+        },
+        "live_adapter_instantiated": {
+          "const": false,
+          "title": "Live Adapter Instantiated",
+          "type": "boolean"
+        },
+        "live_adapter_method_called": {
+          "const": false,
+          "title": "Live Adapter Method Called",
+          "type": "boolean"
+        },
+        "external_effect_used": {
+          "const": false,
+          "title": "External Effect Used",
+          "type": "boolean"
+        },
+        "filesystem_used": {
+          "const": false,
+          "title": "Filesystem Used",
+          "type": "boolean"
+        },
+        "database_used": {
+          "const": false,
+          "title": "Database Used",
+          "type": "boolean"
+        },
+        "provider_used": {
+          "const": false,
+          "title": "Provider Used",
+          "type": "boolean"
+        },
+        "subprocess_used": {
+          "const": false,
+          "title": "Subprocess Used",
+          "type": "boolean"
+        },
+        "operation_committed": {
+          "const": false,
+          "title": "Operation Committed",
+          "type": "boolean"
+        },
+        "execution_authority_created": {
+          "const": false,
+          "title": "Execution Authority Created",
+          "type": "boolean"
+        },
+        "human_approval_created": {
+          "const": false,
+          "title": "Human Approval Created",
+          "type": "boolean"
+        },
+        "authority_evidence_created": {
+          "const": false,
+          "title": "Authority Evidence Created",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "check_id",
+        "ordinal",
+        "name",
+        "mode",
+        "passed",
+        "evidence_ref",
+        "bind_invoked",
+        "bind_receipt_created",
+        "trustlog_written",
+        "request_dispatched",
+        "endpoint_resolved",
+        "credential_material_accessed",
+        "credential_material_embedded",
+        "authorization_header_constructed",
+        "token_embedded",
+        "secret_embedded",
+        "network_used",
+        "dns_used",
+        "webhook_called",
+        "live_adapter_instantiated",
+        "live_adapter_method_called",
+        "external_effect_used",
+        "filesystem_used",
+        "database_used",
+        "provider_used",
+        "subprocess_used",
+        "operation_committed",
+        "execution_authority_created",
+        "human_approval_created",
+        "authority_evidence_created"
+      ],
+      "title": "BindPreDispatchReviewCheck",
+      "type": "object"
+    },
+    "BindPreDispatchReviewDecision": {
+      "additionalProperties": false,
+      "description": "Closed reviewer decision with mandatory non-authority acknowledgements.",
+      "properties": {
+        "bind_pre_dispatch_review_decision_id": {
+          "minLength": 1,
+          "title": "Bind Pre Dispatch Review Decision Id",
+          "type": "string"
+        },
+        "reviewer_id": {
+          "minLength": 1,
+          "title": "Reviewer Id",
+          "type": "string"
+        },
+        "reviewer_role": {
+          "minLength": 1,
+          "title": "Reviewer Role",
+          "type": "string"
+        },
+        "reviewer_attestation": {
+          "minLength": 1,
+          "title": "Reviewer Attestation",
+          "type": "string"
+        },
+        "reviewed_at": {
+          "title": "Reviewed At",
+          "type": "string"
+        },
+        "review_outcome": {
+          "enum": [
+            "ACCEPTED_FOR_FUTURE_BIND_DISPATCH_GATE_REVIEW",
+            "REJECTED_FOR_FUTURE_BIND_DISPATCH_GATE_REVIEW"
+          ],
+          "title": "Review Outcome",
+          "type": "string"
+        },
+        "review_reason": {
+          "minLength": 1,
+          "title": "Review Reason",
+          "type": "string"
+        },
+        "acknowledged_not_bind_authorization": {
+          "const": true,
+          "title": "Acknowledged Not Bind Authorization",
+          "type": "boolean"
+        },
+        "acknowledged_no_bind_invocation": {
+          "const": true,
+          "title": "Acknowledged No Bind Invocation",
+          "type": "boolean"
+        },
+        "acknowledged_no_bind_receipt": {
+          "const": true,
+          "title": "Acknowledged No Bind Receipt",
+          "type": "boolean"
+        },
+        "acknowledged_no_trustlog_write": {
+          "const": true,
+          "title": "Acknowledged No Trustlog Write",
+          "type": "boolean"
+        },
+        "acknowledged_no_dispatch": {
+          "const": true,
+          "title": "Acknowledged No Dispatch",
+          "type": "boolean"
+        },
+        "acknowledged_no_credential_access": {
+          "const": true,
+          "title": "Acknowledged No Credential Access",
+          "type": "boolean"
+        },
+        "acknowledged_no_network_call": {
+          "const": true,
+          "title": "Acknowledged No Network Call",
+          "type": "boolean"
+        },
+        "acknowledged_semantic_match_not_authority": {
+          "const": true,
+          "title": "Acknowledged Semantic Match Not Authority",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "bind_pre_dispatch_review_decision_id",
+        "reviewer_id",
+        "reviewer_role",
+        "reviewer_attestation",
+        "reviewed_at",
+        "review_outcome",
+        "review_reason",
+        "acknowledged_not_bind_authorization",
+        "acknowledged_no_bind_invocation",
+        "acknowledged_no_bind_receipt",
+        "acknowledged_no_trustlog_write",
+        "acknowledged_no_dispatch",
+        "acknowledged_no_credential_access",
+        "acknowledged_no_network_call",
+        "acknowledged_semantic_match_not_authority"
+      ],
+      "title": "BindPreDispatchReviewDecision",
+      "type": "object"
+    },
+    "BindPreDispatchReviewResult": {
+      "additionalProperties": false,
+      "description": "Deterministic outcome that explicitly creates no authority.",
+      "properties": {
+        "accepted_for_future_bind_dispatch_gate_review": {
+          "title": "Accepted For Future Bind Dispatch Gate Review",
+          "type": "boolean"
+        },
+        "rejection_reasons": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Rejection Reasons",
+          "type": "array"
+        },
+        "review_reason": {
+          "title": "Review Reason",
+          "type": "string"
+        },
+        "comparison_mode": {
+          "const": "deterministic_local_bind_pre_dispatch_review_only",
+          "title": "Comparison Mode",
+          "type": "string"
+        },
+        "semantic_match_used": {
+          "const": false,
+          "title": "Semantic Match Used",
+          "type": "boolean"
+        },
+        "creates_bind_authorization": {
+          "const": false,
+          "title": "Creates Bind Authorization",
+          "type": "boolean"
+        },
+        "creates_execution_authority": {
+          "const": false,
+          "title": "Creates Execution Authority",
+          "type": "boolean"
+        },
+        "creates_human_approval": {
+          "const": false,
+          "title": "Creates Human Approval",
+          "type": "boolean"
+        },
+        "creates_authority_evidence": {
+          "const": false,
+          "title": "Creates Authority Evidence",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "accepted_for_future_bind_dispatch_gate_review",
+        "rejection_reasons",
+        "review_reason",
+        "comparison_mode",
+        "semantic_match_used",
+        "creates_bind_authorization",
+        "creates_execution_authority",
+        "creates_human_approval",
+        "creates_authority_evidence"
+      ],
+      "title": "BindPreDispatchReviewResult",
+      "type": "object"
+    },
+    "FutureBindInvocationRequirement": {
+      "additionalProperties": false,
+      "description": "A future proof boundary that this packet does not satisfy.",
+      "properties": {
+        "ordinal": {
+          "maximum": 13,
+          "minimum": 1,
+          "title": "Ordinal",
+          "type": "integer"
+        },
+        "name": {
+          "enum": [
+            "valid_authority_evidence",
+            "valid_human_approval_where_required",
+            "final_policy_admissibility",
+            "final_endpoint_identity_binding",
+            "final_credential_resolution_boundary",
+            "final_authorization_header_construction_boundary",
+            "runtime_risk_review",
+            "idempotency_key_binding",
+            "request_dispatch_boundary",
+            "bind_invocation_boundary",
+            "bind_receipt_creation_boundary",
+            "trustlog_write_boundary_after_bind",
+            "postcondition_and_rollback_requirements_for_later_apply_path"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "separate_future_artifact_required": {
+          "const": true,
+          "title": "Separate Future Artifact Required",
+          "type": "boolean"
+        },
+        "satisfied_by_this_packet": {
+          "const": false,
+          "title": "Satisfied By This Packet",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "ordinal",
+        "name",
+        "separate_future_artifact_required",
+        "satisfied_by_this_packet"
+      ],
+      "title": "FutureBindInvocationRequirement",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false,
+  "description": "Closed content-addressed, non-effecting Bind review packet.",
+  "properties": {
+    "format_version": {
+      "const": "canonical-live-adapter-dry-run-bind-pre-dispatch-review/v1",
+      "title": "Format Version",
+      "type": "string"
+    },
+    "live_adapter_dry_run_bind_pre_dispatch_review_id": {
+      "title": "Live Adapter Dry Run Bind Pre Dispatch Review Id",
+      "type": "string"
+    },
+    "live_adapter_dry_run_bind_pre_dispatch_review_hash": {
+      "title": "Live Adapter Dry Run Bind Pre Dispatch Review Hash",
+      "type": "string"
+    },
+    "bind_pre_dispatch_review_mechanism": {
+      "const": "review_live_adapter_dry_run_bind_pre_dispatch_without_bind_invocation/v1",
+      "title": "Bind Pre Dispatch Review Mechanism",
+      "type": "string"
+    },
+    "bind_pre_dispatch_review_recorded_at": {
+      "title": "Bind Pre Dispatch Review Recorded At",
+      "type": "string"
+    },
+    "source_operator_dispatch_review_id": {
+      "title": "Source Operator Dispatch Review Id",
+      "type": "string"
+    },
+    "source_operator_dispatch_review_hash": {
+      "title": "Source Operator Dispatch Review Hash",
+      "type": "string"
+    },
+    "source_operator_dispatch_review_packet": {
+      "additionalProperties": true,
+      "title": "Source Operator Dispatch Review Packet",
+      "type": "object"
+    },
+    "source_credential_authorization_hash": {
+      "title": "Source Credential Authorization Hash",
+      "type": "string"
+    },
+    "source_endpoint_allowlist_evaluation_hash": {
+      "title": "Source Endpoint Allowlist Evaluation Hash",
+      "type": "string"
+    },
+    "source_dispatch_readiness_hash": {
+      "title": "Source Dispatch Readiness Hash",
+      "type": "string"
+    },
+    "source_live_adapter_dry_run_request_hash": {
+      "title": "Source Live Adapter Dry Run Request Hash",
+      "type": "string"
+    },
+    "request_descriptor": {
+      "additionalProperties": true,
+      "title": "Request Descriptor",
+      "type": "object"
+    },
+    "execution_intent": {
+      "additionalProperties": true,
+      "title": "Execution Intent",
+      "type": "object"
+    },
+    "execution_intent_id": {
+      "title": "Execution Intent Id",
+      "type": "string"
+    },
+    "execution_intent_hash": {
+      "title": "Execution Intent Hash",
+      "type": "string"
+    },
+    "adapter_contract_descriptor": {
+      "additionalProperties": true,
+      "title": "Adapter Contract Descriptor",
+      "type": "object"
+    },
+    "adapter_contract_id": {
+      "title": "Adapter Contract Id",
+      "type": "string"
+    },
+    "adapter_contract_hash": {
+      "title": "Adapter Contract Hash",
+      "type": "string"
+    },
+    "adapter_contract_version": {
+      "title": "Adapter Contract Version",
+      "type": "string"
+    },
+    "endpoint_candidate": {
+      "additionalProperties": true,
+      "title": "Endpoint Candidate",
+      "type": "object"
+    },
+    "endpoint_candidate_digest": {
+      "title": "Endpoint Candidate Digest",
+      "type": "string"
+    },
+    "endpoint_identity_binding": {
+      "additionalProperties": true,
+      "title": "Endpoint Identity Binding",
+      "type": "object"
+    },
+    "endpoint_identity_binding_digest": {
+      "title": "Endpoint Identity Binding Digest",
+      "type": "string"
+    },
+    "credential_reference": {
+      "additionalProperties": true,
+      "title": "Credential Reference",
+      "type": "object"
+    },
+    "credential_reference_digest": {
+      "title": "Credential Reference Digest",
+      "type": "string"
+    },
+    "credential_scope_binding": {
+      "additionalProperties": true,
+      "title": "Credential Scope Binding",
+      "type": "object"
+    },
+    "credential_scope_binding_digest": {
+      "title": "Credential Scope Binding Digest",
+      "type": "string"
+    },
+    "operator_review_decision": {
+      "additionalProperties": true,
+      "title": "Operator Review Decision",
+      "type": "object"
+    },
+    "operator_review_decision_digest": {
+      "title": "Operator Review Decision Digest",
+      "type": "string"
+    },
+    "bind_pre_dispatch_review_decision": {
+      "$ref": "#/$defs/BindPreDispatchReviewDecision"
+    },
+    "bind_pre_dispatch_review_decision_digest": {
+      "title": "Bind Pre Dispatch Review Decision Digest",
+      "type": "string"
+    },
+    "bind_pre_dispatch_review_result": {
+      "$ref": "#/$defs/BindPreDispatchReviewResult"
+    },
+    "bind_pre_dispatch_review_result_digest": {
+      "title": "Bind Pre Dispatch Review Result Digest",
+      "type": "string"
+    },
+    "bind_boundary_preconditions": {
+      "additionalProperties": true,
+      "title": "Bind Boundary Preconditions",
+      "type": "object"
+    },
+    "bind_boundary_precondition_digest": {
+      "title": "Bind Boundary Precondition Digest",
+      "type": "string"
+    },
+    "bind_pre_dispatch_review_checks": {
+      "type": "array",
+      "minItems": 37,
+      "maxItems": 37,
+      "prefixItems": [
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BindPreDispatchReviewCheck"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 1
+                },
+                "name": {
+                  "const": "source_operator_dispatch_review_verified"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BindPreDispatchReviewCheck"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 2
+                },
+                "name": {
+                  "const": "source_request_not_dispatched"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BindPreDispatchReviewCheck"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 3
+                },
+                "name": {
+                  "const": "source_bind_not_invoked"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BindPreDispatchReviewCheck"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 4
+                },
+                "name": {
+                  "const": "source_operator_review_accepted"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BindPreDispatchReviewCheck"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 5
+                },
+                "name": {
+                  "const": "bind_pre_dispatch_review_decision_closed_schema_valid"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BindPreDispatchReviewCheck"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 6
+                },
+                "name": {
+                  "const": "reviewer_identity_present"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BindPreDispatchReviewCheck"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 7
+                },
+                "name": {
+                  "const": "reviewer_role_present"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BindPreDispatchReviewCheck"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 8
+                },
+                "name": {
+                  "const": "reviewer_attestation_present"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BindPreDispatchReviewCheck"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 9
+                },
+                "name": {
+                  "const": "acknowledged_not_bind_authorization"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BindPreDispatchReviewCheck"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 10
+                },
+                "name": {
+                  "const": "acknowledged_no_bind_invocation"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BindPreDispatchReviewCheck"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 11
+                },
+                "name": {
+                  "const": "acknowledged_no_bind_receipt"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BindPreDispatchReviewCheck"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 12
+                },
+                "name": {
+                  "const": "acknowledged_no_trustlog_write"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BindPreDispatchReviewCheck"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 13
+                },
+                "name": {
+                  "const": "acknowledged_no_dispatch"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BindPreDispatchReviewCheck"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 14
+                },
+                "name": {
+                  "const": "acknowledged_no_credential_access"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BindPreDispatchReviewCheck"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 15
+                },
+                "name": {
+                  "const": "acknowledged_no_network_call"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BindPreDispatchReviewCheck"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 16
+                },
+                "name": {
+                  "const": "acknowledged_semantic_match_not_authority"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BindPreDispatchReviewCheck"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 17
+                },
+                "name": {
+                  "const": "request_descriptor_preserved"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BindPreDispatchReviewCheck"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 18
+                },
+                "name": {
+                  "const": "execution_intent_identity_preserved"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BindPreDispatchReviewCheck"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 19
+                },
+                "name": {
+                  "const": "adapter_contract_identity_preserved"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BindPreDispatchReviewCheck"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 20
+                },
+                "name": {
+                  "const": "endpoint_identity_binding_preserved"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BindPreDispatchReviewCheck"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 21
+                },
+                "name": {
+                  "const": "credential_scope_binding_preserved"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BindPreDispatchReviewCheck"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 22
+                },
+                "name": {
+                  "const": "operator_review_decision_preserved"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BindPreDispatchReviewCheck"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 23
+                },
+                "name": {
+                  "const": "bind_boundary_preconditions_constructed"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BindPreDispatchReviewCheck"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 24
+                },
+                "name": {
+                  "const": "bind_not_invoked"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BindPreDispatchReviewCheck"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 25
+                },
+                "name": {
+                  "const": "bind_receipt_not_created"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BindPreDispatchReviewCheck"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 26
+                },
+                "name": {
+                  "const": "trustlog_not_written"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BindPreDispatchReviewCheck"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 27
+                },
+                "name": {
+                  "const": "request_not_dispatched"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BindPreDispatchReviewCheck"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 28
+                },
+                "name": {
+                  "const": "endpoint_not_resolved"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BindPreDispatchReviewCheck"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 29
+                },
+                "name": {
+                  "const": "credential_material_not_accessed"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BindPreDispatchReviewCheck"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 30
+                },
+                "name": {
+                  "const": "authorization_header_not_constructed"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BindPreDispatchReviewCheck"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 31
+                },
+                "name": {
+                  "const": "network_not_used"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BindPreDispatchReviewCheck"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 32
+                },
+                "name": {
+                  "const": "webhook_not_called"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BindPreDispatchReviewCheck"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 33
+                },
+                "name": {
+                  "const": "live_adapter_not_instantiated"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BindPreDispatchReviewCheck"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 34
+                },
+                "name": {
+                  "const": "no_execution_authority_created"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BindPreDispatchReviewCheck"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 35
+                },
+                "name": {
+                  "const": "no_human_approval_created"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BindPreDispatchReviewCheck"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 36
+                },
+                "name": {
+                  "const": "no_authority_evidence_created"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BindPreDispatchReviewCheck"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 37
+                },
+                "name": {
+                  "const": "future_bind_invocation_gate_required"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "items": false
+    },
+    "bind_pre_dispatch_review_check_digest": {
+      "title": "Bind Pre Dispatch Review Check Digest",
+      "type": "string"
+    },
+    "future_bind_invocation_requirements": {
+      "type": "array",
+      "minItems": 13,
+      "maxItems": 13,
+      "prefixItems": [
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FutureBindInvocationRequirement"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 1
+                },
+                "name": {
+                  "const": "valid_authority_evidence"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FutureBindInvocationRequirement"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 2
+                },
+                "name": {
+                  "const": "valid_human_approval_where_required"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FutureBindInvocationRequirement"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 3
+                },
+                "name": {
+                  "const": "final_policy_admissibility"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FutureBindInvocationRequirement"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 4
+                },
+                "name": {
+                  "const": "final_endpoint_identity_binding"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FutureBindInvocationRequirement"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 5
+                },
+                "name": {
+                  "const": "final_credential_resolution_boundary"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FutureBindInvocationRequirement"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 6
+                },
+                "name": {
+                  "const": "final_authorization_header_construction_boundary"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FutureBindInvocationRequirement"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 7
+                },
+                "name": {
+                  "const": "runtime_risk_review"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FutureBindInvocationRequirement"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 8
+                },
+                "name": {
+                  "const": "idempotency_key_binding"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FutureBindInvocationRequirement"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 9
+                },
+                "name": {
+                  "const": "request_dispatch_boundary"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FutureBindInvocationRequirement"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 10
+                },
+                "name": {
+                  "const": "bind_invocation_boundary"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FutureBindInvocationRequirement"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 11
+                },
+                "name": {
+                  "const": "bind_receipt_creation_boundary"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FutureBindInvocationRequirement"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 12
+                },
+                "name": {
+                  "const": "trustlog_write_boundary_after_bind"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FutureBindInvocationRequirement"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ordinal": {
+                  "const": 13
+                },
+                "name": {
+                  "const": "postcondition_and_rollback_requirements_for_later_apply_path"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "items": false
+    },
+    "future_bind_invocation_requirement_digest": {
+      "title": "Future Bind Invocation Requirement Digest",
+      "type": "string"
+    },
+    "source_to_execution_intent_mapping": {
+      "additionalProperties": true,
+      "title": "Source To Execution Intent Mapping",
+      "type": "object"
+    },
+    "field_mapping_proof": {
+      "additionalProperties": true,
+      "title": "Field Mapping Proof",
+      "type": "object"
+    },
+    "required_field_presence": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "title": "Required Field Presence",
+      "type": "object"
+    },
+    "source_decision_identity": {
+      "additionalProperties": true,
+      "title": "Source Decision Identity",
+      "type": "object"
+    },
+    "candidate_identity": {
+      "additionalProperties": true,
+      "title": "Candidate Identity",
+      "type": "object"
+    },
+    "evidence_lineage": {
+      "additionalProperties": true,
+      "title": "Evidence Lineage",
+      "type": "object"
+    },
+    "replay_summary": {
+      "additionalProperties": true,
+      "title": "Replay Summary",
+      "type": "object"
+    },
+    "bind_pre_dispatch_review_status": {
+      "const": "LIVE_ADAPTER_DRY_RUN_BIND_PRE_DISPATCH_REVIEW_RECORDED_NOT_BOUND",
+      "title": "Bind Pre Dispatch Review Status",
+      "type": "string"
+    },
+    "request_dispatch_state": {
+      "const": "NOT_DISPATCHED",
+      "title": "Request Dispatch State",
+      "type": "string"
+    },
+    "bind_state": {
+      "const": "NOT_BOUND",
+      "title": "Bind State",
+      "type": "string"
+    },
+    "bind_invoked": {
+      "const": false,
+      "title": "Bind Invoked",
+      "type": "boolean"
+    },
+    "bind_receipt_created": {
+      "const": false,
+      "title": "Bind Receipt Created",
+      "type": "boolean"
+    },
+    "trustlog_written": {
+      "const": false,
+      "title": "Trustlog Written",
+      "type": "boolean"
+    },
+    "request_dispatched": {
+      "const": false,
+      "title": "Request Dispatched",
+      "type": "boolean"
+    },
+    "endpoint_resolved": {
+      "const": false,
+      "title": "Endpoint Resolved",
+      "type": "boolean"
+    },
+    "credential_material_accessed": {
+      "const": false,
+      "title": "Credential Material Accessed",
+      "type": "boolean"
+    },
+    "authorization_header_constructed": {
+      "const": false,
+      "title": "Authorization Header Constructed",
+      "type": "boolean"
+    },
+    "network_used": {
+      "const": false,
+      "title": "Network Used",
+      "type": "boolean"
+    },
+    "live_adapter_instantiated": {
+      "const": false,
+      "title": "Live Adapter Instantiated",
+      "type": "boolean"
+    },
+    "webhook_called": {
+      "const": false,
+      "title": "Webhook Called",
+      "type": "boolean"
+    },
+    "fail_closed": {
+      "title": "Fail Closed",
+      "type": "boolean"
+    },
+    "scope_limitations": {
+      "type": "array",
+      "minItems": 24,
+      "maxItems": 24,
+      "prefixItems": [
+        {
+          "const": "NOT_DISPATCHED"
+        },
+        {
+          "const": "NOT_BIND_INVOCATION"
+        },
+        {
+          "const": "NOT_BIND_AUTHORIZATION"
+        },
+        {
+          "const": "NOT_BIND_RECEIPT"
+        },
+        {
+          "const": "NOT_TRUSTLOG_WRITE"
+        },
+        {
+          "const": "NOT_EXECUTION_AUTHORITY"
+        },
+        {
+          "const": "NOT_HUMAN_APPROVAL"
+        },
+        {
+          "const": "NOT_AUTHORITY_EVIDENCE"
+        },
+        {
+          "const": "NOT_CREDENTIAL_RESOLUTION"
+        },
+        {
+          "const": "NOT_CREDENTIAL_ACCESS"
+        },
+        {
+          "const": "NOT_CREDENTIAL_EMBEDDING"
+        },
+        {
+          "const": "NOT_AUTHORIZATION_HEADER"
+        },
+        {
+          "const": "NOT_TOKEN"
+        },
+        {
+          "const": "NOT_SECRET"
+        },
+        {
+          "const": "NOT_ENDPOINT_RESOLUTION"
+        },
+        {
+          "const": "NOT_DNS_RESOLUTION"
+        },
+        {
+          "const": "NOT_NETWORK_CALL"
+        },
+        {
+          "const": "NOT_WEBHOOK_CALL"
+        },
+        {
+          "const": "NOT_LIVE_ADAPTER_INSTANCE"
+        },
+        {
+          "const": "NOT_LIVE_ADAPTER_RESULT"
+        },
+        {
+          "const": "NOT_OPERATION_COMMIT"
+        },
+        {
+          "const": "NOT_PRODUCTION_CLAIM"
+        },
+        {
+          "const": "NOT_CUSTOMER_CLAIM"
+        },
+        {
+          "const": "NOT_REGULATORY_CERTIFICATION"
+        }
+      ],
+      "items": false
+    }
+  },
+  "required": [
+    "format_version",
+    "live_adapter_dry_run_bind_pre_dispatch_review_id",
+    "live_adapter_dry_run_bind_pre_dispatch_review_hash",
+    "bind_pre_dispatch_review_mechanism",
+    "bind_pre_dispatch_review_recorded_at",
+    "source_operator_dispatch_review_id",
+    "source_operator_dispatch_review_hash",
+    "source_operator_dispatch_review_packet",
+    "source_credential_authorization_hash",
+    "source_endpoint_allowlist_evaluation_hash",
+    "source_dispatch_readiness_hash",
+    "source_live_adapter_dry_run_request_hash",
+    "request_descriptor",
+    "execution_intent",
+    "execution_intent_id",
+    "execution_intent_hash",
+    "adapter_contract_descriptor",
+    "adapter_contract_id",
+    "adapter_contract_hash",
+    "adapter_contract_version",
+    "endpoint_candidate",
+    "endpoint_candidate_digest",
+    "endpoint_identity_binding",
+    "endpoint_identity_binding_digest",
+    "credential_reference",
+    "credential_reference_digest",
+    "credential_scope_binding",
+    "credential_scope_binding_digest",
+    "operator_review_decision",
+    "operator_review_decision_digest",
+    "bind_pre_dispatch_review_decision",
+    "bind_pre_dispatch_review_decision_digest",
+    "bind_pre_dispatch_review_result",
+    "bind_pre_dispatch_review_result_digest",
+    "bind_boundary_preconditions",
+    "bind_boundary_precondition_digest",
+    "bind_pre_dispatch_review_checks",
+    "bind_pre_dispatch_review_check_digest",
+    "future_bind_invocation_requirements",
+    "future_bind_invocation_requirement_digest",
+    "source_to_execution_intent_mapping",
+    "field_mapping_proof",
+    "required_field_presence",
+    "source_decision_identity",
+    "candidate_identity",
+    "evidence_lineage",
+    "replay_summary",
+    "bind_pre_dispatch_review_status",
+    "request_dispatch_state",
+    "bind_state",
+    "bind_invoked",
+    "bind_receipt_created",
+    "trustlog_written",
+    "request_dispatched",
+    "endpoint_resolved",
+    "credential_material_accessed",
+    "authorization_header_constructed",
+    "network_used",
+    "live_adapter_instantiated",
+    "webhook_called",
+    "fail_closed",
+    "scope_limitations"
+  ],
+  "title": "CanonicalLiveAdapterDryRunBindPreDispatchReviewPacket",
+  "type": "object"
+}

--- a/veritas_os/policy/live_adapter_dry_run_bind_pre_dispatch_review.py
+++ b/veritas_os/policy/live_adapter_dry_run_bind_pre_dispatch_review.py
@@ -1,0 +1,577 @@
+"""Create deterministic Bind-boundary review evidence without invoking Bind.
+
+This module is deliberately pure: it validates and hashes caller-supplied
+metadata only.  The resulting packet is neither authorization nor execution
+authority and performs no dispatch, credential, persistence, or network work.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from veritas_os.policy.live_adapter_dry_run_operator_dispatch_review import (
+    CanonicalLiveAdapterDryRunOperatorDispatchReviewPacket,
+    LiveAdapterDryRunOperatorDispatchReviewError,
+    verify_live_adapter_dry_run_operator_dispatch_review_packet,
+)
+
+FORMAT_VERSION = "canonical-live-adapter-dry-run-bind-pre-dispatch-review/v1"
+REVIEW_MECHANISM = (
+    "review_live_adapter_dry_run_bind_pre_dispatch_without_bind_invocation/v1"
+)
+STATUS = "LIVE_ADAPTER_DRY_RUN_BIND_PRE_DISPATCH_REVIEW_RECORDED_NOT_BOUND"
+SOURCE_STATUS = (
+    "LIVE_ADAPTER_DRY_RUN_OPERATOR_DISPATCH_REVIEW_RECORDED_NOT_DISPATCHED"
+)
+CHECK_MODE = "deterministic_local_bind_pre_dispatch_review_only"
+DECISION_DOMAIN = "veritas.live-adapter-dry-run-bind-pre-dispatch-review.decision/v1"
+RESULT_DOMAIN = "veritas.live-adapter-dry-run-bind-pre-dispatch-review.result/v1"
+PRECONDITIONS_DOMAIN = (
+    "veritas.live-adapter-dry-run-bind-pre-dispatch-review.preconditions/v1"
+)
+CHECKS_DOMAIN = "veritas.live-adapter-dry-run-bind-pre-dispatch-review.checks/v1"
+REQUIREMENTS_DOMAIN = (
+    "veritas.live-adapter-dry-run-bind-pre-dispatch-review."
+    "future-bind-invocation-requirements/v1"
+)
+PACKET_DOMAIN = "veritas.live-adapter-dry-run-bind-pre-dispatch-review.packet/v1"
+
+REVIEW_OUTCOMES = (
+    "ACCEPTED_FOR_FUTURE_BIND_DISPATCH_GATE_REVIEW",
+    "REJECTED_FOR_FUTURE_BIND_DISPATCH_GATE_REVIEW",
+)
+CHECK_NAMES = (
+    "source_operator_dispatch_review_verified", "source_request_not_dispatched",
+    "source_bind_not_invoked", "source_operator_review_accepted",
+    "bind_pre_dispatch_review_decision_closed_schema_valid",
+    "reviewer_identity_present", "reviewer_role_present",
+    "reviewer_attestation_present", "acknowledged_not_bind_authorization",
+    "acknowledged_no_bind_invocation", "acknowledged_no_bind_receipt",
+    "acknowledged_no_trustlog_write", "acknowledged_no_dispatch",
+    "acknowledged_no_credential_access", "acknowledged_no_network_call",
+    "acknowledged_semantic_match_not_authority",
+    "request_descriptor_preserved", "execution_intent_identity_preserved",
+    "adapter_contract_identity_preserved",
+    "endpoint_identity_binding_preserved", "credential_scope_binding_preserved",
+    "operator_review_decision_preserved",
+    "bind_boundary_preconditions_constructed", "bind_not_invoked",
+    "bind_receipt_not_created", "trustlog_not_written",
+    "request_not_dispatched", "endpoint_not_resolved",
+    "credential_material_not_accessed",
+    "authorization_header_not_constructed", "network_not_used",
+    "webhook_not_called", "live_adapter_not_instantiated",
+    "no_execution_authority_created", "no_human_approval_created",
+    "no_authority_evidence_created", "future_bind_invocation_gate_required",
+)
+EFFECT_FIELDS = (
+    "bind_invoked", "bind_receipt_created", "trustlog_written",
+    "request_dispatched", "endpoint_resolved", "credential_material_accessed",
+    "credential_material_embedded", "authorization_header_constructed",
+    "token_embedded", "secret_embedded", "network_used", "dns_used",
+    "webhook_called", "live_adapter_instantiated",
+    "live_adapter_method_called", "external_effect_used", "filesystem_used",
+    "database_used", "provider_used", "subprocess_used", "operation_committed",
+    "execution_authority_created", "human_approval_created",
+    "authority_evidence_created",
+)
+SCOPE_LIMITATIONS = (
+    "NOT_DISPATCHED", "NOT_BIND_INVOCATION", "NOT_BIND_AUTHORIZATION",
+    "NOT_BIND_RECEIPT", "NOT_TRUSTLOG_WRITE", "NOT_EXECUTION_AUTHORITY",
+    "NOT_HUMAN_APPROVAL", "NOT_AUTHORITY_EVIDENCE",
+    "NOT_CREDENTIAL_RESOLUTION", "NOT_CREDENTIAL_ACCESS",
+    "NOT_CREDENTIAL_EMBEDDING", "NOT_AUTHORIZATION_HEADER", "NOT_TOKEN",
+    "NOT_SECRET", "NOT_ENDPOINT_RESOLUTION", "NOT_DNS_RESOLUTION",
+    "NOT_NETWORK_CALL", "NOT_WEBHOOK_CALL", "NOT_LIVE_ADAPTER_INSTANCE",
+    "NOT_LIVE_ADAPTER_RESULT", "NOT_OPERATION_COMMIT",
+    "NOT_PRODUCTION_CLAIM", "NOT_CUSTOMER_CLAIM",
+    "NOT_REGULATORY_CERTIFICATION",
+)
+FUTURE_REQUIREMENT_NAMES = (
+    "valid_authority_evidence", "valid_human_approval_where_required",
+    "final_policy_admissibility", "final_endpoint_identity_binding",
+    "final_credential_resolution_boundary",
+    "final_authorization_header_construction_boundary", "runtime_risk_review",
+    "idempotency_key_binding", "request_dispatch_boundary",
+    "bind_invocation_boundary", "bind_receipt_creation_boundary",
+    "trustlog_write_boundary_after_bind",
+    "postcondition_and_rollback_requirements_for_later_apply_path",
+)
+COPIED_FIELDS = (
+    "request_descriptor", "execution_intent", "execution_intent_id",
+    "execution_intent_hash", "adapter_contract_descriptor",
+    "adapter_contract_id", "adapter_contract_hash", "adapter_contract_version",
+    "endpoint_candidate", "endpoint_candidate_digest",
+    "endpoint_identity_binding", "endpoint_identity_binding_digest",
+    "credential_reference", "credential_reference_digest",
+    "credential_scope_binding", "credential_scope_binding_digest",
+    "operator_review_decision", "operator_review_decision_digest",
+    "source_to_execution_intent_mapping", "field_mapping_proof",
+    "required_field_presence", "source_decision_identity", "candidate_identity",
+    "evidence_lineage", "replay_summary",
+)
+
+
+class LiveAdapterDryRunBindPreDispatchReviewError(ValueError):
+    """Stable fail-closed refusal for invalid Bind-boundary review evidence."""
+
+
+class BindPreDispatchReviewDecision(BaseModel):
+    """Closed reviewer decision with mandatory non-authority acknowledgements."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    bind_pre_dispatch_review_decision_id: str = Field(min_length=1)
+    reviewer_id: str = Field(min_length=1)
+    reviewer_role: str = Field(min_length=1)
+    reviewer_attestation: str = Field(min_length=1)
+    reviewed_at: str
+    review_outcome: Literal[*REVIEW_OUTCOMES]
+    review_reason: str = Field(min_length=1)
+    acknowledged_not_bind_authorization: Literal[True]
+    acknowledged_no_bind_invocation: Literal[True]
+    acknowledged_no_bind_receipt: Literal[True]
+    acknowledged_no_trustlog_write: Literal[True]
+    acknowledged_no_dispatch: Literal[True]
+    acknowledged_no_credential_access: Literal[True]
+    acknowledged_no_network_call: Literal[True]
+    acknowledged_semantic_match_not_authority: Literal[True]
+
+
+class BindPreDispatchReviewResult(BaseModel):
+    """Deterministic outcome that explicitly creates no authority."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    accepted_for_future_bind_dispatch_gate_review: bool
+    rejection_reasons: tuple[str, ...]
+    review_reason: str
+    comparison_mode: Literal[CHECK_MODE]
+    semantic_match_used: Literal[False]
+    creates_bind_authorization: Literal[False]
+    creates_execution_authority: Literal[False]
+    creates_human_approval: Literal[False]
+    creates_authority_evidence: Literal[False]
+
+
+class BindPreDispatchReviewCheck(BaseModel):
+    """One ordered local check with explicit false effect flags."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    check_id: str
+    ordinal: int = Field(ge=1, le=37)
+    name: Literal[*CHECK_NAMES]
+    mode: Literal[CHECK_MODE]
+    passed: bool
+    evidence_ref: str
+    bind_invoked: Literal[False]
+    bind_receipt_created: Literal[False]
+    trustlog_written: Literal[False]
+    request_dispatched: Literal[False]
+    endpoint_resolved: Literal[False]
+    credential_material_accessed: Literal[False]
+    credential_material_embedded: Literal[False]
+    authorization_header_constructed: Literal[False]
+    token_embedded: Literal[False]
+    secret_embedded: Literal[False]
+    network_used: Literal[False]
+    dns_used: Literal[False]
+    webhook_called: Literal[False]
+    live_adapter_instantiated: Literal[False]
+    live_adapter_method_called: Literal[False]
+    external_effect_used: Literal[False]
+    filesystem_used: Literal[False]
+    database_used: Literal[False]
+    provider_used: Literal[False]
+    subprocess_used: Literal[False]
+    operation_committed: Literal[False]
+    execution_authority_created: Literal[False]
+    human_approval_created: Literal[False]
+    authority_evidence_created: Literal[False]
+
+
+class FutureBindInvocationRequirement(BaseModel):
+    """A future proof boundary that this packet does not satisfy."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    ordinal: int = Field(ge=1, le=13)
+    name: Literal[*FUTURE_REQUIREMENT_NAMES]
+    separate_future_artifact_required: Literal[True]
+    satisfied_by_this_packet: Literal[False]
+
+
+class CanonicalLiveAdapterDryRunBindPreDispatchReviewPacket(BaseModel):
+    """Closed content-addressed, non-effecting Bind review packet."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    format_version: Literal[FORMAT_VERSION]
+    live_adapter_dry_run_bind_pre_dispatch_review_id: str
+    live_adapter_dry_run_bind_pre_dispatch_review_hash: str
+    bind_pre_dispatch_review_mechanism: Literal[REVIEW_MECHANISM]
+    bind_pre_dispatch_review_recorded_at: str
+    source_operator_dispatch_review_id: str
+    source_operator_dispatch_review_hash: str
+    source_operator_dispatch_review_packet: dict[str, Any]
+    source_credential_authorization_hash: str
+    source_endpoint_allowlist_evaluation_hash: str
+    source_dispatch_readiness_hash: str
+    source_live_adapter_dry_run_request_hash: str
+    request_descriptor: dict[str, Any]
+    execution_intent: dict[str, Any]
+    execution_intent_id: str
+    execution_intent_hash: str
+    adapter_contract_descriptor: dict[str, Any]
+    adapter_contract_id: str
+    adapter_contract_hash: str
+    adapter_contract_version: str
+    endpoint_candidate: dict[str, Any]
+    endpoint_candidate_digest: str
+    endpoint_identity_binding: dict[str, Any]
+    endpoint_identity_binding_digest: str
+    credential_reference: dict[str, Any]
+    credential_reference_digest: str
+    credential_scope_binding: dict[str, Any]
+    credential_scope_binding_digest: str
+    operator_review_decision: dict[str, Any]
+    operator_review_decision_digest: str
+    bind_pre_dispatch_review_decision: BindPreDispatchReviewDecision
+    bind_pre_dispatch_review_decision_digest: str
+    bind_pre_dispatch_review_result: BindPreDispatchReviewResult
+    bind_pre_dispatch_review_result_digest: str
+    bind_boundary_preconditions: dict[str, Any]
+    bind_boundary_precondition_digest: str
+    bind_pre_dispatch_review_checks: tuple[BindPreDispatchReviewCheck, ...]
+    bind_pre_dispatch_review_check_digest: str
+    future_bind_invocation_requirements: tuple[FutureBindInvocationRequirement, ...]
+    future_bind_invocation_requirement_digest: str
+    source_to_execution_intent_mapping: dict[str, Any]
+    field_mapping_proof: dict[str, Any]
+    required_field_presence: dict[str, str]
+    source_decision_identity: dict[str, Any]
+    candidate_identity: dict[str, Any]
+    evidence_lineage: dict[str, Any]
+    replay_summary: dict[str, Any]
+    bind_pre_dispatch_review_status: Literal[STATUS]
+    request_dispatch_state: Literal["NOT_DISPATCHED"]
+    bind_state: Literal["NOT_BOUND"]
+    bind_invoked: Literal[False]
+    bind_receipt_created: Literal[False]
+    trustlog_written: Literal[False]
+    request_dispatched: Literal[False]
+    endpoint_resolved: Literal[False]
+    credential_material_accessed: Literal[False]
+    authorization_header_constructed: Literal[False]
+    network_used: Literal[False]
+    live_adapter_instantiated: Literal[False]
+    webhook_called: Literal[False]
+    fail_closed: bool
+    scope_limitations: tuple[Literal[*SCOPE_LIMITATIONS], ...]
+
+
+def _timestamp(value: Any) -> str:
+    try:
+        parsed = value if isinstance(value, datetime) else datetime.fromisoformat(value)
+    except (TypeError, ValueError) as exc:
+        raise LiveAdapterDryRunBindPreDispatchReviewError(
+            "LADRBPR_TIMESTAMP_INVALID"
+        ) from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise LiveAdapterDryRunBindPreDispatchReviewError(
+            "LADRBPR_TIMESTAMP_INVALID"
+        )
+    return parsed.astimezone(timezone.utc).isoformat()
+
+
+def _json_value(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        value = value.model_dump(mode="python")
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        if value != value or value in (float("inf"), float("-inf")):
+            raise LiveAdapterDryRunBindPreDispatchReviewError("LADRBPR_INVALID")
+        return value
+    if isinstance(value, datetime):
+        return _timestamp(value)
+    if isinstance(value, (list, tuple)):
+        return [_json_value(item) for item in value]
+    if isinstance(value, dict) and all(isinstance(key, str) for key in value):
+        return {key: _json_value(item) for key, item in value.items()}
+    raise LiveAdapterDryRunBindPreDispatchReviewError("LADRBPR_INVALID")
+
+
+def _digest(domain: str, value: Any) -> str:
+    encoded = json.dumps(
+        {"domain": domain, "value": _json_value(value)}, allow_nan=False,
+        ensure_ascii=False, separators=(",", ":"), sort_keys=True,
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _packet_hash(raw: dict[str, Any]) -> str:
+    omitted = {
+        "live_adapter_dry_run_bind_pre_dispatch_review_id",
+        "live_adapter_dry_run_bind_pre_dispatch_review_hash",
+    }
+    return _digest(PACKET_DOMAIN, {k: v for k, v in raw.items() if k not in omitted})
+
+
+def _source(value: Any) -> CanonicalLiveAdapterDryRunOperatorDispatchReviewPacket:
+    try:
+        return verify_live_adapter_dry_run_operator_dispatch_review_packet(value)
+    except (LiveAdapterDryRunOperatorDispatchReviewError, TypeError, ValueError) as exc:
+        raise LiveAdapterDryRunBindPreDispatchReviewError(
+            "LADRBPR_SOURCE_INVALID"
+        ) from exc
+
+
+def _validate_source(
+    source: CanonicalLiveAdapterDryRunOperatorDispatchReviewPacket,
+) -> None:
+    if source.request_dispatch_state != "NOT_DISPATCHED":
+        raise LiveAdapterDryRunBindPreDispatchReviewError("LADRBPR_SOURCE_DISPATCHED")
+    if source.operator_dispatch_review_status != SOURCE_STATUS:
+        raise LiveAdapterDryRunBindPreDispatchReviewError(
+            "LADRBPR_SOURCE_STATUS_INVALID"
+        )
+    if source.bind_invoked:
+        raise LiveAdapterDryRunBindPreDispatchReviewError("LADRBPR_SOURCE_BOUND")
+    if source.fail_closed or source.operator_review_decision.review_decision != (
+        "APPROVE_FOR_BIND_PRE_DISPATCH_REVIEW"
+    ):
+        raise LiveAdapterDryRunBindPreDispatchReviewError(
+            "LADRBPR_SOURCE_REVIEW_NOT_ACCEPTED"
+        )
+
+
+def _result(decision: BindPreDispatchReviewDecision) -> dict[str, Any]:
+    accepted = decision.review_outcome == REVIEW_OUTCOMES[0]
+    return {
+        "accepted_for_future_bind_dispatch_gate_review": accepted,
+        "rejection_reasons": [] if accepted else ["bind_pre_dispatch_review_rejected"],
+        "review_reason": decision.review_reason,
+        "comparison_mode": CHECK_MODE,
+        "semantic_match_used": False,
+        "creates_bind_authorization": False,
+        "creates_execution_authority": False,
+        "creates_human_approval": False,
+        "creates_authority_evidence": False,
+    }
+
+
+def _preconditions(source_hash: str, decision_digest: str) -> dict[str, Any]:
+    return {
+        "source_operator_dispatch_review_hash": source_hash,
+        "bind_pre_dispatch_review_decision_digest": decision_digest,
+        "source_verified": True,
+        "source_operator_review_accepted": True,
+        "request_not_dispatched": True,
+        "bind_not_invoked": True,
+        "separate_future_bind_invocation_gate_required": True,
+        "satisfied_by_this_packet": False,
+    }
+
+
+def _checks(source_hash: str, decision_digest: str) -> list[dict[str, Any]]:
+    return [{
+        "check_id": f"ladrbpr-check:v1:{ordinal}:{name.replace('_', '-')}",
+        "ordinal": ordinal, "name": name, "mode": CHECK_MODE, "passed": True,
+        "evidence_ref": f"source:{source_hash}:decision:{decision_digest}:{name}",
+        **{field: False for field in EFFECT_FIELDS},
+    } for ordinal, name in enumerate(CHECK_NAMES, 1)]
+
+
+def _requirements() -> list[dict[str, Any]]:
+    return [{
+        "ordinal": ordinal, "name": name,
+        "separate_future_artifact_required": True,
+        "satisfied_by_this_packet": False,
+    } for ordinal, name in enumerate(FUTURE_REQUIREMENT_NAMES, 1)]
+
+
+def build_live_adapter_dry_run_bind_pre_dispatch_review_packet(
+    source_operator_dispatch_review_packet: Any,
+    bind_pre_dispatch_review_decision: Any,
+    bind_pre_dispatch_review_recorded_at: datetime,
+) -> CanonicalLiveAdapterDryRunBindPreDispatchReviewPacket:
+    """Build and self-verify deterministic pre-dispatch review evidence."""
+    source = _source(_json_value(source_operator_dispatch_review_packet))
+    _validate_source(source)
+    try:
+        decision = BindPreDispatchReviewDecision.model_validate(
+            _json_value(bind_pre_dispatch_review_decision)
+        )
+    except ValidationError as exc:
+        raise LiveAdapterDryRunBindPreDispatchReviewError(
+            "LADRBPR_DECISION_INVALID"
+        ) from exc
+    reviewed_at = _timestamp(decision.reviewed_at)
+    recorded_at = _timestamp(bind_pre_dispatch_review_recorded_at)
+    if datetime.fromisoformat(recorded_at) < datetime.fromisoformat(reviewed_at):
+        raise LiveAdapterDryRunBindPreDispatchReviewError(
+            "LADRBPR_RECORDED_TOO_EARLY"
+        )
+    source_raw = source.model_dump(mode="json")
+    decision_raw = decision.model_dump(mode="json")
+    decision_raw["reviewed_at"] = reviewed_at
+    decision_digest = _digest(DECISION_DOMAIN, decision_raw)
+    result = _result(decision)
+    preconditions = _preconditions(
+        source.live_adapter_dry_run_operator_dispatch_review_hash,
+        decision_digest,
+    )
+    checks = _checks(
+        source.live_adapter_dry_run_operator_dispatch_review_hash,
+        decision_digest,
+    )
+    requirements = _requirements()
+    raw = {
+        "format_version": FORMAT_VERSION,
+        "bind_pre_dispatch_review_mechanism": REVIEW_MECHANISM,
+        "bind_pre_dispatch_review_recorded_at": recorded_at,
+        "source_operator_dispatch_review_id": (
+            source.live_adapter_dry_run_operator_dispatch_review_id
+        ),
+        "source_operator_dispatch_review_hash": (
+            source.live_adapter_dry_run_operator_dispatch_review_hash
+        ),
+        "source_operator_dispatch_review_packet": source_raw,
+        "source_credential_authorization_hash": (
+            source.source_credential_authorization_evaluation_hash
+        ),
+        "source_endpoint_allowlist_evaluation_hash": (
+            source.source_endpoint_allowlist_evaluation_hash
+        ),
+        "source_dispatch_readiness_hash": source.source_dispatch_readiness_hash,
+        "source_live_adapter_dry_run_request_hash": (
+            source.source_live_adapter_dry_run_request_hash
+        ),
+        **{field: source_raw[field] for field in COPIED_FIELDS},
+        "bind_pre_dispatch_review_decision": decision_raw,
+        "bind_pre_dispatch_review_decision_digest": decision_digest,
+        "bind_pre_dispatch_review_result": result,
+        "bind_pre_dispatch_review_result_digest": _digest(RESULT_DOMAIN, result),
+        "bind_boundary_preconditions": preconditions,
+        "bind_boundary_precondition_digest": _digest(
+            PRECONDITIONS_DOMAIN, preconditions
+        ),
+        "bind_pre_dispatch_review_checks": checks,
+        "bind_pre_dispatch_review_check_digest": _digest(CHECKS_DOMAIN, checks),
+        "future_bind_invocation_requirements": requirements,
+        "future_bind_invocation_requirement_digest": _digest(
+            REQUIREMENTS_DOMAIN, requirements
+        ),
+        "bind_pre_dispatch_review_status": STATUS,
+        "request_dispatch_state": "NOT_DISPATCHED", "bind_state": "NOT_BOUND",
+        **{field: False for field in (
+            "bind_invoked", "bind_receipt_created", "trustlog_written",
+            "request_dispatched", "endpoint_resolved",
+            "credential_material_accessed", "authorization_header_constructed",
+            "network_used", "live_adapter_instantiated", "webhook_called",
+        )},
+        "fail_closed": not result["accepted_for_future_bind_dispatch_gate_review"],
+        "scope_limitations": SCOPE_LIMITATIONS,
+    }
+    digest = _packet_hash(raw)
+    raw["live_adapter_dry_run_bind_pre_dispatch_review_hash"] = digest
+    raw["live_adapter_dry_run_bind_pre_dispatch_review_id"] = (
+        f"ladrbpr:v1:sha256:{digest}"
+    )
+    return verify_live_adapter_dry_run_bind_pre_dispatch_review_packet(raw)
+
+
+def verify_live_adapter_dry_run_bind_pre_dispatch_review_packet(
+    raw: Any,
+) -> CanonicalLiveAdapterDryRunBindPreDispatchReviewPacket:
+    """Reverify the source and every deterministic field, digest, hash, and ID."""
+    try:
+        value = raw.model_dump(mode="json") if isinstance(raw, BaseModel) else raw
+        packet = CanonicalLiveAdapterDryRunBindPreDispatchReviewPacket.model_validate(
+            _json_value(value)
+        )
+    except (ValidationError, TypeError,
+            LiveAdapterDryRunBindPreDispatchReviewError) as exc:
+        raise LiveAdapterDryRunBindPreDispatchReviewError(
+            "LADRBPR_PACKET_INVALID"
+        ) from exc
+    actual = packet.model_dump(mode="json")
+    source = _source(packet.source_operator_dispatch_review_packet)
+    _validate_source(source)
+    source_raw = source.model_dump(mode="json")
+    if (packet.source_operator_dispatch_review_id,
+            packet.source_operator_dispatch_review_hash) != (
+                source.live_adapter_dry_run_operator_dispatch_review_id,
+                source.live_adapter_dry_run_operator_dispatch_review_hash):
+        raise LiveAdapterDryRunBindPreDispatchReviewError(
+            "LADRBPR_SOURCE_IDENTITY_MISMATCH"
+        )
+    lineage = (
+        packet.source_credential_authorization_hash,
+        packet.source_endpoint_allowlist_evaluation_hash,
+        packet.source_dispatch_readiness_hash,
+        packet.source_live_adapter_dry_run_request_hash,
+    )
+    if lineage != (
+        source.source_credential_authorization_evaluation_hash,
+        source.source_endpoint_allowlist_evaluation_hash,
+        source.source_dispatch_readiness_hash,
+        source.source_live_adapter_dry_run_request_hash,
+    ):
+        raise LiveAdapterDryRunBindPreDispatchReviewError("LADRBPR_LINEAGE_MISMATCH")
+    for field in COPIED_FIELDS:
+        if _json_value(getattr(packet, field)) != _json_value(source_raw[field]):
+            raise LiveAdapterDryRunBindPreDispatchReviewError(
+                "LADRBPR_SOURCE_FIELD_MISMATCH"
+            )
+    reviewed_at = _timestamp(packet.bind_pre_dispatch_review_decision.reviewed_at)
+    recorded_at = _timestamp(packet.bind_pre_dispatch_review_recorded_at)
+    if datetime.fromisoformat(recorded_at) < datetime.fromisoformat(reviewed_at):
+        raise LiveAdapterDryRunBindPreDispatchReviewError(
+            "LADRBPR_RECORDED_TOO_EARLY"
+        )
+    decision_raw = packet.bind_pre_dispatch_review_decision.model_dump(mode="json")
+    decision_raw["reviewed_at"] = reviewed_at
+    decision_digest = _digest(DECISION_DOMAIN, decision_raw)
+    result = _result(packet.bind_pre_dispatch_review_decision)
+    preconditions = _preconditions(packet.source_operator_dispatch_review_hash,
+                                   decision_digest)
+    checks = _checks(packet.source_operator_dispatch_review_hash, decision_digest)
+    requirements = _requirements()
+    comparisons = (
+        packet.bind_pre_dispatch_review_decision_digest == decision_digest,
+        _json_value(packet.bind_pre_dispatch_review_result) == result,
+        packet.bind_pre_dispatch_review_result_digest == _digest(RESULT_DOMAIN, result),
+        packet.bind_boundary_preconditions == preconditions,
+        packet.bind_boundary_precondition_digest
+        == _digest(PRECONDITIONS_DOMAIN, preconditions),
+        _json_value(packet.bind_pre_dispatch_review_checks) == checks,
+        packet.bind_pre_dispatch_review_check_digest == _digest(CHECKS_DOMAIN, checks),
+        _json_value(packet.future_bind_invocation_requirements) == requirements,
+        packet.future_bind_invocation_requirement_digest
+        == _digest(REQUIREMENTS_DOMAIN, requirements),
+    )
+    if not all(comparisons):
+        raise LiveAdapterDryRunBindPreDispatchReviewError(
+            "LADRBPR_DERIVED_VALUE_MISMATCH"
+        )
+    accepted = result["accepted_for_future_bind_dispatch_gate_review"]
+    if packet.fail_closed != (not accepted) or packet.scope_limitations != (
+        SCOPE_LIMITATIONS
+    ):
+        raise LiveAdapterDryRunBindPreDispatchReviewError(
+            "LADRBPR_FAIL_CLOSED_OR_SCOPE_MISMATCH"
+        )
+    digest = _packet_hash(actual)
+    if packet.live_adapter_dry_run_bind_pre_dispatch_review_hash != digest:
+        raise LiveAdapterDryRunBindPreDispatchReviewError(
+            "LADRBPR_PACKET_HASH_MISMATCH"
+        )
+    if packet.live_adapter_dry_run_bind_pre_dispatch_review_id != (
+        f"ladrbpr:v1:sha256:{digest}"
+    ):
+        raise LiveAdapterDryRunBindPreDispatchReviewError(
+            "LADRBPR_PACKET_ID_MISMATCH"
+        )
+    return packet

--- a/veritas_os/tests/test_live_adapter_dry_run_bind_pre_dispatch_review.py
+++ b/veritas_os/tests/test_live_adapter_dry_run_bind_pre_dispatch_review.py
@@ -1,0 +1,284 @@
+"""Integrity and non-effect tests for Bind pre-dispatch review packet v1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from copy import deepcopy
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator, ValidationError
+
+from veritas_os.policy.live_adapter_dry_run_bind_pre_dispatch_review import (
+    CHECK_NAMES,
+    EFFECT_FIELDS,
+    FUTURE_REQUIREMENT_NAMES,
+    SCOPE_LIMITATIONS,
+    LiveAdapterDryRunBindPreDispatchReviewError,
+    _digest,
+    _packet_hash,
+    build_live_adapter_dry_run_bind_pre_dispatch_review_packet,
+    verify_live_adapter_dry_run_bind_pre_dispatch_review_packet,
+)
+from veritas_os.tests.test_live_adapter_dry_run_operator_dispatch_review import (
+    RECORDED_AT as SOURCE_RECORDED_AT,
+    _packet as operator_packet,
+)
+
+RECORDED_AT = SOURCE_RECORDED_AT + timedelta(seconds=1)
+MODULE = Path(
+    "veritas_os/policy/live_adapter_dry_run_bind_pre_dispatch_review.py"
+)
+SCHEMA = Path(
+    "schemas/live-adapter-dry-run-bind-pre-dispatch-review-v1.schema.json"
+)
+
+
+def _decision(outcome="ACCEPTED_FOR_FUTURE_BIND_DISPATCH_GATE_REVIEW", **changes):
+    value = {
+        "bind_pre_dispatch_review_decision_id": "bind-review:billing:v1",
+        "reviewer_id": "reviewer:bob",
+        "reviewer_role": "bind-boundary-reviewer",
+        "reviewer_attestation": "Reviewed as local evidence, not authority.",
+        "reviewed_at": RECORDED_AT.isoformat(),
+        "review_outcome": outcome,
+        "review_reason": "Suitable for a separate future Bind gate review.",
+        "acknowledged_not_bind_authorization": True,
+        "acknowledged_no_bind_invocation": True,
+        "acknowledged_no_bind_receipt": True,
+        "acknowledged_no_trustlog_write": True,
+        "acknowledged_no_dispatch": True,
+        "acknowledged_no_credential_access": True,
+        "acknowledged_no_network_call": True,
+        "acknowledged_semantic_match_not_authority": True,
+    }
+    value.update(changes)
+    return value
+
+
+def _packet(*, source=None, decision=None, semantic_match=False):
+    source = source or operator_packet(semantic_match=semantic_match)
+    return build_live_adapter_dry_run_bind_pre_dispatch_review_packet(
+        source, decision or _decision(), RECORDED_AT
+    )
+
+
+def _rehash(raw):
+    digest = _packet_hash(raw)
+    raw["live_adapter_dry_run_bind_pre_dispatch_review_hash"] = digest
+    raw["live_adapter_dry_run_bind_pre_dispatch_review_id"] = (
+        f"ladrbpr:v1:sha256:{digest}"
+    )
+
+
+def test_builder_creates_verified_packet_and_reverifies_source(monkeypatch) -> None:
+    import veritas_os.policy.live_adapter_dry_run_bind_pre_dispatch_review as module
+
+    actual = module.verify_live_adapter_dry_run_operator_dispatch_review_packet
+    calls = []
+
+    def recording(value):
+        calls.append(value)
+        return actual(value)
+
+    monkeypatch.setattr(
+        module, "verify_live_adapter_dry_run_operator_dispatch_review_packet",
+        recording,
+    )
+    packet = module.build_live_adapter_dry_run_bind_pre_dispatch_review_packet(
+        operator_packet(), _decision(), RECORDED_AT
+    )
+    assert len(calls) == 2
+    assert module.verify_live_adapter_dry_run_bind_pre_dispatch_review_packet(
+        packet
+    ) == packet
+    assert len(calls) == 3
+    assert not packet.fail_closed
+    assert packet.bind_state == "NOT_BOUND"
+    assert not any(getattr(packet, field) for field in (
+        "bind_invoked", "bind_receipt_created", "trustlog_written",
+        "request_dispatched", "endpoint_resolved", "credential_material_accessed",
+        "authorization_header_constructed", "network_used",
+        "live_adapter_instantiated", "webhook_called",
+    ))
+
+
+@pytest.mark.parametrize("field", [
+    "reviewer_id", "reviewer_role", "reviewer_attestation", "review_reason",
+])
+def test_required_reviewer_text_and_closed_schema(field) -> None:
+    with pytest.raises(LiveAdapterDryRunBindPreDispatchReviewError):
+        _packet(decision=_decision(**{field: ""}))
+    with pytest.raises(LiveAdapterDryRunBindPreDispatchReviewError):
+        _packet(decision=_decision(unexpected=True))
+
+
+@pytest.mark.parametrize("field", [
+    "acknowledged_not_bind_authorization", "acknowledged_no_bind_invocation",
+    "acknowledged_no_bind_receipt", "acknowledged_no_trustlog_write",
+    "acknowledged_no_dispatch", "acknowledged_no_credential_access",
+    "acknowledged_no_network_call",
+    "acknowledged_semantic_match_not_authority",
+])
+def test_every_acknowledgement_is_required(field) -> None:
+    with pytest.raises(LiveAdapterDryRunBindPreDispatchReviewError):
+        _packet(decision=_decision(**{field: False}))
+
+
+def test_rejection_is_recorded_fail_closed() -> None:
+    packet = _packet(decision=_decision(
+        "REJECTED_FOR_FUTURE_BIND_DISPATCH_GATE_REVIEW"
+    ))
+    assert packet.fail_closed
+    assert not (
+        packet.bind_pre_dispatch_review_result
+        .accepted_for_future_bind_dispatch_gate_review
+    )
+
+
+def test_source_fields_lineage_and_semantics_are_preserved() -> None:
+    source = operator_packet(semantic_match=True)
+    packet = _packet(source=source)
+    raw = source.model_dump(mode="json")
+    for field in (
+        "request_descriptor", "execution_intent", "execution_intent_id",
+        "execution_intent_hash", "adapter_contract_descriptor",
+        "adapter_contract_id", "adapter_contract_hash", "adapter_contract_version",
+        "endpoint_candidate", "endpoint_identity_binding", "credential_reference",
+        "credential_scope_binding", "operator_review_decision",
+        "source_to_execution_intent_mapping", "field_mapping_proof",
+        "required_field_presence", "source_decision_identity",
+        "candidate_identity", "evidence_lineage", "replay_summary",
+    ):
+        actual = getattr(packet, field)
+        if hasattr(actual, "model_dump"):
+            actual = actual.model_dump(mode="json")
+        assert actual == raw[field]
+    assert packet.replay_summary["semantic_match"] is True
+    assert not packet.bind_pre_dispatch_review_result.semantic_match_used
+    assert not packet.bind_pre_dispatch_review_result.creates_authority_evidence
+
+
+def test_checks_preconditions_and_requirements_are_exact_and_deterministic() -> None:
+    packet = _packet()
+    assert tuple(check.name for check in packet.bind_pre_dispatch_review_checks) == (
+        CHECK_NAMES
+    )
+    assert all(
+        check.ordinal == ordinal
+        and check.passed
+        and not any(getattr(check, field) for field in EFFECT_FIELDS)
+        for ordinal, check in enumerate(packet.bind_pre_dispatch_review_checks, 1)
+    )
+    assert tuple(
+        requirement.name
+        for requirement in packet.future_bind_invocation_requirements
+    ) == FUTURE_REQUIREMENT_NAMES
+    assert all(
+        requirement.separate_future_artifact_required
+        and not requirement.satisfied_by_this_packet
+        for requirement in packet.future_bind_invocation_requirements
+    )
+    assert not packet.bind_boundary_preconditions["satisfied_by_this_packet"]
+    assert packet.scope_limitations == SCOPE_LIMITATIONS
+
+
+@pytest.mark.parametrize("field", [
+    "source_operator_dispatch_review_packet", "bind_pre_dispatch_review_decision",
+    "bind_pre_dispatch_review_result", "bind_boundary_preconditions",
+    "bind_pre_dispatch_review_checks", "future_bind_invocation_requirements",
+    "fail_closed", "scope_limitations",
+])
+def test_mutation_is_rejected_even_after_outer_rehash(field) -> None:
+    raw = _packet().model_dump(mode="json")
+    if field == "source_operator_dispatch_review_packet":
+        raw[field]["operator_review_decision"]["reviewer_id"] = "forged"
+    elif field == "bind_pre_dispatch_review_decision":
+        raw[field]["review_reason"] = "forged"
+    elif field == "bind_pre_dispatch_review_result":
+        raw[field]["accepted_for_future_bind_dispatch_gate_review"] = False
+    elif field == "bind_boundary_preconditions":
+        raw[field]["source_verified"] = False
+    elif field == "bind_pre_dispatch_review_checks":
+        raw[field][0]["evidence_ref"] = "forged"
+    elif field == "future_bind_invocation_requirements":
+        raw[field][0]["satisfied_by_this_packet"] = True
+    elif field == "fail_closed":
+        raw[field] = True
+    else:
+        raw[field].reverse()
+    _rehash(raw)
+    with pytest.raises(LiveAdapterDryRunBindPreDispatchReviewError):
+        verify_live_adapter_dry_run_bind_pre_dispatch_review_packet(raw)
+
+
+@pytest.mark.parametrize("field", [
+    "live_adapter_dry_run_bind_pre_dispatch_review_id",
+    "live_adapter_dry_run_bind_pre_dispatch_review_hash",
+])
+def test_forged_content_address_is_rejected(field) -> None:
+    raw = _packet().model_dump(mode="json")
+    raw[field] = "forged"
+    with pytest.raises(LiveAdapterDryRunBindPreDispatchReviewError):
+        verify_live_adapter_dry_run_bind_pre_dispatch_review_packet(raw)
+
+
+def test_digests_and_content_address_change_with_content() -> None:
+    first = _packet()
+    second = _packet(decision=_decision(review_reason="Different reason."))
+    assert first.live_adapter_dry_run_bind_pre_dispatch_review_hash != (
+        second.live_adapter_dry_run_bind_pre_dispatch_review_hash
+    )
+    for domain, field in (
+        ("veritas.live-adapter-dry-run-bind-pre-dispatch-review.checks/v1",
+         "bind_pre_dispatch_review_checks"),
+        ("veritas.live-adapter-dry-run-bind-pre-dispatch-review.preconditions/v1",
+         "bind_boundary_preconditions"),
+        ("veritas.live-adapter-dry-run-bind-pre-dispatch-review."
+         "future-bind-invocation-requirements/v1",
+         "future_bind_invocation_requirements"),
+    ):
+        value = first.model_dump(mode="json")[field]
+        old = _digest(domain, value)
+        if isinstance(value, list):
+            value[0]["ordinal"] = 2
+        else:
+            value["source_verified"] = False
+        assert old != _digest(domain, value)
+
+
+def test_schema_accepts_packet_and_rejects_mutations() -> None:
+    schema = json.loads(SCHEMA.read_text())
+    raw = _packet().model_dump(mode="json")
+    Draft202012Validator(schema).validate(raw)
+    for field, value in (("unexpected", True), ("network_used", True)):
+        mutated = deepcopy(raw)
+        mutated[field] = value
+        with pytest.raises(ValidationError):
+            Draft202012Validator(schema).validate(mutated)
+
+
+def test_module_has_no_prohibited_imports_or_effect_calls() -> None:
+    source = MODULE.read_text()
+    tree = ast.parse(source)
+    imports = {
+        alias.name.split(".")[0]
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.Import, ast.ImportFrom))
+        for alias in node.names
+    }
+    assert not imports & {
+        "requests", "httpx", "urllib", "socket", "dns", "subprocess", "os",
+        "pathlib",
+    }
+    called = {
+        node.func.id for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    assert not called & {
+        "open", "apply", "verify_postconditions", "revert", "WebhookBindAdapter",
+        "Bind", "BindReceipt", "TrustLog",
+    }
+    assert "os.environ" not in source


### PR DESCRIPTION
### Motivation

- Record deterministic, local, content-addressed Bind pre-dispatch review evidence for a verified non-dispatched operator dispatch review packet without invoking Bind or producing external effects. 
- Provide a formal closed schema, deterministic hashing domains, and a verifier/builder pair that re-verifies the embedded operator packet and defends against mutation or forged digests. 
- Preserve provenance and semantic-match information without promoting it to authority or execution evidence. 
- Ship tests and documentation so maintainers can review the new Bind pre-dispatch review milestone before any human approval or Bind-related action.

### Description

- Add a pure, closed implementation `veritas_os/policy/live_adapter_dry_run_bind_pre_dispatch_review.py` that implements `build_live_adapter_dry_run_bind_pre_dispatch_review_packet(...)` and `verify_live_adapter_dry_run_bind_pre_dispatch_review_packet(...)`, domain-separated deterministic JSON hashing, deterministic ordered checks (37 checks), deterministic future Bind invocation requirements (13 items), preconditions, result object, and strict Pydantic models. 
- Add tests `veritas_os/tests/test_live_adapter_dry_run_bind_pre_dispatch_review.py` covering builder/verifier behavior, source re-verification, closed schema validation, mutation/forgery rejection, ordered checks, preconditions, requirements, scope limitations, and prohibited-effect imports/calls. 
- Add a closed JSON Schema `schemas/live-adapter-dry-run-bind-pre-dispatch-review-v1.schema.json` generated from the Pydantic model and extended to require exact ordered arrays and scope constants. 
- Add documentation `docs/en/architecture/live-adapter-dry-run-bind-pre-dispatch-review-v1.md` that describes the artifact purpose, fail-closed semantics, non-effect guarantees, and future Bind invocation requirements. 
- Security / non-effect guarantees: the implementation deliberately forbids and does not perform any of these actions: Bind invocation, BindReceipt creation, TrustLog writes, request dispatch, endpoint/DNS resolution, credential access or embedding, authorization-header construction, network access, Webhook calls, live adapter instantiation, subprocess/filesystem/provider/database effects, creation of execution authority, Human Approval, or Authority Evidence; all embedded source packets are reverified and all derived digests are recomputed deterministically. 
- Final invariant: "Canonical Live Adapter Dry-Run Bind Pre-Dispatch Review v1 now records a deterministic Bind pre-dispatch review for a verified non-dispatched operator dispatch review packet without invoking Bind, without creating a BindReceipt, without writing TrustLog, without dispatching the request, without resolving endpoints, without accessing credential material, without constructing authorization headers, without network access, without instantiating a live adapter, without calling Webhook, without external effects, without creating execution authority, and without converting semantic_match into Authority Evidence, Human Approval, or execution authority." 

### Testing

- `ruff check veritas_os/policy/live_adapter_dry_run_bind_pre_dispatch_review.py veritas_os/tests/test_live_adapter_dry_run_bind_pre_dispatch_review.py` — passed. 
- `python -m py_compile veritas_os/policy/live_adapter_dry_run_bind_pre_dispatch_review.py` — passed against available interpreter/site-packages. 
- Generated and validated `schemas/live-adapter-dry-run-bind-pre-dispatch-review-v1.schema.json` via Pydantic model export and `python -m json.tool` — validation passed. 
- `pytest -q veritas_os/tests/test_live_adapter_dry_adapter_dry_run_bind_pre_dispatch_review.py` / full adjacent milestone test suite could not be executed to completion in this environment due to interpreter and dependency resolution limits (pyenv-configured Python `3.12.12` unavailable and project dependencies not (re)installable here); earlier attempts to run `pytest` exposed missing test-runner and dependency packages in the execution environment. 

Note: this PR intentionally contains no Bind, TrustLog, credential store, network, subprocess, Webhook, or provider client usage; it must be reviewed by human maintainers before merging because it touches Bind-boundary review/admissibility evidence and the changes are security-sensitive by policy.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a848811855c8326ac4bbcd22db0617d)