### PR TITLE
feat(bind): add live adapter dry-run final bind authorization readiness v1

### DIFF
--- a/docs/en/architecture/live-adapter-dry-run-final-bind-authorization-readiness-v1.md
+++ b/docs/en/architecture/live-adapter-dry-run-final-bind-authorization-readiness-v1.md
@@ -1,0 +1,63 @@
+# Live Adapter Dry-Run Final Bind Authorization Readiness v1
+
+## Purpose
+
+Canonical Live Adapter Dry-Run Final Bind Authorization Readiness v1 is
+content-addressed **Final Bind Authorization Readiness evidence**. It answers a
+single local question: is a verified, non-dispatched Human Approval linkage
+review path structurally ready to be considered by a separate future Bind
+authorization gate?
+
+The builder re-verifies the complete source packet, preserves its request and
+identity bindings, evaluates an explicit closed review decision, and emits 47
+ordered deterministic checks. Canonical JSON, UTC-normalized caller-supplied
+timestamps, explicit hash domains, and the `ladfbar:v1:sha256:` identifier make
+the result reproducible and mutation-evident.
+
+`semantic_match` in source lineage is preserved as source evidence, but it is
+not promoted into Human Approval, Authority Evidence, Bind authorization, or
+execution authority. The readiness result itself always records
+`semantic_match_used: false` because only exact local structural checks are used.
+
+## Security and non-effect boundary
+
+This packet is readiness evidence only. It:
+
+- does **not** create Bind authorization or invoke Bind;
+- does **not** create a BindReceipt or write TrustLog;
+- does **not** dispatch the request;
+- does **not** create execution authority, Human Approval, or Authority Evidence;
+- does **not** resolve endpoints or DNS;
+- does **not** access or embed credentials, tokens, or secrets;
+- does **not** construct authorization headers;
+- does **not** call a network, provider, or Webhook;
+- does **not** instantiate or call a live adapter; and
+- does **not** commit an operation or cause any external effect.
+
+All effect flags are fixed to false. The source remains `NOT_DISPATCHED`,
+`NOT_BOUND`, `NOT_AUTHORIZED`, and `NOT_APPROVED`. A rejected review is recorded
+as `NOT_READY_FOR_FUTURE_BIND_AUTHORIZATION_GATE` with `fail_closed: true`.
+Incomplete acknowledgements, invalid or mutated source evidence, and malformed
+review decisions are rejected rather than interpreted.
+
+## Separate future gates
+
+This artifact records—but does not satisfy—requirements for a future Bind
+authorization artifact. That separate artifact must cover real Authority
+Evidence and Human Approval verification where required, policy admissibility,
+runtime risk, endpoint and credential boundaries, authorization-header and
+idempotency boundaries, replay review, operator go/no-go confirmation, and an
+explicit Bind authorization decision boundary.
+
+A still-later, separate Bind invocation artifact must prove that authorization
+exists and explicitly govern dispatch, credential material, header construction,
+Bind invocation, BindReceipt creation, the post-Bind TrustLog boundary, and
+postcondition/rollback requirements. Creating this readiness packet satisfies
+none of those future requirements.
+
+## Human approval boundary
+
+This milestone touches Bind-readiness policy evidence and therefore requires
+human maintainer review under the repository authority model. It must not be
+treated as approval to merge, authorization to execute, or authorization to
+dispatch.

