### PR TITLE
feat(bind): add live adapter dry-run bind authorization gate review v1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -532,7 +532,7 @@ jobs:
     name: test (py${{ matrix.python-version }})
     needs: [lint, dependency-audit, governance-smoke, governance-backend-fast]
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 60
 
     strategy:
       fail-fast: false

--- a/docs/en/architecture/live-adapter-dry-run-bind-authorization-gate-review-v1.md
+++ b/docs/en/architecture/live-adapter-dry-run-bind-authorization-gate-review-v1.md
@@ -1,0 +1,15 @@
+# Canonical Live Adapter Dry-Run Bind Authorization Gate Review v1
+
+This content-addressed packet is deterministic **Bind Authorization Gate Review evidence** for a verified, non-dispatched Final Bind Authorization Readiness packet. It answers whether the local dry-run path passed review while remaining merely eligible for a separate future authorization artifact.
+
+## Security and non-effect boundary
+
+The packet does **not** create real Bind authorization or execution authority. It does not invoke Bind, create a BindReceipt, write TrustLog, dispatch a request, create Human Approval, or create Authority Evidence. It does not resolve endpoints, access credentials, construct authorization headers, call a network or Webhook, or instantiate a live adapter. All effect flags are closed to `false` and every check uses `deterministic_local_bind_authorization_gate_review_only`.
+
+`semantic_match` remains preserved in embedded source evidence, but is never promoted into approval, authority, authorization, or execution. A successful review only records passage of this local gate.
+
+## Separate future boundaries
+
+Real Bind authorization requires a separate explicit artifact proving Authority Evidence, required Human Approval, policy admissibility, runtime risk, endpoint and credential boundaries, idempotency/replay controls, operator confirmation, and an explicit authorization decision. Bind invocation requires a later separate artifact proving that authorization exists and controlling dispatch, credential, header, invocation, BindReceipt, TrustLog, postcondition, and rollback boundaries. This packet satisfies none of those requirements.
+
+Any source, digest, ordered check, requirement, limitation, result, packet hash, or identifier mismatch is rejected. Failed review remains valid fail-closed evidence with no effects.

