### PR TITLE
feat(bind): add live adapter dry-run authority evidence linkage review v1

### DIFF
--- a/docs/en/architecture/live-adapter-dry-run-authority-evidence-linkage-v1.md
+++ b/docs/en/architecture/live-adapter-dry-run-authority-evidence-linkage-v1.md
@@ -1,0 +1,70 @@
+# Live Adapter Dry-Run Authority Evidence Linkage Review v1
+
+## Purpose
+
+The Canonical Live Adapter Dry-Run Authority Evidence Linkage Review Packet v1
+is a deterministic, local, content-addressed **Authority Evidence linkage review
+artifact**. It answers whether metadata references declared as Authority
+Evidence are structurally linked to a verified, accepted, non-dispatched Bind
+pre-dispatch review path.
+
+The builder re-verifies the embedded source packet, validates a closed reference
+bundle, compares seven execution bindings exactly, checks declared expiry, and
+records ordered checks and separate future gates. It never reads or resolves the
+referenced evidence. A declared upstream verification state remains metadata;
+it is not actual verification or authority.
+
+## Deterministic local linkage
+
+Every reference must exactly match the source execution intent, adapter
+contract, endpoint candidate, credential reference, target system, target
+resource scope, and purpose. Matching is canonical JSON and domain-separated
+SHA-256 hashing only. There is no fuzzy, semantic, provider, database,
+filesystem, credential-store, or network lookup. Missing, duplicate, pending,
+rejected, expired, incomplete, or mismatched references are rejected fail
+closed.
+
+The source `semantic_match` value is preserved for replay fidelity. It is never
+promoted into Authority Evidence, Human Approval, Bind authorization, or
+execution authority. Both `semantic_match=true` and `semantic_match=false`
+remain source facts rather than authority decisions.
+
+## Security and non-effect boundary
+
+This packet:
+
+- does **not** create or externally verify Authority Evidence;
+- does **not** create Human Approval, execution authority, or Bind
+  authorization;
+- does **not** invoke Bind or create a BindReceipt;
+- does **not** write TrustLog or dispatch the request;
+- does **not** resolve endpoints or DNS;
+- does **not** access credentials or construct authorization headers;
+- does **not** call a network or Webhook;
+- does **not** instantiate or call a live adapter; and
+- performs no filesystem, database, provider, subprocess, or operation-commit
+  effect.
+
+All packet-level effect flags and every ordered check's effect flags are fixed
+to false. The state remains `NOT_DISPATCHED`, `NOT_BOUND`, and
+`NOT_AUTHORIZED`.
+
+## Separate future artifacts
+
+Before any future Bind invocation, separate explicit artifacts must establish
+real Authority Evidence verification and, where required, explicit Human
+Approval with approver identity, role, scope, timestamp, freshness, and reason.
+Approval is not execution and remains separate from Bind authorization.
+
+A separate future Bind authorization artifact must also establish final policy
+admissibility, runtime risk, endpoint identity, credential resolution,
+authorization-header construction, idempotency, dispatch and Bind boundaries,
+BindReceipt and post-Bind TrustLog boundaries, and later apply-path
+postcondition and rollback requirements. This linkage review satisfies none of
+those future requirements.
+
+## Human approval warning
+
+This milestone touches Bind-boundary policy evidence and therefore requires
+maintainer review and explicit human approval. It must not be interpreted as a
+production, customer, regulatory, authorization, or execution claim.