--- a/schemas/live-adapter-dry-run-final-bind-authorization-readiness-v1.schema.json
+++ b/schemas/live-adapter-dry-run-final-bind-authorization-readiness-v1.schema.json
@@ -1,0 +1,1720 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://veritas-os.example/schemas/live-adapter-dry-run-final-bind-authorization-readiness-v1.schema.json",
+  "title": "Canonical Live Adapter Dry-Run Final Bind Authorization Readiness Packet v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "format_version",
+    "live_adapter_dry_run_final_bind_authorization_readiness_id",
+    "live_adapter_dry_run_final_bind_authorization_readiness_hash",
+    "final_bind_authorization_readiness_mechanism",
+    "final_bind_authorization_readiness_recorded_at",
+    "source_human_approval_linkage_review_id",
+    "source_human_approval_linkage_review_hash",
+    "source_human_approval_linkage_review_packet",
+    "source_authority_evidence_linkage_review_hash",
+    "source_bind_pre_dispatch_review_hash",
+    "source_operator_dispatch_review_hash",
+    "source_credential_authorization_hash",
+    "source_endpoint_allowlist_evaluation_hash",
+    "source_dispatch_readiness_hash",
+    "source_live_adapter_dry_run_request_hash",
+    "request_descriptor",
+    "execution_intent",
+    "execution_intent_id",
+    "execution_intent_hash",
+    "adapter_contract_descriptor",
+    "adapter_contract_id",
+    "adapter_contract_hash",
+    "adapter_contract_version",
+    "endpoint_candidate",
+    "endpoint_candidate_digest",
+    "endpoint_identity_binding",
+    "endpoint_identity_binding_digest",
+    "credential_reference",
+    "credential_reference_digest",
+    "credential_scope_binding",
+    "credential_scope_binding_digest",
+    "authority_evidence_reference_bundle",
+    "authority_evidence_reference_bundle_digest",
+    "authority_evidence_linkage_result",
+    "authority_evidence_linkage_result_digest",
+    "human_approval_reference_bundle",
+    "human_approval_reference_bundle_digest",
+    "human_approval_linkage_result",
+    "human_approval_linkage_result_digest",
+    "final_bind_authorization_readiness_review_decision",
+    "final_bind_authorization_readiness_review_decision_digest",
+    "final_bind_authorization_readiness_result",
+    "final_bind_authorization_readiness_result_digest",
+    "final_bind_authorization_readiness_checks",
+    "final_bind_authorization_readiness_check_digest",
+    "future_bind_authorization_gate_requirements",
+    "future_bind_authorization_gate_requirements_digest",
+    "future_bind_invocation_requirements",
+    "future_bind_invocation_requirements_digest",
+    "source_to_execution_intent_mapping",
+    "field_mapping_proof",
+    "required_field_presence",
+    "source_decision_identity",
+    "candidate_identity",
+    "evidence_lineage",
+    "replay_summary",
+    "final_bind_authorization_readiness_status",
+    "request_dispatch_state",
+    "bind_state",
+    "authority_state",
+    "human_approval_state",
+    "final_readiness_state",
+    "authority_evidence_created",
+    "human_approval_created",
+    "execution_authority_created",
+    "bind_authorization_created",
+    "bind_invoked",
+    "bind_receipt_created",
+    "trustlog_written",
+    "request_dispatched",
+    "endpoint_resolved",
+    "credential_material_accessed",
+    "authorization_header_constructed",
+    "network_used",
+    "live_adapter_instantiated",
+    "webhook_called",
+    "fail_closed",
+    "scope_limitations"
+  ],
+  "properties": {
+    "format_version": {
+      "const": "canonical-live-adapter-dry-run-final-bind-authorization-readiness/v1"
+    },
+    "live_adapter_dry_run_final_bind_authorization_readiness_id": {
+      "type": "string"
+    },
+    "live_adapter_dry_run_final_bind_authorization_readiness_hash": {
+      "type": "string"
+    },
+    "final_bind_authorization_readiness_mechanism": {
+      "const": "evaluate_live_adapter_dry_run_final_bind_authorization_readiness_without_authorization/v1"
+    },
+    "final_bind_authorization_readiness_recorded_at": {
+      "type": "string"
+    },
+    "source_human_approval_linkage_review_id": {
+      "type": "string"
+    },
+    "source_human_approval_linkage_review_hash": {
+      "type": "string"
+    },
+    "source_human_approval_linkage_review_packet": {
+      "type": "object"
+    },
+    "source_authority_evidence_linkage_review_hash": {
+      "type": "string"
+    },
+    "source_bind_pre_dispatch_review_hash": {
+      "type": "string"
+    },
+    "source_operator_dispatch_review_hash": {
+      "type": "string"
+    },
+    "source_credential_authorization_hash": {
+      "type": "string"
+    },
+    "source_endpoint_allowlist_evaluation_hash": {
+      "type": "string"
+    },
+    "source_dispatch_readiness_hash": {
+      "type": "string"
+    },
+    "source_live_adapter_dry_run_request_hash": {
+      "type": "string"
+    },
+    "request_descriptor": {
+      "type": "object"
+    },
+    "execution_intent": {
+      "type": "object"
+    },
+    "execution_intent_id": {
+      "type": "string"
+    },
+    "execution_intent_hash": {
+      "type": "string"
+    },
+    "adapter_contract_descriptor": {
+      "type": "object"
+    },
+    "adapter_contract_id": {
+      "type": "string"
+    },
+    "adapter_contract_hash": {
+      "type": "string"
+    },
+    "adapter_contract_version": {
+      "type": "string"
+    },
+    "endpoint_candidate": {
+      "type": "object"
+    },
+    "endpoint_candidate_digest": {
+      "type": "string"
+    },
+    "endpoint_identity_binding": {
+      "type": "object"
+    },
+    "endpoint_identity_binding_digest": {
+      "type": "string"
+    },
+    "credential_reference": {
+      "type": "object"
+    },
+    "credential_reference_digest": {
+      "type": "string"
+    },
+    "credential_scope_binding": {
+      "type": "object"
+    },
+    "credential_scope_binding_digest": {
+      "type": "string"
+    },
+    "authority_evidence_reference_bundle": {
+      "type": "object"
+    },
+    "authority_evidence_reference_bundle_digest": {
+      "type": "string"
+    },
+    "authority_evidence_linkage_result": {
+      "type": "object"
+    },
+    "authority_evidence_linkage_result_digest": {
+      "type": "string"
+    },
+    "human_approval_reference_bundle": {
+      "type": "object"
+    },
+    "human_approval_reference_bundle_digest": {
+      "type": "string"
+    },
+    "human_approval_linkage_result": {
+      "type": "object"
+    },
+    "human_approval_linkage_result_digest": {
+      "type": "string"
+    },
+    "final_bind_authorization_readiness_review_decision": {
+      "$ref": "#/$defs/decision"
+    },
+    "final_bind_authorization_readiness_review_decision_digest": {
+      "type": "string"
+    },
+    "final_bind_authorization_readiness_result": {
+      "$ref": "#/$defs/result"
+    },
+    "final_bind_authorization_readiness_result_digest": {
+      "type": "string"
+    },
+    "final_bind_authorization_readiness_checks": {
+      "type": "array",
+      "prefixItems": [
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 1
+                },
+                "name": {
+                  "const": "source_human_approval_linkage_review_verified"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 2
+                },
+                "name": {
+                  "const": "source_request_not_dispatched"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 3
+                },
+                "name": {
+                  "const": "source_bind_not_invoked"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 4
+                },
+                "name": {
+                  "const": "source_bind_not_authorized"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 5
+                },
+                "name": {
+                  "const": "source_human_approval_linkage_passed"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 6
+                },
+                "name": {
+                  "const": "source_authority_evidence_linkage_passed"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 7
+                },
+                "name": {
+                  "const": "source_bind_pre_dispatch_review_passed"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 8
+                },
+                "name": {
+                  "const": "final_review_decision_closed_schema_valid"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 9
+                },
+                "name": {
+                  "const": "reviewer_identity_present"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 10
+                },
+                "name": {
+                  "const": "reviewer_role_present"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 11
+                },
+                "name": {
+                  "const": "reviewer_attestation_present"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 12
+                },
+                "name": {
+                  "const": "acknowledged_not_bind_authorization"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 13
+                },
+                "name": {
+                  "const": "acknowledged_no_bind_invocation"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 14
+                },
+                "name": {
+                  "const": "acknowledged_no_bind_receipt"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 15
+                },
+                "name": {
+                  "const": "acknowledged_no_trustlog_write"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 16
+                },
+                "name": {
+                  "const": "acknowledged_no_dispatch"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 17
+                },
+                "name": {
+                  "const": "acknowledged_no_execution_authority"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 18
+                },
+                "name": {
+                  "const": "acknowledged_no_human_approval_creation"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 19
+                },
+                "name": {
+                  "const": "acknowledged_no_authority_evidence_creation"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 20
+                },
+                "name": {
+                  "const": "acknowledged_no_credential_access"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 21
+                },
+                "name": {
+                  "const": "acknowledged_no_authorization_header"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 22
+                },
+                "name": {
+                  "const": "acknowledged_no_network_call"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 23
+                },
+                "name": {
+                  "const": "acknowledged_semantic_match_not_authority"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 24
+                },
+                "name": {
+                  "const": "request_descriptor_preserved"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 25
+                },
+                "name": {
+                  "const": "execution_intent_identity_preserved"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 26
+                },
+                "name": {
+                  "const": "adapter_contract_identity_preserved"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 27
+                },
+                "name": {
+                  "const": "endpoint_identity_binding_preserved"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 28
+                },
+                "name": {
+                  "const": "credential_scope_binding_preserved"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 29
+                },
+                "name": {
+                  "const": "authority_evidence_linkage_result_preserved"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 30
+                },
+                "name": {
+                  "const": "human_approval_linkage_result_preserved"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 31
+                },
+                "name": {
+                  "const": "final_readiness_result_constructed"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 32
+                },
+                "name": {
+                  "const": "future_bind_authorization_gate_required"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 33
+                },
+                "name": {
+                  "const": "future_bind_invocation_gate_required"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 34
+                },
+                "name": {
+                  "const": "bind_authorization_not_created"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 35
+                },
+                "name": {
+                  "const": "execution_authority_not_created"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 36
+                },
+                "name": {
+                  "const": "human_approval_not_created"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 37
+                },
+                "name": {
+                  "const": "authority_evidence_not_created"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 38
+                },
+                "name": {
+                  "const": "bind_not_invoked"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 39
+                },
+                "name": {
+                  "const": "bind_receipt_not_created"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 40
+                },
+                "name": {
+                  "const": "trustlog_not_written"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 41
+                },
+                "name": {
+                  "const": "request_not_dispatched"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 42
+                },
+                "name": {
+                  "const": "endpoint_not_resolved"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 43
+                },
+                "name": {
+                  "const": "credential_material_not_accessed"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 44
+                },
+                "name": {
+                  "const": "authorization_header_not_constructed"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 45
+                },
+                "name": {
+                  "const": "network_not_used"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 46
+                },
+                "name": {
+                  "const": "webhook_not_called"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/check"
+            },
+            {
+              "properties": {
+                "ordinal": {
+                  "const": 47
+                },
+                "name": {
+                  "const": "live_adapter_not_instantiated"
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ]
+            }
+          ]
+        }
+      ],
+      "items": false
+    },
+    "final_bind_authorization_readiness_check_digest": {
+      "type": "string"
+    },
+    "future_bind_authorization_gate_requirements": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/requirement"
+      }
+    },
+    "future_bind_authorization_gate_requirements_digest": {
+      "type": "string"
+    },
+    "future_bind_invocation_requirements": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/requirement"
+      }
+    },
+    "future_bind_invocation_requirements_digest": {
+      "type": "string"
+    },
+    "source_to_execution_intent_mapping": {
+      "type": "object"
+    },
+    "field_mapping_proof": {
+      "type": "object"
+    },
+    "required_field_presence": {
+      "type": "object"
+    },
+    "source_decision_identity": {
+      "type": "object"
+    },
+    "candidate_identity": {
+      "type": "object"
+    },
+    "evidence_lineage": {
+      "type": "object"
+    },
+    "replay_summary": {
+      "type": "object"
+    },
+    "final_bind_authorization_readiness_status": {
+      "const": "LIVE_ADAPTER_DRY_RUN_FINAL_BIND_AUTHORIZATION_READINESS_RECORDED_NOT_AUTHORIZED"
+    },
+    "request_dispatch_state": {
+      "const": "NOT_DISPATCHED"
+    },
+    "bind_state": {
+      "const": "NOT_BOUND"
+    },
+    "authority_state": {
+      "const": "NOT_AUTHORIZED"
+    },
+    "human_approval_state": {
+      "const": "NOT_APPROVED"
+    },
+    "final_readiness_state": {
+      "enum": [
+        "READY_FOR_FUTURE_BIND_AUTHORIZATION_GATE",
+        "NOT_READY_FOR_FUTURE_BIND_AUTHORIZATION_GATE"
+      ]
+    },
+    "authority_evidence_created": {
+      "const": false
+    },
+    "human_approval_created": {
+      "const": false
+    },
+    "execution_authority_created": {
+      "const": false
+    },
+    "bind_authorization_created": {
+      "const": false
+    },
+    "bind_invoked": {
+      "const": false
+    },
+    "bind_receipt_created": {
+      "const": false
+    },
+    "trustlog_written": {
+      "const": false
+    },
+    "request_dispatched": {
+      "const": false
+    },
+    "endpoint_resolved": {
+      "const": false
+    },
+    "credential_material_accessed": {
+      "const": false
+    },
+    "authorization_header_constructed": {
+      "const": false
+    },
+    "network_used": {
+      "const": false
+    },
+    "live_adapter_instantiated": {
+      "const": false
+    },
+    "webhook_called": {
+      "const": false
+    },
+    "fail_closed": {
+      "type": "boolean"
+    },
+    "scope_limitations": {
+      "type": "array",
+      "prefixItems": [
+        {
+          "const": "NOT_DISPATCHED"
+        },
+        {
+          "const": "NOT_BIND_INVOCATION"
+        },
+        {
+          "const": "NOT_BIND_AUTHORIZATION"
+        },
+        {
+          "const": "NOT_BIND_AUTHORIZATION_CREATION"
+        },
+        {
+          "const": "NOT_BIND_RECEIPT"
+        },
+        {
+          "const": "NOT_TRUSTLOG_WRITE"
+        },
+        {
+          "const": "NOT_EXECUTION_AUTHORITY"
+        },
+        {
+          "const": "NOT_HUMAN_APPROVAL"
+        },
+        {
+          "const": "NOT_HUMAN_APPROVAL_CREATION"
+        },
+        {
+          "const": "NOT_AUTHORITY_EVIDENCE"
+        },
+        {
+          "const": "NOT_AUTHORITY_EVIDENCE_CREATION"
+        },
+        {
+          "const": "NOT_CREDENTIAL_RESOLUTION"
+        },
+        {
+          "const": "NOT_CREDENTIAL_ACCESS"
+        },
+        {
+          "const": "NOT_CREDENTIAL_EMBEDDING"
+        },
+        {
+          "const": "NOT_AUTHORIZATION_HEADER"
+        },
+        {
+          "const": "NOT_TOKEN"
+        },
+        {
+          "const": "NOT_SECRET"
+        },
+        {
+          "const": "NOT_ENDPOINT_RESOLUTION"
+        },
+        {
+          "const": "NOT_DNS_RESOLUTION"
+        },
+        {
+          "const": "NOT_NETWORK_CALL"
+        },
+        {
+          "const": "NOT_WEBHOOK_CALL"
+        },
+        {
+          "const": "NOT_LIVE_ADAPTER_INSTANCE"
+        },
+        {
+          "const": "NOT_LIVE_ADAPTER_RESULT"
+        },
+        {
+          "const": "NOT_OPERATION_COMMIT"
+        },
+        {
+          "const": "NOT_PRODUCTION_CLAIM"
+        },
+        {
+          "const": "NOT_CUSTOMER_CLAIM"
+        },
+        {
+          "const": "NOT_REGULATORY_CERTIFICATION"
+        }
+      ],
+      "items": false,
+      "minItems": 27,
+      "maxItems": 27
+    }
+  },
+  "$defs": {
+    "decision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "final_bind_authorization_readiness_review_decision_id",
+        "reviewer_id",
+        "reviewer_role",
+        "reviewer_attestation",
+        "reviewed_at",
+        "review_outcome",
+        "review_reason",
+        "acknowledged_not_bind_authorization",
+        "acknowledged_no_bind_invocation",
+        "acknowledged_no_bind_receipt",
+        "acknowledged_no_trustlog_write",
+        "acknowledged_no_dispatch",
+        "acknowledged_no_execution_authority",
+        "acknowledged_no_human_approval_creation",
+        "acknowledged_no_authority_evidence_creation",
+        "acknowledged_no_credential_access",
+        "acknowledged_no_authorization_header",
+        "acknowledged_no_network_call",
+        "acknowledged_semantic_match_not_authority"
+      ],
+      "properties": {
+        "final_bind_authorization_readiness_review_decision_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "reviewer_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "reviewer_role": {
+          "type": "string",
+          "minLength": 1
+        },
+        "reviewer_attestation": {
+          "type": "string",
+          "minLength": 1
+        },
+        "reviewed_at": {
+          "type": "string",
+          "minLength": 1
+        },
+        "review_outcome": {
+          "enum": [
+            "ACCEPTED_FOR_FUTURE_BIND_AUTHORIZATION_GATE_REVIEW",
+            "REJECTED_FOR_FUTURE_BIND_AUTHORIZATION_GATE_REVIEW"
+          ]
+        },
+        "review_reason": {
+          "type": "string",
+          "minLength": 1
+        },
+        "acknowledged_not_bind_authorization": {
+          "const": true
+        },
+        "acknowledged_no_bind_invocation": {
+          "const": true
+        },
+        "acknowledged_no_bind_receipt": {
+          "const": true
+        },
+        "acknowledged_no_trustlog_write": {
+          "const": true
+        },
+        "acknowledged_no_dispatch": {
+          "const": true
+        },
+        "acknowledged_no_execution_authority": {
+          "const": true
+        },
+        "acknowledged_no_human_approval_creation": {
+          "const": true
+        },
+        "acknowledged_no_authority_evidence_creation": {
+          "const": true
+        },
+        "acknowledged_no_credential_access": {
+          "const": true
+        },
+        "acknowledged_no_authorization_header": {
+          "const": true
+        },
+        "acknowledged_no_network_call": {
+          "const": true
+        },
+        "acknowledged_semantic_match_not_authority": {
+          "const": true
+        }
+      }
+    },
+    "result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source_human_approval_linkage_passed",
+        "source_authority_evidence_linkage_passed",
+        "source_bind_pre_dispatch_review_passed",
+        "all_required_local_linkage_artifacts_present",
+        "all_required_local_linkage_artifacts_verified",
+        "accepted_for_future_bind_authorization_gate_review",
+        "rejection_reasons",
+        "comparison_mode",
+        "semantic_match_used",
+        "creates_bind_authorization",
+        "creates_execution_authority",
+        "creates_human_approval",
+        "creates_authority_evidence"
+      ],
+      "properties": {
+        "source_human_approval_linkage_passed": {
+          "type": "boolean"
+        },
+        "source_authority_evidence_linkage_passed": {
+          "type": "boolean"
+        },
+        "source_bind_pre_dispatch_review_passed": {
+          "type": "boolean"
+        },
+        "all_required_local_linkage_artifacts_present": {
+          "type": "boolean"
+        },
+        "all_required_local_linkage_artifacts_verified": {
+          "type": "boolean"
+        },
+        "accepted_for_future_bind_authorization_gate_review": {
+          "type": "boolean"
+        },
+        "rejection_reasons": {
+          "type": "array"
+        },
+        "comparison_mode": {
+          "const": "deterministic_local_final_bind_authorization_readiness_only"
+        },
+        "semantic_match_used": {
+          "const": false
+        },
+        "creates_bind_authorization": {
+          "const": false
+        },
+        "creates_execution_authority": {
+          "const": false
+        },
+        "creates_human_approval": {
+          "const": false
+        },
+        "creates_authority_evidence": {
+          "const": false
+        }
+      }
+    },
+    "check": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "check_id",
+        "ordinal",
+        "name",
+        "mode",
+        "passed",
+        "evidence_ref",
+        "bind_authorization_created",
+        "execution_authority_created",
+        "human_approval_created",
+        "authority_evidence_created",
+        "bind_invoked",
+        "bind_receipt_created",
+        "trustlog_written",
+        "request_dispatched",
+        "endpoint_resolved",
+        "credential_material_accessed",
+        "credential_material_embedded",
+        "authorization_header_constructed",
+        "token_embedded",
+        "secret_embedded",
+        "network_used",
+        "dns_used",
+        "webhook_called",
+        "live_adapter_instantiated",
+        "live_adapter_method_called",
+        "external_effect_used",
+        "filesystem_used",
+        "database_used",
+        "provider_used",
+        "subprocess_used",
+        "operation_committed"
+      ],
+      "properties": {
+        "check_id": {
+          "type": "string"
+        },
+        "ordinal": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "mode": {
+          "const": "deterministic_local_final_bind_authorization_readiness_only"
+        },
+        "passed": {
+          "type": "boolean"
+        },
+        "evidence_ref": {
+          "type": "string"
+        },
+        "bind_authorization_created": {
+          "const": false
+        },
+        "execution_authority_created": {
+          "const": false
+        },
+        "human_approval_created": {
+          "const": false
+        },
+        "authority_evidence_created": {
+          "const": false
+        },
+        "bind_invoked": {
+          "const": false
+        },
+        "bind_receipt_created": {
+          "const": false
+        },
+        "trustlog_written": {
+          "const": false
+        },
+        "request_dispatched": {
+          "const": false
+        },
+        "endpoint_resolved": {
+          "const": false
+        },
+        "credential_material_accessed": {
+          "const": false
+        },
+        "credential_material_embedded": {
+          "const": false
+        },
+        "authorization_header_constructed": {
+          "const": false
+        },
+        "token_embedded": {
+          "const": false
+        },
+        "secret_embedded": {
+          "const": false
+        },
+        "network_used": {
+          "const": false
+        },
+        "dns_used": {
+          "const": false
+        },
+        "webhook_called": {
+          "const": false
+        },
+        "live_adapter_instantiated": {
+          "const": false
+        },
+        "live_adapter_method_called": {
+          "const": false
+        },
+        "external_effect_used": {
+          "const": false
+        },
+        "filesystem_used": {
+          "const": false
+        },
+        "database_used": {
+          "const": false
+        },
+        "provider_used": {
+          "const": false
+        },
+        "subprocess_used": {
+          "const": false
+        },
+        "operation_committed": {
+          "const": false
+        }
+      }
+    },
+    "requirement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "ordinal",
+        "name",
+        "separate_future_artifact_required",
+        "satisfied_by_this_packet"
+      ],
+      "properties": {
+        "ordinal": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "name": {
+          "type": "string"
+        },
+        "separate_future_artifact_required": {
+          "const": true
+        },
+        "satisfied_by_this_packet": {
+          "const": false
+        }
+      }
+    }
+  }
+}