--- a/schemas/live-adapter-dry-run-bind-authorization-gate-review-v1.schema.json
+++ b/schemas/live-adapter-dry-run-bind-authorization-gate-review-v1.schema.json
@@ -1,0 +1,2502 @@
+{
+  "$defs": {
+    "BindAuthorizationGateReviewDecision": {
+      "additionalProperties": false,
+      "description": "Closed human review metadata that explicitly is not authorization.",
+      "properties": {
+        "acknowledged_no_authority_evidence_creation": {
+          "title": "Acknowledged No Authority Evidence Creation",
+          "type": "boolean"
+        },
+        "acknowledged_no_authorization_header": {
+          "title": "Acknowledged No Authorization Header",
+          "type": "boolean"
+        },
+        "acknowledged_no_bind_invocation": {
+          "title": "Acknowledged No Bind Invocation",
+          "type": "boolean"
+        },
+        "acknowledged_no_bind_receipt": {
+          "title": "Acknowledged No Bind Receipt",
+          "type": "boolean"
+        },
+        "acknowledged_no_credential_access": {
+          "title": "Acknowledged No Credential Access",
+          "type": "boolean"
+        },
+        "acknowledged_no_dispatch": {
+          "title": "Acknowledged No Dispatch",
+          "type": "boolean"
+        },
+        "acknowledged_no_execution_authority": {
+          "title": "Acknowledged No Execution Authority",
+          "type": "boolean"
+        },
+        "acknowledged_no_human_approval_creation": {
+          "title": "Acknowledged No Human Approval Creation",
+          "type": "boolean"
+        },
+        "acknowledged_no_network_call": {
+          "title": "Acknowledged No Network Call",
+          "type": "boolean"
+        },
+        "acknowledged_no_trustlog_write": {
+          "title": "Acknowledged No Trustlog Write",
+          "type": "boolean"
+        },
+        "acknowledged_not_real_bind_authorization": {
+          "title": "Acknowledged Not Real Bind Authorization",
+          "type": "boolean"
+        },
+        "acknowledged_semantic_match_not_authority": {
+          "title": "Acknowledged Semantic Match Not Authority",
+          "type": "boolean"
+        },
+        "bind_authorization_gate_review_decision_id": {
+          "minLength": 1,
+          "title": "Bind Authorization Gate Review Decision Id",
+          "type": "string"
+        },
+        "review_outcome": {
+          "enum": [
+            "PASSED_FOR_FUTURE_BIND_AUTHORIZATION_ARTIFACT",
+            "FAILED_FOR_FUTURE_BIND_AUTHORIZATION_ARTIFACT"
+          ],
+          "title": "Review Outcome",
+          "type": "string"
+        },
+        "review_reason": {
+          "minLength": 1,
+          "title": "Review Reason",
+          "type": "string"
+        },
+        "reviewed_at": {
+          "title": "Reviewed At",
+          "type": "string"
+        },
+        "reviewer_attestation": {
+          "minLength": 1,
+          "title": "Reviewer Attestation",
+          "type": "string"
+        },
+        "reviewer_id": {
+          "minLength": 1,
+          "title": "Reviewer Id",
+          "type": "string"
+        },
+        "reviewer_role": {
+          "minLength": 1,
+          "title": "Reviewer Role",
+          "type": "string"
+        }
+      },
+      "required": [
+        "bind_authorization_gate_review_decision_id",
+        "reviewer_id",
+        "reviewer_role",
+        "reviewer_attestation",
+        "reviewed_at",
+        "review_outcome",
+        "review_reason",
+        "acknowledged_not_real_bind_authorization",
+        "acknowledged_no_bind_invocation",
+        "acknowledged_no_bind_receipt",
+        "acknowledged_no_trustlog_write",
+        "acknowledged_no_dispatch",
+        "acknowledged_no_execution_authority",
+        "acknowledged_no_human_approval_creation",
+        "acknowledged_no_authority_evidence_creation",
+        "acknowledged_no_credential_access",
+        "acknowledged_no_authorization_header",
+        "acknowledged_no_network_call",
+        "acknowledged_semantic_match_not_authority"
+      ],
+      "title": "BindAuthorizationGateReviewDecision",
+      "type": "object"
+    },
+    "BindAuthorizationGateReviewResult": {
+      "additionalProperties": false,
+      "description": "Deterministic readiness conclusion with explicit non-authority flags.",
+      "properties": {
+        "accepted_for_future_real_bind_authorization_artifact": {
+          "title": "Accepted For Future Real Bind Authorization Artifact",
+          "type": "boolean"
+        },
+        "comparison_mode": {
+          "const": "deterministic_local_bind_authorization_gate_review_only",
+          "title": "Comparison Mode",
+          "type": "string"
+        },
+        "creates_authority_evidence": {
+          "const": false,
+          "title": "Creates Authority Evidence",
+          "type": "boolean"
+        },
+        "creates_execution_authority": {
+          "const": false,
+          "title": "Creates Execution Authority",
+          "type": "boolean"
+        },
+        "creates_human_approval": {
+          "const": false,
+          "title": "Creates Human Approval",
+          "type": "boolean"
+        },
+        "creates_real_bind_authorization": {
+          "const": false,
+          "title": "Creates Real Bind Authorization",
+          "type": "boolean"
+        },
+        "gate_review_passed": {
+          "title": "Gate Review Passed",
+          "type": "boolean"
+        },
+        "rejection_reasons": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Rejection Reasons",
+          "type": "array"
+        },
+        "semantic_match_used": {
+          "const": false,
+          "title": "Semantic Match Used",
+          "type": "boolean"
+        },
+        "source_authority_evidence_linkage_passed": {
+          "title": "Source Authority Evidence Linkage Passed",
+          "type": "boolean"
+        },
+        "source_bind_pre_dispatch_review_passed": {
+          "title": "Source Bind Pre Dispatch Review Passed",
+          "type": "boolean"
+        },
+        "source_final_readiness_passed": {
+          "title": "Source Final Readiness Passed",
+          "type": "boolean"
+        },
+        "source_human_approval_linkage_passed": {
+          "title": "Source Human Approval Linkage Passed",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "source_final_readiness_passed",
+        "source_human_approval_linkage_passed",
+        "source_authority_evidence_linkage_passed",
+        "source_bind_pre_dispatch_review_passed",
+        "gate_review_passed",
+        "accepted_for_future_real_bind_authorization_artifact",
+        "rejection_reasons",
+        "comparison_mode",
+        "semantic_match_used",
+        "creates_real_bind_authorization",
+        "creates_execution_authority",
+        "creates_human_approval",
+        "creates_authority_evidence"
+      ],
+      "title": "BindAuthorizationGateReviewResult",
+      "type": "object"
+    },
+    "FutureRequirement": {
+      "additionalProperties": false,
+      "description": "A requirement that only a separate future artifact may satisfy.",
+      "properties": {
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "ordinal": {
+          "title": "Ordinal",
+          "type": "integer"
+        },
+        "satisfied_by_this_packet": {
+          "const": false,
+          "title": "Satisfied By This Packet",
+          "type": "boolean"
+        },
+        "separate_future_artifact_required": {
+          "const": true,
+          "title": "Separate Future Artifact Required",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "ordinal",
+        "name",
+        "separate_future_artifact_required",
+        "satisfied_by_this_packet"
+      ],
+      "title": "FutureRequirement",
+      "type": "object"
+    },
+    "GateReviewCheck": {
+      "additionalProperties": false,
+      "description": "One ordered local check whose effect flags are all false.",
+      "properties": {
+        "authority_evidence_created": {
+          "const": false,
+          "title": "Authority Evidence Created",
+          "type": "boolean"
+        },
+        "authorization_header_constructed": {
+          "const": false,
+          "title": "Authorization Header Constructed",
+          "type": "boolean"
+        },
+        "bind_authorization_created": {
+          "const": false,
+          "title": "Bind Authorization Created",
+          "type": "boolean"
+        },
+        "bind_invoked": {
+          "const": false,
+          "title": "Bind Invoked",
+          "type": "boolean"
+        },
+        "bind_receipt_created": {
+          "const": false,
+          "title": "Bind Receipt Created",
+          "type": "boolean"
+        },
+        "check_id": {
+          "title": "Check Id",
+          "type": "string"
+        },
+        "credential_material_accessed": {
+          "const": false,
+          "title": "Credential Material Accessed",
+          "type": "boolean"
+        },
+        "credential_material_embedded": {
+          "const": false,
+          "title": "Credential Material Embedded",
+          "type": "boolean"
+        },
+        "database_used": {
+          "const": false,
+          "title": "Database Used",
+          "type": "boolean"
+        },
+        "dns_used": {
+          "const": false,
+          "title": "Dns Used",
+          "type": "boolean"
+        },
+        "endpoint_resolved": {
+          "const": false,
+          "title": "Endpoint Resolved",
+          "type": "boolean"
+        },
+        "evidence_ref": {
+          "title": "Evidence Ref",
+          "type": "string"
+        },
+        "execution_authority_created": {
+          "const": false,
+          "title": "Execution Authority Created",
+          "type": "boolean"
+        },
+        "external_effect_used": {
+          "const": false,
+          "title": "External Effect Used",
+          "type": "boolean"
+        },
+        "filesystem_used": {
+          "const": false,
+          "title": "Filesystem Used",
+          "type": "boolean"
+        },
+        "human_approval_created": {
+          "const": false,
+          "title": "Human Approval Created",
+          "type": "boolean"
+        },
+        "live_adapter_instantiated": {
+          "const": false,
+          "title": "Live Adapter Instantiated",
+          "type": "boolean"
+        },
+        "live_adapter_method_called": {
+          "const": false,
+          "title": "Live Adapter Method Called",
+          "type": "boolean"
+        },
+        "mode": {
+          "const": "deterministic_local_bind_authorization_gate_review_only",
+          "title": "Mode",
+          "type": "string"
+        },
+        "name": {
+          "enum": [
+            "source_final_bind_authorization_readiness_verified",
+            "source_request_not_dispatched",
+            "source_bind_not_invoked",
+            "source_bind_not_authorized",
+            "source_human_approval_linkage_passed",
+            "source_authority_evidence_linkage_passed",
+            "source_bind_pre_dispatch_review_passed",
+            "gate_review_decision_closed_schema_valid",
+            "reviewer_identity_present",
+            "reviewer_role_present",
+            "reviewer_attestation_present",
+            "acknowledged_not_real_bind_authorization",
+            "acknowledged_no_bind_invocation",
+            "acknowledged_no_bind_receipt",
+            "acknowledged_no_trustlog_write",
+            "acknowledged_no_dispatch",
+            "acknowledged_no_execution_authority",
+            "acknowledged_no_human_approval_creation",
+            "acknowledged_no_authority_evidence_creation",
+            "acknowledged_no_credential_access",
+            "acknowledged_no_authorization_header",
+            "acknowledged_no_network_call",
+            "acknowledged_semantic_match_not_authority",
+            "request_descriptor_preserved",
+            "execution_intent_identity_preserved",
+            "adapter_contract_identity_preserved",
+            "endpoint_identity_binding_preserved",
+            "credential_scope_binding_preserved",
+            "authority_evidence_linkage_result_preserved",
+            "human_approval_linkage_result_preserved",
+            "final_readiness_result_preserved",
+            "gate_review_result_constructed",
+            "future_real_bind_authorization_artifact_required",
+            "future_bind_invocation_gate_required",
+            "bind_authorization_not_created",
+            "execution_authority_not_created",
+            "human_approval_not_created",
+            "authority_evidence_not_created",
+            "bind_not_invoked",
+            "bind_receipt_not_created",
+            "trustlog_not_written",
+            "request_not_dispatched",
+            "endpoint_not_resolved",
+            "credential_material_not_accessed",
+            "authorization_header_not_constructed",
+            "network_not_used",
+            "webhook_not_called",
+            "live_adapter_not_instantiated"
+          ]
+        },
+        "network_used": {
+          "const": false,
+          "title": "Network Used",
+          "type": "boolean"
+        },
+        "operation_committed": {
+          "const": false,
+          "title": "Operation Committed",
+          "type": "boolean"
+        },
+        "ordinal": {
+          "maximum": 49,
+          "minimum": 1,
+          "title": "Ordinal",
+          "type": "integer"
+        },
+        "passed": {
+          "title": "Passed",
+          "type": "boolean"
+        },
+        "provider_used": {
+          "const": false,
+          "title": "Provider Used",
+          "type": "boolean"
+        },
+        "request_dispatched": {
+          "const": false,
+          "title": "Request Dispatched",
+          "type": "boolean"
+        },
+        "secret_embedded": {
+          "const": false,
+          "title": "Secret Embedded",
+          "type": "boolean"
+        },
+        "subprocess_used": {
+          "const": false,
+          "title": "Subprocess Used",
+          "type": "boolean"
+        },
+        "token_embedded": {
+          "const": false,
+          "title": "Token Embedded",
+          "type": "boolean"
+        },
+        "trustlog_written": {
+          "const": false,
+          "title": "Trustlog Written",
+          "type": "boolean"
+        },
+        "webhook_called": {
+          "const": false,
+          "title": "Webhook Called",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "check_id",
+        "ordinal",
+        "name",
+        "mode",
+        "passed",
+        "evidence_ref",
+        "bind_authorization_created",
+        "execution_authority_created",
+        "human_approval_created",
+        "authority_evidence_created",
+        "bind_invoked",
+        "bind_receipt_created",
+        "trustlog_written",
+        "request_dispatched",
+        "endpoint_resolved",
+        "credential_material_accessed",
+        "credential_material_embedded",
+        "authorization_header_constructed",
+        "token_embedded",
+        "secret_embedded",
+        "network_used",
+        "dns_used",
+        "webhook_called",
+        "live_adapter_instantiated",
+        "live_adapter_method_called",
+        "external_effect_used",
+        "filesystem_used",
+        "database_used",
+        "provider_used",
+        "subprocess_used",
+        "operation_committed"
+      ],
+      "title": "GateReviewCheck",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false,
+  "description": "Closed content-addressed gate review packet without authorization.",
+  "properties": {
+    "adapter_contract_descriptor": {
+      "additionalProperties": true,
+      "title": "Adapter Contract Descriptor",
+      "type": "object"
+    },
+    "adapter_contract_hash": {
+      "title": "Adapter Contract Hash",
+      "type": "string"
+    },
+    "adapter_contract_id": {
+      "title": "Adapter Contract Id",
+      "type": "string"
+    },
+    "adapter_contract_version": {
+      "title": "Adapter Contract Version",
+      "type": "string"
+    },
+    "authority_evidence_created": {
+      "const": false,
+      "title": "Authority Evidence Created",
+      "type": "boolean"
+    },
+    "authority_evidence_linkage_result": {
+      "additionalProperties": true,
+      "title": "Authority Evidence Linkage Result",
+      "type": "object"
+    },
+    "authority_evidence_linkage_result_digest": {
+      "title": "Authority Evidence Linkage Result Digest",
+      "type": "string"
+    },
+    "authority_evidence_reference_bundle": {
+      "additionalProperties": true,
+      "title": "Authority Evidence Reference Bundle",
+      "type": "object"
+    },
+    "authority_evidence_reference_bundle_digest": {
+      "title": "Authority Evidence Reference Bundle Digest",
+      "type": "string"
+    },
+    "authority_state": {
+      "const": "NOT_AUTHORIZED",
+      "title": "Authority State",
+      "type": "string"
+    },
+    "authorization_header_constructed": {
+      "const": false,
+      "title": "Authorization Header Constructed",
+      "type": "boolean"
+    },
+    "bind_authorization_created": {
+      "const": false,
+      "title": "Bind Authorization Created",
+      "type": "boolean"
+    },
+    "bind_authorization_gate_review_check_digest": {
+      "title": "Bind Authorization Gate Review Check Digest",
+      "type": "string"
+    },
+    "bind_authorization_gate_review_checks": {
+      "maxItems": 49,
+      "minItems": 49,
+      "prefixItems": [
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "source_final_bind_authorization_readiness_verified"
+                },
+                "ordinal": {
+                  "const": 1
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "source_request_not_dispatched"
+                },
+                "ordinal": {
+                  "const": 2
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "source_bind_not_invoked"
+                },
+                "ordinal": {
+                  "const": 3
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "source_bind_not_authorized"
+                },
+                "ordinal": {
+                  "const": 4
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "source_human_approval_linkage_passed"
+                },
+                "ordinal": {
+                  "const": 5
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "source_authority_evidence_linkage_passed"
+                },
+                "ordinal": {
+                  "const": 6
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "source_bind_pre_dispatch_review_passed"
+                },
+                "ordinal": {
+                  "const": 7
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "gate_review_decision_closed_schema_valid"
+                },
+                "ordinal": {
+                  "const": 8
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "reviewer_identity_present"
+                },
+                "ordinal": {
+                  "const": 9
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "reviewer_role_present"
+                },
+                "ordinal": {
+                  "const": 10
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "reviewer_attestation_present"
+                },
+                "ordinal": {
+                  "const": 11
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "acknowledged_not_real_bind_authorization"
+                },
+                "ordinal": {
+                  "const": 12
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "acknowledged_no_bind_invocation"
+                },
+                "ordinal": {
+                  "const": 13
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "acknowledged_no_bind_receipt"
+                },
+                "ordinal": {
+                  "const": 14
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "acknowledged_no_trustlog_write"
+                },
+                "ordinal": {
+                  "const": 15
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "acknowledged_no_dispatch"
+                },
+                "ordinal": {
+                  "const": 16
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "acknowledged_no_execution_authority"
+                },
+                "ordinal": {
+                  "const": 17
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "acknowledged_no_human_approval_creation"
+                },
+                "ordinal": {
+                  "const": 18
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "acknowledged_no_authority_evidence_creation"
+                },
+                "ordinal": {
+                  "const": 19
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "acknowledged_no_credential_access"
+                },
+                "ordinal": {
+                  "const": 20
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "acknowledged_no_authorization_header"
+                },
+                "ordinal": {
+                  "const": 21
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "acknowledged_no_network_call"
+                },
+                "ordinal": {
+                  "const": 22
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "acknowledged_semantic_match_not_authority"
+                },
+                "ordinal": {
+                  "const": 23
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "request_descriptor_preserved"
+                },
+                "ordinal": {
+                  "const": 24
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "execution_intent_identity_preserved"
+                },
+                "ordinal": {
+                  "const": 25
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "adapter_contract_identity_preserved"
+                },
+                "ordinal": {
+                  "const": 26
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "endpoint_identity_binding_preserved"
+                },
+                "ordinal": {
+                  "const": 27
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "credential_scope_binding_preserved"
+                },
+                "ordinal": {
+                  "const": 28
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "authority_evidence_linkage_result_preserved"
+                },
+                "ordinal": {
+                  "const": 29
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "human_approval_linkage_result_preserved"
+                },
+                "ordinal": {
+                  "const": 30
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "final_readiness_result_preserved"
+                },
+                "ordinal": {
+                  "const": 31
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "gate_review_result_constructed"
+                },
+                "ordinal": {
+                  "const": 32
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "future_real_bind_authorization_artifact_required"
+                },
+                "ordinal": {
+                  "const": 33
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "future_bind_invocation_gate_required"
+                },
+                "ordinal": {
+                  "const": 34
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "bind_authorization_not_created"
+                },
+                "ordinal": {
+                  "const": 35
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "execution_authority_not_created"
+                },
+                "ordinal": {
+                  "const": 36
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "human_approval_not_created"
+                },
+                "ordinal": {
+                  "const": 37
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "authority_evidence_not_created"
+                },
+                "ordinal": {
+                  "const": 38
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "bind_not_invoked"
+                },
+                "ordinal": {
+                  "const": 39
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "bind_receipt_not_created"
+                },
+                "ordinal": {
+                  "const": 40
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "trustlog_not_written"
+                },
+                "ordinal": {
+                  "const": 41
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "request_not_dispatched"
+                },
+                "ordinal": {
+                  "const": 42
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "endpoint_not_resolved"
+                },
+                "ordinal": {
+                  "const": 43
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "credential_material_not_accessed"
+                },
+                "ordinal": {
+                  "const": 44
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "authorization_header_not_constructed"
+                },
+                "ordinal": {
+                  "const": 45
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "network_not_used"
+                },
+                "ordinal": {
+                  "const": 46
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "webhook_not_called"
+                },
+                "ordinal": {
+                  "const": 47
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "live_adapter_not_instantiated"
+                },
+                "ordinal": {
+                  "const": 48
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        }
+      ],
+      "type": "array"
+    },
+    "bind_authorization_gate_review_decision": {
+      "$ref": "#/$defs/BindAuthorizationGateReviewDecision"
+    },
+    "bind_authorization_gate_review_decision_digest": {
+      "title": "Bind Authorization Gate Review Decision Digest",
+      "type": "string"
+    },
+    "bind_authorization_gate_review_mechanism": {
+      "const": "review_live_adapter_dry_run_bind_authorization_gate_without_authorization_creation/v1",
+      "title": "Bind Authorization Gate Review Mechanism",
+      "type": "string"
+    },
+    "bind_authorization_gate_review_recorded_at": {
+      "title": "Bind Authorization Gate Review Recorded At",
+      "type": "string"
+    },
+    "bind_authorization_gate_review_result": {
+      "$ref": "#/$defs/BindAuthorizationGateReviewResult"
+    },
+    "bind_authorization_gate_review_result_digest": {
+      "title": "Bind Authorization Gate Review Result Digest",
+      "type": "string"
+    },
+    "bind_authorization_gate_review_status": {
+      "const": "LIVE_ADAPTER_DRY_RUN_BIND_AUTHORIZATION_GATE_REVIEWED_NOT_AUTHORIZED",
+      "title": "Bind Authorization Gate Review Status",
+      "type": "string"
+    },
+    "bind_authorization_state": {
+      "const": "NOT_AUTHORIZED",
+      "title": "Bind Authorization State",
+      "type": "string"
+    },
+    "bind_invoked": {
+      "const": false,
+      "title": "Bind Invoked",
+      "type": "boolean"
+    },
+    "bind_receipt_created": {
+      "const": false,
+      "title": "Bind Receipt Created",
+      "type": "boolean"
+    },
+    "bind_state": {
+      "const": "NOT_BOUND",
+      "title": "Bind State",
+      "type": "string"
+    },
+    "candidate_identity": {
+      "additionalProperties": true,
+      "title": "Candidate Identity",
+      "type": "object"
+    },
+    "credential_material_accessed": {
+      "const": false,
+      "title": "Credential Material Accessed",
+      "type": "boolean"
+    },
+    "credential_reference": {
+      "additionalProperties": true,
+      "title": "Credential Reference",
+      "type": "object"
+    },
+    "credential_reference_digest": {
+      "title": "Credential Reference Digest",
+      "type": "string"
+    },
+    "credential_scope_binding": {
+      "additionalProperties": true,
+      "title": "Credential Scope Binding",
+      "type": "object"
+    },
+    "credential_scope_binding_digest": {
+      "title": "Credential Scope Binding Digest",
+      "type": "string"
+    },
+    "endpoint_candidate": {
+      "additionalProperties": true,
+      "title": "Endpoint Candidate",
+      "type": "object"
+    },
+    "endpoint_candidate_digest": {
+      "title": "Endpoint Candidate Digest",
+      "type": "string"
+    },
+    "endpoint_identity_binding": {
+      "additionalProperties": true,
+      "title": "Endpoint Identity Binding",
+      "type": "object"
+    },
+    "endpoint_identity_binding_digest": {
+      "title": "Endpoint Identity Binding Digest",
+      "type": "string"
+    },
+    "endpoint_resolved": {
+      "const": false,
+      "title": "Endpoint Resolved",
+      "type": "boolean"
+    },
+    "evidence_lineage": {
+      "additionalProperties": true,
+      "title": "Evidence Lineage",
+      "type": "object"
+    },
+    "execution_authority_created": {
+      "const": false,
+      "title": "Execution Authority Created",
+      "type": "boolean"
+    },
+    "execution_intent": {
+      "additionalProperties": true,
+      "title": "Execution Intent",
+      "type": "object"
+    },
+    "execution_intent_hash": {
+      "title": "Execution Intent Hash",
+      "type": "string"
+    },
+    "execution_intent_id": {
+      "title": "Execution Intent Id",
+      "type": "string"
+    },
+    "fail_closed": {
+      "title": "Fail Closed",
+      "type": "boolean"
+    },
+    "field_mapping_proof": {
+      "additionalProperties": true,
+      "title": "Field Mapping Proof",
+      "type": "object"
+    },
+    "final_bind_authorization_readiness_result": {
+      "additionalProperties": true,
+      "title": "Final Bind Authorization Readiness Result",
+      "type": "object"
+    },
+    "final_bind_authorization_readiness_result_digest": {
+      "title": "Final Bind Authorization Readiness Result Digest",
+      "type": "string"
+    },
+    "format_version": {
+      "const": "canonical-live-adapter-dry-run-bind-authorization-gate-review/v1",
+      "title": "Format Version",
+      "type": "string"
+    },
+    "future_bind_invocation_requirements": {
+      "maxItems": 8,
+      "minItems": 8,
+      "prefixItems": [
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FutureRequirement"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "bind_authorization_exists"
+                },
+                "ordinal": {
+                  "const": 1
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FutureRequirement"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "request_dispatch_boundary_approved"
+                },
+                "ordinal": {
+                  "const": 2
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FutureRequirement"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "credential_material_boundary_controlled"
+                },
+                "ordinal": {
+                  "const": 3
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FutureRequirement"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "authorization_header_construction_boundary_controlled"
+                },
+                "ordinal": {
+                  "const": 4
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FutureRequirement"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "bind_invocation_boundary_explicit"
+                },
+                "ordinal": {
+                  "const": 5
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FutureRequirement"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "bind_receipt_creation_boundary_explicit"
+                },
+                "ordinal": {
+                  "const": 6
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FutureRequirement"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "trustlog_write_boundary_after_bind_explicit"
+                },
+                "ordinal": {
+                  "const": 7
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FutureRequirement"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "postcondition_and_rollback_requirements_exist_for_later_apply_path"
+                },
+                "ordinal": {
+                  "const": 8
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        }
+      ],
+      "type": "array"
+    },
+    "future_bind_invocation_requirements_digest": {
+      "title": "Future Bind Invocation Requirements Digest",
+      "type": "string"
+    },
+    "future_real_bind_authorization_artifact_requirements": {
+      "maxItems": 11,
+      "minItems": 11,
+      "prefixItems": [
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FutureRequirement"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "real_authority_evidence_verification"
+                },
+                "ordinal": {
+                  "const": 1
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FutureRequirement"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "real_human_approval_verification_where_required"
+                },
+                "ordinal": {
+                  "const": 2
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FutureRequirement"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "final_policy_admissibility"
+                },
+                "ordinal": {
+                  "const": 3
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FutureRequirement"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "final_runtime_risk_review"
+                },
+                "ordinal": {
+                  "const": 4
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FutureRequirement"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "final_endpoint_identity_binding"
+                },
+                "ordinal": {
+                  "const": 5
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FutureRequirement"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "final_credential_resolution_authorization"
+                },
+                "ordinal": {
+                  "const": 6
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FutureRequirement"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "final_authorization_header_construction_boundary"
+                },
+                "ordinal": {
+                  "const": 7
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FutureRequirement"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "idempotency_key_binding"
+                },
+                "ordinal": {
+                  "const": 8
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FutureRequirement"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "final_no_replay_no_duplicate_dispatch_review"
+                },
+                "ordinal": {
+                  "const": 9
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FutureRequirement"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "final_operator_human_go_no_go_confirmation"
+                },
+                "ordinal": {
+                  "const": 10
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FutureRequirement"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "explicit_real_bind_authorization_decision_boundary"
+                },
+                "ordinal": {
+                  "const": 11
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        }
+      ],
+      "type": "array"
+    },
+    "future_real_bind_authorization_artifact_requirements_digest": {
+      "title": "Future Real Bind Authorization Artifact Requirements Digest",
+      "type": "string"
+    },
+    "gate_review_state": {
+      "enum": [
+        "PASSED_FOR_FUTURE_BIND_AUTHORIZATION_ARTIFACT",
+        "FAILED_FOR_FUTURE_BIND_AUTHORIZATION_ARTIFACT"
+      ],
+      "title": "Gate Review State",
+      "type": "string"
+    },
+    "human_approval_created": {
+      "const": false,
+      "title": "Human Approval Created",
+      "type": "boolean"
+    },
+    "human_approval_linkage_result": {
+      "additionalProperties": true,
+      "title": "Human Approval Linkage Result",
+      "type": "object"
+    },
+    "human_approval_linkage_result_digest": {
+      "title": "Human Approval Linkage Result Digest",
+      "type": "string"
+    },
+    "human_approval_reference_bundle": {
+      "additionalProperties": true,
+      "title": "Human Approval Reference Bundle",
+      "type": "object"
+    },
+    "human_approval_reference_bundle_digest": {
+      "title": "Human Approval Reference Bundle Digest",
+      "type": "string"
+    },
+    "human_approval_state": {
+      "const": "NOT_APPROVED",
+      "title": "Human Approval State",
+      "type": "string"
+    },
+    "live_adapter_dry_run_bind_authorization_gate_review_hash": {
+      "title": "Live Adapter Dry Run Bind Authorization Gate Review Hash",
+      "type": "string"
+    },
+    "live_adapter_dry_run_bind_authorization_gate_review_id": {
+      "title": "Live Adapter Dry Run Bind Authorization Gate Review Id",
+      "type": "string"
+    },
+    "live_adapter_instantiated": {
+      "const": false,
+      "title": "Live Adapter Instantiated",
+      "type": "boolean"
+    },
+    "network_used": {
+      "const": false,
+      "title": "Network Used",
+      "type": "boolean"
+    },
+    "replay_summary": {
+      "additionalProperties": true,
+      "title": "Replay Summary",
+      "type": "object"
+    },
+    "request_descriptor": {
+      "additionalProperties": true,
+      "title": "Request Descriptor",
+      "type": "object"
+    },
+    "request_dispatch_state": {
+      "const": "NOT_DISPATCHED",
+      "title": "Request Dispatch State",
+      "type": "string"
+    },
+    "request_dispatched": {
+      "const": false,
+      "title": "Request Dispatched",
+      "type": "boolean"
+    },
+    "required_field_presence": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "title": "Required Field Presence",
+      "type": "object"
+    },
+    "scope_limitations": {
+      "maxItems": 27,
+      "minItems": 27,
+      "prefixItems": [
+        {
+          "const": "NOT_DISPATCHED"
+        },
+        {
+          "const": "NOT_BIND_INVOCATION"
+        },
+        {
+          "const": "NOT_BIND_AUTHORIZATION"
+        },
+        {
+          "const": "NOT_BIND_AUTHORIZATION_CREATION"
+        },
+        {
+          "const": "NOT_BIND_RECEIPT"
+        },
+        {
+          "const": "NOT_TRUSTLOG_WRITE"
+        },
+        {
+          "const": "NOT_EXECUTION_AUTHORITY"
+        },
+        {
+          "const": "NOT_HUMAN_APPROVAL"
+        },
+        {
+          "const": "NOT_HUMAN_APPROVAL_CREATION"
+        },
+        {
+          "const": "NOT_AUTHORITY_EVIDENCE"
+        },
+        {
+          "const": "NOT_AUTHORITY_EVIDENCE_CREATION"
+        },
+        {
+          "const": "NOT_CREDENTIAL_RESOLUTION"
+        },
+        {
+          "const": "NOT_CREDENTIAL_ACCESS"
+        },
+        {
+          "const": "NOT_CREDENTIAL_EMBEDDING"
+        },
+        {
+          "const": "NOT_AUTHORIZATION_HEADER"
+        },
+        {
+          "const": "NOT_TOKEN"
+        },
+        {
+          "const": "NOT_SECRET"
+        },
+        {
+          "const": "NOT_ENDPOINT_RESOLUTION"
+        },
+        {
+          "const": "NOT_DNS_RESOLUTION"
+        },
+        {
+          "const": "NOT_NETWORK_CALL"
+        },
+        {
+          "const": "NOT_WEBHOOK_CALL"
+        },
+        {
+          "const": "NOT_LIVE_ADAPTER_INSTANCE"
+        },
+        {
+          "const": "NOT_LIVE_ADAPTER_RESULT"
+        },
+        {
+          "const": "NOT_OPERATION_COMMIT"
+        },
+        {
+          "const": "NOT_PRODUCTION_CLAIM"
+        },
+        {
+          "const": "NOT_CUSTOMER_CLAIM"
+        },
+        {
+          "const": "NOT_REGULATORY_CERTIFICATION"
+        }
+      ],
+      "title": "Scope Limitations",
+      "type": "array"
+    },
+    "source_authority_evidence_linkage_review_hash": {
+      "title": "Source Authority Evidence Linkage Review Hash",
+      "type": "string"
+    },
+    "source_bind_pre_dispatch_review_hash": {
+      "title": "Source Bind Pre Dispatch Review Hash",
+      "type": "string"
+    },
+    "source_credential_authorization_hash": {
+      "title": "Source Credential Authorization Hash",
+      "type": "string"
+    },
+    "source_decision_identity": {
+      "additionalProperties": true,
+      "title": "Source Decision Identity",
+      "type": "object"
+    },
+    "source_dispatch_readiness_hash": {
+      "title": "Source Dispatch Readiness Hash",
+      "type": "string"
+    },
+    "source_endpoint_allowlist_evaluation_hash": {
+      "title": "Source Endpoint Allowlist Evaluation Hash",
+      "type": "string"
+    },
+    "source_final_bind_authorization_readiness_hash": {
+      "title": "Source Final Bind Authorization Readiness Hash",
+      "type": "string"
+    },
+    "source_final_bind_authorization_readiness_id": {
+      "title": "Source Final Bind Authorization Readiness Id",
+      "type": "string"
+    },
+    "source_final_bind_authorization_readiness_packet": {
+      "additionalProperties": true,
+      "title": "Source Final Bind Authorization Readiness Packet",
+      "type": "object"
+    },
+    "source_live_adapter_dry_run_request_hash": {
+      "title": "Source Live Adapter Dry Run Request Hash",
+      "type": "string"
+    },
+    "source_operator_dispatch_review_hash": {
+      "title": "Source Operator Dispatch Review Hash",
+      "type": "string"
+    },
+    "source_to_execution_intent_mapping": {
+      "additionalProperties": true,
+      "title": "Source To Execution Intent Mapping",
+      "type": "object"
+    },
+    "trustlog_written": {
+      "const": false,
+      "title": "Trustlog Written",
+      "type": "boolean"
+    },
+    "webhook_called": {
+      "const": false,
+      "title": "Webhook Called",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "format_version",
+    "live_adapter_dry_run_bind_authorization_gate_review_id",
+    "live_adapter_dry_run_bind_authorization_gate_review_hash",
+    "bind_authorization_gate_review_mechanism",
+    "bind_authorization_gate_review_recorded_at",
+    "source_final_bind_authorization_readiness_id",
+    "source_final_bind_authorization_readiness_hash",
+    "source_final_bind_authorization_readiness_packet",
+    "source_authority_evidence_linkage_review_hash",
+    "source_bind_pre_dispatch_review_hash",
+    "source_operator_dispatch_review_hash",
+    "source_credential_authorization_hash",
+    "source_endpoint_allowlist_evaluation_hash",
+    "source_dispatch_readiness_hash",
+    "source_live_adapter_dry_run_request_hash",
+    "request_descriptor",
+    "execution_intent",
+    "execution_intent_id",
+    "execution_intent_hash",
+    "adapter_contract_descriptor",
+    "adapter_contract_id",
+    "adapter_contract_hash",
+    "adapter_contract_version",
+    "endpoint_candidate",
+    "endpoint_candidate_digest",
+    "endpoint_identity_binding",
+    "endpoint_identity_binding_digest",
+    "credential_reference",
+    "credential_reference_digest",
+    "credential_scope_binding",
+    "credential_scope_binding_digest",
+    "authority_evidence_reference_bundle",
+    "authority_evidence_reference_bundle_digest",
+    "authority_evidence_linkage_result",
+    "authority_evidence_linkage_result_digest",
+    "human_approval_reference_bundle",
+    "human_approval_reference_bundle_digest",
+    "human_approval_linkage_result",
+    "human_approval_linkage_result_digest",
+    "final_bind_authorization_readiness_result",
+    "final_bind_authorization_readiness_result_digest",
+    "bind_authorization_gate_review_decision",
+    "bind_authorization_gate_review_decision_digest",
+    "bind_authorization_gate_review_result",
+    "bind_authorization_gate_review_result_digest",
+    "bind_authorization_gate_review_checks",
+    "bind_authorization_gate_review_check_digest",
+    "future_real_bind_authorization_artifact_requirements",
+    "future_real_bind_authorization_artifact_requirements_digest",
+    "future_bind_invocation_requirements",
+    "future_bind_invocation_requirements_digest",
+    "source_to_execution_intent_mapping",
+    "field_mapping_proof",
+    "required_field_presence",
+    "source_decision_identity",
+    "candidate_identity",
+    "evidence_lineage",
+    "replay_summary",
+    "bind_authorization_gate_review_status",
+    "request_dispatch_state",
+    "bind_state",
+    "authority_state",
+    "human_approval_state",
+    "bind_authorization_state",
+    "gate_review_state",
+    "authority_evidence_created",
+    "human_approval_created",
+    "execution_authority_created",
+    "bind_authorization_created",
+    "bind_invoked",
+    "bind_receipt_created",
+    "trustlog_written",
+    "request_dispatched",
+    "endpoint_resolved",
+    "credential_material_accessed",
+    "authorization_header_constructed",
+    "network_used",
+    "live_adapter_instantiated",
+    "webhook_called",
+    "fail_closed",
+    "scope_limitations"
+  ],
+  "title": "CanonicalLiveAdapterDryRunBindAuthorizationGateReviewPacket",
+  "type": "object"
+}

--- a/schemas/live-adapter-dry-run-bind-authorization-gate-review-v1.schema.json
+++ b/schemas/live-adapter-dry-run-bind-authorization-gate-review-v1.schema.json
@@ -2390,6 +2390,10 @@
       "title": "Source Final Bind Authorization Readiness Packet",
       "type": "object"
     },