--- a/schemas/live-adapter-dry-run-authority-evidence-linkage-v1.schema.json
+++ b/schemas/live-adapter-dry-run-authority-evidence-linkage-v1.schema.json
@@ -1,0 +1,1641 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://veritas-os.example/schemas/live-adapter-dry-run-authority-evidence-linkage-v1.schema.json",
+  "title": "Canonical Live Adapter Dry-Run Authority Evidence Linkage Review Packet v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "format_version",
+    "live_adapter_dry_run_authority_evidence_linkage_review_id",
+    "live_adapter_dry_run_authority_evidence_linkage_review_hash",
+    "authority_evidence_linkage_review_mechanism",
+    "authority_evidence_linkage_review_recorded_at",
+    "source_bind_pre_dispatch_review_id",
+    "source_bind_pre_dispatch_review_hash",
+    "source_bind_pre_dispatch_review_packet",
+    "source_operator_dispatch_review_hash",
+    "source_credential_authorization_hash",
+    "source_endpoint_allowlist_evaluation_hash",
+    "source_dispatch_readiness_hash",
+    "source_live_adapter_dry_run_request_hash",
+    "request_descriptor",
+    "execution_intent",
+    "execution_intent_id",
+    "execution_intent_hash",
+    "adapter_contract_descriptor",
+    "adapter_contract_id",
+    "adapter_contract_hash",
+    "adapter_contract_version",
+    "endpoint_candidate",
+    "endpoint_candidate_digest",
+    "endpoint_identity_binding",
+    "endpoint_identity_binding_digest",
+    "credential_reference",
+    "credential_reference_digest",
+    "credential_scope_binding",
+    "credential_scope_binding_digest",
+    "operator_review_decision",
+    "operator_review_decision_digest",
+    "bind_pre_dispatch_review_decision",
+    "bind_pre_dispatch_review_decision_digest",
+    "authority_evidence_reference_bundle",
+    "authority_evidence_reference_bundle_digest",
+    "authority_evidence_linkage_result",
+    "authority_evidence_linkage_result_digest",
+    "authority_evidence_binding_matrix",
+    "authority_evidence_binding_matrix_digest",
+    "authority_evidence_linkage_checks",
+    "authority_evidence_linkage_check_digest",
+    "future_human_approval_requirements",
+    "future_human_approval_requirement_digest",
+    "future_bind_authorization_requirements",
+    "future_bind_authorization_requirement_digest",
+    "source_to_execution_intent_mapping",
+    "field_mapping_proof",
+    "required_field_presence",
+    "source_decision_identity",
+    "candidate_identity",
+    "evidence_lineage",
+    "replay_summary",
+    "authority_evidence_linkage_status",
+    "request_dispatch_state",
+    "bind_state",
+    "authority_state",
+    "authority_evidence_created",
+    "human_approval_created",
+    "execution_authority_created",
+    "bind_authorization_created",
+    "bind_invoked",
+    "bind_receipt_created",
+    "trustlog_written",
+    "request_dispatched",
+    "endpoint_resolved",
+    "credential_material_accessed",
+    "authorization_header_constructed",
+    "network_used",
+    "live_adapter_instantiated",
+    "webhook_called",
+    "fail_closed",
+    "scope_limitations"
+  ],
+  "properties": {
+    "format_version": {
+      "const": "canonical-live-adapter-dry-run-authority-evidence-linkage-review/v1"
+    },
+    "live_adapter_dry_run_authority_evidence_linkage_review_id": {
+      "type": "string"
+    },
+    "live_adapter_dry_run_authority_evidence_linkage_review_hash": {
+      "type": "string"
+    },
+    "authority_evidence_linkage_review_mechanism": {
+      "const": "review_live_adapter_dry_run_authority_evidence_linkage_without_authority_creation/v1"
+    },
+    "authority_evidence_linkage_review_recorded_at": {
+      "type": "string"
+    },
+    "source_bind_pre_dispatch_review_id": {
+      "type": "string"
+    },
+    "source_bind_pre_dispatch_review_hash": {
+      "type": "string"
+    },
+    "source_bind_pre_dispatch_review_packet": {
+      "type": "object"
+    },
+    "source_operator_dispatch_review_hash": {
+      "type": "string"
+    },
+    "source_credential_authorization_hash": {
+      "type": "string"
+    },
+    "source_endpoint_allowlist_evaluation_hash": {
+      "type": "string"
+    },
+    "source_dispatch_readiness_hash": {
+      "type": "string"
+    },
+    "source_live_adapter_dry_run_request_hash": {
+      "type": "string"
+    },
+    "request_descriptor": {
+      "type": "object"
+    },
+    "execution_intent": {
+      "type": "object"
+    },
+    "execution_intent_id": {
+      "type": "string"
+    },
+    "execution_intent_hash": {
+      "type": "string"
+    },
+    "adapter_contract_descriptor": {
+      "type": "object"
+    },
+    "adapter_contract_id": {
+      "type": "string"
+    },
+    "adapter_contract_hash": {
+      "type": "string"
+    },
+    "adapter_contract_version": {
+      "type": "string"
+    },
+    "endpoint_candidate": {
+      "type": "object"
+    },
+    "endpoint_candidate_digest": {
+      "type": "string"
+    },
+    "endpoint_identity_binding": {
+      "type": "object"
+    },
+    "endpoint_identity_binding_digest": {
+      "type": "string"
+    },
+    "credential_reference": {
+      "type": "object"
+    },
+    "credential_reference_digest": {
+      "type": "string"
+    },
+    "credential_scope_binding": {
+      "type": "object"
+    },
+    "credential_scope_binding_digest": {
+      "type": "string"
+    },
+    "operator_review_decision": {
+      "type": "object"
+    },
+    "operator_review_decision_digest": {
+      "type": "string"
+    },
+    "bind_pre_dispatch_review_decision": {
+      "type": "object"
+    },
+    "bind_pre_dispatch_review_decision_digest": {
+      "type": "string"
+    },
+    "authority_evidence_reference_bundle": {
+      "$ref": "#/$defs/bundle"
+    },
+    "authority_evidence_reference_bundle_digest": {
+      "type": "string"
+    },
+    "authority_evidence_linkage_result": {
+      "$ref": "#/$defs/result"
+    },
+    "authority_evidence_linkage_result_digest": {
+      "type": "string"
+    },
+    "authority_evidence_binding_matrix": {
+      "type": "array",
+      "minItems": 7,
+      "items": {
+        "$ref": "#/$defs/claim"
+      }
+    },
+    "authority_evidence_binding_matrix_digest": {
+      "type": "string"
+    },
+    "authority_evidence_linkage_checks": {
+      "type": "array",
+      "minItems": 46,
+      "maxItems": 46,
+      "prefixItems": [
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "source_bind_pre_dispatch_review_verified"
+                },
+                "ordinal": {
+                  "const": 1
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "source_request_not_dispatched"
+                },
+                "ordinal": {
+                  "const": 2
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "source_bind_not_invoked"
+                },
+                "ordinal": {
+                  "const": 3
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "source_bind_pre_dispatch_review_accepted"
+                },
+                "ordinal": {
+                  "const": 4
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "authority_evidence_reference_bundle_closed_schema_valid"
+                },
+                "ordinal": {
+                  "const": 5
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "authority_evidence_references_present"
+                },
+                "ordinal": {
+                  "const": 6
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "authority_evidence_reference_ids_unique"
+                },
+                "ordinal": {
+                  "const": 7
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "authority_evidence_reference_hashes_present"
+                },
+                "ordinal": {
+                  "const": 8
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "authority_policy_ids_present"
+                },
+                "ordinal": {
+                  "const": 9
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "authority_scope_present"
+                },
+                "ordinal": {
+                  "const": 10
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "declared_verification_state_allowed"
+                },
+                "ordinal": {
+                  "const": 11
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "rejected_declared_verification_state_fails_closed"
+                },
+                "ordinal": {
+                  "const": 12
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "pending_declared_verification_state_fails_closed"
+                },
+                "ordinal": {
+                  "const": 13
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "authority_expiry_checked_against_recorded_at"
+                },
+                "ordinal": {
+                  "const": 14
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "expired_authority_reference_fails_closed"
+                },
+                "ordinal": {
+                  "const": 15
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "execution_intent_id_exactly_linked"
+                },
+                "ordinal": {
+                  "const": 16
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "adapter_contract_id_exactly_linked"
+                },
+                "ordinal": {
+                  "const": 17
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "endpoint_candidate_id_exactly_linked"
+                },
+                "ordinal": {
+                  "const": 18
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "credential_reference_id_exactly_linked"
+                },
+                "ordinal": {
+                  "const": 19
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "target_system_exactly_linked"
+                },
+                "ordinal": {
+                  "const": 20
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "target_resource_scope_exactly_linked"
+                },
+                "ordinal": {
+                  "const": 21
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "purpose_exactly_linked"
+                },
+                "ordinal": {
+                  "const": 22
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "authority_evidence_binding_matrix_constructed"
+                },
+                "ordinal": {
+                  "const": 23
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "all_binding_claims_matched"
+                },
+                "ordinal": {
+                  "const": 24
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "request_descriptor_preserved"
+                },
+                "ordinal": {
+                  "const": 25
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "execution_intent_identity_preserved"
+                },
+                "ordinal": {
+                  "const": 26
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "adapter_contract_identity_preserved"
+                },
+                "ordinal": {
+                  "const": 27
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "endpoint_identity_binding_preserved"
+                },
+                "ordinal": {
+                  "const": 28
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "credential_scope_binding_preserved"
+                },
+                "ordinal": {
+                  "const": 29
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "bind_pre_dispatch_review_decision_preserved"
+                },
+                "ordinal": {
+                  "const": 30
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "authority_evidence_not_created"
+                },
+                "ordinal": {
+                  "const": 31
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "human_approval_not_created"
+                },
+                "ordinal": {
+                  "const": 32
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "execution_authority_not_created"
+                },
+                "ordinal": {
+                  "const": 33
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "bind_authorization_not_created"
+                },
+                "ordinal": {
+                  "const": 34
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "bind_not_invoked"
+                },
+                "ordinal": {
+                  "const": 35
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "bind_receipt_not_created"
+                },
+                "ordinal": {
+                  "const": 36
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "trustlog_not_written"
+                },
+                "ordinal": {
+                  "const": 37
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "request_not_dispatched"
+                },
+                "ordinal": {
+                  "const": 38
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "endpoint_not_resolved"
+                },
+                "ordinal": {
+                  "const": 39
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "credential_material_not_accessed"
+                },
+                "ordinal": {
+                  "const": 40
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "authorization_header_not_constructed"
+                },
+                "ordinal": {
+                  "const": 41
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "network_not_used"
+                },
+                "ordinal": {
+                  "const": 42
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "webhook_not_called"
+                },
+                "ordinal": {
+                  "const": 43
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "live_adapter_not_instantiated"
+                },
+                "ordinal": {
+                  "const": 44
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "future_human_approval_gate_required"
+                },
+                "ordinal": {
+                  "const": 45
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "future_bind_authorization_gate_required"
+                },
+                "ordinal": {
+                  "const": 46
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "authority_evidence_linkage_check_digest": {
+      "type": "string"
+    },
+    "future_human_approval_requirements": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/requirement"
+      }
+    },
+    "future_human_approval_requirement_digest": {
+      "type": "string"
+    },
+    "future_bind_authorization_requirements": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/requirement"
+      }
+    },
+    "future_bind_authorization_requirement_digest": {
+      "type": "string"
+    },
+    "source_to_execution_intent_mapping": {
+      "type": "object"
+    },
+    "field_mapping_proof": {
+      "type": "object"
+    },
+    "required_field_presence": {
+      "type": "object"
+    },
+    "source_decision_identity": {
+      "type": "object"
+    },
+    "candidate_identity": {
+      "type": "object"
+    },
+    "evidence_lineage": {
+      "type": "object"
+    },
+    "replay_summary": {
+      "type": "object"
+    },
+    "authority_evidence_linkage_status": {
+      "const": "LIVE_ADAPTER_DRY_RUN_AUTHORITY_EVIDENCE_LINKAGE_REVIEWED_NOT_AUTHORIZED"
+    },
+    "request_dispatch_state": {
+      "const": "NOT_DISPATCHED"
+    },
+    "bind_state": {
+      "const": "NOT_BOUND"
+    },
+    "authority_state": {
+      "const": "NOT_AUTHORIZED"
+    },
+    "authority_evidence_created": {
+      "const": false
+    },
+    "human_approval_created": {
+      "const": false
+    },
+    "execution_authority_created": {
+      "const": false
+    },
+    "bind_authorization_created": {
+      "const": false
+    },
+    "bind_invoked": {
+      "const": false
+    },
+    "bind_receipt_created": {
+      "const": false
+    },
+    "trustlog_written": {
+      "const": false
+    },
+    "request_dispatched": {
+      "const": false
+    },
+    "endpoint_resolved": {
+      "const": false
+    },
+    "credential_material_accessed": {
+      "const": false
+    },
+    "authorization_header_constructed": {
+      "const": false
+    },
+    "network_used": {
+      "const": false
+    },
+    "live_adapter_instantiated": {
+      "const": false
+    },
+    "webhook_called": {
+      "const": false
+    },
+    "fail_closed": {
+      "const": false
+    },
+    "scope_limitations": {
+      "type": "array",
+      "minItems": 26,
+      "maxItems": 26,
+      "prefixItems": [
+        {
+          "const": "NOT_DISPATCHED"
+        },
+        {
+          "const": "NOT_BIND_INVOCATION"
+        },
+        {
+          "const": "NOT_BIND_AUTHORIZATION"
+        },
+        {
+          "const": "NOT_BIND_RECEIPT"
+        },
+        {
+          "const": "NOT_TRUSTLOG_WRITE"
+        },
+        {
+          "const": "NOT_EXECUTION_AUTHORITY"
+        },
+        {
+          "const": "NOT_HUMAN_APPROVAL"
+        },
+        {
+          "const": "NOT_AUTHORITY_EVIDENCE"
+        },
+        {
+          "const": "NOT_AUTHORITY_EVIDENCE_CREATION"
+        },
+        {
+          "const": "NOT_AUTHORITY_EVIDENCE_EXTERNAL_VERIFICATION"
+        },
+        {
+          "const": "NOT_CREDENTIAL_RESOLUTION"
+        },
+        {
+          "const": "NOT_CREDENTIAL_ACCESS"
+        },
+        {
+          "const": "NOT_CREDENTIAL_EMBEDDING"
+        },
+        {
+          "const": "NOT_AUTHORIZATION_HEADER"
+        },
+        {
+          "const": "NOT_TOKEN"
+        },
+        {
+          "const": "NOT_SECRET"
+        },
+        {
+          "const": "NOT_ENDPOINT_RESOLUTION"
+        },
+        {
+          "const": "NOT_DNS_RESOLUTION"
+        },
+        {
+          "const": "NOT_NETWORK_CALL"
+        },
+        {
+          "const": "NOT_WEBHOOK_CALL"
+        },
+        {
+          "const": "NOT_LIVE_ADAPTER_INSTANCE"
+        },
+        {
+          "const": "NOT_LIVE_ADAPTER_RESULT"
+        },
+        {
+          "const": "NOT_OPERATION_COMMIT"
+        },
+        {
+          "const": "NOT_PRODUCTION_CLAIM"
+        },
+        {
+          "const": "NOT_CUSTOMER_CLAIM"
+        },
+        {
+          "const": "NOT_REGULATORY_CERTIFICATION"
+        }
+      ]
+    }
+  },
+  "$defs": {
+    "reference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "authority_evidence_reference_id",
+        "authority_evidence_kind",
+        "authority_source_type",
+        "authority_source_id",
+        "authority_policy_id",
+        "authority_policy_version",
+        "authority_scope",
+        "authority_subject",
+        "authority_issuer",
+        "authority_issued_at",
+        "authority_expires_at",
+        "authority_evidence_hash",
+        "authority_evidence_format",
+        "declared_verification_state",
+        "linked_execution_intent_id",
+        "linked_adapter_contract_id",
+        "linked_endpoint_candidate_id",
+        "linked_credential_reference_id",
+        "linked_target_system",
+        "linked_target_resource_scope",
+        "linked_purpose"
+      ],
+      "properties": {
+        "authority_evidence_reference_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "authority_evidence_kind": {
+          "type": "string",
+          "minLength": 1
+        },
+        "authority_source_type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "authority_source_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "authority_policy_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "authority_policy_version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "authority_scope": {
+          "type": "string",
+          "minLength": 1
+        },
+        "authority_subject": {
+          "type": "string",
+          "minLength": 1
+        },
+        "authority_issuer": {
+          "type": "string",
+          "minLength": 1
+        },
+        "authority_issued_at": {
+          "type": "string",
+          "minLength": 1
+        },
+        "authority_expires_at": {
+          "type": "string",
+          "minLength": 1
+        },
+        "authority_evidence_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "authority_evidence_format": {
+          "type": "string",
+          "minLength": 1
+        },
+        "declared_verification_state": {
+          "enum": [
+            "DECLARED_VERIFIED_BY_UPSTREAM_ARTIFACT",
+            "DECLARED_PENDING_EXTERNAL_VERIFICATION",
+            "DECLARED_REJECTED_BY_UPSTREAM_ARTIFACT"
+          ]
+        },
+        "linked_execution_intent_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "linked_adapter_contract_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "linked_endpoint_candidate_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "linked_credential_reference_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "linked_target_system": {
+          "type": "string",
+          "minLength": 1
+        },
+        "linked_target_resource_scope": {
+          "type": "string",
+          "minLength": 1
+        },
+        "linked_purpose": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "claim": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "binding_claim_id",
+        "authority_evidence_reference_id",
+        "claim_type",
+        "expected_value",
+        "actual_value",
+        "matched",
+        "comparison_mode"
+      ],
+      "properties": {
+        "binding_claim_id": {
+          "type": "string"
+        },
+        "authority_evidence_reference_id": {
+          "type": "string"
+        },
+        "claim_type": {
+          "type": "string"
+        },
+        "expected_value": {
+          "type": "string"
+        },
+        "actual_value": {
+          "type": "string"
+        },
+        "matched": {
+          "type": "boolean"
+        },
+        "comparison_mode": {
+          "const": "deterministic_local_authority_reference_binding_only"
+        }
+      }
+    },
+    "bundle": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "authority_evidence_reference_bundle_id",
+        "bundle_declared_by",
+        "bundle_declared_at",
+        "bundle_scope",
+        "authority_evidence_references",
+        "authority_evidence_binding_claims",
+        "bundle_limitations"
+      ],
+      "properties": {
+        "authority_evidence_reference_bundle_id": {
+          "type": "string"
+        },
+        "bundle_declared_by": {
+          "type": "string"
+        },
+        "bundle_declared_at": {
+          "type": "string"
+        },
+        "bundle_scope": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "authority_evidence_references": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/reference"
+          }
+        },
+        "authority_evidence_binding_claims": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/claim"
+          }
+        },
+        "bundle_limitations": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "all_required_references_present",
+        "all_references_structurally_linked",
+        "all_binding_claims_matched",
+        "rejected_reference_ids",
+        "rejection_reasons",
+        "comparison_mode",
+        "semantic_match_used",
+        "creates_authority_evidence",
+        "creates_human_approval",
+        "creates_execution_authority",
+        "creates_bind_authorization"
+      ],
+      "properties": {
+        "all_required_references_present": {
+          "const": true
+        },
+        "all_references_structurally_linked": {
+          "const": true
+        },
+        "all_binding_claims_matched": {
+          "const": true
+        },
+        "rejected_reference_ids": {
+          "const": []
+        },
+        "rejection_reasons": {
+          "const": []
+        },
+        "comparison_mode": {
+          "const": "deterministic_local_authority_evidence_linkage_review_only"
+        },
+        "semantic_match_used": {
+          "const": false
+        },
+        "creates_authority_evidence": {
+          "const": false
+        },
+        "creates_human_approval": {
+          "const": false
+        },
+        "creates_execution_authority": {
+          "const": false
+        },
+        "creates_bind_authorization": {
+          "const": false
+        }
+      }
+    },
+    "check": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "check_id",
+        "ordinal",
+        "name",
+        "mode",
+        "passed",
+        "evidence_ref",
+        "authority_evidence_created",
+        "human_approval_created",
+        "execution_authority_created",
+        "bind_authorization_created",
+        "bind_invoked",
+        "bind_receipt_created",
+        "trustlog_written",
+        "request_dispatched",
+        "endpoint_resolved",
+        "credential_material_accessed",
+        "credential_material_embedded",
+        "authorization_header_constructed",
+        "token_embedded",
+        "secret_embedded",
+        "network_used",
+        "dns_used",
+        "webhook_called",
+        "live_adapter_instantiated",
+        "live_adapter_method_called",
+        "external_effect_used",
+        "filesystem_used",
+        "database_used",
+        "provider_used",
+        "subprocess_used",
+        "operation_committed"
+      ],
+      "properties": {
+        "check_id": {
+          "type": "string"
+        },
+        "ordinal": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 46
+        },
+        "name": {
+          "enum": [
+            "source_bind_pre_dispatch_review_verified",
+            "source_request_not_dispatched",
+            "source_bind_not_invoked",
+            "source_bind_pre_dispatch_review_accepted",
+            "authority_evidence_reference_bundle_closed_schema_valid",
+            "authority_evidence_references_present",
+            "authority_evidence_reference_ids_unique",
+            "authority_evidence_reference_hashes_present",
+            "authority_policy_ids_present",
+            "authority_scope_present",
+            "declared_verification_state_allowed",
+            "rejected_declared_verification_state_fails_closed",
+            "pending_declared_verification_state_fails_closed",
+            "authority_expiry_checked_against_recorded_at",
+            "expired_authority_reference_fails_closed",
+            "execution_intent_id_exactly_linked",
+            "adapter_contract_id_exactly_linked",
+            "endpoint_candidate_id_exactly_linked",
+            "credential_reference_id_exactly_linked",
+            "target_system_exactly_linked",
+            "target_resource_scope_exactly_linked",
+            "purpose_exactly_linked",
+            "authority_evidence_binding_matrix_constructed",
+            "all_binding_claims_matched",
+            "request_descriptor_preserved",
+            "execution_intent_identity_preserved",
+            "adapter_contract_identity_preserved",
+            "endpoint_identity_binding_preserved",
+            "credential_scope_binding_preserved",
+            "bind_pre_dispatch_review_decision_preserved",
+            "authority_evidence_not_created",
+            "human_approval_not_created",
+            "execution_authority_not_created",
+            "bind_authorization_not_created",
+            "bind_not_invoked",
+            "bind_receipt_not_created",
+            "trustlog_not_written",
+            "request_not_dispatched",
+            "endpoint_not_resolved",
+            "credential_material_not_accessed",
+            "authorization_header_not_constructed",
+            "network_not_used",
+            "webhook_not_called",
+            "live_adapter_not_instantiated",
+            "future_human_approval_gate_required",
+            "future_bind_authorization_gate_required"
+          ]
+        },
+        "mode": {
+          "const": "deterministic_local_authority_evidence_linkage_review_only"
+        },
+        "passed": {
+          "const": true
+        },
+        "evidence_ref": {
+          "type": "string"
+        },
+        "authority_evidence_created": {
+          "const": false
+        },
+        "human_approval_created": {
+          "const": false
+        },
+        "execution_authority_created": {
+          "const": false
+        },
+        "bind_authorization_created": {
+          "const": false
+        },
+        "bind_invoked": {
+          "const": false
+        },
+        "bind_receipt_created": {
+          "const": false
+        },
+        "trustlog_written": {
+          "const": false
+        },
+        "request_dispatched": {
+          "const": false
+        },
+        "endpoint_resolved": {
+          "const": false
+        },
+        "credential_material_accessed": {
+          "const": false
+        },
+        "credential_material_embedded": {
+          "const": false
+        },
+        "authorization_header_constructed": {
+          "const": false
+        },
+        "token_embedded": {
+          "const": false
+        },
+        "secret_embedded": {
+          "const": false
+        },
+        "network_used": {
+          "const": false
+        },
+        "dns_used": {
+          "const": false
+        },
+        "webhook_called": {
+          "const": false
+        },
+        "live_adapter_instantiated": {
+          "const": false
+        },
+        "live_adapter_method_called": {
+          "const": false
+        },
+        "external_effect_used": {
+          "const": false
+        },
+        "filesystem_used": {
+          "const": false
+        },
+        "database_used": {
+          "const": false
+        },
+        "provider_used": {
+          "const": false
+        },
+        "subprocess_used": {
+          "const": false
+        },
+        "operation_committed": {
+          "const": false
+        }
+      }
+    },
+    "requirement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "ordinal",
+        "name",
+        "separate_future_artifact_required",
+        "satisfied_by_this_packet"
+      ],
+      "properties": {
+        "ordinal": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "name": {
+          "type": "string"
+        },
+        "separate_future_artifact_required": {
+          "const": true
+        },
+        "satisfied_by_this_packet": {
+          "const": false
+        }
+      }
+    }
+  }
+}