--- a/veritas_os/policy/live_adapter_dry_run_final_bind_authorization_readiness.py
+++ b/veritas_os/policy/live_adapter_dry_run_final_bind_authorization_readiness.py
@@ -1,0 +1,547 @@
+"""Record final Bind authorization readiness without creating authority.
+
+This module performs only deterministic, local comparisons over a previously
+verified Human Approval linkage review packet.  It deliberately has no runtime,
+credential, persistence, adapter, or transport dependencies.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from veritas_os.policy.live_adapter_dry_run_human_approval_linkage import (
+    CanonicalLiveAdapterDryRunHumanApprovalLinkageReviewPacket,
+    LiveAdapterDryRunHumanApprovalLinkageError,
+    verify_live_adapter_dry_run_human_approval_linkage_review_packet,
+)
+
+FORMAT_VERSION = "canonical-live-adapter-dry-run-final-bind-authorization-readiness/v1"
+MECHANISM = (
+    "evaluate_live_adapter_dry_run_final_bind_authorization_readiness_without_"
+    "authorization/v1"
+)
+STATUS = "LIVE_ADAPTER_DRY_RUN_FINAL_BIND_AUTHORIZATION_READINESS_RECORDED_NOT_AUTHORIZED"
+SOURCE_STATUS = "LIVE_ADAPTER_DRY_RUN_HUMAN_APPROVAL_LINKAGE_REVIEWED_NOT_APPROVED"
+CHECK_MODE = "deterministic_local_final_bind_authorization_readiness_only"
+OUTCOMES = (
+    "ACCEPTED_FOR_FUTURE_BIND_AUTHORIZATION_GATE_REVIEW",
+    "REJECTED_FOR_FUTURE_BIND_AUTHORIZATION_GATE_REVIEW",
+)
+CHECK_NAMES = (
+    "source_human_approval_linkage_review_verified", "source_request_not_dispatched",
+    "source_bind_not_invoked", "source_bind_not_authorized",
+    "source_human_approval_linkage_passed", "source_authority_evidence_linkage_passed",
+    "source_bind_pre_dispatch_review_passed", "final_review_decision_closed_schema_valid",
+    "reviewer_identity_present", "reviewer_role_present", "reviewer_attestation_present",
+    "acknowledged_not_bind_authorization", "acknowledged_no_bind_invocation",
+    "acknowledged_no_bind_receipt", "acknowledged_no_trustlog_write",
+    "acknowledged_no_dispatch", "acknowledged_no_execution_authority",
+    "acknowledged_no_human_approval_creation",
+    "acknowledged_no_authority_evidence_creation", "acknowledged_no_credential_access",
+    "acknowledged_no_authorization_header", "acknowledged_no_network_call",
+    "acknowledged_semantic_match_not_authority", "request_descriptor_preserved",
+    "execution_intent_identity_preserved", "adapter_contract_identity_preserved",
+    "endpoint_identity_binding_preserved", "credential_scope_binding_preserved",
+    "authority_evidence_linkage_result_preserved", "human_approval_linkage_result_preserved",
+    "final_readiness_result_constructed", "future_bind_authorization_gate_required",
+    "future_bind_invocation_gate_required", "bind_authorization_not_created",
+    "execution_authority_not_created", "human_approval_not_created",
+    "authority_evidence_not_created", "bind_not_invoked", "bind_receipt_not_created",
+    "trustlog_not_written", "request_not_dispatched", "endpoint_not_resolved",
+    "credential_material_not_accessed", "authorization_header_not_constructed",
+    "network_not_used", "webhook_not_called", "live_adapter_not_instantiated",
+)
+EFFECT_FIELDS = (
+    "bind_authorization_created", "execution_authority_created", "human_approval_created",
+    "authority_evidence_created", "bind_invoked", "bind_receipt_created",
+    "trustlog_written", "request_dispatched", "endpoint_resolved",
+    "credential_material_accessed", "credential_material_embedded",
+    "authorization_header_constructed", "token_embedded", "secret_embedded",
+    "network_used", "dns_used", "webhook_called", "live_adapter_instantiated",
+    "live_adapter_method_called", "external_effect_used", "filesystem_used",
+    "database_used", "provider_used", "subprocess_used", "operation_committed",
+)
+ACKNOWLEDGEMENTS = (
+    "acknowledged_not_bind_authorization", "acknowledged_no_bind_invocation",
+    "acknowledged_no_bind_receipt", "acknowledged_no_trustlog_write",
+    "acknowledged_no_dispatch", "acknowledged_no_execution_authority",
+    "acknowledged_no_human_approval_creation",
+    "acknowledged_no_authority_evidence_creation", "acknowledged_no_credential_access",
+    "acknowledged_no_authorization_header", "acknowledged_no_network_call",
+    "acknowledged_semantic_match_not_authority",
+)
+SCOPE_LIMITATIONS = (
+    "NOT_DISPATCHED", "NOT_BIND_INVOCATION", "NOT_BIND_AUTHORIZATION",
+    "NOT_BIND_AUTHORIZATION_CREATION", "NOT_BIND_RECEIPT", "NOT_TRUSTLOG_WRITE",
+    "NOT_EXECUTION_AUTHORITY", "NOT_HUMAN_APPROVAL", "NOT_HUMAN_APPROVAL_CREATION",
+    "NOT_AUTHORITY_EVIDENCE", "NOT_AUTHORITY_EVIDENCE_CREATION",
+    "NOT_CREDENTIAL_RESOLUTION", "NOT_CREDENTIAL_ACCESS", "NOT_CREDENTIAL_EMBEDDING",
+    "NOT_AUTHORIZATION_HEADER", "NOT_TOKEN", "NOT_SECRET", "NOT_ENDPOINT_RESOLUTION",
+    "NOT_DNS_RESOLUTION", "NOT_NETWORK_CALL", "NOT_WEBHOOK_CALL",
+    "NOT_LIVE_ADAPTER_INSTANCE", "NOT_LIVE_ADAPTER_RESULT", "NOT_OPERATION_COMMIT",
+    "NOT_PRODUCTION_CLAIM", "NOT_CUSTOMER_CLAIM", "NOT_REGULATORY_CERTIFICATION",
+)
+AUTHORIZATION_REQUIREMENTS = (
+    "real_authority_evidence_verification", "real_human_approval_verification_where_required",
+    "final_policy_admissibility", "final_runtime_risk_review",
+    "final_endpoint_identity_binding", "final_credential_resolution_authorization",
+    "final_authorization_header_construction_boundary", "idempotency_key_binding",
+    "final_no_replay_no_duplicate_dispatch_review",
+    "final_operator_human_go_no_go_confirmation", "bind_authorization_decision_boundary",
+)
+INVOCATION_REQUIREMENTS = (
+    "bind_authorization_exists", "request_dispatch_boundary_approved",
+    "credential_material_boundary_controlled",
+    "authorization_header_construction_boundary_controlled",
+    "bind_invocation_boundary_explicit", "bind_receipt_creation_boundary_explicit",
+    "trustlog_write_boundary_after_bind_explicit",
+    "postcondition_and_rollback_requirements_exist_for_later_apply_path",
+)
+DOMAINS = {
+    "decision": "veritas.live-adapter-dry-run-final-bind-authorization-readiness.review-decision/v1",
+    "result": "veritas.live-adapter-dry-run-final-bind-authorization-readiness.result/v1",
+    "checks": "veritas.live-adapter-dry-run-final-bind-authorization-readiness.checks/v1",
+    "authorization": "veritas.live-adapter-dry-run-final-bind-authorization-readiness.future-bind-authorization-gate-requirements/v1",
+    "invocation": "veritas.live-adapter-dry-run-final-bind-authorization-readiness.future-bind-invocation-requirements/v1",
+    "packet": "veritas.live-adapter-dry-run-final-bind-authorization-readiness.packet/v1",
+}
+COPIED_FIELDS = (
+    "request_descriptor", "execution_intent", "execution_intent_id", "execution_intent_hash",
+    "adapter_contract_descriptor", "adapter_contract_id", "adapter_contract_hash",
+    "adapter_contract_version", "endpoint_candidate", "endpoint_candidate_digest",
+    "endpoint_identity_binding", "endpoint_identity_binding_digest", "credential_reference",
+    "credential_reference_digest", "credential_scope_binding", "credential_scope_binding_digest",
+    "authority_evidence_reference_bundle", "authority_evidence_reference_bundle_digest",
+    "authority_evidence_linkage_result", "authority_evidence_linkage_result_digest",
+    "human_approval_reference_bundle", "human_approval_reference_bundle_digest",
+    "human_approval_linkage_result", "human_approval_linkage_result_digest",
+    "source_to_execution_intent_mapping", "field_mapping_proof", "required_field_presence",
+    "source_decision_identity", "candidate_identity", "evidence_lineage", "replay_summary",
+)
+
+
+class LiveAdapterDryRunFinalBindAuthorizationReadinessError(ValueError):
+    """Stable fail-closed error for invalid final readiness evidence."""
+
+
+class FinalBindAuthorizationReadinessReviewDecision(BaseModel):
+    """Closed human review metadata that explicitly is not authorization."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    final_bind_authorization_readiness_review_decision_id: str = Field(min_length=1)
+    reviewer_id: str = Field(min_length=1)
+    reviewer_role: str = Field(min_length=1)
+    reviewer_attestation: str = Field(min_length=1)
+    reviewed_at: str
+    review_outcome: Literal[*OUTCOMES]
+    review_reason: str = Field(min_length=1)
+    acknowledged_not_bind_authorization: bool
+    acknowledged_no_bind_invocation: bool
+    acknowledged_no_bind_receipt: bool
+    acknowledged_no_trustlog_write: bool
+    acknowledged_no_dispatch: bool
+    acknowledged_no_execution_authority: bool
+    acknowledged_no_human_approval_creation: bool
+    acknowledged_no_authority_evidence_creation: bool
+    acknowledged_no_credential_access: bool
+    acknowledged_no_authorization_header: bool
+    acknowledged_no_network_call: bool
+    acknowledged_semantic_match_not_authority: bool
+
+
+class FinalReadinessResult(BaseModel):
+    """Deterministic readiness conclusion with explicit non-authority flags."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    source_human_approval_linkage_passed: bool
+    source_authority_evidence_linkage_passed: bool
+    source_bind_pre_dispatch_review_passed: bool
+    all_required_local_linkage_artifacts_present: bool
+    all_required_local_linkage_artifacts_verified: bool
+    accepted_for_future_bind_authorization_gate_review: bool
+    rejection_reasons: tuple[str, ...]
+    comparison_mode: Literal[CHECK_MODE]
+    semantic_match_used: Literal[False]
+    creates_bind_authorization: Literal[False]
+    creates_execution_authority: Literal[False]
+    creates_human_approval: Literal[False]
+    creates_authority_evidence: Literal[False]
+
+
+class ReadinessCheck(BaseModel):
+    """One ordered local check whose effect flags are all false."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    check_id: str
+    ordinal: int = Field(ge=1, le=47)
+    name: Literal[*CHECK_NAMES]
+    mode: Literal[CHECK_MODE]
+    passed: bool
+    evidence_ref: str
+    bind_authorization_created: Literal[False]
+    execution_authority_created: Literal[False]
+    human_approval_created: Literal[False]
+    authority_evidence_created: Literal[False]
+    bind_invoked: Literal[False]
+    bind_receipt_created: Literal[False]
+    trustlog_written: Literal[False]
+    request_dispatched: Literal[False]
+    endpoint_resolved: Literal[False]
+    credential_material_accessed: Literal[False]
+    credential_material_embedded: Literal[False]
+    authorization_header_constructed: Literal[False]
+    token_embedded: Literal[False]
+    secret_embedded: Literal[False]
+    network_used: Literal[False]
+    dns_used: Literal[False]
+    webhook_called: Literal[False]
+    live_adapter_instantiated: Literal[False]
+    live_adapter_method_called: Literal[False]
+    external_effect_used: Literal[False]
+    filesystem_used: Literal[False]
+    database_used: Literal[False]
+    provider_used: Literal[False]
+    subprocess_used: Literal[False]
+    operation_committed: Literal[False]
+
+
+class FutureRequirement(BaseModel):
+    """A requirement that only a separate future artifact may satisfy."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    ordinal: int
+    name: str
+    separate_future_artifact_required: Literal[True]
+    satisfied_by_this_packet: Literal[False]
+
+
+class CanonicalLiveAdapterDryRunFinalBindAuthorizationReadinessPacket(BaseModel):
+    """Closed content-addressed final readiness packet without authorization."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    format_version: Literal[FORMAT_VERSION]
+    live_adapter_dry_run_final_bind_authorization_readiness_id: str
+    live_adapter_dry_run_final_bind_authorization_readiness_hash: str
+    final_bind_authorization_readiness_mechanism: Literal[MECHANISM]
+    final_bind_authorization_readiness_recorded_at: str
+    source_human_approval_linkage_review_id: str
+    source_human_approval_linkage_review_hash: str
+    source_human_approval_linkage_review_packet: dict[str, Any]
+    source_authority_evidence_linkage_review_hash: str
+    source_bind_pre_dispatch_review_hash: str
+    source_operator_dispatch_review_hash: str
+    source_credential_authorization_hash: str
+    source_endpoint_allowlist_evaluation_hash: str
+    source_dispatch_readiness_hash: str
+    source_live_adapter_dry_run_request_hash: str
+    request_descriptor: dict[str, Any]
+    execution_intent: dict[str, Any]
+    execution_intent_id: str
+    execution_intent_hash: str
+    adapter_contract_descriptor: dict[str, Any]
+    adapter_contract_id: str
+    adapter_contract_hash: str
+    adapter_contract_version: str
+    endpoint_candidate: dict[str, Any]
+    endpoint_candidate_digest: str
+    endpoint_identity_binding: dict[str, Any]
+    endpoint_identity_binding_digest: str
+    credential_reference: dict[str, Any]
+    credential_reference_digest: str
+    credential_scope_binding: dict[str, Any]
+    credential_scope_binding_digest: str
+    authority_evidence_reference_bundle: dict[str, Any]
+    authority_evidence_reference_bundle_digest: str
+    authority_evidence_linkage_result: dict[str, Any]
+    authority_evidence_linkage_result_digest: str
+    human_approval_reference_bundle: dict[str, Any]
+    human_approval_reference_bundle_digest: str
+    human_approval_linkage_result: dict[str, Any]
+    human_approval_linkage_result_digest: str
+    final_bind_authorization_readiness_review_decision: FinalBindAuthorizationReadinessReviewDecision
+    final_bind_authorization_readiness_review_decision_digest: str
+    final_bind_authorization_readiness_result: FinalReadinessResult
+    final_bind_authorization_readiness_result_digest: str
+    final_bind_authorization_readiness_checks: tuple[ReadinessCheck, ...]
+    final_bind_authorization_readiness_check_digest: str
+    future_bind_authorization_gate_requirements: tuple[FutureRequirement, ...]
+    future_bind_authorization_gate_requirements_digest: str
+    future_bind_invocation_requirements: tuple[FutureRequirement, ...]
+    future_bind_invocation_requirements_digest: str
+    source_to_execution_intent_mapping: dict[str, Any]
+    field_mapping_proof: dict[str, Any]
+    required_field_presence: dict[str, str]
+    source_decision_identity: dict[str, Any]
+    candidate_identity: dict[str, Any]
+    evidence_lineage: dict[str, Any]
+    replay_summary: dict[str, Any]
+    final_bind_authorization_readiness_status: Literal[STATUS]
+    request_dispatch_state: Literal["NOT_DISPATCHED"]
+    bind_state: Literal["NOT_BOUND"]
+    authority_state: Literal["NOT_AUTHORIZED"]
+    human_approval_state: Literal["NOT_APPROVED"]
+    final_readiness_state: Literal[
+        "READY_FOR_FUTURE_BIND_AUTHORIZATION_GATE",
+        "NOT_READY_FOR_FUTURE_BIND_AUTHORIZATION_GATE",
+    ]
+    authority_evidence_created: Literal[False]
+    human_approval_created: Literal[False]
+    execution_authority_created: Literal[False]
+    bind_authorization_created: Literal[False]
+    bind_invoked: Literal[False]
+    bind_receipt_created: Literal[False]
+    trustlog_written: Literal[False]
+    request_dispatched: Literal[False]
+    endpoint_resolved: Literal[False]
+    credential_material_accessed: Literal[False]
+    authorization_header_constructed: Literal[False]
+    network_used: Literal[False]
+    live_adapter_instantiated: Literal[False]
+    webhook_called: Literal[False]
+    fail_closed: bool
+    scope_limitations: tuple[Literal[*SCOPE_LIMITATIONS], ...]
+
+
+def _timestamp(value: Any) -> str:
+    try:
+        parsed = value if isinstance(value, datetime) else datetime.fromisoformat(value)
+    except (TypeError, ValueError) as exc:
+        raise LiveAdapterDryRunFinalBindAuthorizationReadinessError(
+            "LADFBAR_TIMESTAMP_INVALID"
+        ) from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise LiveAdapterDryRunFinalBindAuthorizationReadinessError(
+            "LADFBAR_TIMESTAMP_INVALID"
+        )
+    return parsed.astimezone(timezone.utc).isoformat()
+
+
+def _json(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        value = value.model_dump(mode="python")
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float) and value == value and value not in (float("inf"), float("-inf")):
+        return value
+    if isinstance(value, datetime):
+        return _timestamp(value)
+    if isinstance(value, (list, tuple)):
+        return [_json(item) for item in value]
+    if isinstance(value, dict) and all(isinstance(key, str) for key in value):
+        return {key: _json(item) for key, item in value.items()}
+    raise LiveAdapterDryRunFinalBindAuthorizationReadinessError("LADFBAR_INVALID")
+
+
+def _digest(domain: str, value: Any) -> str:
+    encoded = json.dumps(
+        {"domain": domain, "value": _json(value)}, allow_nan=False,
+        ensure_ascii=False, separators=(",", ":"), sort_keys=True,
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _packet_hash(raw: dict[str, Any]) -> str:
+    omitted = {
+        "live_adapter_dry_run_final_bind_authorization_readiness_id",
+        "live_adapter_dry_run_final_bind_authorization_readiness_hash",
+    }
+    return _digest(DOMAINS["packet"], {key: value for key, value in raw.items() if key not in omitted})
+
+
+def _source(value: Any) -> CanonicalLiveAdapterDryRunHumanApprovalLinkageReviewPacket:
+    try:
+        return verify_live_adapter_dry_run_human_approval_linkage_review_packet(value)
+    except (LiveAdapterDryRunHumanApprovalLinkageError, TypeError, ValueError) as exc:
+        raise LiveAdapterDryRunFinalBindAuthorizationReadinessError(
+            "LADFBAR_SOURCE_INVALID"
+        ) from exc
+
+
+def _validate_source(source: CanonicalLiveAdapterDryRunHumanApprovalLinkageReviewPacket) -> None:
+    if source.request_dispatch_state != "NOT_DISPATCHED" or source.request_dispatched:
+        raise LiveAdapterDryRunFinalBindAuthorizationReadinessError("LADFBAR_SOURCE_DISPATCHED")
+    if source.bind_state != "NOT_BOUND" or source.bind_invoked:
+        raise LiveAdapterDryRunFinalBindAuthorizationReadinessError("LADFBAR_SOURCE_BOUND")
+    if source.authority_state != "NOT_AUTHORIZED":
+        raise LiveAdapterDryRunFinalBindAuthorizationReadinessError("LADFBAR_SOURCE_AUTHORIZED")
+    if source.human_approval_state != "NOT_APPROVED":
+        raise LiveAdapterDryRunFinalBindAuthorizationReadinessError("LADFBAR_SOURCE_APPROVED")
+    if source.human_approval_linkage_status != SOURCE_STATUS:
+        raise LiveAdapterDryRunFinalBindAuthorizationReadinessError("LADFBAR_SOURCE_STATUS")
+    human = source.human_approval_linkage_result
+    authority = source.authority_evidence_linkage_result
+    bind = source.source_authority_evidence_linkage_review_packet[
+        "source_bind_pre_dispatch_review_packet"
+    ][
+        "bind_pre_dispatch_review_result"
+    ]
+    if source.fail_closed or not (
+        human.all_required_approval_references_present
+        and human.all_approval_references_structurally_linked
+        and human.all_binding_claims_matched
+        and authority["all_required_references_present"]
+        and authority["all_references_structurally_linked"]
+        and authority["all_binding_claims_matched"]
+        and bind["accepted_for_future_bind_dispatch_gate_review"]
+    ):
+        raise LiveAdapterDryRunFinalBindAuthorizationReadinessError("LADFBAR_SOURCE_REJECTED")
+
+
+def _decision(value: Any) -> FinalBindAuthorizationReadinessReviewDecision:
+    try:
+        decision = FinalBindAuthorizationReadinessReviewDecision.model_validate(_json(value))
+        normalized = decision.model_copy(update={"reviewed_at": _timestamp(decision.reviewed_at)})
+    except (ValidationError, TypeError, LiveAdapterDryRunFinalBindAuthorizationReadinessError) as exc:
+        raise LiveAdapterDryRunFinalBindAuthorizationReadinessError("LADFBAR_DECISION_INVALID") from exc
+    if not all(getattr(normalized, field) for field in ACKNOWLEDGEMENTS):
+        raise LiveAdapterDryRunFinalBindAuthorizationReadinessError("LADFBAR_ACKNOWLEDGEMENT_MISSING")
+    return normalized
+
+
+def _requirements(names: tuple[str, ...]) -> list[dict[str, Any]]:
+    return [{"ordinal": ordinal, "name": name, "separate_future_artifact_required": True,
+             "satisfied_by_this_packet": False}
+            for ordinal, name in enumerate(names, 1)]
+
+
+def _derived(source: CanonicalLiveAdapterDryRunHumanApprovalLinkageReviewPacket,
+             decision: FinalBindAuthorizationReadinessReviewDecision) -> tuple[Any, ...]:
+    accepted = decision.review_outcome == OUTCOMES[0]
+    result = {
+        "source_human_approval_linkage_passed": True,
+        "source_authority_evidence_linkage_passed": True,
+        "source_bind_pre_dispatch_review_passed": True,
+        "all_required_local_linkage_artifacts_present": True,
+        "all_required_local_linkage_artifacts_verified": True,
+        "accepted_for_future_bind_authorization_gate_review": accepted,
+        "rejection_reasons": [] if accepted else ["FINAL_READINESS_REVIEW_REJECTED"],
+        "comparison_mode": CHECK_MODE, "semantic_match_used": False,
+        "creates_bind_authorization": False, "creates_execution_authority": False,
+        "creates_human_approval": False, "creates_authority_evidence": False,
+    }
+    decision_digest = _digest(DOMAINS["decision"], decision)
+    checks = [{
+        "check_id": f"ladfbar-check:v1:{ordinal}:{name.replace('_', '-')}",
+        "ordinal": ordinal, "name": name, "mode": CHECK_MODE,
+        "passed": accepted if name == "final_readiness_result_constructed" else True,
+        "evidence_ref": f"decision:{decision_digest}:{name}",
+        **{field: False for field in EFFECT_FIELDS},
+    } for ordinal, name in enumerate(CHECK_NAMES, 1)]
+    return result, checks, _requirements(AUTHORIZATION_REQUIREMENTS), _requirements(INVOCATION_REQUIREMENTS)
+
+
+def build_live_adapter_dry_run_final_bind_authorization_readiness_packet(
+    source_human_approval_linkage_review_packet: Any,
+    final_bind_authorization_readiness_review_decision: Any,
+    final_bind_authorization_readiness_recorded_at: datetime,
+) -> CanonicalLiveAdapterDryRunFinalBindAuthorizationReadinessPacket:
+    """Build and self-verify deterministic final readiness evidence."""
+    source = _source(_json(source_human_approval_linkage_review_packet))
+    _validate_source(source)
+    decision = _decision(final_bind_authorization_readiness_review_decision)
+    recorded_at = _timestamp(final_bind_authorization_readiness_recorded_at)
+    result, checks, authorization, invocation = _derived(source, decision)
+    source_raw = source.model_dump(mode="json")
+    accepted = result["accepted_for_future_bind_authorization_gate_review"]
+    raw = {
+        "format_version": FORMAT_VERSION,
+        "final_bind_authorization_readiness_mechanism": MECHANISM,
+        "final_bind_authorization_readiness_recorded_at": recorded_at,
+        "source_human_approval_linkage_review_id": source.live_adapter_dry_run_human_approval_linkage_review_id,
+        "source_human_approval_linkage_review_hash": source.live_adapter_dry_run_human_approval_linkage_review_hash,
+        "source_human_approval_linkage_review_packet": source_raw,
+        "source_authority_evidence_linkage_review_hash": source.source_authority_evidence_linkage_review_hash,
+        "source_bind_pre_dispatch_review_hash": source.source_bind_pre_dispatch_review_hash,
+        "source_operator_dispatch_review_hash": source.source_operator_dispatch_review_hash,
+        "source_credential_authorization_hash": source.source_credential_authorization_hash,
+        "source_endpoint_allowlist_evaluation_hash": source.source_endpoint_allowlist_evaluation_hash,
+        "source_dispatch_readiness_hash": source.source_dispatch_readiness_hash,
+        "source_live_adapter_dry_run_request_hash": source.source_live_adapter_dry_run_request_hash,
+        **{field: source_raw[field] for field in COPIED_FIELDS},
+        "final_bind_authorization_readiness_review_decision": decision.model_dump(mode="json"),
+        "final_bind_authorization_readiness_review_decision_digest": _digest(DOMAINS["decision"], decision),
+        "final_bind_authorization_readiness_result": result,
+        "final_bind_authorization_readiness_result_digest": _digest(DOMAINS["result"], result),
+        "final_bind_authorization_readiness_checks": checks,
+        "final_bind_authorization_readiness_check_digest": _digest(DOMAINS["checks"], checks),
+        "future_bind_authorization_gate_requirements": authorization,
+        "future_bind_authorization_gate_requirements_digest": _digest(DOMAINS["authorization"], authorization),
+        "future_bind_invocation_requirements": invocation,
+        "future_bind_invocation_requirements_digest": _digest(DOMAINS["invocation"], invocation),
+        "final_bind_authorization_readiness_status": STATUS,
+        "request_dispatch_state": "NOT_DISPATCHED", "bind_state": "NOT_BOUND",
+        "authority_state": "NOT_AUTHORIZED", "human_approval_state": "NOT_APPROVED",
+        "final_readiness_state": ("READY_FOR_FUTURE_BIND_AUTHORIZATION_GATE" if accepted
+                                  else "NOT_READY_FOR_FUTURE_BIND_AUTHORIZATION_GATE"),
+        **{field: False for field in EFFECT_FIELDS if field in {
+            "authority_evidence_created", "human_approval_created", "execution_authority_created",
+            "bind_authorization_created", "bind_invoked", "bind_receipt_created",
+            "trustlog_written", "request_dispatched", "endpoint_resolved",
+            "credential_material_accessed", "authorization_header_constructed", "network_used",
+            "live_adapter_instantiated", "webhook_called",
+        }},
+        "fail_closed": not accepted, "scope_limitations": SCOPE_LIMITATIONS,
+    }
+    digest = _packet_hash(raw)
+    raw["live_adapter_dry_run_final_bind_authorization_readiness_hash"] = digest
+    raw["live_adapter_dry_run_final_bind_authorization_readiness_id"] = f"ladfbar:v1:sha256:{digest}"
+    return verify_live_adapter_dry_run_final_bind_authorization_readiness_packet(raw)
+
+
+def verify_live_adapter_dry_run_final_bind_authorization_readiness_packet(
+    raw: Any,
+) -> CanonicalLiveAdapterDryRunFinalBindAuthorizationReadinessPacket:
+    """Reverify source, derived content, digests, packet hash, and packet ID."""
+    try:
+        value = raw.model_dump(mode="json") if isinstance(raw, BaseModel) else raw
+        packet = CanonicalLiveAdapterDryRunFinalBindAuthorizationReadinessPacket.model_validate(_json(value))
+    except (ValidationError, TypeError, LiveAdapterDryRunFinalBindAuthorizationReadinessError) as exc:
+        raise LiveAdapterDryRunFinalBindAuthorizationReadinessError("LADFBAR_PACKET_INVALID") from exc
+    actual = packet.model_dump(mode="json")
+    source = _source(packet.source_human_approval_linkage_review_packet)
+    _validate_source(source)
+    source_raw = source.model_dump(mode="json")
+    identities = (
+        packet.source_human_approval_linkage_review_id == source.live_adapter_dry_run_human_approval_linkage_review_id,
+        packet.source_human_approval_linkage_review_hash == source.live_adapter_dry_run_human_approval_linkage_review_hash,
+        packet.source_authority_evidence_linkage_review_hash == source.source_authority_evidence_linkage_review_hash,
+        packet.source_bind_pre_dispatch_review_hash == source.source_bind_pre_dispatch_review_hash,
+        packet.source_operator_dispatch_review_hash == source.source_operator_dispatch_review_hash,
+        packet.source_credential_authorization_hash == source.source_credential_authorization_hash,
+        packet.source_endpoint_allowlist_evaluation_hash == source.source_endpoint_allowlist_evaluation_hash,
+        packet.source_dispatch_readiness_hash == source.source_dispatch_readiness_hash,
+        packet.source_live_adapter_dry_run_request_hash == source.source_live_adapter_dry_run_request_hash,
+    )
+    if not all(identities) or any(_json(getattr(packet, field)) != _json(source_raw[field]) for field in COPIED_FIELDS):
+        raise LiveAdapterDryRunFinalBindAuthorizationReadinessError("LADFBAR_SOURCE_MISMATCH")
+    decision = _decision(packet.final_bind_authorization_readiness_review_decision)
+    result, checks, authorization, invocation = _derived(source, decision)
+    accepted = result["accepted_for_future_bind_authorization_gate_review"]
+    expected = (
+        packet.final_bind_authorization_readiness_review_decision_digest == _digest(DOMAINS["decision"], decision),
+        _json(packet.final_bind_authorization_readiness_result) == result,
+        packet.final_bind_authorization_readiness_result_digest == _digest(DOMAINS["result"], result),
+        _json(packet.final_bind_authorization_readiness_checks) == checks,
+        packet.final_bind_authorization_readiness_check_digest == _digest(DOMAINS["checks"], checks),
+        _json(packet.future_bind_authorization_gate_requirements) == authorization,
+        packet.future_bind_authorization_gate_requirements_digest == _digest(DOMAINS["authorization"], authorization),
+        _json(packet.future_bind_invocation_requirements) == invocation,
+        packet.future_bind_invocation_requirements_digest == _digest(DOMAINS["invocation"], invocation),
+        packet.scope_limitations == SCOPE_LIMITATIONS,
+        packet.fail_closed is (not accepted),
+        packet.final_readiness_state == ("READY_FOR_FUTURE_BIND_AUTHORIZATION_GATE" if accepted else "NOT_READY_FOR_FUTURE_BIND_AUTHORIZATION_GATE"),
+        packet.final_bind_authorization_readiness_recorded_at == _timestamp(packet.final_bind_authorization_readiness_recorded_at),
+    )
+    if not all(expected):
+        raise LiveAdapterDryRunFinalBindAuthorizationReadinessError("LADFBAR_DERIVED_MISMATCH")
+    digest = _packet_hash(actual)
+    if packet.live_adapter_dry_run_final_bind_authorization_readiness_hash != digest:
+        raise LiveAdapterDryRunFinalBindAuthorizationReadinessError("LADFBAR_HASH_MISMATCH")
+    if packet.live_adapter_dry_run_final_bind_authorization_readiness_id != f"ladfbar:v1:sha256:{digest}":
+        raise LiveAdapterDryRunFinalBindAuthorizationReadinessError("LADFBAR_ID_MISMATCH")
+    return packet

--- a/veritas_os/tests/test_live_adapter_dry_run_final_bind_authorization_readiness.py
+++ b/veritas_os/tests/test_live_adapter_dry_run_final_bind_authorization_readiness.py
@@ -1,0 +1,235 @@
+"""Integrity and non-effect tests for final Bind readiness packet v1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from copy import deepcopy
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator, ValidationError
+
+from veritas_os.policy.live_adapter_dry_run_final_bind_authorization_readiness import (
+    ACKNOWLEDGEMENTS,
+    AUTHORIZATION_REQUIREMENTS,
+    CHECK_NAMES,
+    INVOCATION_REQUIREMENTS,
+    OUTCOMES,
+    SCOPE_LIMITATIONS,
+    LiveAdapterDryRunFinalBindAuthorizationReadinessError,
+    _packet_hash,
+    build_live_adapter_dry_run_final_bind_authorization_readiness_packet,
+    verify_live_adapter_dry_run_final_bind_authorization_readiness_packet,
+)
+from veritas_os.tests.test_live_adapter_dry_run_human_approval_linkage import (
+    RECORDED_AT as SOURCE_RECORDED_AT,
+    _packet as source_packet,
+)
+
+RECORDED_AT = SOURCE_RECORDED_AT + timedelta(seconds=1)
+MODULE = Path("veritas_os/policy/live_adapter_dry_run_final_bind_authorization_readiness.py")
+SCHEMA = Path("schemas/live-adapter-dry-run-final-bind-authorization-readiness-v1.schema.json")
+
+
+def _decision(*, accepted=True, **changes):
+    value = {
+        "final_bind_authorization_readiness_review_decision_id": "final-review:billing:v1",
+        "reviewer_id": "operator:alice", "reviewer_role": "bind-readiness-reviewer",
+        "reviewer_attestation": "I reviewed local readiness only.",
+        "reviewed_at": RECORDED_AT.isoformat(),
+        "review_outcome": OUTCOMES[0] if accepted else OUTCOMES[1],
+        "review_reason": "local linkage artifacts reviewed",
+        **{field: True for field in ACKNOWLEDGEMENTS},
+    }
+    value.update(changes)
+    return value
+
+
+def _packet(*, source=None, decision=None, semantic_match=False):
+    source = source or source_packet(semantic_match=semantic_match)
+    return build_live_adapter_dry_run_final_bind_authorization_readiness_packet(
+        source, decision or _decision(), RECORDED_AT
+    )
+
+
+def _rehash(raw):
+    digest = _packet_hash(raw)
+    raw["live_adapter_dry_run_final_bind_authorization_readiness_hash"] = digest
+    raw["live_adapter_dry_run_final_bind_authorization_readiness_id"] = (
+        f"ladfbar:v1:sha256:{digest}"
+    )
+
+
+def test_builder_creates_and_verifies_ready_packet(monkeypatch) -> None:
+    import veritas_os.policy.live_adapter_dry_run_final_bind_authorization_readiness as module
+
+    actual = module.verify_live_adapter_dry_run_human_approval_linkage_review_packet
+    calls = []
+
+    def recording(value):
+        calls.append(value)
+        return actual(value)
+
+    monkeypatch.setattr(
+        module, "verify_live_adapter_dry_run_human_approval_linkage_review_packet", recording
+    )
+    packet = module.build_live_adapter_dry_run_final_bind_authorization_readiness_packet(
+        source_packet(), _decision(), RECORDED_AT
+    )
+    assert len(calls) == 2
+    assert module.verify_live_adapter_dry_run_final_bind_authorization_readiness_packet(packet) == packet
+    assert len(calls) == 3
+    assert not packet.fail_closed
+    assert packet.final_readiness_state == "READY_FOR_FUTURE_BIND_AUTHORIZATION_GATE"
+    assert not packet.bind_authorization_created
+
+
+def test_rejected_review_records_fail_closed_not_ready() -> None:
+    packet = _packet(decision=_decision(accepted=False))
+    assert packet.fail_closed
+    assert packet.final_readiness_state == "NOT_READY_FOR_FUTURE_BIND_AUTHORIZATION_GATE"
+    assert not packet.final_bind_authorization_readiness_result.accepted_for_future_bind_authorization_gate_review
+
+
+@pytest.mark.parametrize("field", ACKNOWLEDGEMENTS)
+def test_every_acknowledgement_is_required(field) -> None:
+    with pytest.raises(LiveAdapterDryRunFinalBindAuthorizationReadinessError):
+        _packet(decision=_decision(**{field: False}))
+
+
+@pytest.mark.parametrize("field", [
+    "reviewer_id", "reviewer_role", "reviewer_attestation",
+    "final_bind_authorization_readiness_review_decision_id", "review_reason",
+])
+def test_review_identity_and_attestation_are_required(field) -> None:
+    with pytest.raises(LiveAdapterDryRunFinalBindAuthorizationReadinessError):
+        _packet(decision=_decision(**{field: ""}))
+
+
+def test_review_decision_is_closed() -> None:
+    with pytest.raises(LiveAdapterDryRunFinalBindAuthorizationReadinessError):
+        _packet(decision=_decision(unexpected=True))
+
+
+@pytest.mark.parametrize("field", [
+    "request_descriptor", "execution_intent", "execution_intent_id", "execution_intent_hash",
+    "adapter_contract_descriptor", "adapter_contract_id", "adapter_contract_hash",
+    "adapter_contract_version", "endpoint_identity_binding", "endpoint_identity_binding_digest",
+    "credential_scope_binding", "credential_scope_binding_digest",
+    "authority_evidence_linkage_result", "human_approval_linkage_result",
+    "source_bind_pre_dispatch_review_hash", "source_operator_dispatch_review_hash",
+    "source_credential_authorization_hash", "source_endpoint_allowlist_evaluation_hash",
+    "source_dispatch_readiness_hash", "source_live_adapter_dry_run_request_hash",
+])
+def test_source_content_and_lineage_are_preserved(field) -> None:
+    packet = _packet()
+    source = packet.source_human_approval_linkage_review_packet
+    assert getattr(packet, field) == source[field]
+
+
+def test_checks_and_future_requirements_are_exact_and_ordered() -> None:
+    packet = _packet()
+    assert tuple(check.name for check in packet.final_bind_authorization_readiness_checks) == CHECK_NAMES
+    assert tuple(item.name for item in packet.future_bind_authorization_gate_requirements) == AUTHORIZATION_REQUIREMENTS
+    assert tuple(item.name for item in packet.future_bind_invocation_requirements) == INVOCATION_REQUIREMENTS
+    assert all(not getattr(check, field) for check in packet.final_bind_authorization_readiness_checks
+               for field in ("bind_authorization_created", "network_used", "operation_committed"))
+
+
+@pytest.mark.parametrize("field", [
+    "final_bind_authorization_readiness_review_decision",
+    "final_bind_authorization_readiness_result", "final_bind_authorization_readiness_checks",
+    "future_bind_authorization_gate_requirements", "future_bind_invocation_requirements",
+    "scope_limitations",
+])
+def test_mutated_derived_content_is_rejected(field) -> None:
+    raw = _packet().model_dump(mode="json")
+    if field == "final_bind_authorization_readiness_review_decision":
+        raw[field]["review_reason"] = "forged"
+    elif field == "final_bind_authorization_readiness_result":
+        raw[field]["all_required_local_linkage_artifacts_verified"] = False
+    elif field == "final_bind_authorization_readiness_checks":
+        raw[field][0]["evidence_ref"] = "forged"
+    elif field.startswith("future_"):
+        raw[field][0]["name"] = "forged"
+    else:
+        raw[field].reverse()
+    _rehash(raw)
+    with pytest.raises(LiveAdapterDryRunFinalBindAuthorizationReadinessError):
+        verify_live_adapter_dry_run_final_bind_authorization_readiness_packet(raw)
+
+
+@pytest.mark.parametrize("field", [
+    "authority_evidence_created", "human_approval_created", "execution_authority_created",
+    "bind_authorization_created", "bind_invoked", "bind_receipt_created", "trustlog_written",
+    "request_dispatched", "endpoint_resolved", "credential_material_accessed",
+    "authorization_header_constructed", "network_used", "live_adapter_instantiated",
+    "webhook_called",
+])
+def test_effect_mutations_are_rejected(field) -> None:
+    raw = _packet().model_dump(mode="json")
+    raw[field] = True
+    _rehash(raw)
+    with pytest.raises(LiveAdapterDryRunFinalBindAuthorizationReadinessError):
+        verify_live_adapter_dry_run_final_bind_authorization_readiness_packet(raw)
+
+
+@pytest.mark.parametrize("field", [
+    "live_adapter_dry_run_final_bind_authorization_readiness_id",
+    "live_adapter_dry_run_final_bind_authorization_readiness_hash",
+])
+def test_forged_content_address_is_rejected(field) -> None:
+    raw = _packet().model_dump(mode="json")
+    raw[field] = "forged"
+    with pytest.raises(LiveAdapterDryRunFinalBindAuthorizationReadinessError):
+        verify_live_adapter_dry_run_final_bind_authorization_readiness_packet(raw)
+
+
+def test_semantic_match_is_never_promoted() -> None:
+    for semantic_match in (False, True):
+        packet = _packet(semantic_match=semantic_match)
+        assert not packet.final_bind_authorization_readiness_result.semantic_match_used
+        assert not packet.human_approval_created
+        assert not packet.authority_evidence_created
+        assert not packet.execution_authority_created
+        assert not packet.bind_authorization_created
+
+
+def test_schema_validates_packet_and_rejects_effect_mutation() -> None:
+    schema = json.loads(SCHEMA.read_text())
+    raw = _packet().model_dump(mode="json")
+    Draft202012Validator(schema).validate(raw)
+    raw["bind_authorization_created"] = True
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(raw)
+
+
+def test_module_has_no_prohibited_imports_or_calls() -> None:
+    tree = ast.parse(MODULE.read_text())
+    imports = {alias.name.split(".")[0] for node in ast.walk(tree)
+               if isinstance(node, (ast.Import, ast.ImportFrom)) for alias in node.names}
+    assert not imports.intersection({
+        "requests", "httpx", "urllib", "socket", "dns", "subprocess", "os", "pathlib",
+    })
+    text = MODULE.read_text()
+    for prohibited in (
+        "WebhookBindAdapter", "BindReceipt", "TrustLog", "open(", "os.environ",
+        "read_text", "write_text", "credential_store", "verify_postconditions",
+        "revert(", "apply(",
+    ):
+        assert prohibited not in text
+
+
+def test_packet_hash_changes_with_content() -> None:
+    raw = _packet().model_dump(mode="json")
+    changed = deepcopy(raw)
+    changed["final_bind_authorization_readiness_recorded_at"] = (
+        RECORDED_AT + timedelta(seconds=1)
+    ).isoformat()
+    assert _packet_hash(changed) != _packet_hash(raw)
+
+
+def test_scope_limitations_are_exact() -> None:
+    assert _packet().scope_limitations == SCOPE_LIMITATIONS


### PR DESCRIPTION
### Motivation

- Record deterministic, content-addressed Final Bind Authorization Readiness evidence for a verified, non-dispatched Human Approval linkage review packet so a future explicit Bind authorization gate can evaluate readiness without performing any authorization or external effects.

### Description

- Add a closed Pydantic canonical packet builder and verifier in `veritas_os/policy/live_adapter_dry_run_final_bind_authorization_readiness.py`, a matching closed JSON Schema `schemas/live-adapter-dry-run-final-bind-authorization-readiness-v1.schema.json`, comprehensive integrity and non-effect tests `veritas_os/tests/test_live_adapter_dry_run_final_bind_authorization_readiness.py`, and documentation `docs/en/architecture/live-adapter-dry-run-final-bind-authorization-readiness-v1.md`.
- The implementation re-verifies the embedded `CanonicalLiveAdapterDryRunHumanApprovalLinkageReviewPacket`, enforces source state invariants (`NOT_DISPATCHED`, `NOT_BOUND`, `NOT_AUTHORIZED`, `NOT_APPROVED`), preserves request/identity/lineage fields, produces deterministic domain-separated digests and a stable `ladfbar:v1:sha256:<hash>` id, emits 47 ordered deterministic checks, and constructs deterministic future Bind authorization/invocation requirement lists; all effect flags are fixed false and the packet is explicitly readiness evidence only.
- Final invariant: Canonical Live Adapter Dry-Run Final Bind Authorization Readiness v1 now records deterministic final readiness evidence for a verified non-dispatched Human Approval linkage review packet without creating Bind authorization, without creating execution authority, without creating Human Approval, without creating Authority Evidence, without invoking Bind, without creating a BindReceipt, without writing TrustLog, without dispatching the request, without resolving endpoints, without accessing credential material, without constructing authorization headers, without network access, without instantiating a live adapter, without calling Webhook, without external effects, and without converting semantic_match into Human Approval, Authority Evidence, Bind authorization, or execution authority.

### Testing

- Ran unit/regression checks for the new milestone: `pytest -q veritas_os/tests/test_live_adapter_dry_run_final_bind_authorization_readiness.py` succeeded in the available isolated dependency path; a combined milestone selection run reached 190 passing tests before the environment-limited run was interrupted with no failures observed up to that point.
- Static/format checks and schema/compile validations succeeded: `ruff check` on the new files passed, `python -m py_compile` for the new module passed, and `python -m json.tool` validated the generated schema; `git diff --check` produced no whitespace/errors.
- Security / non-effect guarantees were validated by tests that assert the packet rejects any mutation that would create authorization/effects and by module-level assertions that prohibited imports/calls (no network, DNS, subprocess, credential store, Bind/BindReceipt/TrustLog, Webhook, or live adapter usage).

Automated checks exercised: new unit tests, schema validation, static linting, and byte-compile; human maintainer review is required before merging because this change touches Bind-readiness policy evidence and must not be treated as approval or authorization.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a851d2379588326878418e455843023)