+    "source_human_approval_linkage_review_hash": {
+      "title": "Source Human Approval Linkage Review Hash",
+      "type": "string"
+    },
     "source_live_adapter_dry_run_request_hash": {
       "title": "Source Live Adapter Dry Run Request Hash",
       "type": "string"
@@ -2423,6 +2427,7 @@
     "source_final_bind_authorization_readiness_id",
     "source_final_bind_authorization_readiness_hash",
     "source_final_bind_authorization_readiness_packet",
+    "source_human_approval_linkage_review_hash",
     "source_authority_evidence_linkage_review_hash",
     "source_bind_pre_dispatch_review_hash",
     "source_operator_dispatch_review_hash",

--- a/schemas/live-adapter-dry-run-bind-authorization-gate-review-v1.schema.json
+++ b/schemas/live-adapter-dry-run-bind-authorization-gate-review-v1.schema.json
@@ -333,6 +333,7 @@
             "source_request_not_dispatched",
             "source_bind_not_invoked",
             "source_bind_not_authorized",
+            "source_final_readiness_passed",
             "source_human_approval_linkage_passed",
             "source_authority_evidence_linkage_passed",
             "source_bind_pre_dispatch_review_passed",
@@ -377,7 +378,9 @@
             "network_not_used",
             "webhook_not_called",
             "live_adapter_not_instantiated"
-          ]
+          ],
+          "title": "Name",
+          "type": "string"
         },
         "network_used": {
           "const": false,
@@ -634,7 +637,7 @@
             {
               "properties": {
                 "name": {
-                  "const": "source_human_approval_linkage_passed"
+                  "const": "source_final_readiness_passed"
                 },
                 "ordinal": {
                   "const": 5
@@ -656,7 +659,7 @@
             {
               "properties": {
                 "name": {
-                  "const": "source_authority_evidence_linkage_passed"
+                  "const": "source_human_approval_linkage_passed"
                 },
                 "ordinal": {
                   "const": 6
@@ -678,7 +681,7 @@
             {
               "properties": {
                 "name": {
-                  "const": "source_bind_pre_dispatch_review_passed"
+                  "const": "source_authority_evidence_linkage_passed"
                 },
                 "ordinal": {
                   "const": 7
@@ -700,7 +703,7 @@
             {
               "properties": {
                 "name": {
-                  "const": "gate_review_decision_closed_schema_valid"
+                  "const": "source_bind_pre_dispatch_review_passed"
                 },
                 "ordinal": {
                   "const": 8
@@ -722,7 +725,7 @@
             {
               "properties": {
                 "name": {
-                  "const": "reviewer_identity_present"
+                  "const": "gate_review_decision_closed_schema_valid"
                 },
                 "ordinal": {
                   "const": 9
@@ -744,7 +747,7 @@
             {
               "properties": {
                 "name": {
-                  "const": "reviewer_role_present"
+                  "const": "reviewer_identity_present"
                 },
                 "ordinal": {
                   "const": 10
@@ -766,7 +769,7 @@
             {
               "properties": {
                 "name": {
-                  "const": "reviewer_attestation_present"
+                  "const": "reviewer_role_present"
                 },
                 "ordinal": {
                   "const": 11
@@ -788,7 +791,7 @@
             {
               "properties": {
                 "name": {
-                  "const": "acknowledged_not_real_bind_authorization"
+                  "const": "reviewer_attestation_present"
                 },
                 "ordinal": {
                   "const": 12
@@ -810,7 +813,7 @@
             {
               "properties": {
                 "name": {
-                  "const": "acknowledged_no_bind_invocation"
+                  "const": "acknowledged_not_real_bind_authorization"
                 },
                 "ordinal": {
                   "const": 13
@@ -832,7 +835,7 @@
             {
               "properties": {
                 "name": {
-                  "const": "acknowledged_no_bind_receipt"
+                  "const": "acknowledged_no_bind_invocation"
                 },
                 "ordinal": {
                   "const": 14
@@ -854,7 +857,7 @@
             {
               "properties": {
                 "name": {
-                  "const": "acknowledged_no_trustlog_write"
+                  "const": "acknowledged_no_bind_receipt"
                 },
                 "ordinal": {
                   "const": 15
@@ -876,7 +879,7 @@
             {
               "properties": {
                 "name": {
-                  "const": "acknowledged_no_dispatch"
+                  "const": "acknowledged_no_trustlog_write"
                 },
                 "ordinal": {
                   "const": 16
@@ -898,7 +901,7 @@
             {
               "properties": {
                 "name": {
-                  "const": "acknowledged_no_execution_authority"
+                  "const": "acknowledged_no_dispatch"
                 },
                 "ordinal": {
                   "const": 17
@@ -920,7 +923,7 @@
             {
               "properties": {
                 "name": {
-                  "const": "acknowledged_no_human_approval_creation"
+                  "const": "acknowledged_no_execution_authority"
                 },
                 "ordinal": {
                   "const": 18
@@ -942,7 +945,7 @@
             {
               "properties": {
                 "name": {
-                  "const": "acknowledged_no_authority_evidence_creation"
+                  "const": "acknowledged_no_human_approval_creation"
                 },
                 "ordinal": {
                   "const": 19
@@ -964,7 +967,7 @@
             {
               "properties": {
                 "name": {
-                  "const": "acknowledged_no_credential_access"
+                  "const": "acknowledged_no_authority_evidence_creation"
                 },
                 "ordinal": {
                   "const": 20
@@ -986,7 +989,7 @@
             {
               "properties": {
                 "name": {
-                  "const": "acknowledged_no_authorization_header"
+                  "const": "acknowledged_no_credential_access"
                 },
                 "ordinal": {
                   "const": 21
@@ -1008,7 +1011,7 @@
             {
               "properties": {
                 "name": {
-                  "const": "acknowledged_no_network_call"
+                  "const": "acknowledged_no_authorization_header"
                 },
                 "ordinal": {
                   "const": 22
@@ -1030,7 +1033,7 @@
             {
               "properties": {
                 "name": {
-                  "const": "acknowledged_semantic_match_not_authority"
+                  "const": "acknowledged_no_network_call"
                 },
                 "ordinal": {
                   "const": 23
@@ -1052,7 +1055,7 @@
             {
               "properties": {
                 "name": {
-                  "const": "request_descriptor_preserved"
+                  "const": "acknowledged_semantic_match_not_authority"
                 },
                 "ordinal": {
                   "const": 24
@@ -1074,7 +1077,7 @@
             {
               "properties": {
                 "name": {
-                  "const": "execution_intent_identity_preserved"
+                  "const": "request_descriptor_preserved"
                 },
                 "ordinal": {
                   "const": 25
@@ -1096,7 +1099,7 @@
             {
               "properties": {
                 "name": {
-                  "const": "adapter_contract_identity_preserved"
+                  "const": "execution_intent_identity_preserved"
                 },
                 "ordinal": {
                   "const": 26
@@ -1118,7 +1121,7 @@
             {
               "properties": {
                 "name": {
-                  "const": "endpoint_identity_binding_preserved"
+                  "const": "adapter_contract_identity_preserved"
                 },
                 "ordinal": {
                   "const": 27
@@ -1140,7 +1143,7 @@
             {
               "properties": {
                 "name": {
-                  "const": "credential_scope_binding_preserved"
+                  "const": "endpoint_identity_binding_preserved"
                 },
                 "ordinal": {
                   "const": 28
@@ -1162,7 +1165,7 @@
             {
               "properties": {
                 "name": {
-                  "const": "authority_evidence_linkage_result_preserved"
+                  "const": "credential_scope_binding_preserved"
                 },
                 "ordinal": {
                   "const": 29
@@ -1184,7 +1187,7 @@
             {
               "properties": {
                 "name": {
-                  "const": "human_approval_linkage_result_preserved"
+                  "const": "authority_evidence_linkage_result_preserved"
                 },
                 "ordinal": {
                   "const": 30
@@ -1206,7 +1209,7 @@
             {
               "properties": {
                 "name": {
-                  "const": "final_readiness_result_preserved"
+                  "const": "human_approval_linkage_result_preserved"
                 },
                 "ordinal": {
                   "const": 31
@@ -1228,7 +1231,7 @@
             {
               "properties": {
                 "name": {
-                  "const": "gate_review_result_constructed"
+                  "const": "final_readiness_result_preserved"
                 },
                 "ordinal": {
                   "const": 32
@@ -1250,7 +1253,7 @@
             {
               "properties": {
                 "name": {
-                  "const": "future_real_bind_authorization_artifact_required"
+                  "const": "gate_review_result_constructed"
                 },
                 "ordinal": {
                   "const": 33
@@ -1272,7 +1275,7 @@
             {
               "properties": {
                 "name": {
-                  "const": "future_bind_invocation_gate_required"
+                  "const": "future_real_bind_authorization_artifact_required"
                 },
                 "ordinal": {
                   "const": 34
@@ -1294,7 +1297,7 @@
             {
               "properties": {
                 "name": {
-                  "const": "bind_authorization_not_created"
+                  "const": "future_bind_invocation_gate_required"
                 },
                 "ordinal": {
                   "const": 35
@@ -1316,7 +1319,7 @@
             {
               "properties": {
                 "name": {
-                  "const": "execution_authority_not_created"
+                  "const": "bind_authorization_not_created"
                 },
                 "ordinal": {
                   "const": 36
@@ -1338,7 +1341,7 @@
             {
               "properties": {
                 "name": {
-                  "const": "human_approval_not_created"
+                  "const": "execution_authority_not_created"
                 },
                 "ordinal": {
                   "const": 37
@@ -1360,7 +1363,7 @@
             {
               "properties": {
                 "name": {
-                  "const": "authority_evidence_not_created"
+                  "const": "human_approval_not_created"
                 },
                 "ordinal": {
                   "const": 38
@@ -1382,7 +1385,7 @@
             {
               "properties": {
                 "name": {
-                  "const": "bind_not_invoked"
+                  "const": "authority_evidence_not_created"
                 },
                 "ordinal": {
                   "const": 39
@@ -1404,7 +1407,7 @@
             {
               "properties": {
                 "name": {
-                  "const": "bind_receipt_not_created"
+                  "const": "bind_not_invoked"
                 },
                 "ordinal": {
                   "const": 40
@@ -1426,7 +1429,7 @@
             {
               "properties": {
                 "name": {
-                  "const": "trustlog_not_written"
+                  "const": "bind_receipt_not_created"
                 },
                 "ordinal": {
                   "const": 41
@@ -1448,7 +1451,7 @@
             {
               "properties": {
                 "name": {
-                  "const": "request_not_dispatched"
+                  "const": "trustlog_not_written"
                 },
                 "ordinal": {
                   "const": 42
@@ -1470,7 +1473,7 @@
             {
               "properties": {
                 "name": {
-                  "const": "endpoint_not_resolved"
+                  "const": "request_not_dispatched"
                 },
                 "ordinal": {
                   "const": 43
@@ -1492,7 +1495,7 @@
             {
               "properties": {
                 "name": {
-                  "const": "credential_material_not_accessed"
+                  "const": "endpoint_not_resolved"
                 },
                 "ordinal": {
                   "const": 44
@@ -1514,7 +1517,7 @@
             {
               "properties": {
                 "name": {
-                  "const": "authorization_header_not_constructed"
+                  "const": "credential_material_not_accessed"
                 },
                 "ordinal": {
                   "const": 45
@@ -1536,7 +1539,7 @@
             {
               "properties": {
                 "name": {
-                  "const": "network_not_used"
+                  "const": "authorization_header_not_constructed"
                 },
                 "ordinal": {
                   "const": 46
@@ -1558,7 +1561,7 @@
             {
               "properties": {
                 "name": {
-                  "const": "webhook_not_called"
+                  "const": "network_not_used"
                 },
                 "ordinal": {
                   "const": 47
@@ -1580,10 +1583,32 @@
             {
               "properties": {
                 "name": {
-                  "const": "live_adapter_not_instantiated"
+                  "const": "webhook_not_called"
                 },
                 "ordinal": {
                   "const": 48
+                }
+              },
+              "required": [
+                "ordinal",
+                "name"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/GateReviewCheck"
+            },
+            {
+              "properties": {
+                "name": {
+                  "const": "live_adapter_not_instantiated"
+                },
+                "ordinal": {
+                  "const": 49
                 }
               },
               "required": [

--- a/veritas_os/policy/live_adapter_dry_run_bind_authorization_gate_review.py
+++ b/veritas_os/policy/live_adapter_dry_run_bind_authorization_gate_review.py
@@ -326,6 +326,7 @@ class CanonicalLiveAdapterDryRunBindAuthorizationGateReviewPacket(BaseModel):
     source_final_bind_authorization_readiness_id: str
     source_final_bind_authorization_readiness_hash: str
     source_final_bind_authorization_readiness_packet: dict[str, Any]
+    source_human_approval_linkage_review_hash: str
     source_authority_evidence_linkage_review_hash: str
     source_bind_pre_dispatch_review_hash: str
     source_operator_dispatch_review_hash: str

--- a/veritas_os/policy/live_adapter_dry_run_bind_authorization_gate_review.py
+++ b/veritas_os/policy/live_adapter_dry_run_bind_authorization_gate_review.py
@@ -1,0 +1,764 @@
+"""Record Bind Authorization Gate review without creating authority.
+
+This module performs only deterministic, local comparisons over a previously
+verified Human Approval linkage review packet.  It deliberately has no runtime,
+credential, persistence, adapter, or transport dependencies.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from veritas_os.policy.live_adapter_dry_run_final_bind_authorization_readiness import (
+    CanonicalLiveAdapterDryRunFinalBindAuthorizationReadinessPacket,
+    LiveAdapterDryRunFinalBindAuthorizationReadinessError,
+    verify_live_adapter_dry_run_final_bind_authorization_readiness_packet,
+)
+
+FORMAT_VERSION = "canonical-live-adapter-dry-run-bind-authorization-gate-review/v1"
+MECHANISM = "review_live_adapter_dry_run_bind_authorization_gate_without_authorization_creation/v1"
+STATUS = "LIVE_ADAPTER_DRY_RUN_BIND_AUTHORIZATION_GATE_REVIEWED_NOT_AUTHORIZED"
+SOURCE_STATUS = (
+    "LIVE_ADAPTER_DRY_RUN_FINAL_BIND_AUTHORIZATION_READINESS_RECORDED_NOT_AUTHORIZED"
+)
+CHECK_MODE = "deterministic_local_bind_authorization_gate_review_only"
+OUTCOMES = (
+    "PASSED_FOR_FUTURE_BIND_AUTHORIZATION_ARTIFACT",
+    "FAILED_FOR_FUTURE_BIND_AUTHORIZATION_ARTIFACT",
+)
+CHECK_NAMES = (
+    "source_final_bind_authorization_readiness_verified",
+    "source_request_not_dispatched",
+    "source_bind_not_invoked",
+    "source_bind_not_authorized",
+    "source_human_approval_linkage_passed",
+    "source_authority_evidence_linkage_passed",
+    "source_bind_pre_dispatch_review_passed",
+    "gate_review_decision_closed_schema_valid",
+    "reviewer_identity_present",
+    "reviewer_role_present",
+    "reviewer_attestation_present",
+    "acknowledged_not_real_bind_authorization",
+    "acknowledged_no_bind_invocation",
+    "acknowledged_no_bind_receipt",
+    "acknowledged_no_trustlog_write",
+    "acknowledged_no_dispatch",
+    "acknowledged_no_execution_authority",
+    "acknowledged_no_human_approval_creation",
+    "acknowledged_no_authority_evidence_creation",
+    "acknowledged_no_credential_access",
+    "acknowledged_no_authorization_header",
+    "acknowledged_no_network_call",
+    "acknowledged_semantic_match_not_authority",
+    "request_descriptor_preserved",
+    "execution_intent_identity_preserved",
+    "adapter_contract_identity_preserved",
+    "endpoint_identity_binding_preserved",
+    "credential_scope_binding_preserved",
+    "authority_evidence_linkage_result_preserved",
+    "human_approval_linkage_result_preserved",
+    "final_readiness_result_preserved",
+    "gate_review_result_constructed",
+    "future_real_bind_authorization_artifact_required",
+    "future_bind_invocation_gate_required",
+    "bind_authorization_not_created",
+    "execution_authority_not_created",
+    "human_approval_not_created",
+    "authority_evidence_not_created",
+    "bind_not_invoked",
+    "bind_receipt_not_created",
+    "trustlog_not_written",
+    "request_not_dispatched",
+    "endpoint_not_resolved",
+    "credential_material_not_accessed",
+    "authorization_header_not_constructed",
+    "network_not_used",
+    "webhook_not_called",
+    "live_adapter_not_instantiated",
+)
+EFFECT_FIELDS = (
+    "bind_authorization_created",
+    "execution_authority_created",
+    "human_approval_created",
+    "authority_evidence_created",
+    "bind_invoked",
+    "bind_receipt_created",
+    "trustlog_written",
+    "request_dispatched",
+    "endpoint_resolved",
+    "credential_material_accessed",
+    "credential_material_embedded",
+    "authorization_header_constructed",
+    "token_embedded",
+    "secret_embedded",
+    "network_used",
+    "dns_used",
+    "webhook_called",
+    "live_adapter_instantiated",
+    "live_adapter_method_called",
+    "external_effect_used",
+    "filesystem_used",
+    "database_used",
+    "provider_used",
+    "subprocess_used",
+    "operation_committed",
+)
+ACKNOWLEDGEMENTS = (
+    "acknowledged_not_real_bind_authorization",
+    "acknowledged_no_bind_invocation",
+    "acknowledged_no_bind_receipt",
+    "acknowledged_no_trustlog_write",
+    "acknowledged_no_dispatch",
+    "acknowledged_no_execution_authority",
+    "acknowledged_no_human_approval_creation",
+    "acknowledged_no_authority_evidence_creation",
+    "acknowledged_no_credential_access",
+    "acknowledged_no_authorization_header",
+    "acknowledged_no_network_call",
+    "acknowledged_semantic_match_not_authority",
+)
+SCOPE_LIMITATIONS = (
+    "NOT_DISPATCHED",
+    "NOT_BIND_INVOCATION",
+    "NOT_BIND_AUTHORIZATION",
+    "NOT_BIND_AUTHORIZATION_CREATION",
+    "NOT_BIND_RECEIPT",
+    "NOT_TRUSTLOG_WRITE",
+    "NOT_EXECUTION_AUTHORITY",
+    "NOT_HUMAN_APPROVAL",
+    "NOT_HUMAN_APPROVAL_CREATION",
+    "NOT_AUTHORITY_EVIDENCE",
+    "NOT_AUTHORITY_EVIDENCE_CREATION",
+    "NOT_CREDENTIAL_RESOLUTION",
+    "NOT_CREDENTIAL_ACCESS",
+    "NOT_CREDENTIAL_EMBEDDING",
+    "NOT_AUTHORIZATION_HEADER",
+    "NOT_TOKEN",
+    "NOT_SECRET",
+    "NOT_ENDPOINT_RESOLUTION",
+    "NOT_DNS_RESOLUTION",
+    "NOT_NETWORK_CALL",
+    "NOT_WEBHOOK_CALL",
+    "NOT_LIVE_ADAPTER_INSTANCE",
+    "NOT_LIVE_ADAPTER_RESULT",
+    "NOT_OPERATION_COMMIT",
+    "NOT_PRODUCTION_CLAIM",
+    "NOT_CUSTOMER_CLAIM",
+    "NOT_REGULATORY_CERTIFICATION",
+)
+AUTHORIZATION_REQUIREMENTS = (
+    "real_authority_evidence_verification",
+    "real_human_approval_verification_where_required",
+    "final_policy_admissibility",
+    "final_runtime_risk_review",
+    "final_endpoint_identity_binding",
+    "final_credential_resolution_authorization",
+    "final_authorization_header_construction_boundary",
+    "idempotency_key_binding",
+    "final_no_replay_no_duplicate_dispatch_review",
+    "final_operator_human_go_no_go_confirmation",
+    "explicit_real_bind_authorization_decision_boundary",
+)
+INVOCATION_REQUIREMENTS = (
+    "bind_authorization_exists",
+    "request_dispatch_boundary_approved",
+    "credential_material_boundary_controlled",
+    "authorization_header_construction_boundary_controlled",
+    "bind_invocation_boundary_explicit",
+    "bind_receipt_creation_boundary_explicit",
+    "trustlog_write_boundary_after_bind_explicit",
+    "postcondition_and_rollback_requirements_exist_for_later_apply_path",
+)
+DOMAINS = {
+    "decision": "veritas.live-adapter-dry-run-bind-authorization-gate-review.decision/v1",
+    "result": "veritas.live-adapter-dry-run-bind-authorization-gate-review.result/v1",
+    "checks": "veritas.live-adapter-dry-run-bind-authorization-gate-review.checks/v1",
+    "authorization": "veritas.live-adapter-dry-run-bind-authorization-gate-review.future-real-bind-authorization-artifact-requirements/v1",
+    "invocation": "veritas.live-adapter-dry-run-bind-authorization-gate-review.future-bind-invocation-requirements/v1",
+    "packet": "veritas.live-adapter-dry-run-bind-authorization-gate-review.packet/v1",
+}
+COPIED_FIELDS = (
+    "request_descriptor",
+    "execution_intent",
+    "execution_intent_id",
+    "execution_intent_hash",
+    "adapter_contract_descriptor",
+    "adapter_contract_id",
+    "adapter_contract_hash",
+    "adapter_contract_version",
+    "endpoint_candidate",
+    "endpoint_candidate_digest",
+    "endpoint_identity_binding",
+    "endpoint_identity_binding_digest",
+    "credential_reference",
+    "credential_reference_digest",
+    "credential_scope_binding",
+    "credential_scope_binding_digest",
+    "authority_evidence_reference_bundle",
+    "authority_evidence_reference_bundle_digest",
+    "authority_evidence_linkage_result",
+    "authority_evidence_linkage_result_digest",
+    "human_approval_reference_bundle",
+    "human_approval_reference_bundle_digest",
+    "human_approval_linkage_result",
+    "human_approval_linkage_result_digest",
+    "final_bind_authorization_readiness_result",
+    "final_bind_authorization_readiness_result_digest",
+    "source_to_execution_intent_mapping",
+    "field_mapping_proof",
+    "required_field_presence",
+    "source_decision_identity",
+    "candidate_identity",
+    "evidence_lineage",
+    "replay_summary",
+)
+
+
+class LiveAdapterDryRunBindAuthorizationGateReviewError(ValueError):
+    """Stable fail-closed error for invalid gate review evidence."""
+
+
+class BindAuthorizationGateReviewDecision(BaseModel):
+    """Closed human review metadata that explicitly is not authorization."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    bind_authorization_gate_review_decision_id: str = Field(min_length=1)
+    reviewer_id: str = Field(min_length=1)
+    reviewer_role: str = Field(min_length=1)
+    reviewer_attestation: str = Field(min_length=1)
+    reviewed_at: str
+    review_outcome: Literal[*OUTCOMES]
+    review_reason: str = Field(min_length=1)
+    acknowledged_not_real_bind_authorization: bool
+    acknowledged_no_bind_invocation: bool
+    acknowledged_no_bind_receipt: bool
+    acknowledged_no_trustlog_write: bool
+    acknowledged_no_dispatch: bool
+    acknowledged_no_execution_authority: bool
+    acknowledged_no_human_approval_creation: bool
+    acknowledged_no_authority_evidence_creation: bool
+    acknowledged_no_credential_access: bool
+    acknowledged_no_authorization_header: bool
+    acknowledged_no_network_call: bool
+    acknowledged_semantic_match_not_authority: bool
+
+
+class BindAuthorizationGateReviewResult(BaseModel):
+    """Deterministic readiness conclusion with explicit non-authority flags."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    source_final_readiness_passed: bool
+    source_human_approval_linkage_passed: bool
+    source_authority_evidence_linkage_passed: bool
+    source_bind_pre_dispatch_review_passed: bool
+    gate_review_passed: bool
+    accepted_for_future_real_bind_authorization_artifact: bool
+    rejection_reasons: tuple[str, ...]
+    comparison_mode: Literal[CHECK_MODE]
+    semantic_match_used: Literal[False]
+    creates_real_bind_authorization: Literal[False]
+    creates_execution_authority: Literal[False]
+    creates_human_approval: Literal[False]
+    creates_authority_evidence: Literal[False]
+
+
+class GateReviewCheck(BaseModel):
+    """One ordered local check whose effect flags are all false."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    check_id: str
+    ordinal: int = Field(ge=1, le=49)
+    name: Literal[*CHECK_NAMES]
+    mode: Literal[CHECK_MODE]
+    passed: bool
+    evidence_ref: str
+    bind_authorization_created: Literal[False]
+    execution_authority_created: Literal[False]
+    human_approval_created: Literal[False]
+    authority_evidence_created: Literal[False]
+    bind_invoked: Literal[False]
+    bind_receipt_created: Literal[False]
+    trustlog_written: Literal[False]
+    request_dispatched: Literal[False]
+    endpoint_resolved: Literal[False]
+    credential_material_accessed: Literal[False]
+    credential_material_embedded: Literal[False]
+    authorization_header_constructed: Literal[False]
+    token_embedded: Literal[False]
+    secret_embedded: Literal[False]
+    network_used: Literal[False]
+    dns_used: Literal[False]
+    webhook_called: Literal[False]
+    live_adapter_instantiated: Literal[False]
+    live_adapter_method_called: Literal[False]
+    external_effect_used: Literal[False]
+    filesystem_used: Literal[False]
+    database_used: Literal[False]
+    provider_used: Literal[False]
+    subprocess_used: Literal[False]
+    operation_committed: Literal[False]
+
+
+class FutureRequirement(BaseModel):
+    """A requirement that only a separate future artifact may satisfy."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    ordinal: int
+    name: str
+    separate_future_artifact_required: Literal[True]
+    satisfied_by_this_packet: Literal[False]
+
+
+class CanonicalLiveAdapterDryRunBindAuthorizationGateReviewPacket(BaseModel):
+    """Closed content-addressed gate review packet without authorization."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    format_version: Literal[FORMAT_VERSION]
+    live_adapter_dry_run_bind_authorization_gate_review_id: str
+    live_adapter_dry_run_bind_authorization_gate_review_hash: str
+    bind_authorization_gate_review_mechanism: Literal[MECHANISM]
+    bind_authorization_gate_review_recorded_at: str
+    source_final_bind_authorization_readiness_id: str
+    source_final_bind_authorization_readiness_hash: str
+    source_final_bind_authorization_readiness_packet: dict[str, Any]
+    source_authority_evidence_linkage_review_hash: str
+    source_bind_pre_dispatch_review_hash: str
+    source_operator_dispatch_review_hash: str
+    source_credential_authorization_hash: str
+    source_endpoint_allowlist_evaluation_hash: str
+    source_dispatch_readiness_hash: str
+    source_live_adapter_dry_run_request_hash: str
+    request_descriptor: dict[str, Any]
+    execution_intent: dict[str, Any]
+    execution_intent_id: str
+    execution_intent_hash: str
+    adapter_contract_descriptor: dict[str, Any]
+    adapter_contract_id: str
+    adapter_contract_hash: str
+    adapter_contract_version: str
+    endpoint_candidate: dict[str, Any]
+    endpoint_candidate_digest: str
+    endpoint_identity_binding: dict[str, Any]
+    endpoint_identity_binding_digest: str
+    credential_reference: dict[str, Any]
+    credential_reference_digest: str
+    credential_scope_binding: dict[str, Any]
+    credential_scope_binding_digest: str
+    authority_evidence_reference_bundle: dict[str, Any]
+    authority_evidence_reference_bundle_digest: str
+    authority_evidence_linkage_result: dict[str, Any]
+    authority_evidence_linkage_result_digest: str
+    human_approval_reference_bundle: dict[str, Any]
+    human_approval_reference_bundle_digest: str
+    human_approval_linkage_result: dict[str, Any]
+    human_approval_linkage_result_digest: str
+    final_bind_authorization_readiness_result: dict[str, Any]
+    final_bind_authorization_readiness_result_digest: str
+    bind_authorization_gate_review_decision: BindAuthorizationGateReviewDecision
+    bind_authorization_gate_review_decision_digest: str
+    bind_authorization_gate_review_result: BindAuthorizationGateReviewResult
+    bind_authorization_gate_review_result_digest: str
+    bind_authorization_gate_review_checks: tuple[GateReviewCheck, ...]
+    bind_authorization_gate_review_check_digest: str
+    future_real_bind_authorization_artifact_requirements: tuple[FutureRequirement, ...]
+    future_real_bind_authorization_artifact_requirements_digest: str
+    future_bind_invocation_requirements: tuple[FutureRequirement, ...]
+    future_bind_invocation_requirements_digest: str
+    source_to_execution_intent_mapping: dict[str, Any]
+    field_mapping_proof: dict[str, Any]
+    required_field_presence: dict[str, str]
+    source_decision_identity: dict[str, Any]
+    candidate_identity: dict[str, Any]
+    evidence_lineage: dict[str, Any]
+    replay_summary: dict[str, Any]
+    bind_authorization_gate_review_status: Literal[STATUS]
+    request_dispatch_state: Literal["NOT_DISPATCHED"]
+    bind_state: Literal["NOT_BOUND"]
+    authority_state: Literal["NOT_AUTHORIZED"]
+    human_approval_state: Literal["NOT_APPROVED"]
+    bind_authorization_state: Literal["NOT_AUTHORIZED"]
+    gate_review_state: Literal[
+        "PASSED_FOR_FUTURE_BIND_AUTHORIZATION_ARTIFACT",
+        "FAILED_FOR_FUTURE_BIND_AUTHORIZATION_ARTIFACT",
+    ]
+    authority_evidence_created: Literal[False]
+    human_approval_created: Literal[False]
+    execution_authority_created: Literal[False]
+    bind_authorization_created: Literal[False]
+    bind_invoked: Literal[False]
+    bind_receipt_created: Literal[False]
+    trustlog_written: Literal[False]
+    request_dispatched: Literal[False]
+    endpoint_resolved: Literal[False]
+    credential_material_accessed: Literal[False]
+    authorization_header_constructed: Literal[False]
+    network_used: Literal[False]
+    live_adapter_instantiated: Literal[False]
+    webhook_called: Literal[False]
+    fail_closed: bool
+    scope_limitations: tuple[Literal[*SCOPE_LIMITATIONS], ...]
+
+
+def _timestamp(value: Any) -> str:
+    try:
+        parsed = value if isinstance(value, datetime) else datetime.fromisoformat(value)
+    except (TypeError, ValueError) as exc:
+        raise LiveAdapterDryRunBindAuthorizationGateReviewError(
+            "LADBAGR_TIMESTAMP_INVALID"
+        ) from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise LiveAdapterDryRunBindAuthorizationGateReviewError(
+            "LADBAGR_TIMESTAMP_INVALID"
+        )
+    return parsed.astimezone(timezone.utc).isoformat()
+
+
+def _json(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        value = value.model_dump(mode="python")
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if (
+        isinstance(value, float)
+        and value == value
+        and value not in (float("inf"), float("-inf"))
+    ):
+        return value
+    if isinstance(value, datetime):
+        return _timestamp(value)
+    if isinstance(value, (list, tuple)):
+        return [_json(item) for item in value]
+    if isinstance(value, dict) and all(isinstance(key, str) for key in value):
+        return {key: _json(item) for key, item in value.items()}
+    raise LiveAdapterDryRunBindAuthorizationGateReviewError("LADBAGR_INVALID")
+
+
+def _digest(domain: str, value: Any) -> str:
+    encoded = json.dumps(
+        {"domain": domain, "value": _json(value)},
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _packet_hash(raw: dict[str, Any]) -> str:
+    omitted = {
+        "live_adapter_dry_run_bind_authorization_gate_review_id",
+        "live_adapter_dry_run_bind_authorization_gate_review_hash",
+    }
+    return _digest(
+        DOMAINS["packet"],
+        {key: value for key, value in raw.items() if key not in omitted},
+    )
+
+
+def _source(
+    value: Any,
+) -> CanonicalLiveAdapterDryRunFinalBindAuthorizationReadinessPacket:
+    try:
+        return verify_live_adapter_dry_run_final_bind_authorization_readiness_packet(
+            value
+        )
+    except (
+        LiveAdapterDryRunFinalBindAuthorizationReadinessError,
+        TypeError,
+        ValueError,
+    ) as exc:
+        raise LiveAdapterDryRunBindAuthorizationGateReviewError(
+            "LADBAGR_SOURCE_INVALID"
+        ) from exc
+
+
+def _validate_source(
+    source: CanonicalLiveAdapterDryRunFinalBindAuthorizationReadinessPacket,
+) -> None:
+    if source.request_dispatch_state != "NOT_DISPATCHED" or source.request_dispatched:
+        raise LiveAdapterDryRunBindAuthorizationGateReviewError(
+            "LADBAGR_SOURCE_DISPATCHED"
+        )
+    if source.bind_state != "NOT_BOUND" or source.bind_invoked:
+        raise LiveAdapterDryRunBindAuthorizationGateReviewError("LADBAGR_SOURCE_BOUND")
+    if source.authority_state != "NOT_AUTHORIZED":
+        raise LiveAdapterDryRunBindAuthorizationGateReviewError(
+            "LADBAGR_SOURCE_AUTHORIZED"
+        )
+    if source.human_approval_state != "NOT_APPROVED":
+        raise LiveAdapterDryRunBindAuthorizationGateReviewError(
+            "LADBAGR_SOURCE_APPROVED"
+        )
+    if source.final_bind_authorization_readiness_status != SOURCE_STATUS:
+        raise LiveAdapterDryRunBindAuthorizationGateReviewError("LADBAGR_SOURCE_STATUS")
+    result = source.final_bind_authorization_readiness_result
+    if (
+        source.fail_closed
+        or not result.accepted_for_future_bind_authorization_gate_review
+    ):
+        raise LiveAdapterDryRunBindAuthorizationGateReviewError(
+            "LADBAGR_SOURCE_REJECTED"
+        )
+
+
+def _decision(value: Any) -> BindAuthorizationGateReviewDecision:
+    try:
+        decision = BindAuthorizationGateReviewDecision.model_validate(_json(value))
+        normalized = decision.model_copy(
+            update={"reviewed_at": _timestamp(decision.reviewed_at)}
+        )
+    except (
+        ValidationError,
+        TypeError,
+        LiveAdapterDryRunBindAuthorizationGateReviewError,
+    ) as exc:
+        raise LiveAdapterDryRunBindAuthorizationGateReviewError(
+            "LADBAGR_DECISION_INVALID"
+        ) from exc
+    if not all(getattr(normalized, field) for field in ACKNOWLEDGEMENTS):
+        raise LiveAdapterDryRunBindAuthorizationGateReviewError(
+            "LADBAGR_ACKNOWLEDGEMENT_MISSING"
+        )
+    return normalized
+
+
+def _requirements(names: tuple[str, ...]) -> list[dict[str, Any]]:
+    return [
+        {
+            "ordinal": ordinal,
+            "name": name,
+            "separate_future_artifact_required": True,
+            "satisfied_by_this_packet": False,
+        }
+        for ordinal, name in enumerate(names, 1)
+    ]
+
+
+def _derived(
+    source: CanonicalLiveAdapterDryRunFinalBindAuthorizationReadinessPacket,
+    decision: BindAuthorizationGateReviewDecision,
+) -> tuple[Any, ...]:
+    accepted = decision.review_outcome == OUTCOMES[0]
+    result = {
+        "source_final_readiness_passed": True,
+        "source_human_approval_linkage_passed": True,
+        "source_authority_evidence_linkage_passed": True,
+        "source_bind_pre_dispatch_review_passed": True,
+        "gate_review_passed": accepted,
+        "accepted_for_future_real_bind_authorization_artifact": accepted,
+        "rejection_reasons": []
+        if accepted
+        else ["BIND_AUTHORIZATION_GATE_REVIEW_FAILED"],
+        "comparison_mode": CHECK_MODE,
+        "semantic_match_used": False,
+        "creates_real_bind_authorization": False,
+        "creates_execution_authority": False,
+        "creates_human_approval": False,
+        "creates_authority_evidence": False,
+    }
+    decision_digest = _digest(DOMAINS["decision"], decision)
+    checks = [
+        {
+            "check_id": f"ladbagr-check:v1:{ordinal}:{name.replace('_', '-')}",
+            "ordinal": ordinal,
+            "name": name,
+            "mode": CHECK_MODE,
+            "passed": accepted if name == "gate_review_result_constructed" else True,
+            "evidence_ref": f"decision:{decision_digest}:{name}",
+            **{field: False for field in EFFECT_FIELDS},
+        }
+        for ordinal, name in enumerate(CHECK_NAMES, 1)
+    ]
+    return (
+        result,
+        checks,
+        _requirements(AUTHORIZATION_REQUIREMENTS),
+        _requirements(INVOCATION_REQUIREMENTS),
+    )
+
+
+def build_live_adapter_dry_run_bind_authorization_gate_review_packet(
+    source_final_bind_authorization_readiness_packet: Any,
+    bind_authorization_gate_review_decision: Any,
+    bind_authorization_gate_review_recorded_at: datetime,
+) -> CanonicalLiveAdapterDryRunBindAuthorizationGateReviewPacket:
+    """Build and self-verify deterministic, non-authorizing gate review evidence."""
+    source = _source(_json(source_final_bind_authorization_readiness_packet))
+    _validate_source(source)
+    decision = _decision(bind_authorization_gate_review_decision)
+    recorded_at = _timestamp(bind_authorization_gate_review_recorded_at)
+    result, checks, authorization, invocation = _derived(source, decision)
+    source_raw = source.model_dump(mode="json")
+    accepted = result["accepted_for_future_real_bind_authorization_artifact"]
+    raw = {
+        "format_version": FORMAT_VERSION,
+        "bind_authorization_gate_review_mechanism": MECHANISM,
+        "bind_authorization_gate_review_recorded_at": recorded_at,
+        "source_final_bind_authorization_readiness_id": source.live_adapter_dry_run_final_bind_authorization_readiness_id,
+        "source_final_bind_authorization_readiness_hash": source.live_adapter_dry_run_final_bind_authorization_readiness_hash,
+        "source_final_bind_authorization_readiness_packet": source_raw,
+        **{field: source_raw[field] for field in COPIED_FIELDS},
+        **{
+            field: source_raw[field]
+            for field in (
+                "source_human_approval_linkage_review_hash",
+                "source_authority_evidence_linkage_review_hash",
+                "source_bind_pre_dispatch_review_hash",
+                "source_operator_dispatch_review_hash",
+                "source_credential_authorization_hash",
+                "source_endpoint_allowlist_evaluation_hash",
+                "source_dispatch_readiness_hash",
+                "source_live_adapter_dry_run_request_hash",
+            )
+        },
+        "bind_authorization_gate_review_decision": decision.model_dump(mode="json"),
+        "bind_authorization_gate_review_decision_digest": _digest(
+            DOMAINS["decision"], decision
+        ),
+        "bind_authorization_gate_review_result": result,
+        "bind_authorization_gate_review_result_digest": _digest(
+            DOMAINS["result"], result
+        ),
+        "bind_authorization_gate_review_checks": checks,
+        "bind_authorization_gate_review_check_digest": _digest(
+            DOMAINS["checks"], checks
+        ),
+        "future_real_bind_authorization_artifact_requirements": authorization,
+        "future_real_bind_authorization_artifact_requirements_digest": _digest(
+            DOMAINS["authorization"], authorization
+        ),
+        "future_bind_invocation_requirements": invocation,
+        "future_bind_invocation_requirements_digest": _digest(
+            DOMAINS["invocation"], invocation
+        ),
+        "bind_authorization_gate_review_status": STATUS,
+        "request_dispatch_state": "NOT_DISPATCHED",
+        "bind_state": "NOT_BOUND",
+        "authority_state": "NOT_AUTHORIZED",
+        "human_approval_state": "NOT_APPROVED",
+        "bind_authorization_state": "NOT_AUTHORIZED",
+        "gate_review_state": OUTCOMES[0] if accepted else OUTCOMES[1],
+        **{
+            field: False
+            for field in EFFECT_FIELDS
+            if field
+            in {
+                "authority_evidence_created",
+                "human_approval_created",
+                "execution_authority_created",
+                "bind_authorization_created",
+                "bind_invoked",
+                "bind_receipt_created",
+                "trustlog_written",
+                "request_dispatched",
+                "endpoint_resolved",
+                "credential_material_accessed",
+                "authorization_header_constructed",
+                "network_used",
+                "live_adapter_instantiated",
+                "webhook_called",
+            }
+        },
+        "fail_closed": not accepted,
+        "scope_limitations": SCOPE_LIMITATIONS,
+    }
+    digest = _packet_hash(raw)
+    raw["live_adapter_dry_run_bind_authorization_gate_review_hash"] = digest
+    raw["live_adapter_dry_run_bind_authorization_gate_review_id"] = (
+        f"ladbagr:v1:sha256:{digest}"
+    )
+    return verify_live_adapter_dry_run_bind_authorization_gate_review_packet(raw)
+
+
+def verify_live_adapter_dry_run_bind_authorization_gate_review_packet(
+    raw: Any,
+) -> CanonicalLiveAdapterDryRunBindAuthorizationGateReviewPacket:
+    """Reverify the embedded source and every deterministic derived field."""
+    try:
+        value = raw.model_dump(mode="json") if isinstance(raw, BaseModel) else raw
+        packet = (
+            CanonicalLiveAdapterDryRunBindAuthorizationGateReviewPacket.model_validate(
+                _json(value)
+            )
+        )
+    except (
+        ValidationError,
+        TypeError,
+        LiveAdapterDryRunBindAuthorizationGateReviewError,
+    ) as exc:
+        raise LiveAdapterDryRunBindAuthorizationGateReviewError(
+            "LADBAGR_PACKET_INVALID"
+        ) from exc
+    actual = packet.model_dump(mode="json")
+    source = _source(packet.source_final_bind_authorization_readiness_packet)
+    _validate_source(source)
+    source_raw = source.model_dump(mode="json")
+    if (
+        packet.source_final_bind_authorization_readiness_id
+        != source.live_adapter_dry_run_final_bind_authorization_readiness_id
+        or packet.source_final_bind_authorization_readiness_hash
+        != source.live_adapter_dry_run_final_bind_authorization_readiness_hash
+        or any(
+            _json(getattr(packet, field)) != _json(source_raw[field])
+            for field in COPIED_FIELDS
+        )
+        or any(
+            getattr(packet, field) != source_raw[field]
+            for field in (
+                "source_human_approval_linkage_review_hash",
+                "source_authority_evidence_linkage_review_hash",
+                "source_bind_pre_dispatch_review_hash",
+                "source_operator_dispatch_review_hash",
+                "source_credential_authorization_hash",
+                "source_endpoint_allowlist_evaluation_hash",
+                "source_dispatch_readiness_hash",
+                "source_live_adapter_dry_run_request_hash",
+            )
+        )
+    ):
+        raise LiveAdapterDryRunBindAuthorizationGateReviewError(
+            "LADBAGR_SOURCE_MISMATCH"
+        )
+    decision = _decision(packet.bind_authorization_gate_review_decision)
+    result, checks, authorization, invocation = _derived(source, decision)
+    accepted = result["accepted_for_future_real_bind_authorization_artifact"]
+    expected = (
+        packet.bind_authorization_gate_review_decision_digest
+        == _digest(DOMAINS["decision"], decision),
+        _json(packet.bind_authorization_gate_review_result) == result,
+        packet.bind_authorization_gate_review_result_digest
+        == _digest(DOMAINS["result"], result),
+        _json(packet.bind_authorization_gate_review_checks) == checks,
+        packet.bind_authorization_gate_review_check_digest
+        == _digest(DOMAINS["checks"], checks),
+        _json(packet.future_real_bind_authorization_artifact_requirements)
+        == authorization,
+        packet.future_real_bind_authorization_artifact_requirements_digest
+        == _digest(DOMAINS["authorization"], authorization),
+        _json(packet.future_bind_invocation_requirements) == invocation,
+        packet.future_bind_invocation_requirements_digest
+        == _digest(DOMAINS["invocation"], invocation),
+        packet.scope_limitations == SCOPE_LIMITATIONS,
+        packet.fail_closed is (not accepted),
+        packet.gate_review_state == (OUTCOMES[0] if accepted else OUTCOMES[1]),
+        packet.bind_authorization_gate_review_recorded_at
+        == _timestamp(packet.bind_authorization_gate_review_recorded_at),
+    )
+    if not all(expected):
+        raise LiveAdapterDryRunBindAuthorizationGateReviewError(
+            "LADBAGR_DERIVED_MISMATCH"
+        )
+    digest = _packet_hash(actual)
+    if packet.live_adapter_dry_run_bind_authorization_gate_review_hash != digest:
+        raise LiveAdapterDryRunBindAuthorizationGateReviewError("LADBAGR_HASH_MISMATCH")
+    if (
+        packet.live_adapter_dry_run_bind_authorization_gate_review_id
+        != f"ladbagr:v1:sha256:{digest}"
+    ):
+        raise LiveAdapterDryRunBindAuthorizationGateReviewError("LADBAGR_ID_MISMATCH")
+    return packet

--- a/veritas_os/policy/live_adapter_dry_run_bind_authorization_gate_review.py
+++ b/veritas_os/policy/live_adapter_dry_run_bind_authorization_gate_review.py
@@ -1,8 +1,8 @@
 """Record Bind Authorization Gate review without creating authority.
 
 This module performs only deterministic, local comparisons over a previously
-verified Human Approval linkage review packet.  It deliberately has no runtime,
-credential, persistence, adapter, or transport dependencies.
+verified Final Bind Authorization Readiness packet.  It deliberately has no
+runtime, credential, persistence, adapter, or transport dependencies.
 """
 
 from __future__ import annotations
@@ -36,6 +36,7 @@ CHECK_NAMES = (
     "source_request_not_dispatched",
     "source_bind_not_invoked",
     "source_bind_not_authorized",
+    "source_final_readiness_passed",
     "source_human_approval_linkage_passed",
     "source_authority_evidence_linkage_passed",
     "source_bind_pre_dispatch_review_passed",

--- a/veritas_os/tests/test_live_adapter_dry_run_bind_authorization_gate_review.py
+++ b/veritas_os/tests/test_live_adapter_dry_run_bind_authorization_gate_review.py
@@ -104,6 +104,21 @@ def test_failed_review_is_valid_fail_closed_evidence():
     assert not packet.bind_authorization_gate_review_result.gate_review_passed
 
 
+def test_packet_and_content_address_are_deterministic():
+    first = _packet()
+    second = _packet()
+
+    assert first == second
+    assert (
+        first.live_adapter_dry_run_bind_authorization_gate_review_hash
+        == second.live_adapter_dry_run_bind_authorization_gate_review_hash
+    )
+    assert (
+        first.live_adapter_dry_run_bind_authorization_gate_review_id
+        == second.live_adapter_dry_run_bind_authorization_gate_review_id
+    )
+
+
 @pytest.mark.parametrize("field", ACKNOWLEDGEMENTS)
 def test_every_acknowledgement_is_required(field):
     with pytest.raises(LiveAdapterDryRunBindAuthorizationGateReviewError):
@@ -177,6 +192,8 @@ def test_source_human_approval_linkage_review_hash_mutation_is_rejected():
 
 def test_checks_requirements_and_scope_are_exact_ordered_and_non_effecting():
     packet = _packet()
+    assert len(CHECK_NAMES) == 49
+    assert len(packet.bind_authorization_gate_review_checks) == 49
     assert (
         tuple(check.name for check in packet.bind_authorization_gate_review_checks)
         == CHECK_NAMES
@@ -252,6 +269,28 @@ def test_effect_mutations_are_rejected(field):
     _rehash(raw)
     with pytest.raises(LiveAdapterDryRunBindAuthorizationGateReviewError):
         verify_live_adapter_dry_run_bind_authorization_gate_review_packet(raw)
+
+
+def test_all_packet_external_effect_flags_remain_false():
+    packet = _packet()
+    effect_fields = (
+        "authority_evidence_created",
+        "human_approval_created",
+        "execution_authority_created",
+        "bind_authorization_created",
+        "bind_invoked",
+        "bind_receipt_created",
+        "trustlog_written",
+        "request_dispatched",
+        "endpoint_resolved",
+        "credential_material_accessed",
+        "authorization_header_constructed",
+        "network_used",
+        "live_adapter_instantiated",
+        "webhook_called",
+    )
+
+    assert all(not getattr(packet, field) for field in effect_fields)
 
 
 @pytest.mark.parametrize(

--- a/veritas_os/tests/test_live_adapter_dry_run_bind_authorization_gate_review.py
+++ b/veritas_os/tests/test_live_adapter_dry_run_bind_authorization_gate_review.py
@@ -1,0 +1,310 @@
+"""Integrity and non-effect tests for Bind Authorization Gate Review v1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from copy import deepcopy
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator, ValidationError
+
+from veritas_os.policy.live_adapter_dry_run_bind_authorization_gate_review import (
+    ACKNOWLEDGEMENTS,
+    AUTHORIZATION_REQUIREMENTS,
+    CHECK_NAMES,
+    INVOCATION_REQUIREMENTS,
+    OUTCOMES,
+    SCOPE_LIMITATIONS,
+    LiveAdapterDryRunBindAuthorizationGateReviewError,
+    _packet_hash,
+    build_live_adapter_dry_run_bind_authorization_gate_review_packet,
+    verify_live_adapter_dry_run_bind_authorization_gate_review_packet,
+)
+from veritas_os.tests.test_live_adapter_dry_run_final_bind_authorization_readiness import (
+    RECORDED_AT as SOURCE_RECORDED_AT,
+    _packet as source_packet,
+)
+
+RECORDED_AT = SOURCE_RECORDED_AT + timedelta(seconds=1)
+MODULE = Path(
+    "veritas_os/policy/live_adapter_dry_run_bind_authorization_gate_review.py"
+)
+SCHEMA = Path(
+    "schemas/live-adapter-dry-run-bind-authorization-gate-review-v1.schema.json"
+)
+
+
+def _decision(*, passed=True, **changes):
+    value = {
+        "bind_authorization_gate_review_decision_id": "gate-review:billing:v1",
+        "reviewer_id": "operator:alice",
+        "reviewer_role": "bind-gate-reviewer",
+        "reviewer_attestation": "I reviewed local gate evidence only.",
+        "reviewed_at": RECORDED_AT.isoformat(),
+        "review_outcome": OUTCOMES[0] if passed else OUTCOMES[1],
+        "review_reason": "deterministic local gate review",
+        **{field: True for field in ACKNOWLEDGEMENTS},
+    }
+    value.update(changes)
+    return value
+
+
+def _packet(*, source=None, decision=None, semantic_match=False):
+    source = source or source_packet(semantic_match=semantic_match)
+    return build_live_adapter_dry_run_bind_authorization_gate_review_packet(
+        source, decision or _decision(), RECORDED_AT
+    )
+
+
+def _rehash(raw):
+    digest = _packet_hash(raw)
+    raw["live_adapter_dry_run_bind_authorization_gate_review_hash"] = digest
+    raw["live_adapter_dry_run_bind_authorization_gate_review_id"] = (
+        f"ladbagr:v1:sha256:{digest}"
+    )
+
+
+def test_builder_creates_valid_verified_packet_and_reverifies_source(monkeypatch):
+    import veritas_os.policy.live_adapter_dry_run_bind_authorization_gate_review as module
+
+    actual = (
+        module.verify_live_adapter_dry_run_final_bind_authorization_readiness_packet
+    )
+    calls = []
+
+    def recording(value):
+        calls.append(value)
+        return actual(value)
+
+    monkeypatch.setattr(
+        module,
+        "verify_live_adapter_dry_run_final_bind_authorization_readiness_packet",
+        recording,
+    )
+    packet = module.build_live_adapter_dry_run_bind_authorization_gate_review_packet(
+        source_packet(), _decision(), RECORDED_AT
+    )
+    assert len(calls) == 2
+    assert (
+        module.verify_live_adapter_dry_run_bind_authorization_gate_review_packet(packet)
+        == packet
+    )
+    assert len(calls) == 3
+    assert not packet.fail_closed
+    assert packet.gate_review_state == OUTCOMES[0]
+
+
+def test_failed_review_is_valid_fail_closed_evidence():
+    packet = _packet(decision=_decision(passed=False))
+    assert packet.fail_closed
+    assert packet.gate_review_state == OUTCOMES[1]
+    assert not packet.bind_authorization_gate_review_result.gate_review_passed
+
+
+@pytest.mark.parametrize("field", ACKNOWLEDGEMENTS)
+def test_every_acknowledgement_is_required(field):
+    with pytest.raises(LiveAdapterDryRunBindAuthorizationGateReviewError):
+        _packet(decision=_decision(**{field: False}))
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "reviewer_id",
+        "reviewer_role",
+        "reviewer_attestation",
+        "bind_authorization_gate_review_decision_id",
+        "review_reason",
+    ],
+)
+def test_review_identity_and_attestation_are_required(field):
+    with pytest.raises(LiveAdapterDryRunBindAuthorizationGateReviewError):
+        _packet(decision=_decision(**{field: ""}))
+
+
+def test_decision_schema_is_closed():
+    with pytest.raises(LiveAdapterDryRunBindAuthorizationGateReviewError):
+        _packet(decision=_decision(unexpected=True))
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "request_descriptor",
+        "execution_intent",
+        "execution_intent_id",
+        "execution_intent_hash",
+        "adapter_contract_descriptor",
+        "adapter_contract_id",
+        "adapter_contract_hash",
+        "adapter_contract_version",
+        "endpoint_identity_binding",
+        "endpoint_identity_binding_digest",
+        "credential_scope_binding",
+        "credential_scope_binding_digest",
+        "authority_evidence_linkage_result",
+        "human_approval_linkage_result",
+        "final_bind_authorization_readiness_result",
+        "source_human_approval_linkage_review_hash",
+        "source_authority_evidence_linkage_review_hash",
+        "source_bind_pre_dispatch_review_hash",
+        "source_operator_dispatch_review_hash",
+        "source_credential_authorization_hash",
+        "source_endpoint_allowlist_evaluation_hash",
+        "source_dispatch_readiness_hash",
+        "source_live_adapter_dry_run_request_hash",
+    ],
+)
+def test_source_content_and_lineage_are_preserved(field):
+    packet = _packet()
+    assert (
+        getattr(packet, field)
+        == packet.source_final_bind_authorization_readiness_packet[field]
+    )
+
+
+def test_checks_requirements_and_scope_are_exact_ordered_and_non_effecting():
+    packet = _packet()
+    assert (
+        tuple(check.name for check in packet.bind_authorization_gate_review_checks)
+        == CHECK_NAMES
+    )
+    assert (
+        tuple(
+            item.name
+            for item in packet.future_real_bind_authorization_artifact_requirements
+        )
+        == AUTHORIZATION_REQUIREMENTS
+    )
+    assert (
+        tuple(item.name for item in packet.future_bind_invocation_requirements)
+        == INVOCATION_REQUIREMENTS
+    )
+    assert packet.scope_limitations == SCOPE_LIMITATIONS
+    assert all(
+        not check.operation_committed and not check.network_used
+        for check in packet.bind_authorization_gate_review_checks
+    )
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "bind_authorization_gate_review_result",
+        "bind_authorization_gate_review_checks",
+        "future_real_bind_authorization_artifact_requirements",
+        "future_bind_invocation_requirements",
+        "scope_limitations",
+        "fail_closed",
+    ],
+)
+def test_derived_mutation_is_rejected(field):
+    raw = _packet().model_dump(mode="json")
+    if field == "bind_authorization_gate_review_result":
+        raw[field]["gate_review_passed"] = False
+    elif field == "bind_authorization_gate_review_checks":
+        raw[field][0]["evidence_ref"] = "forged"
+    elif field.startswith("future_"):
+        raw[field][0]["name"] = "forged"
+    elif field == "scope_limitations":
+        raw[field].reverse()
+    else:
+        raw[field] = True
+    _rehash(raw)
+    with pytest.raises(LiveAdapterDryRunBindAuthorizationGateReviewError):
+        verify_live_adapter_dry_run_bind_authorization_gate_review_packet(raw)
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "authority_evidence_created",
+        "human_approval_created",
+        "execution_authority_created",
+        "bind_authorization_created",
+        "bind_invoked",
+        "bind_receipt_created",
+        "trustlog_written",
+        "request_dispatched",
+        "endpoint_resolved",
+        "credential_material_accessed",
+        "authorization_header_constructed",
+        "network_used",
+        "live_adapter_instantiated",
+        "webhook_called",
+    ],
+)
+def test_effect_mutations_are_rejected(field):
+    raw = _packet().model_dump(mode="json")
+    raw[field] = True
+    _rehash(raw)
+    with pytest.raises(LiveAdapterDryRunBindAuthorizationGateReviewError):
+        verify_live_adapter_dry_run_bind_authorization_gate_review_packet(raw)
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "live_adapter_dry_run_bind_authorization_gate_review_id",
+        "live_adapter_dry_run_bind_authorization_gate_review_hash",
+    ],
+)
+def test_forged_content_address_is_rejected(field):
+    raw = _packet().model_dump(mode="json")
+    raw[field] = "forged"
+    with pytest.raises(LiveAdapterDryRunBindAuthorizationGateReviewError):
+        verify_live_adapter_dry_run_bind_authorization_gate_review_packet(raw)
+
+
+def test_semantic_match_is_preserved_only_in_source_and_never_promoted():
+    for semantic_match in (False, True):
+        packet = _packet(semantic_match=semantic_match)
+        assert not packet.bind_authorization_gate_review_result.semantic_match_used
+        assert not any(
+            (
+                packet.human_approval_created,
+                packet.authority_evidence_created,
+                packet.execution_authority_created,
+                packet.bind_authorization_created,
+            )
+        )
+
+
+def test_schema_validates_output_and_rejects_mutation():
+    schema = json.loads(SCHEMA.read_text())
+    raw = _packet().model_dump(mode="json")
+    Draft202012Validator(schema).validate(raw)
+    raw["bind_authorization_created"] = True
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(raw)
+
+
+def test_module_has_no_prohibited_imports_or_calls():
+    text = MODULE.read_text()
+    tree = ast.parse(text)
+    imports = {
+        alias.name.split(".")[0]
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.Import, ast.ImportFrom))
+        for alias in node.names
+    }
+    assert not imports.intersection(
+        {"requests", "httpx", "urllib", "socket", "dns", "subprocess", "os", "pathlib"}
+    )
+    for prohibited in (
+        "WebhookBindAdapter",
+        "BindReceipt",
+        "TrustLog",
+        "open(",
+        "os.environ",
+        "read_text",
+        "write_text",
+        "credential_store",
+        "verify_postconditions",
+        "revert(",
+        "apply(",
+    ):
+        assert prohibited not in text

--- a/veritas_os/tests/test_live_adapter_dry_run_bind_authorization_gate_review.py
+++ b/veritas_os/tests/test_live_adapter_dry_run_bind_authorization_gate_review.py
@@ -166,6 +166,15 @@ def test_source_content_and_lineage_are_preserved(field):
     )
 
 
+def test_source_human_approval_linkage_review_hash_mutation_is_rejected():
+    raw = _packet().model_dump(mode="json")
+    raw["source_human_approval_linkage_review_hash"] = "0" * 64
+    _rehash(raw)
+
+    with pytest.raises(LiveAdapterDryRunBindAuthorizationGateReviewError):
+        verify_live_adapter_dry_run_bind_authorization_gate_review_packet(raw)
+
+
 def test_checks_requirements_and_scope_are_exact_ordered_and_non_effecting():
     packet = _packet()
     assert (


### PR DESCRIPTION
### Motivation

- Add a deterministic, content-addressed Bind Authorization Gate Review packet that records whether a verified non-dispatched Final Bind Authorization Readiness packet passed a local gate-review, while explicitly avoiding any runtime/effect creation. 
- Provide a verifiable milestone artifact that preserves lineage and source hashes and enables a separate future real Bind-authorization artifact without producing authorization, execution authority, dispatch, or any external side effects.

### Description

- Implemented builder and verifier in `veritas_os/policy/live_adapter_dry_run_bind_authorization_gate_review.py`, introducing closed Pydantic models for the decision, result, ordered gate checks, future-requirements, and the canonical packet; the builder is `build_live_adapter_dry_run_bind_authorization_gate_review_packet(...)` and the verifier is `verify_live_adapter_dry_run_bind_authorization_gate_review_packet(...)`.
- Added deterministic, domain-separated hashing and packet/id construction, strict preservation of source final readiness packet fields/hashes/lineage, deterministic gate review result and 49 ordered checks, and deterministic future real-bind-artifact and invocation requirements.
- Added schema `schemas/live-adapter-dry-run-bind-authorization-gate-review-v1.schema.json`, comprehensive tests `veritas_os/tests/test_live_adapter_dry_run_bind_authorization_gate_review.py`, and documentation `docs/en/architecture/live-adapter-dry-run-bind-authorization-gate-review-v1.md`.
- Security / non-effect guarantees: the implementation and schema enforce that this artifact does NOT create real Bind authorization, execution authority, Human Approval, Authority Evidence, BindReceipt, TrustLog writes, dispatch the request, resolve endpoints, access credentials, construct authorization headers, use network/DNS/Webhook, or instantiate a live adapter; effect flags are closed to `false` and fail-closed behavior is enforced on mismatches.
- Final invariant: Canonical Live Adapter Dry-Run Bind Authorization Gate Review v1 now records deterministic Bind Authorization Gate review evidence for a verified non-dispatched Final Bind Authorization Readiness packet without creating real Bind authorization, without creating execution authority, without creating Human Approval, without creating Authority Evidence, without invoking Bind, without creating a BindReceipt, without writing TrustLog, without dispatching the request, without resolving endpoints, without accessing credential material, without constructing authorization headers, without network access, without instantiating a live adapter, without calling Webhook, without external effects, and without converting semantic_match into Human Approval, Authority Evidence, Bind authorization, or execution authority.

### Testing

- Static/quality checks: `ruff` formatting and `ruff check` were run against the new module and tests and passed locally in the environment where formatting and linting were executed.
- Sanity/format checks: `python -m py_compile veritas_os/policy/live_adapter_dry_run_bind_authorization_gate_review.py` succeeded and `python -m json.tool schemas/live-adapter-dry-run-bind-authorization-gate-review-v1.schema.json` validated the generated schema.
- Unit tests: comprehensive tests were added (`veritas_os/tests/test_live_adapter_dry_run_bind_authorization_gate_review.py`) that cover builder/verifier round-trip, source re-verification, required-state assertions, acknowledgement requirements, ordered deterministic checks, digest stability, non-effect invariants, schema validation, and prohibited imports/calls; a local `pytest -q veritas_os/tests/test_live_adapter_dry_run_bind_authorization_gate_review.py` run was attempted but could not complete because the configured Python/runtime dependencies (project pinned Python and `pydantic` in the environment) were not available in the execution environment.
- Repo checks: `git diff --check` and commit were performed; an attempt to create the PR with `gh pr create` failed because the environment was not authenticated to GitHub (no `GH_TOKEN` / `gh auth`), so the branch/commit is prepared for a maintainer to open the PR and perform CI.

Notes: this change adds new production-facing policy evidence code and tests and therefore requires human maintainer review and approval before merging, per the repository high-risk rules.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a85364adfc483269fb05de81347ef4d)