--- a/veritas_os/policy/live_adapter_dry_run_authority_evidence_linkage.py
+++ b/veritas_os/policy/live_adapter_dry_run_authority_evidence_linkage.py
@@ -1,0 +1,630 @@
+"""Record local Authority Evidence reference linkage without creating authority.
+
+Only caller-supplied metadata is validated and content-addressed.  The module
+does not resolve evidence, credentials, endpoints, or perform external effects.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from veritas_os.policy.live_adapter_dry_run_bind_pre_dispatch_review import (
+    CanonicalLiveAdapterDryRunBindPreDispatchReviewPacket,
+    LiveAdapterDryRunBindPreDispatchReviewError,
+    verify_live_adapter_dry_run_bind_pre_dispatch_review_packet,
+)
+
+FORMAT_VERSION = (
+    "canonical-live-adapter-dry-run-authority-evidence-linkage-review/v1"
+)
+REVIEW_MECHANISM = (
+    "review_live_adapter_dry_run_authority_evidence_linkage_without_"
+    "authority_creation/v1"
+)
+STATUS = "LIVE_ADAPTER_DRY_RUN_AUTHORITY_EVIDENCE_LINKAGE_REVIEWED_NOT_AUTHORIZED"
+SOURCE_STATUS = "LIVE_ADAPTER_DRY_RUN_BIND_PRE_DISPATCH_REVIEW_RECORDED_NOT_BOUND"
+CHECK_MODE = "deterministic_local_authority_evidence_linkage_review_only"
+BINDING_MODE = "deterministic_local_authority_reference_binding_only"
+DECLARED_STATES = (
+    "DECLARED_VERIFIED_BY_UPSTREAM_ARTIFACT",
+    "DECLARED_PENDING_EXTERNAL_VERIFICATION",
+    "DECLARED_REJECTED_BY_UPSTREAM_ARTIFACT",
+)
+DOMAINS = {
+    "bundle": "veritas.live-adapter-dry-run-authority-evidence-linkage.reference-bundle/v1",
+    "matrix": "veritas.live-adapter-dry-run-authority-evidence-linkage.binding-matrix/v1",
+    "result": "veritas.live-adapter-dry-run-authority-evidence-linkage.result/v1",
+    "checks": "veritas.live-adapter-dry-run-authority-evidence-linkage.checks/v1",
+    "human": "veritas.live-adapter-dry-run-authority-evidence-linkage.future-human-approval-requirements/v1",
+    "bind": "veritas.live-adapter-dry-run-authority-evidence-linkage.future-bind-authorization-requirements/v1",
+    "packet": "veritas.live-adapter-dry-run-authority-evidence-linkage.packet/v1",
+}
+CHECK_NAMES = (
+    "source_bind_pre_dispatch_review_verified", "source_request_not_dispatched",
+    "source_bind_not_invoked", "source_bind_pre_dispatch_review_accepted",
+    "authority_evidence_reference_bundle_closed_schema_valid",
+    "authority_evidence_references_present", "authority_evidence_reference_ids_unique",
+    "authority_evidence_reference_hashes_present", "authority_policy_ids_present",
+    "authority_scope_present", "declared_verification_state_allowed",
+    "rejected_declared_verification_state_fails_closed",
+    "pending_declared_verification_state_fails_closed",
+    "authority_expiry_checked_against_recorded_at",
+    "expired_authority_reference_fails_closed", "execution_intent_id_exactly_linked",
+    "adapter_contract_id_exactly_linked", "endpoint_candidate_id_exactly_linked",
+    "credential_reference_id_exactly_linked", "target_system_exactly_linked",
+    "target_resource_scope_exactly_linked", "purpose_exactly_linked",
+    "authority_evidence_binding_matrix_constructed", "all_binding_claims_matched",
+    "request_descriptor_preserved", "execution_intent_identity_preserved",
+    "adapter_contract_identity_preserved", "endpoint_identity_binding_preserved",
+    "credential_scope_binding_preserved", "bind_pre_dispatch_review_decision_preserved",
+    "authority_evidence_not_created", "human_approval_not_created",
+    "execution_authority_not_created", "bind_authorization_not_created",
+    "bind_not_invoked", "bind_receipt_not_created", "trustlog_not_written",
+    "request_not_dispatched", "endpoint_not_resolved",
+    "credential_material_not_accessed", "authorization_header_not_constructed",
+    "network_not_used", "webhook_not_called", "live_adapter_not_instantiated",
+    "future_human_approval_gate_required", "future_bind_authorization_gate_required",
+)
+EFFECT_FIELDS = (
+    "authority_evidence_created", "human_approval_created",
+    "execution_authority_created", "bind_authorization_created", "bind_invoked",
+    "bind_receipt_created", "trustlog_written", "request_dispatched",
+    "endpoint_resolved", "credential_material_accessed",
+    "credential_material_embedded", "authorization_header_constructed",
+    "token_embedded", "secret_embedded", "network_used", "dns_used",
+    "webhook_called", "live_adapter_instantiated", "live_adapter_method_called",
+    "external_effect_used", "filesystem_used", "database_used", "provider_used",
+    "subprocess_used", "operation_committed",
+)
+SCOPE_LIMITATIONS = (
+    "NOT_DISPATCHED", "NOT_BIND_INVOCATION", "NOT_BIND_AUTHORIZATION",
+    "NOT_BIND_RECEIPT", "NOT_TRUSTLOG_WRITE", "NOT_EXECUTION_AUTHORITY",
+    "NOT_HUMAN_APPROVAL", "NOT_AUTHORITY_EVIDENCE",
+    "NOT_AUTHORITY_EVIDENCE_CREATION",
+    "NOT_AUTHORITY_EVIDENCE_EXTERNAL_VERIFICATION", "NOT_CREDENTIAL_RESOLUTION",
+    "NOT_CREDENTIAL_ACCESS", "NOT_CREDENTIAL_EMBEDDING",
+    "NOT_AUTHORIZATION_HEADER", "NOT_TOKEN", "NOT_SECRET",
+    "NOT_ENDPOINT_RESOLUTION", "NOT_DNS_RESOLUTION", "NOT_NETWORK_CALL",
+    "NOT_WEBHOOK_CALL", "NOT_LIVE_ADAPTER_INSTANCE", "NOT_LIVE_ADAPTER_RESULT",
+    "NOT_OPERATION_COMMIT", "NOT_PRODUCTION_CLAIM", "NOT_CUSTOMER_CLAIM",
+    "NOT_REGULATORY_CERTIFICATION",
+)
+HUMAN_REQUIREMENTS = (
+    "explicit_human_approval_where_required", "approver_identity",
+    "approver_authority_or_role", "approval_scope_binding", "approval_timestamp",
+    "approval_expiry_or_freshness_boundary", "approval_reason",
+    "acknowledgement_approval_is_not_execution_by_itself",
+    "acknowledgement_bind_authorization_remains_separate",
+)
+BIND_REQUIREMENTS = (
+    "valid_authority_evidence_through_real_authority_verification_path",
+    "valid_human_approval_where_required", "final_policy_admissibility",
+    "final_runtime_risk_review", "final_endpoint_identity_binding",
+    "final_credential_resolution_boundary",
+    "final_authorization_header_construction_boundary", "idempotency_key_binding",
+    "request_dispatch_boundary", "bind_invocation_boundary",
+    "bind_receipt_creation_boundary", "trustlog_write_boundary_after_bind",
+    "postcondition_and_rollback_requirements_for_later_apply_path",
+)
+COPIED_FIELDS = (
+    "request_descriptor", "execution_intent", "execution_intent_id",
+    "execution_intent_hash", "adapter_contract_descriptor", "adapter_contract_id",
+    "adapter_contract_hash", "adapter_contract_version", "endpoint_candidate",
+    "endpoint_candidate_digest", "endpoint_identity_binding",
+    "endpoint_identity_binding_digest", "credential_reference",
+    "credential_reference_digest", "credential_scope_binding",
+    "credential_scope_binding_digest", "operator_review_decision",
+    "operator_review_decision_digest", "bind_pre_dispatch_review_decision",
+    "bind_pre_dispatch_review_decision_digest", "source_to_execution_intent_mapping",
+    "field_mapping_proof", "required_field_presence", "source_decision_identity",
+    "candidate_identity", "evidence_lineage", "replay_summary",
+)
+
+
+class LiveAdapterDryRunAuthorityEvidenceLinkageError(ValueError):
+    """Stable fail-closed error for invalid linkage review evidence."""
+
+
+class AuthorityEvidenceReference(BaseModel):
+    """Closed metadata-only reference; no referenced resource is accessed."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    authority_evidence_reference_id: str = Field(min_length=1)
+    authority_evidence_kind: str = Field(min_length=1)
+    authority_source_type: str = Field(min_length=1)
+    authority_source_id: str = Field(min_length=1)
+    authority_policy_id: str = Field(min_length=1)
+    authority_policy_version: str = Field(min_length=1)
+    authority_scope: str = Field(min_length=1)
+    authority_subject: str = Field(min_length=1)
+    authority_issuer: str = Field(min_length=1)
+    authority_issued_at: str
+    authority_expires_at: str
+    authority_evidence_hash: str = Field(min_length=1)
+    authority_evidence_format: str = Field(min_length=1)
+    declared_verification_state: Literal[*DECLARED_STATES]
+    linked_execution_intent_id: str = Field(min_length=1)
+    linked_adapter_contract_id: str = Field(min_length=1)
+    linked_endpoint_candidate_id: str = Field(min_length=1)
+    linked_credential_reference_id: str = Field(min_length=1)
+    linked_target_system: str = Field(min_length=1)
+    linked_target_resource_scope: str = Field(min_length=1)
+    linked_purpose: str = Field(min_length=1)
+
+
+class AuthorityEvidenceBindingClaim(BaseModel):
+    """One caller-declared exact local comparison claim."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    binding_claim_id: str = Field(min_length=1)
+    authority_evidence_reference_id: str = Field(min_length=1)
+    claim_type: str = Field(min_length=1)
+    expected_value: str
+    actual_value: str
+    matched: bool
+    comparison_mode: Literal[BINDING_MODE]
+
+
+class AuthorityEvidenceReferenceBundle(BaseModel):
+    """Closed collection of declared Authority Evidence reference metadata."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    authority_evidence_reference_bundle_id: str = Field(min_length=1)
+    bundle_declared_by: str = Field(min_length=1)
+    bundle_declared_at: str
+    bundle_scope: tuple[str, ...] = Field(min_length=1)
+    authority_evidence_references: tuple[AuthorityEvidenceReference, ...]
+    authority_evidence_binding_claims: tuple[AuthorityEvidenceBindingClaim, ...]
+    bundle_limitations: tuple[str, ...] = Field(min_length=1)
+
+
+class AuthorityEvidenceLinkageResult(BaseModel):
+    """Deterministic result that explicitly creates no authority."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    all_required_references_present: bool
+    all_references_structurally_linked: bool
+    all_binding_claims_matched: bool
+    rejected_reference_ids: tuple[str, ...]
+    rejection_reasons: tuple[str, ...]
+    comparison_mode: Literal[CHECK_MODE]
+    semantic_match_used: Literal[False]
+    creates_authority_evidence: Literal[False]
+    creates_human_approval: Literal[False]
+    creates_execution_authority: Literal[False]
+    creates_bind_authorization: Literal[False]
+
+
+class AuthorityEvidenceLinkageCheck(BaseModel):
+    """One ordered deterministic check with false effect flags."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    check_id: str
+    ordinal: int = Field(ge=1, le=46)
+    name: Literal[*CHECK_NAMES]
+    mode: Literal[CHECK_MODE]
+    passed: Literal[True]
+    evidence_ref: str
+    authority_evidence_created: Literal[False]
+    human_approval_created: Literal[False]
+    execution_authority_created: Literal[False]
+    bind_authorization_created: Literal[False]
+    bind_invoked: Literal[False]
+    bind_receipt_created: Literal[False]
+    trustlog_written: Literal[False]
+    request_dispatched: Literal[False]
+    endpoint_resolved: Literal[False]
+    credential_material_accessed: Literal[False]
+    credential_material_embedded: Literal[False]
+    authorization_header_constructed: Literal[False]
+    token_embedded: Literal[False]
+    secret_embedded: Literal[False]
+    network_used: Literal[False]
+    dns_used: Literal[False]
+    webhook_called: Literal[False]
+    live_adapter_instantiated: Literal[False]
+    live_adapter_method_called: Literal[False]
+    external_effect_used: Literal[False]
+    filesystem_used: Literal[False]
+    database_used: Literal[False]
+    provider_used: Literal[False]
+    subprocess_used: Literal[False]
+    operation_committed: Literal[False]
+
+
+class FutureRequirement(BaseModel):
+    """A separate future proof that this packet does not satisfy."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    ordinal: int
+    name: str
+    separate_future_artifact_required: Literal[True]
+    satisfied_by_this_packet: Literal[False]
+
+
+class CanonicalLiveAdapterDryRunAuthorityEvidenceLinkageReviewPacket(BaseModel):
+    """Closed, content-addressed, non-authorizing linkage review packet."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    format_version: Literal[FORMAT_VERSION]
+    live_adapter_dry_run_authority_evidence_linkage_review_id: str
+    live_adapter_dry_run_authority_evidence_linkage_review_hash: str
+    authority_evidence_linkage_review_mechanism: Literal[REVIEW_MECHANISM]
+    authority_evidence_linkage_review_recorded_at: str
+    source_bind_pre_dispatch_review_id: str
+    source_bind_pre_dispatch_review_hash: str
+    source_bind_pre_dispatch_review_packet: dict[str, Any]
+    source_operator_dispatch_review_hash: str
+    source_credential_authorization_hash: str
+    source_endpoint_allowlist_evaluation_hash: str
+    source_dispatch_readiness_hash: str
+    source_live_adapter_dry_run_request_hash: str
+    request_descriptor: dict[str, Any]
+    execution_intent: dict[str, Any]
+    execution_intent_id: str
+    execution_intent_hash: str
+    adapter_contract_descriptor: dict[str, Any]
+    adapter_contract_id: str
+    adapter_contract_hash: str
+    adapter_contract_version: str
+    endpoint_candidate: dict[str, Any]
+    endpoint_candidate_digest: str
+    endpoint_identity_binding: dict[str, Any]
+    endpoint_identity_binding_digest: str
+    credential_reference: dict[str, Any]
+    credential_reference_digest: str
+    credential_scope_binding: dict[str, Any]
+    credential_scope_binding_digest: str
+    operator_review_decision: dict[str, Any]
+    operator_review_decision_digest: str
+    bind_pre_dispatch_review_decision: dict[str, Any]
+    bind_pre_dispatch_review_decision_digest: str
+    authority_evidence_reference_bundle: AuthorityEvidenceReferenceBundle
+    authority_evidence_reference_bundle_digest: str
+    authority_evidence_linkage_result: AuthorityEvidenceLinkageResult
+    authority_evidence_linkage_result_digest: str
+    authority_evidence_binding_matrix: tuple[AuthorityEvidenceBindingClaim, ...]
+    authority_evidence_binding_matrix_digest: str
+    authority_evidence_linkage_checks: tuple[AuthorityEvidenceLinkageCheck, ...]
+    authority_evidence_linkage_check_digest: str
+    future_human_approval_requirements: tuple[FutureRequirement, ...]
+    future_human_approval_requirement_digest: str
+    future_bind_authorization_requirements: tuple[FutureRequirement, ...]
+    future_bind_authorization_requirement_digest: str
+    source_to_execution_intent_mapping: dict[str, Any]
+    field_mapping_proof: dict[str, Any]
+    required_field_presence: dict[str, str]
+    source_decision_identity: dict[str, Any]
+    candidate_identity: dict[str, Any]
+    evidence_lineage: dict[str, Any]
+    replay_summary: dict[str, Any]
+    authority_evidence_linkage_status: Literal[STATUS]
+    request_dispatch_state: Literal["NOT_DISPATCHED"]
+    bind_state: Literal["NOT_BOUND"]
+    authority_state: Literal["NOT_AUTHORIZED"]
+    authority_evidence_created: Literal[False]
+    human_approval_created: Literal[False]
+    execution_authority_created: Literal[False]
+    bind_authorization_created: Literal[False]
+    bind_invoked: Literal[False]
+    bind_receipt_created: Literal[False]
+    trustlog_written: Literal[False]
+    request_dispatched: Literal[False]
+    endpoint_resolved: Literal[False]
+    credential_material_accessed: Literal[False]
+    authorization_header_constructed: Literal[False]
+    network_used: Literal[False]
+    live_adapter_instantiated: Literal[False]
+    webhook_called: Literal[False]
+    fail_closed: Literal[False]
+    scope_limitations: tuple[Literal[*SCOPE_LIMITATIONS], ...]
+
+
+def _timestamp(value: Any) -> str:
+    try:
+        parsed = value if isinstance(value, datetime) else datetime.fromisoformat(value)
+    except (TypeError, ValueError) as exc:
+        raise LiveAdapterDryRunAuthorityEvidenceLinkageError(
+            "LADRAEL_TIMESTAMP_INVALID"
+        ) from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise LiveAdapterDryRunAuthorityEvidenceLinkageError(
+            "LADRAEL_TIMESTAMP_INVALID"
+        )
+    return parsed.astimezone(timezone.utc).isoformat()
+
+
+def _json(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        value = value.model_dump(mode="python")
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float) and value == value and value not in (
+        float("inf"), float("-inf")
+    ):
+        return value
+    if isinstance(value, datetime):
+        return _timestamp(value)
+    if isinstance(value, (list, tuple)):
+        return [_json(item) for item in value]
+    if isinstance(value, dict) and all(isinstance(key, str) for key in value):
+        return {key: _json(item) for key, item in value.items()}
+    raise LiveAdapterDryRunAuthorityEvidenceLinkageError("LADRAEL_INVALID")
+
+
+def _digest(domain: str, value: Any) -> str:
+    encoded = json.dumps(
+        {"domain": domain, "value": _json(value)}, allow_nan=False,
+        ensure_ascii=False, separators=(",", ":"), sort_keys=True,
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _packet_hash(raw: dict[str, Any]) -> str:
+    omitted = {
+        "live_adapter_dry_run_authority_evidence_linkage_review_id",
+        "live_adapter_dry_run_authority_evidence_linkage_review_hash",
+    }
+    return _digest(DOMAINS["packet"], {k: v for k, v in raw.items() if k not in omitted})
+
+
+def _source(value: Any) -> CanonicalLiveAdapterDryRunBindPreDispatchReviewPacket:
+    try:
+        return verify_live_adapter_dry_run_bind_pre_dispatch_review_packet(value)
+    except (LiveAdapterDryRunBindPreDispatchReviewError, TypeError, ValueError) as exc:
+        raise LiveAdapterDryRunAuthorityEvidenceLinkageError(
+            "LADRAEL_SOURCE_INVALID"
+        ) from exc
+
+
+def _source_value(source: CanonicalLiveAdapterDryRunBindPreDispatchReviewPacket,
+                  name: str) -> str:
+    if name == "endpoint_candidate_id":
+        return str(source.endpoint_candidate["endpoint_candidate_id"])
+    if name == "credential_reference_id":
+        return str(source.credential_reference["credential_reference_id"])
+    if name == "target_resource_scope":
+        return str(source.credential_reference["target_resource_scope"])
+    if name == "purpose":
+        return str(source.credential_reference["credential_purpose"])
+    if name == "target_system":
+        return str(source.credential_reference["target_system"])
+    return str(source.execution_intent[name])
+
+
+def _validate_source(source: CanonicalLiveAdapterDryRunBindPreDispatchReviewPacket) -> None:
+    if source.request_dispatch_state != "NOT_DISPATCHED":
+        raise LiveAdapterDryRunAuthorityEvidenceLinkageError("LADRAEL_SOURCE_DISPATCHED")
+    if source.bind_state != "NOT_BOUND" or source.bind_invoked:
+        raise LiveAdapterDryRunAuthorityEvidenceLinkageError("LADRAEL_SOURCE_BOUND")
+    if source.bind_pre_dispatch_review_status != SOURCE_STATUS:
+        raise LiveAdapterDryRunAuthorityEvidenceLinkageError("LADRAEL_SOURCE_STATUS")
+    if source.fail_closed or not (
+        source.bind_pre_dispatch_review_result
+        .accepted_for_future_bind_dispatch_gate_review
+    ):
+        raise LiveAdapterDryRunAuthorityEvidenceLinkageError("LADRAEL_SOURCE_REJECTED")
+
+
+def _bundle(value: Any, recorded_at: str) -> AuthorityEvidenceReferenceBundle:
+    try:
+        bundle = AuthorityEvidenceReferenceBundle.model_validate(_json(value))
+    except (ValidationError, TypeError) as exc:
+        raise LiveAdapterDryRunAuthorityEvidenceLinkageError(
+            "LADRAEL_BUNDLE_INVALID"
+        ) from exc
+    references = bundle.authority_evidence_references
+    ids = [item.authority_evidence_reference_id for item in references]
+    if not references:
+        raise LiveAdapterDryRunAuthorityEvidenceLinkageError("LADRAEL_REFERENCES_MISSING")
+    if len(ids) != len(set(ids)):
+        raise LiveAdapterDryRunAuthorityEvidenceLinkageError("LADRAEL_REFERENCE_IDS_DUPLICATE")
+    scopes = {item.authority_scope for item in references}
+    if not set(bundle.bundle_scope).issubset(scopes):
+        raise LiveAdapterDryRunAuthorityEvidenceLinkageError("LADRAEL_SCOPE_MISSING")
+    when = datetime.fromisoformat(recorded_at)
+    for item in references:
+        if item.declared_verification_state != DECLARED_STATES[0]:
+            raise LiveAdapterDryRunAuthorityEvidenceLinkageError("LADRAEL_STATE_FAIL_CLOSED")
+        issued = datetime.fromisoformat(_timestamp(item.authority_issued_at))
+        expires = datetime.fromisoformat(_timestamp(item.authority_expires_at))
+        if expires <= when or issued > when or expires <= issued:
+            raise LiveAdapterDryRunAuthorityEvidenceLinkageError("LADRAEL_EXPIRED")
+    return bundle
+
+
+def _matrix(source: CanonicalLiveAdapterDryRunBindPreDispatchReviewPacket,
+            bundle: AuthorityEvidenceReferenceBundle) -> list[dict[str, Any]]:
+    pairs = (
+        ("execution_intent_id", "linked_execution_intent_id", source.execution_intent_id),
+        ("adapter_contract_id", "linked_adapter_contract_id", source.adapter_contract_id),
+        ("endpoint_candidate_id", "linked_endpoint_candidate_id",
+         _source_value(source, "endpoint_candidate_id")),
+        ("credential_reference_id", "linked_credential_reference_id",
+         _source_value(source, "credential_reference_id")),
+        ("target_system", "linked_target_system", _source_value(source, "target_system")),
+        ("target_resource_scope", "linked_target_resource_scope",
+         _source_value(source, "target_resource_scope")),
+        ("purpose", "linked_purpose", _source_value(source, "purpose")),
+    )
+    matrix = []
+    for reference in bundle.authority_evidence_references:
+        for claim_type, attribute, expected in pairs:
+            actual = str(getattr(reference, attribute))
+            matrix.append({
+                "binding_claim_id": (
+                    f"ladrael-claim:v1:{reference.authority_evidence_reference_id}:"
+                    f"{claim_type}"
+                ),
+                "authority_evidence_reference_id": reference.authority_evidence_reference_id,
+                "claim_type": claim_type, "expected_value": expected,
+                "actual_value": actual, "matched": expected == actual,
+                "comparison_mode": BINDING_MODE,
+            })
+    return matrix
+
+
+def _requirements(names: tuple[str, ...]) -> list[dict[str, Any]]:
+    return [{"ordinal": ordinal, "name": name,
+             "separate_future_artifact_required": True,
+             "satisfied_by_this_packet": False}
+            for ordinal, name in enumerate(names, 1)]
+
+
+def _derived(source: CanonicalLiveAdapterDryRunBindPreDispatchReviewPacket,
+             bundle: AuthorityEvidenceReferenceBundle) -> tuple[Any, ...]:
+    matrix = _matrix(source, bundle)
+    supplied_claims = [claim.model_dump(mode="json")
+                       for claim in bundle.authority_evidence_binding_claims]
+    claims_valid = all(
+        claim["matched"] == (claim["expected_value"] == claim["actual_value"])
+        and claim["authority_evidence_reference_id"] in {
+            ref.authority_evidence_reference_id
+            for ref in bundle.authority_evidence_references
+        }
+        for claim in supplied_claims
+    )
+    linked = all(claim["matched"] for claim in matrix)
+    if not linked or not claims_valid:
+        raise LiveAdapterDryRunAuthorityEvidenceLinkageError("LADRAEL_LINK_MISMATCH")
+    result = {
+        "all_required_references_present": True,
+        "all_references_structurally_linked": True,
+        "all_binding_claims_matched": True,
+        "rejected_reference_ids": [], "rejection_reasons": [],
+        "comparison_mode": CHECK_MODE, "semantic_match_used": False,
+        "creates_authority_evidence": False, "creates_human_approval": False,
+        "creates_execution_authority": False, "creates_bind_authorization": False,
+    }
+    bundle_digest = _digest(DOMAINS["bundle"], bundle)
+    checks = [{
+        "check_id": f"ladrael-check:v1:{ordinal}:{name.replace('_', '-')}",
+        "ordinal": ordinal, "name": name, "mode": CHECK_MODE, "passed": True,
+        "evidence_ref": f"bundle:{bundle_digest}:{name}",
+        **{field: False for field in EFFECT_FIELDS},
+    } for ordinal, name in enumerate(CHECK_NAMES, 1)]
+    return matrix, result, checks, _requirements(HUMAN_REQUIREMENTS), _requirements(BIND_REQUIREMENTS)
+
+
+def build_live_adapter_dry_run_authority_evidence_linkage_review_packet(
+    source_bind_pre_dispatch_review_packet: Any,
+    authority_evidence_reference_bundle: Any,
+    authority_evidence_linkage_review_recorded_at: datetime,
+) -> CanonicalLiveAdapterDryRunAuthorityEvidenceLinkageReviewPacket:
+    """Build and self-verify deterministic metadata-only linkage evidence."""
+    source = _source(_json(source_bind_pre_dispatch_review_packet))
+    _validate_source(source)
+    recorded_at = _timestamp(authority_evidence_linkage_review_recorded_at)
+    bundle = _bundle(authority_evidence_reference_bundle, recorded_at)
+    matrix, result, checks, human, bind = _derived(source, bundle)
+    source_raw = source.model_dump(mode="json")
+    raw = {
+        "format_version": FORMAT_VERSION,
+        "authority_evidence_linkage_review_mechanism": REVIEW_MECHANISM,
+        "authority_evidence_linkage_review_recorded_at": recorded_at,
+        "source_bind_pre_dispatch_review_id": source.live_adapter_dry_run_bind_pre_dispatch_review_id,
+        "source_bind_pre_dispatch_review_hash": source.live_adapter_dry_run_bind_pre_dispatch_review_hash,
+        "source_bind_pre_dispatch_review_packet": source_raw,
+        "source_operator_dispatch_review_hash": source.source_operator_dispatch_review_hash,
+        "source_credential_authorization_hash": source.source_credential_authorization_hash,
+        "source_endpoint_allowlist_evaluation_hash": source.source_endpoint_allowlist_evaluation_hash,
+        "source_dispatch_readiness_hash": source.source_dispatch_readiness_hash,
+        "source_live_adapter_dry_run_request_hash": source.source_live_adapter_dry_run_request_hash,
+        **{field: source_raw[field] for field in COPIED_FIELDS},
+        "authority_evidence_reference_bundle": bundle.model_dump(mode="json"),
+        "authority_evidence_reference_bundle_digest": _digest(DOMAINS["bundle"], bundle),
+        "authority_evidence_linkage_result": result,
+        "authority_evidence_linkage_result_digest": _digest(DOMAINS["result"], result),
+        "authority_evidence_binding_matrix": matrix,
+        "authority_evidence_binding_matrix_digest": _digest(DOMAINS["matrix"], matrix),
+        "authority_evidence_linkage_checks": checks,
+        "authority_evidence_linkage_check_digest": _digest(DOMAINS["checks"], checks),
+        "future_human_approval_requirements": human,
+        "future_human_approval_requirement_digest": _digest(DOMAINS["human"], human),
+        "future_bind_authorization_requirements": bind,
+        "future_bind_authorization_requirement_digest": _digest(DOMAINS["bind"], bind),
+        "authority_evidence_linkage_status": STATUS,
+        "request_dispatch_state": "NOT_DISPATCHED", "bind_state": "NOT_BOUND",
+        "authority_state": "NOT_AUTHORIZED",
+        **{field: False for field in EFFECT_FIELDS if field in {
+            "authority_evidence_created", "human_approval_created",
+            "execution_authority_created", "bind_authorization_created", "bind_invoked",
+            "bind_receipt_created", "trustlog_written", "request_dispatched",
+            "endpoint_resolved", "credential_material_accessed",
+            "authorization_header_constructed", "network_used",
+            "live_adapter_instantiated", "webhook_called",
+        }},
+        "fail_closed": False, "scope_limitations": SCOPE_LIMITATIONS,
+    }
+    digest = _packet_hash(raw)
+    raw["live_adapter_dry_run_authority_evidence_linkage_review_hash"] = digest
+    raw["live_adapter_dry_run_authority_evidence_linkage_review_id"] = (
+        f"ladrael:v1:sha256:{digest}"
+    )
+    return verify_live_adapter_dry_run_authority_evidence_linkage_review_packet(raw)
+
+
+def verify_live_adapter_dry_run_authority_evidence_linkage_review_packet(
+    raw: Any,
+) -> CanonicalLiveAdapterDryRunAuthorityEvidenceLinkageReviewPacket:
+    """Reverify the source plus every derived value, digest, packet hash and ID."""
+    try:
+        value = raw.model_dump(mode="json") if isinstance(raw, BaseModel) else raw
+        packet = CanonicalLiveAdapterDryRunAuthorityEvidenceLinkageReviewPacket.model_validate(
+            _json(value)
+        )
+    except (ValidationError, TypeError,
+            LiveAdapterDryRunAuthorityEvidenceLinkageError) as exc:
+        raise LiveAdapterDryRunAuthorityEvidenceLinkageError(
+            "LADRAEL_PACKET_INVALID"
+        ) from exc
+    actual = packet.model_dump(mode="json")
+    source = _source(packet.source_bind_pre_dispatch_review_packet)
+    _validate_source(source)
+    source_raw = source.model_dump(mode="json")
+    identities = (
+        packet.source_bind_pre_dispatch_review_id == source.live_adapter_dry_run_bind_pre_dispatch_review_id,
+        packet.source_bind_pre_dispatch_review_hash == source.live_adapter_dry_run_bind_pre_dispatch_review_hash,
+        packet.source_operator_dispatch_review_hash == source.source_operator_dispatch_review_hash,
+        packet.source_credential_authorization_hash == source.source_credential_authorization_hash,
+        packet.source_endpoint_allowlist_evaluation_hash == source.source_endpoint_allowlist_evaluation_hash,
+        packet.source_dispatch_readiness_hash == source.source_dispatch_readiness_hash,
+        packet.source_live_adapter_dry_run_request_hash == source.source_live_adapter_dry_run_request_hash,
+    )
+    if not all(identities) or any(
+        _json(getattr(packet, field)) != _json(source_raw[field])
+        for field in COPIED_FIELDS
+    ):
+        raise LiveAdapterDryRunAuthorityEvidenceLinkageError("LADRAEL_SOURCE_MISMATCH")
+    recorded_at = _timestamp(packet.authority_evidence_linkage_review_recorded_at)
+    bundle = _bundle(packet.authority_evidence_reference_bundle, recorded_at)
+    matrix, result, checks, human, bind = _derived(source, bundle)
+    expected = (
+        packet.authority_evidence_reference_bundle_digest == _digest(DOMAINS["bundle"], bundle),
+        _json(packet.authority_evidence_binding_matrix) == matrix,
+        packet.authority_evidence_binding_matrix_digest == _digest(DOMAINS["matrix"], matrix),
+        _json(packet.authority_evidence_linkage_result) == result,
+        packet.authority_evidence_linkage_result_digest == _digest(DOMAINS["result"], result),
+        _json(packet.authority_evidence_linkage_checks) == checks,
+        packet.authority_evidence_linkage_check_digest == _digest(DOMAINS["checks"], checks),
+        _json(packet.future_human_approval_requirements) == human,
+        packet.future_human_approval_requirement_digest == _digest(DOMAINS["human"], human),
+        _json(packet.future_bind_authorization_requirements) == bind,
+        packet.future_bind_authorization_requirement_digest == _digest(DOMAINS["bind"], bind),
+        packet.scope_limitations == SCOPE_LIMITATIONS,
+    )
+    if not all(expected):
+        raise LiveAdapterDryRunAuthorityEvidenceLinkageError("LADRAEL_DERIVED_MISMATCH")
+    digest = _packet_hash(actual)
+    if packet.live_adapter_dry_run_authority_evidence_linkage_review_hash != digest:
+        raise LiveAdapterDryRunAuthorityEvidenceLinkageError("LADRAEL_HASH_MISMATCH")
+    if packet.live_adapter_dry_run_authority_evidence_linkage_review_id != (
+        f"ladrael:v1:sha256:{digest}"
+    ):
+        raise LiveAdapterDryRunAuthorityEvidenceLinkageError("LADRAEL_ID_MISMATCH")
+    return packet

--- a/veritas_os/tests/test_live_adapter_dry_run_authority_evidence_linkage.py
+++ b/veritas_os/tests/test_live_adapter_dry_run_authority_evidence_linkage.py
@@ -1,0 +1,312 @@
+"""Integrity, linkage, and non-effect tests for Authority Evidence review v1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from copy import deepcopy
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator, ValidationError
+
+from veritas_os.policy.live_adapter_dry_run_authority_evidence_linkage import (
+    BIND_REQUIREMENTS,
+    CHECK_NAMES,
+    EFFECT_FIELDS,
+    HUMAN_REQUIREMENTS,
+    SCOPE_LIMITATIONS,
+    LiveAdapterDryRunAuthorityEvidenceLinkageError,
+    _packet_hash,
+    build_live_adapter_dry_run_authority_evidence_linkage_review_packet,
+    verify_live_adapter_dry_run_authority_evidence_linkage_review_packet,
+)
+from veritas_os.tests.test_live_adapter_dry_run_bind_pre_dispatch_review import (
+    RECORDED_AT as SOURCE_RECORDED_AT,
+    _packet as source_packet,
+)
+
+RECORDED_AT = SOURCE_RECORDED_AT + timedelta(seconds=1)
+DEFAULT_SOURCE = source_packet()
+MODULE = Path(
+    "veritas_os/policy/live_adapter_dry_run_authority_evidence_linkage.py"
+)
+SCHEMA = Path(
+    "schemas/live-adapter-dry-run-authority-evidence-linkage-v1.schema.json"
+)
+
+
+def _reference(source=None, **changes):
+    source = source or DEFAULT_SOURCE
+    value = {
+        "authority_evidence_reference_id": "authority-ref:billing:v1",
+        "authority_evidence_kind": "delegated-policy-attestation",
+        "authority_source_type": "upstream-artifact",
+        "authority_source_id": "authority-source:billing:v1",
+        "authority_policy_id": "policy:billing:v1",
+        "authority_policy_version": "1",
+        "authority_scope": "billing-dispatch",
+        "authority_subject": "operator:alice",
+        "authority_issuer": "authority:billing",
+        "authority_issued_at": (RECORDED_AT - timedelta(days=1)).isoformat(),
+        "authority_expires_at": (RECORDED_AT + timedelta(days=1)).isoformat(),
+        "authority_evidence_hash": "sha256:declared-metadata-only",
+        "authority_evidence_format": "declared-reference/v1",
+        "declared_verification_state": "DECLARED_VERIFIED_BY_UPSTREAM_ARTIFACT",
+        "linked_execution_intent_id": source.execution_intent_id,
+        "linked_adapter_contract_id": source.adapter_contract_id,
+        "linked_endpoint_candidate_id": source.endpoint_candidate[
+            "endpoint_candidate_id"
+        ],
+        "linked_credential_reference_id": source.credential_reference[
+            "credential_reference_id"
+        ],
+        "linked_target_system": source.credential_reference["target_system"],
+        "linked_target_resource_scope": source.credential_reference[
+            "target_resource_scope"
+        ],
+        "linked_purpose": source.credential_reference["credential_purpose"],
+    }
+    value.update(changes)
+    return value
+
+
+def _bundle(source=None, references=None, **changes):
+    source = source or DEFAULT_SOURCE
+    value = {
+        "authority_evidence_reference_bundle_id": "authority-bundle:billing:v1",
+        "bundle_declared_by": "operator:alice",
+        "bundle_declared_at": RECORDED_AT.isoformat(),
+        "bundle_scope": ["billing-dispatch"],
+        "authority_evidence_references": (
+            [_reference(source)] if references is None else references
+        ),
+        "authority_evidence_binding_claims": [],
+        "bundle_limitations": ["metadata-only", "no-external-verification"],
+    }
+    value.update(changes)
+    return value
+
+
+def _packet(*, source=None, bundle=None, semantic_match=False):
+    source = source or (
+        source_packet(semantic_match=True) if semantic_match else DEFAULT_SOURCE
+    )
+    return build_live_adapter_dry_run_authority_evidence_linkage_review_packet(
+        source, bundle or _bundle(source), RECORDED_AT
+    )
+
+
+def _rehash(raw):
+    digest = _packet_hash(raw)
+    raw["live_adapter_dry_run_authority_evidence_linkage_review_hash"] = digest
+    raw["live_adapter_dry_run_authority_evidence_linkage_review_id"] = (
+        f"ladrael:v1:sha256:{digest}"
+    )
+
+
+def test_builder_creates_verified_exactly_linked_packet(monkeypatch) -> None:
+    import veritas_os.policy.live_adapter_dry_run_authority_evidence_linkage as module
+
+    actual = module.verify_live_adapter_dry_run_bind_pre_dispatch_review_packet
+    calls = []
+
+    def recording(value):
+        calls.append(value)
+        return actual(value)
+
+    monkeypatch.setattr(
+        module, "verify_live_adapter_dry_run_bind_pre_dispatch_review_packet",
+        recording,
+    )
+    packet = module.build_live_adapter_dry_run_authority_evidence_linkage_review_packet(
+        source_packet(), _bundle(), RECORDED_AT
+    )
+    assert len(calls) == 2
+    assert module.verify_live_adapter_dry_run_authority_evidence_linkage_review_packet(
+        packet
+    ) == packet
+    assert len(calls) == 3
+    assert not packet.fail_closed
+    assert packet.authority_state == "NOT_AUTHORIZED"
+    assert packet.authority_evidence_linkage_result.all_references_structurally_linked
+
+
+@pytest.mark.parametrize("change", [
+    {"unexpected": True}, {"authority_evidence_references": []},
+    {"bundle_scope": ["missing-scope"]},
+])
+def test_bundle_is_closed_and_required_references_cover_scope(change) -> None:
+    with pytest.raises(LiveAdapterDryRunAuthorityEvidenceLinkageError):
+        _packet(bundle=_bundle(**change))
+
+
+def test_duplicate_reference_ids_fail_closed() -> None:
+    reference = _reference()
+    with pytest.raises(LiveAdapterDryRunAuthorityEvidenceLinkageError):
+        _packet(bundle=_bundle(references=[reference, reference]))
+
+
+@pytest.mark.parametrize("state", [
+    "DECLARED_PENDING_EXTERNAL_VERIFICATION",
+    "DECLARED_REJECTED_BY_UPSTREAM_ARTIFACT",
+])
+def test_non_verified_declared_state_fails_closed(state) -> None:
+    with pytest.raises(LiveAdapterDryRunAuthorityEvidenceLinkageError):
+        _packet(bundle=_bundle(references=[_reference(
+            declared_verification_state=state
+        )]))
+
+
+def test_expired_reference_fails_closed() -> None:
+    with pytest.raises(LiveAdapterDryRunAuthorityEvidenceLinkageError):
+        _packet(bundle=_bundle(references=[_reference(
+            authority_expires_at=RECORDED_AT.isoformat()
+        )]))
+
+
+@pytest.mark.parametrize("field", [
+    "linked_execution_intent_id", "linked_adapter_contract_id",
+    "linked_endpoint_candidate_id", "linked_credential_reference_id",
+    "linked_target_system", "linked_target_resource_scope", "linked_purpose",
+])
+def test_every_structural_link_requires_exact_match(field) -> None:
+    with pytest.raises(LiveAdapterDryRunAuthorityEvidenceLinkageError):
+        _packet(bundle=_bundle(references=[_reference(**{field: "mismatch"})]))
+
+
+def test_source_fields_lineage_and_semantic_match_are_preserved() -> None:
+    source = source_packet(semantic_match=True)
+    packet = _packet(source=source)
+    raw = source.model_dump(mode="json")
+    for field in (
+        "request_descriptor", "execution_intent", "execution_intent_id",
+        "execution_intent_hash", "adapter_contract_descriptor",
+        "adapter_contract_id", "adapter_contract_hash", "adapter_contract_version",
+        "endpoint_candidate", "endpoint_identity_binding", "credential_reference",
+        "credential_scope_binding", "bind_pre_dispatch_review_decision",
+        "source_to_execution_intent_mapping", "field_mapping_proof",
+        "required_field_presence", "source_decision_identity", "candidate_identity",
+        "evidence_lineage", "replay_summary",
+    ):
+        actual = getattr(packet, field)
+        if hasattr(actual, "model_dump"):
+            actual = actual.model_dump(mode="json")
+        assert actual == raw[field]
+    assert packet.replay_summary["semantic_match"] is True
+    assert not packet.authority_evidence_linkage_result.semantic_match_used
+    assert not packet.authority_evidence_created
+
+
+def test_checks_matrix_requirements_and_limitations_are_deterministic() -> None:
+    first = _packet()
+    second = _packet()
+    assert first == second
+    assert tuple(check.name for check in first.authority_evidence_linkage_checks) == (
+        CHECK_NAMES
+    )
+    assert all(
+        check.ordinal == ordinal and not any(
+            getattr(check, field) for field in EFFECT_FIELDS
+        )
+        for ordinal, check in enumerate(first.authority_evidence_linkage_checks, 1)
+    )
+    assert tuple(x.name for x in first.future_human_approval_requirements) == (
+        HUMAN_REQUIREMENTS
+    )
+    assert tuple(x.name for x in first.future_bind_authorization_requirements) == (
+        BIND_REQUIREMENTS
+    )
+    assert first.scope_limitations == SCOPE_LIMITATIONS
+
+
+@pytest.mark.parametrize("field", [
+    "source_bind_pre_dispatch_review_packet", "authority_evidence_reference_bundle",
+    "authority_evidence_binding_matrix", "authority_evidence_linkage_result",
+    "authority_evidence_linkage_checks", "future_human_approval_requirements",
+    "future_bind_authorization_requirements", "scope_limitations",
+])
+def test_mutated_content_is_rejected_even_after_outer_rehash(field) -> None:
+    raw = _packet().model_dump(mode="json")
+    if field == "source_bind_pre_dispatch_review_packet":
+        raw[field]["request_descriptor"]["purpose"] = "forged"
+    elif field == "authority_evidence_reference_bundle":
+        raw[field]["bundle_declared_by"] = "forged"
+    elif field == "authority_evidence_binding_matrix":
+        raw[field][0]["actual_value"] = "forged"
+    elif field == "authority_evidence_linkage_result":
+        raw[field]["all_references_structurally_linked"] = False
+    elif field == "authority_evidence_linkage_checks":
+        raw[field][0]["evidence_ref"] = "forged"
+    elif field.startswith("future_"):
+        raw[field][0]["name"] = "forged"
+    else:
+        raw[field].reverse()
+    _rehash(raw)
+    with pytest.raises(LiveAdapterDryRunAuthorityEvidenceLinkageError):
+        verify_live_adapter_dry_run_authority_evidence_linkage_review_packet(raw)
+
+
+@pytest.mark.parametrize("field,value", [
+    ("fail_closed", True), ("authority_evidence_created", True),
+    ("human_approval_created", True), ("execution_authority_created", True),
+    ("bind_authorization_created", True),
+])
+def test_authority_or_fail_closed_mutation_is_rejected(field, value) -> None:
+    raw = _packet().model_dump(mode="json")
+    raw[field] = value
+    _rehash(raw)
+    with pytest.raises(LiveAdapterDryRunAuthorityEvidenceLinkageError):
+        verify_live_adapter_dry_run_authority_evidence_linkage_review_packet(raw)
+
+
+@pytest.mark.parametrize("field", [
+    "live_adapter_dry_run_authority_evidence_linkage_review_id",
+    "live_adapter_dry_run_authority_evidence_linkage_review_hash",
+])
+def test_forged_content_address_is_rejected(field) -> None:
+    raw = _packet().model_dump(mode="json")
+    raw[field] = "forged"
+    with pytest.raises(LiveAdapterDryRunAuthorityEvidenceLinkageError):
+        verify_live_adapter_dry_run_authority_evidence_linkage_review_packet(raw)
+
+
+def test_schema_validates_packet_and_rejects_mutation() -> None:
+    schema = json.loads(SCHEMA.read_text())
+    raw = _packet().model_dump(mode="json")
+    Draft202012Validator(schema).validate(raw)
+    raw["authority_evidence_created"] = True
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(raw)
+
+
+def test_module_has_no_prohibited_imports_or_calls() -> None:
+    tree = ast.parse(MODULE.read_text())
+    imports = {
+        alias.name.split(".")[0]
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.Import, ast.ImportFrom))
+        for alias in node.names
+    }
+    assert not imports.intersection({
+        "requests", "httpx", "urllib", "socket", "dns", "subprocess", "os",
+        "pathlib",
+    })
+    text = MODULE.read_text()
+    for prohibited in (
+        "WebhookBindAdapter", "BindReceipt", "TrustLog", "open(", "os.environ",
+        "read_text", "write_text", "credential_store", "verify_postconditions",
+        "revert(", "apply(",
+    ):
+        assert prohibited not in text
+
+
+def test_packet_hash_changes_with_content() -> None:
+    raw = _packet().model_dump(mode="json")
+    before = _packet_hash(raw)
+    changed = deepcopy(raw)
+    changed["authority_evidence_linkage_review_recorded_at"] = (
+        RECORDED_AT + timedelta(seconds=1)
+    ).isoformat()
+    assert _packet_hash(changed) != before


### PR DESCRIPTION
### Motivation

- Introduce a deterministic, local artifact that records whether declared Authority Evidence references are structurally linked to an already-verified, non-dispatched Bind pre-dispatch review packet without producing any external effects.
- Provide a content-addressed canonical packet that preserves source lineage and prevents forged/mutated evidence through domain-separated hashing and self-verification.
- Enforce strict closed schemas and deterministic ordered checks so downstream reviewers can reason about future Human Approval and Bind authorization requirements without any authority creation.
- Preserve replay fidelity (including `semantic_match`) while preventing promotion of semantic facts into Authority Evidence or execution authority.

### Description

- Add `veritas_os/policy/live_adapter_dry_run_authority_evidence_linkage.py` implementing closed Pydantic models for `AuthorityEvidenceReferenceBundle`, `AuthorityEvidenceReference`, `AuthorityEvidenceBindingClaim`, binding matrix, deterministic linkage result, ordered checks, future-human/future-bind requirements, and the canonical packet builder and verifier that re-verify the embedded Bind pre-dispatch review packet and recompute all digests and the packet id/hash.
- Add `veritas_os/tests/test_live_adapter_dry_run_authority_evidence_linkage.py` with comprehensive integrity, mutation-resistance, linkage, expiry, declared-state, schema, and prohibited-imports/effects tests that exercise both builder and verifier behaviour and the deterministic checks/matrix construction.
- Add `schemas/live-adapter-dry-run-authority-evidence-linkage-v1.schema.json` as a closed JSON Schema with strict const/enums for format/version/status, exact ordered checks, false effect flags, and scope limitations.
- Add documentation at `docs/en/architecture/live-adapter-dry-run-authority-evidence-linkage-v1.md` describing the purpose, deterministic local linkage rules, non-effect/security guarantees, and required future artifacts for Human Approval and Bind authorization.

### Security / non-effect guarantees

- The implementation is metadata-only: it does not fetch, resolve, or read authority evidence, credentials, endpoints, or network resources, and it does not write TrustLog, invoke Bind, create BindReceipts, create Human Approval, create execution authority, perform dispatch, instantiate adapters, call Webhooks, or perform any filesystem/database/provider/subprocess commits. All effect flags are constrained to false.
- The builder and verifier re-verify the source canonical Bind pre-dispatch packet using `verify_live_adapter_dry_run_bind_pre_dispatch_review_packet(...)` and will fail-closed on missing/duplicate/pending/rejected/expired/mutated references or any derived-value mismatch.
- This change touches Bind-boundary evidence and therefore requires human maintainer review before merge; it must not be treated as producing Authority Evidence, approvals, or authorization.

### Testing

- `pytest -q veritas_os/tests/test_live_adapter_dry_run_authority_evidence_linkage.py` — passed (35 passed).
- Full dry-run / Bind regression suite (combined tests listed in the AGENTS instructions) executed — passed (533 passed).
- `ruff check veritas_os/policy/live_adapter_dry_run_authority_evidence_linkage.py veritas_os/tests/test_live_adapter_dry_run_authority_evidence_linkage.py` — passed.
- `python -m py_compile veritas_os/policy/live_adapter_dry_run_authority_evidence_linkage.py` — OK.
- `python -m json.tool schemas/live-adapter-dry-run-authority-evidence-linkage-v1.schema.json` — OK.
- `git diff --check` — clean.

Final invariant

"Canonical Live Adapter Dry-Run Authority Evidence Linkage Review v1 now records a deterministic local linkage review for declared Authority Evidence references from a verified non-dispatched Bind pre-dispatch review packet without creating Authority Evidence, without externally verifying Authority Evidence, without creating Human Approval, without creating execution authority, without creating Bind authorization, without invoking Bind, without creating a BindReceipt, without writing TrustLog, without dispatching the request, without resolving endpoints, without accessing credential material, without constructing authorization headers, without network access, without instantiating a live adapter, without calling Webhook, without external effects, and without converting semantic_match into Authority Evidence, Human Approval, or execution authority."

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a849679d89c832682b85e2a14a66df3)