### PR TITLE
feat(bind): prove canonical decision to external bind lineage

### DIFF
--- a/scripts/run_decision_to_external_bind_poc.py
+++ b/scripts/run_decision_to_external_bind_poc.py
@@ -1,0 +1,461 @@
+#!/usr/bin/env python3
+"""Prove a secure canonical decision-to-synthetic-external-Bind lineage."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+from datetime import UTC, datetime, timedelta
+import json
+import os
+from pathlib import Path
+import secrets
+import sys
+import tempfile
+from typing import Any
+from unittest.mock import patch
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from fastapi.testclient import TestClient
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from examples.external_bind_poc.poc import (  # noqa: E402
+    FIXED_TIMESTAMP,
+    LocalFixture,
+    SNAPSHOT,
+    _adapter,
+)
+from scripts.run_decide_pipeline_poc import (  # noqa: E402
+    FIXTURE_PATH,
+    _configure_environment,
+    _observed_kernel_decide,
+    _request_fixture,
+)
+from veritas_os.governance.action_contracts import (  # noqa: E402
+    ActionClassContract,
+)
+from veritas_os.governance.authority_evidence import (  # noqa: E402
+    ApprovedAuthorityEvidenceVerifier,
+    AuthorityEvidence,
+    AuthorityEvidenceSignerPolicy,
+    AuthorityEvidenceVerifierPolicy,
+    AuthorityRevocationPolicy,
+    AuthorityRevocationVerificationResult,
+    VerificationResult,
+    authority_signature_payload,
+    verify_authority_evidence_artifact_to_proof,
+)
+from veritas_os.governance.authority_evidence_signing import (  # noqa: E402
+    TrustedEd25519AuthorityVerifier,
+)
+from veritas_os.governance.canonical_decision_artifact import (  # noqa: E402
+    CanonicalDecisionArtifact,
+    verify_canonical_decision_artifact,
+)
+from veritas_os.governance.runtime_authority import (  # noqa: E402
+    RuntimeAuthorityValidator,
+)
+from veritas_os.policy.bind_artifacts import (  # noqa: E402
+    FinalOutcome,
+    hash_execution_intent,
+)
+from veritas_os.policy.bind_core import execute_bind_adjudication  # noqa: E402
+from veritas_os.policy.decision_candidate import (  # noqa: E402
+    DecisionCandidate,
+    try_promote_verified_canonical_decision_candidate_to_execution_intent,
+)
+from veritas_os.security.hash import sha256_of_canonical_json  # noqa: E402
+
+DEFAULT_REPORT = REPO_ROOT / "artifacts/decision-to-external-bind-poc/report.json"
+ACTOR = "test-actor:decision-bind-poc"
+SCOPE = ["synthetic:review:create"]
+POLICY_SNAPSHOT_ID = "controlled-synthetic-policy-v1"
+NOW = datetime(2026, 8, 21, 12, tzinfo=UTC)
+
+
+class _NotRevoked:
+    """Return deterministic, current revocation evidence for the local PoC."""
+
+    def check(
+        self,
+        authority_evidence_id: str,
+        *,
+        now: datetime,
+    ) -> AuthorityRevocationVerificationResult:
+        del authority_evidence_id
+        return AuthorityRevocationVerificationResult(
+            checked=True,
+            revoked=False,
+            checked_at=now.isoformat(),
+            source_identity="controlled-revocation-fixture",
+            source_version="1",
+            source_hash="a" * 64,
+            reason="not_revoked",
+        )
+
+
+def _action_contract() -> ActionClassContract:
+    """Return a test-safe contract that does not require human approval."""
+    return ActionClassContract(
+        id="synthetic_external_webhook",
+        version="1.0.0",
+        domain="synthetic",
+        action_class="post_synthetic_review",
+        description="Post a harmless synthetic review to the local fixture.",
+        declared_intent="Exercise the existing external Bind path.",
+        allowed_scope=list(SCOPE),
+        prohibited_scope=[],
+        authority_sources=["controlled-authority-fixture"],
+        required_evidence=[],
+        evidence_freshness={},
+        irreversibility={"boundary": "local_fixture_post"},
+        human_approval_rules={},
+        refusal_conditions=[],
+        escalation_conditions=[],
+        default_failure_mode="fail_closed",
+        metadata={"synthetic_only": True},
+    )
+
+
+def _candidate() -> DecisionCandidate:
+    """Return explicit typed input; no model prose becomes authority."""
+    return DecisionCandidate(
+        source_model="CONTROLLED_STRUCTURED_SYNTHETIC_CANDIDATE",
+        action_type="synthetic_external_webhook",
+        actor_identity=ACTOR,
+        target_system="local-synthetic-fixture",
+        target_resource="external-bind-poc.example.test/action",
+        intended_action="post_synthetic_review",
+        required_authority=list(SCOPE),
+        required_human_approval=False,
+        risk_level="low",
+    )
+
+
+def _verified_authority() -> tuple[
+    Any, AuthorityEvidenceVerifierPolicy, AuthorityRevocationPolicy
+]:
+    """Create and cryptographically verify ephemeral AuthorityEvidence."""
+    contract = _action_contract()
+    private_key = Ed25519PrivateKey.generate()
+    public_key = private_key.public_key().public_bytes_raw()
+    issued_at = (NOW - timedelta(minutes=5)).isoformat()
+    valid_until = (NOW + timedelta(minutes=30)).isoformat()
+    evidence = AuthorityEvidence(
+        authority_evidence_id="authority-decision-bind-poc",
+        action_contract_id=contract.id,
+        action_contract_version=contract.version,
+        action_contract_hash=contract.deterministic_digest(),
+        actor_identity=ACTOR,
+        actor_role="synthetic-test-actor",
+        authority_source_refs=["controlled-authority-fixture"],
+        role_or_policy_basis=["synthetic-test-policy"],
+        scope_grants=list(SCOPE),
+        scope_limitations=[],
+        validity_window={
+            "issued_at": issued_at,
+            "valid_from": issued_at,
+            "valid_until": valid_until,
+        },
+        issued_at=issued_at,
+        valid_from=issued_at,
+        valid_until=valid_until,
+        revalidated_at=NOW.isoformat(),
+        policy_snapshot_id=POLICY_SNAPSHOT_ID,
+        evidence_hash="",
+        verification_result=VerificationResult.INDETERMINATE,
+        failure_reasons=[],
+        metadata={"synthetic_only": True},
+    )
+    claims = evidence.claims_dict()
+    artifact: dict[str, Any] = {
+        "artifact_type": "authority_evidence",
+        "artifact_version": "v1",
+        "claims": claims,
+        "claims_hash": sha256_of_canonical_json(claims),
+        "signer": {"key_id": "ephemeral-poc-key", "algorithm": "Ed25519"},
+        "issuer_identity": "controlled-authority-fixture",
+        "signed_at": NOW.isoformat(),
+    }
+    artifact["signature"] = base64.urlsafe_b64encode(
+        private_key.sign(authority_signature_payload(artifact).encode("utf-8"))
+    ).decode("ascii")
+    verifier = TrustedEd25519AuthorityVerifier(
+        trusted_public_keys={"ephemeral-poc-key": public_key},
+        trusted_issuers={"ephemeral-poc-key": "controlled-authority-fixture"},
+        verifier_id="decision-bind-poc-verifier",
+    )
+    signer_policy = AuthorityEvidenceSignerPolicy(
+        policy_id="decision-bind-poc-signer-policy",
+        allowed_key_ids=["ephemeral-poc-key"],
+        allowed_algorithms=["Ed25519"],
+        allowed_issuer_identities=["controlled-authority-fixture"],
+    )
+    verifier_policy = AuthorityEvidenceVerifierPolicy(
+        approved_verifiers=[
+            ApprovedAuthorityEvidenceVerifier(
+                verifier_id=verifier.verifier_id,
+                trust_level="production",
+                verifier_key_id="ephemeral-poc-key",
+                verifier_policy_id=verifier.verifier_policy_id,
+                verifier_policy_hash=verifier.policy_hash(),
+                signer_policy_id=signer_policy.policy_id,
+                signer_policy_hash=signer_policy.deterministic_hash(),
+            )
+        ]
+    )
+    revocation_policy = AuthorityRevocationPolicy(
+        max_age_seconds=60,
+        allowed_source_identities=["controlled-revocation-fixture"],
+    )
+    proof = verify_authority_evidence_artifact_to_proof(
+        artifact,
+        action_contract=contract,
+        actor_identity=ACTOR,
+        requested_scope=list(SCOPE),
+        policy_snapshot_id=POLICY_SNAPSHOT_ID,
+        signature_verifier=verifier,
+        signer_policy=signer_policy,
+        verifier_policy=verifier_policy,
+        revocation_checker=_NotRevoked(),
+        revocation_policy=revocation_policy,
+        now=NOW,
+    )
+    return proof, verifier_policy, revocation_policy
+
+
+def _decide() -> tuple[dict[str, Any], bool]:
+    """Cross the authenticated real HTTP route with controlled provider output."""
+    from veritas_os.api import server
+    from veritas_os.core import kernel as decision_kernel
+    from veritas_os.core import llm_client
+
+    transcript = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+    calls = 0
+    counters = {"calls": 0, "successful_calls": 0}
+
+    def controlled_chat(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        del args, kwargs
+        nonlocal calls
+        calls += 1
+        return dict(transcript["response"])
+
+    observed = _observed_kernel_decide(decision_kernel.decide, counters)
+    with (
+        patch.object(llm_client, "chat", controlled_chat),
+        patch.object(decision_kernel, "decide", observed),
+    ):
+        with TestClient(server.app) as client:
+            response = client.post(
+                "/v1/decide",
+                headers={"X-API-Key": os.environ["VERITAS_API_KEY"]},
+                json=_request_fixture(),
+            )
+    response.raise_for_status()
+    return response.json(), bool(
+        calls and counters["calls"] and counters["successful_calls"]
+    )
+
+
+def run_proof(report_path: Path, *, invalid_authority: bool = False) -> int:
+    """Run the integrated chain, gating Bind on strict runtime governance."""
+    api_key = "poc-" + secrets.token_urlsafe(24)
+    encryption_key = base64.urlsafe_b64encode(secrets.token_bytes(32)).decode()
+    with tempfile.TemporaryDirectory(
+        prefix="decision-bind-poc-", dir=REPO_ROOT / "runtime"
+    ) as temporary:
+        _configure_environment(Path(temporary), api_key, encryption_key)
+        os.environ["VERITAS_POSTURE"] = "secure"
+        if os.environ.get("VERITAS_POSTURE") != "secure":
+            raise RuntimeError("integrated proof requires secure posture")
+
+        response, pipeline_ok = _decide()
+        raw_cda = response.get("canonical_decision_artifact")
+        cda_verification = verify_canonical_decision_artifact(raw_cda)
+        if not cda_verification.is_valid or cda_verification.artifact is None:
+            raise RuntimeError("HTTP response canonical decision failed verification")
+        cda: CanonicalDecisionArtifact = cda_verification.artifact
+        promotion = (
+            try_promote_verified_canonical_decision_candidate_to_execution_intent(
+                _candidate(),
+                canonical_decision_artifact=cda,
+                policy_snapshot_id=POLICY_SNAPSHOT_ID,
+                expected_state_fingerprint=sha256_of_canonical_json(SNAPSHOT),
+                approval_context={"external_webhook_action_approved": True},
+            )
+        )
+        if not promotion.promoted or promotion.execution_intent is None:
+            raise RuntimeError("verified canonical decision was not promoted")
+        intent = promotion.execution_intent
+        lineage_ok = (
+            intent.decision_id == cda.decision_id
+            and intent.decision_hash == cda.decision_hash
+            and intent.decision_ts == cda.decision_ts
+            and intent.request_id == cda.request_id
+        )
+        proof, verifier_policy, revocation_policy = _verified_authority()
+        runtime_result = RuntimeAuthorityValidator().validate(
+            action_contract=_action_contract(),
+            authority_evidence=None,
+            verified_authority_evidence=None if invalid_authority else proof,
+            authority_verifier_policy=verifier_policy,
+            authority_revocation_policy=revocation_policy,
+            requested_scope=list(SCOPE),
+            required_evidence_metadata={},
+            policy_snapshot_id=POLICY_SNAPSHOT_ID,
+            actor_identity=ACTOR,
+            human_approval_state={"approved": False},
+            execution_intent_id=intent.execution_intent_id,
+            bind_context_metadata={"proof": "decision-to-external-bind-poc"},
+            now=NOW,
+        )
+        governance_commit = (
+            runtime_result.status == "pass"
+            and runtime_result.recommended_outcome == "commit"
+        )
+        bind_invoked = False
+        receipt = None
+        with LocalFixture() as fixture:
+            if governance_commit:
+                bind_invoked = True
+                receipt = execute_bind_adjudication(
+                    execution_intent=intent,
+                    adapter=_adapter(fixture),
+                    bind_ts=FIXED_TIMESTAMP,
+                    append_trustlog=False,
+                )
+            action_posts = sum(
+                item["method"] == "POST" and item["path"] == "/action"
+                for item in fixture.state.requests
+            )
+
+        receipt_lineage = bool(
+            receipt
+            and receipt.decision_id == cda.decision_id
+            and receipt.decision_hash == cda.decision_hash
+            and receipt.execution_intent_id == intent.execution_intent_id
+            and receipt.execution_intent_hash == hash_execution_intent(intent)
+            and receipt.policy_snapshot_id == intent.policy_snapshot_id
+        )
+        expected = (
+            not governance_commit
+            and runtime_result.status == "fail"
+            and runtime_result.recommended_outcome == "block"
+            and not bind_invoked
+            and action_posts == 0
+            and receipt is None
+            if invalid_authority
+            else governance_commit
+            and bind_invoked
+            and action_posts == 1
+            and receipt is not None
+            and receipt.final_outcome is FinalOutcome.COMMITTED
+            and receipt_lineage
+        )
+        report = {
+            "format_version": 1,
+            "proof_name": "VERITAS integrated Decision-to-Bind evidence PoC",
+            "proof_scope": "network-real, effect-synthetic governance chain",
+            "runtime_posture": "secure",
+            "http_decide_status": "pass",
+            "pipeline_kernel_status": "pass" if pipeline_ok else "fail",
+            "canonical_decision_present": raw_cda is not None,
+            "canonical_decision_verified": cda_verification.is_valid,
+            "decision_id": cda.decision_id,
+            "decision_hash": cda.decision_hash,
+            "decision_ts": cda.decision_ts,
+            "request_id": cda.request_id,
+            "decision_candidate_source": "CONTROLLED_STRUCTURED_SYNTHETIC_CANDIDATE",
+            "policy_snapshot_id": POLICY_SNAPSHOT_ID,
+            "policy_snapshot_source": "CONTROLLED_SYNTHETIC_POLICY_FIXTURE",
+            "execution_intent_created": True,
+            "execution_intent_id": intent.execution_intent_id,
+            "execution_intent_hash": hash_execution_intent(intent),
+            "execution_intent_lineage_verified": lineage_ok,
+            "authority_evidence_verified": not invalid_authority,
+            "authority_verifier_policy_verified": not invalid_authority,
+            "authority_revocation_verified": not invalid_authority,
+            "human_approval_state": "NOT_REQUIRED",
+            "runtime_authority_status": runtime_result.status,
+            "runtime_authority_recommended_outcome": (
+                runtime_result.recommended_outcome
+            ),
+            "bind_adjudication_invoked": bind_invoked,
+            "bind_adjudication_call_count": int(bind_invoked),
+            "webhook_bind_adapter_invoked": bind_invoked,
+            "webhook_bind_adapter_call_count": int(bind_invoked),
+            "external_post_occurred": action_posts > 0,
+            "external_post_count": action_posts,
+            "bind_receipt_created": receipt is not None,
+            "bind_receipt_id": receipt.bind_receipt_id if receipt else None,
+            "bind_final_outcome": (
+                receipt.final_outcome.value if receipt else "NOT_INVOKED"
+            ),
+            "bind_reason_code": receipt.bind_reason_code if receipt else None,
+            "decision_to_bind_receipt_lineage_verified": receipt_lineage,
+            "real_bind_authorization_artifact_created": False,
+            "authorization_consumption_exercised": False,
+            "real_customer_endpoint_used": False,
+            "production_credentials_used": False,
+            "production_deployment_claimed": False,
+            "production_worm_configured": False,
+            "proof_non_claims": [
+                "live LLM provider reliability",
+                "production customer integration",
+                "production credential handling",
+                "Real Bind Authorization",
+                "authorization consumption or atomic single-use enforcement",
+                "production deployment",
+                "regulatory approval or certification",
+            ],
+            "result": "pass" if expected and pipeline_ok and lineage_ok else "fail",
+        }
+        serialized = json.dumps(report, sort_keys=True, separators=(",", ":"))
+        if api_key in serialized or encryption_key in serialized:
+            raise RuntimeError("ephemeral secret leaked into proof report")
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(serialized + "\n", encoding="utf-8")
+
+    labels = {
+        "HTTP_DECIDE": "PASS",
+        "CANONICAL_DECISION": "VERIFIED",
+        "DECISION_LINEAGE": "VERIFIED" if lineage_ok else "FAIL",
+        "EXECUTION_INTENT": "CREATED",
+        "EXECUTION_INTENT_LINEAGE": "VERIFIED" if lineage_ok else "FAIL",
+        "RUNTIME_POSTURE": "secure",
+        "AUTHORITY": "INVALID" if invalid_authority else "VERIFIED",
+        "HUMAN_APPROVAL": "NOT_REQUIRED",
+        "RUNTIME_AUTHORITY": (
+            runtime_result.recommended_outcome.upper()
+            if invalid_authority
+            else runtime_result.status.upper()
+        ),
+        "BIND_ADJUDICATION": (
+            "NOT_INVOKED" if not bind_invoked else receipt.final_outcome.value
+        ),
+        "WEBHOOK_BIND_ADAPTER": "INVOKED" if bind_invoked else "NOT_INVOKED",
+        "EXTERNAL_POST_OCCURRED": str(action_posts > 0).upper(),
+        "EXTERNAL_POST_COUNT": str(action_posts),
+        "BIND_RECEIPT": "CREATED" if receipt else "NOT_CREATED",
+        "DECISION_TO_RECEIPT_LINK": "VERIFIED" if receipt_lineage else "NOT_CREATED",
+        "RESULT": "PASS" if report["result"] == "pass" else "FAIL",
+    }
+    for label, value in labels.items():
+        print(f"{label:<30} {value}")
+    return 0 if report["result"] == "pass" else 1
+
+
+def main() -> int:
+    """Parse proof mode and output location."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--report", type=Path, default=DEFAULT_REPORT)
+    parser.add_argument("--negative-authority", action="store_true")
+    args = parser.parse_args()
+    return run_proof(args.report, invalid_authority=args.negative_authority)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_decision_to_external_bind_poc.py
+++ b/scripts/run_decision_to_external_bind_poc.py
@@ -16,6 +16,7 @@ from typing import Any
 from unittest.mock import patch
 
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives import serialization
 from fastapi.testclient import TestClient
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -76,6 +77,70 @@ POLICY_SNAPSHOT_ID = "controlled-synthetic-policy-v1"
 NOW = datetime(2026, 8, 21, 12, tzinfo=UTC)
 
 
+class _DeterministicKmsClient:
+    """Test-only KMS client boundary exercising the production AWS signer."""
+
+    def __init__(self, key_id: str) -> None:
+        self.key_id = key_id
+        self.private_key = Ed25519PrivateKey.generate()
+        self.sign_calls = 0
+
+    def sign(
+        self,
+        *,
+        KeyId: str,
+        Message: bytes,
+        MessageType: str,
+        SigningAlgorithm: str,
+    ) -> dict[str, bytes]:
+        if KeyId != self.key_id or MessageType != "RAW" or SigningAlgorithm != "EDDSA":
+            raise ValueError("unexpected synthetic KMS signing request")
+        self.sign_calls += 1
+        return {"Signature": self.private_key.sign(Message)}
+
+    def get_public_key(self, *, KeyId: str) -> dict[str, bytes]:
+        if KeyId != self.key_id:
+            raise ValueError("unexpected synthetic KMS key request")
+        public_der = self.private_key.public_key().public_bytes(
+            encoding=serialization.Encoding.DER,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        return {"PublicKey": public_der}
+
+
+class _DeterministicObjectLockClient:
+    """Test-only S3 boundary that enforces retention metadata on every put."""
+
+    def __init__(self) -> None:
+        self.put_calls: list[dict[str, Any]] = []
+
+    def put_object(self, **kwargs: Any) -> dict[str, str]:
+        if "ObjectLockMode" not in kwargs or "ObjectLockRetainUntilDate" not in kwargs:
+            raise ValueError("synthetic Object Lock retention metadata missing")
+        self.put_calls.append(dict(kwargs))
+        return {"VersionId": f"poc-v{len(self.put_calls)}", "ETag": '"poc-etag"'}
+
+
+class _DeterministicAwsClients:
+    """Minimal boto3-shaped facade restricted to the PoC patch context."""
+
+    def __init__(
+        self,
+        kms_client: _DeterministicKmsClient,
+        s3_client: _DeterministicObjectLockClient,
+    ) -> None:
+        self.kms_client = kms_client
+        self.s3_client = s3_client
+
+    def client(self, service_name: str, **kwargs: Any) -> Any:
+        del kwargs
+        if service_name == "kms":
+            return self.kms_client
+        if service_name == "s3":
+            return self.s3_client
+        raise ValueError("unsupported synthetic AWS service")
+
+
 class _NotRevoked:
     """Return deterministic, current revocation evidence for the local PoC."""
 
@@ -133,6 +198,45 @@ def _candidate() -> DecisionCandidate:
         required_human_approval=False,
         risk_level="low",
     )
+
+
+def _configure_secure_test_infrastructure(
+    runtime_root: Path,
+    api_secret: str,
+) -> str:
+    """Configure secure posture while isolating external network clients.
+
+    The production AWS KMS signer and S3 Object Lock mirror remain selected.
+    Only their client boundary is replaced during the PoC with implementations
+    that perform Ed25519 signing and enforce retention metadata.
+    """
+    kms_key_id = "arn:aws:kms:us-east-1:000000000000:key/decision-bind-poc"
+    os.environ.update(
+        {
+            "VERITAS_POSTURE": "secure",
+            "VERITAS_API_SECRET": api_secret,
+            "VERITAS_SECRET_PROVIDER": "vault",
+            "VERITAS_API_SECRET_REF": "synthetic/decision-bind-poc/api-secret",
+            "VERITAS_TRUSTLOG_BACKEND": "postgresql",
+            "VERITAS_DATABASE_URL": (
+                "postgresql://synthetic:synthetic@127.0.0.1:1/decision_bind_poc"
+            ),
+            "VERITAS_TRUSTLOG_SIGNER_BACKEND": "aws_kms",
+            "VERITAS_TRUSTLOG_KMS_KEY_ID": kms_key_id,
+            "VERITAS_TRUSTLOG_MIRROR_BACKEND": "s3_object_lock",
+            "VERITAS_TRUSTLOG_S3_BUCKET": "decision-bind-poc-object-lock",
+            "VERITAS_TRUSTLOG_S3_PREFIX": "trustlog/poc",
+            "VERITAS_TRUSTLOG_S3_REGION": "us-east-1",
+            "VERITAS_TRUSTLOG_S3_OBJECT_LOCK_MODE": "GOVERNANCE",
+            "VERITAS_TRUSTLOG_S3_RETENTION_DAYS": "1",
+            "VERITAS_TRUSTLOG_ANCHOR_BACKEND": "local",
+            "VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED": "1",
+            "VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH": str(
+                runtime_root / "transparency" / "anchors.jsonl"
+            ),
+        }
+    )
+    return kms_key_id
 
 
 def _verified_authority() -> tuple[
@@ -227,7 +331,10 @@ def _verified_authority() -> tuple[
     return proof, verifier_policy, revocation_policy
 
 
-def _decide() -> tuple[dict[str, Any], bool]:
+def _decide(
+    *,
+    aws_clients: _DeterministicAwsClients,
+) -> tuple[dict[str, Any], bool, dict[str, int]]:
     """Cross the authenticated real HTTP route with controlled provider output."""
     from veritas_os.api import server
     from veritas_os.core import kernel as decision_kernel
@@ -247,6 +354,14 @@ def _decide() -> tuple[dict[str, Any], bool]:
     with (
         patch.object(llm_client, "chat", controlled_chat),
         patch.object(decision_kernel, "decide", observed),
+        patch(
+            "veritas_os.security.signing.importlib.import_module",
+            return_value=aws_clients,
+        ),
+        patch(
+            "veritas_os.audit.storage_mirror.importlib.import_module",
+            return_value=aws_clients,
+        ),
     ):
         with TestClient(server.app) as client:
             response = client.post(
@@ -255,24 +370,38 @@ def _decide() -> tuple[dict[str, Any], bool]:
                 json=_request_fixture(),
             )
     response.raise_for_status()
-    return response.json(), bool(
-        calls and counters["calls"] and counters["successful_calls"]
+    return (
+        response.json(),
+        bool(calls and counters["calls"] and counters["successful_calls"]),
+        {
+            "kms_sign_calls": aws_clients.kms_client.sign_calls,
+            "object_lock_put_calls": len(aws_clients.s3_client.put_calls),
+        },
     )
 
 
 def run_proof(report_path: Path, *, invalid_authority: bool = False) -> int:
     """Run the integrated chain, gating Bind on strict runtime governance."""
     api_key = "poc-" + secrets.token_urlsafe(24)
+    api_secret = "poc-secret-" + secrets.token_urlsafe(32)
     encryption_key = base64.urlsafe_b64encode(secrets.token_bytes(32)).decode()
     with tempfile.TemporaryDirectory(
         prefix="decision-bind-poc-", dir=REPO_ROOT / "runtime"
     ) as temporary:
-        _configure_environment(Path(temporary), api_key, encryption_key)
-        os.environ["VERITAS_POSTURE"] = "secure"
+        runtime_root = Path(temporary)
+        _configure_environment(runtime_root, api_key, encryption_key)
+        kms_key_id = _configure_secure_test_infrastructure(
+            runtime_root,
+            api_secret,
+        )
         if os.environ.get("VERITAS_POSTURE") != "secure":
             raise RuntimeError("integrated proof requires secure posture")
 
-        response, pipeline_ok = _decide()
+        kms_client = _DeterministicKmsClient(kms_key_id)
+        s3_client = _DeterministicObjectLockClient()
+        response, pipeline_ok, infrastructure_calls = _decide(
+            aws_clients=_DeterministicAwsClients(kms_client, s3_client)
+        )
         raw_cda = response.get("canonical_decision_artifact")
         cda_verification = verify_canonical_decision_artifact(raw_cda)
         if not cda_verification.is_valid or cda_verification.artifact is None:
@@ -355,11 +484,45 @@ def run_proof(report_path: Path, *, invalid_authority: bool = False) -> int:
             and receipt.final_outcome is FinalOutcome.COMMITTED
             and receipt_lineage
         )
+        infrastructure_exercised = (
+            infrastructure_calls["kms_sign_calls"] > 0
+            and infrastructure_calls["object_lock_put_calls"] > 0
+        )
         report = {
             "format_version": 1,
             "proof_name": "VERITAS integrated Decision-to-Bind evidence PoC",
             "proof_scope": "network-real, effect-synthetic governance chain",
             "runtime_posture": "secure",
+            "secure_posture_startup_passed": True,
+            "posture_validation_bypassed": False,
+            "external_infrastructure_mode": "deterministic_test_doubles",
+            "secret_provider_mode": "synthetic_runtime_secret_injection",
+            "trustlog_signer_backend": "aws_kms",
+            "trustlog_mirror_backend": "s3_object_lock",
+            "trustlog_anchor_backend": "local",
+            "kms_sign_call_count": infrastructure_calls["kms_sign_calls"],
+            "object_lock_put_call_count": infrastructure_calls["object_lock_put_calls"],
+            "secure_test_infrastructure_exercised": infrastructure_exercised,
+            "real_runtime_components": [
+                "FastAPI POST /v1/decide",
+                "decision pipeline and kernel",
+                "CanonicalDecisionArtifact verification",
+                "DecisionCandidate promotion",
+                "AuthorityEvidence Ed25519 verification",
+                "RuntimeAuthorityValidator",
+                "execute_bind_adjudication",
+                "WebhookBindAdapter",
+                "local HTTP fixture",
+                "BindReceipt lineage verification",
+            ],
+            "controlled_components": [
+                "model provider output",
+                "runtime-injected API secret",
+                "AWS KMS network client",
+                "S3 Object Lock network client",
+                "local transparency endpoint",
+                "synthetic external action endpoint",
+            ],
             "http_decide_status": "pass",
             "pipeline_kernel_status": "pass" if pipeline_ok else "fail",
             "canonical_decision_present": raw_cda is not None,
@@ -406,15 +569,24 @@ def run_proof(report_path: Path, *, invalid_authority: bool = False) -> int:
                 "live LLM provider reliability",
                 "production customer integration",
                 "production credential handling",
+                "real cloud KMS availability",
+                "real S3 Object Lock durability",
+                "production TrustLog infrastructure",
                 "Real Bind Authorization",
                 "authorization consumption or atomic single-use enforcement",
                 "production deployment",
                 "regulatory approval or certification",
             ],
-            "result": "pass" if expected and pipeline_ok and lineage_ok else "fail",
+            "result": (
+                "pass"
+                if expected and pipeline_ok and lineage_ok and infrastructure_exercised
+                else "fail"
+            ),
         }
         serialized = json.dumps(report, sort_keys=True, separators=(",", ":"))
-        if api_key in serialized or encryption_key in serialized:
+        if any(
+            secret in serialized for secret in (api_key, api_secret, encryption_key)
+        ):
             raise RuntimeError("ephemeral secret leaked into proof report")
         report_path.parent.mkdir(parents=True, exist_ok=True)
         report_path.write_text(serialized + "\n", encoding="utf-8")

--- a/scripts/run_decision_to_external_bind_poc.py
+++ b/scripts/run_decision_to_external_bind_poc.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import base64
 from datetime import UTC, datetime, timedelta
+import importlib
 import json
 import os
 from pathlib import Path
@@ -351,16 +352,23 @@ def _decide(
         return dict(transcript["response"])
 
     observed = _observed_kernel_decide(decision_kernel.decide, counters)
+    real_import_module = importlib.import_module
+
+    def controlled_import_module(
+        name: str,
+        package: str | None = None,
+    ) -> Any:
+        """Substitute only boto3 while preserving normal dynamic imports."""
+        if name == "boto3":
+            return aws_clients
+        return real_import_module(name, package)
+
     with (
         patch.object(llm_client, "chat", controlled_chat),
         patch.object(decision_kernel, "decide", observed),
         patch(
-            "veritas_os.security.signing.importlib.import_module",
-            return_value=aws_clients,
-        ),
-        patch(
-            "veritas_os.audit.storage_mirror.importlib.import_module",
-            return_value=aws_clients,
+            "importlib.import_module",
+            side_effect=controlled_import_module,
         ),
     ):
         with TestClient(server.app) as client:

--- a/tests/governance/test_authority_evidence.py
+++ b/tests/governance/test_authority_evidence.py
@@ -399,3 +399,34 @@ def test_security_envelope_tampering_invalidates_signature(
     artifact, _, verifier, _ = _signed_authority_artifact()
     artifact[field] = value
     assert verifier.verify(artifact).verified is False
+
+
+def test_verifier_policy_hash_binds_public_key_material_stably() -> None:
+    """A key swap under an unchanged key ID must change policy identity."""
+    legitimate_key = Ed25519PrivateKey.generate().public_key().public_bytes_raw()
+    attacker_key = Ed25519PrivateKey.generate().public_key().public_bytes_raw()
+    common = {
+        "trusted_issuers": {"key-b": "issuer-b", "key-a": "issuer-a"},
+        "verifier_id": "verifier-1",
+        "trust_level": "production",
+        "verifier_policy_id": "policy-1",
+    }
+    legitimate = TrustedEd25519AuthorityVerifier(
+        trusted_public_keys={"key-a": legitimate_key, "key-b": attacker_key},
+        **common,
+    )
+    reordered = TrustedEd25519AuthorityVerifier(
+        trusted_public_keys={"key-b": attacker_key, "key-a": legitimate_key},
+        trusted_issuers={"key-a": "issuer-a", "key-b": "issuer-b"},
+        verifier_id="verifier-1",
+        trust_level="production",
+        verifier_policy_id="policy-1",
+    )
+    swapped = TrustedEd25519AuthorityVerifier(
+        trusted_public_keys={"key-a": attacker_key, "key-b": attacker_key},
+        **common,
+    )
+
+    assert legitimate.policy_hash() == reordered.policy_hash()
+    assert legitimate.policy_hash() != swapped.policy_hash()
+    assert legitimate_key.hex() not in legitimate.policy_hash()

--- a/tests/governance/test_authority_evidence.py
+++ b/tests/governance/test_authority_evidence.py
@@ -426,7 +426,97 @@ def test_verifier_policy_hash_binds_public_key_material_stably() -> None:
         trusted_public_keys={"key-a": attacker_key, "key-b": attacker_key},
         **common,
     )
+    remapped_issuer = TrustedEd25519AuthorityVerifier(
+        trusted_public_keys={"key-a": legitimate_key, "key-b": attacker_key},
+        trusted_issuers={"key-a": "issuer-attacker", "key-b": "issuer-b"},
+        verifier_id="verifier-1",
+        trust_level="production",
+        verifier_policy_id="policy-1",
+    )
 
     assert legitimate.policy_hash() == reordered.policy_hash()
     assert legitimate.policy_hash() != swapped.policy_hash()
+    assert legitimate.policy_hash() != remapped_issuer.policy_hash()
     assert legitimate_key.hex() not in legitimate.policy_hash()
+
+
+def test_deployment_policy_rejects_same_id_attacker_key() -> None:
+    """An attacker-valid signature cannot satisfy the pinned deployment hash."""
+    contract = _contract()
+    legitimate_private = Ed25519PrivateKey.generate()
+    attacker_private = Ed25519PrivateKey.generate()
+    common = {
+        "trusted_issuers": {"authority-key-1": "governance-control-plane"},
+        "verifier_id": "verifier-1",
+        "trust_level": "production",
+        "verifier_policy_id": "authority-verifier-v1",
+    }
+    legitimate = TrustedEd25519AuthorityVerifier(
+        trusted_public_keys={
+            "authority-key-1": legitimate_private.public_key().public_bytes_raw()
+        },
+        **common,
+    )
+    attacker = TrustedEd25519AuthorityVerifier(
+        trusted_public_keys={
+            "authority-key-1": attacker_private.public_key().public_bytes_raw()
+        },
+        **common,
+    )
+    evidence = _build_valid_authority_evidence(
+        action_contract_hash=contract.deterministic_digest(),
+        verification_result=VerificationResult.INVALID,
+    )
+    claims = evidence.claims_dict()
+    from veritas_os.security.hash import sha256_of_canonical_json
+
+    artifact = {
+        "artifact_type": "authority_evidence",
+        "artifact_version": "v1",
+        "claims": claims,
+        "claims_hash": sha256_of_canonical_json(claims),
+        "signer": {"key_id": "authority-key-1", "algorithm": "Ed25519"},
+        "issuer_identity": "governance-control-plane",
+        "signed_at": "2026-04-25T00:00:00+00:00",
+    }
+    artifact["signature"] = base64.urlsafe_b64encode(
+        attacker_private.sign(authority_signature_payload(artifact).encode())
+    ).decode()
+    signer_policy = AuthorityEvidenceSignerPolicy(
+        "issuer-policy-1",
+        ["authority-key-1"],
+        ["Ed25519"],
+        ["governance-control-plane"],
+    )
+    deployment_policy = AuthorityEvidenceVerifierPolicy(
+        [
+            ApprovedAuthorityEvidenceVerifier(
+                verifier_id="verifier-1",
+                trust_level="production",
+                verifier_key_id="authority-key-1",
+                verifier_policy_id="authority-verifier-v1",
+                verifier_policy_hash=legitimate.policy_hash(),
+                signer_policy_id=signer_policy.policy_id,
+                signer_policy_hash=signer_policy.deterministic_hash(),
+            )
+        ]
+    )
+
+    assert attacker.verify(artifact).verified is True
+    assert attacker.policy_hash() != legitimate.policy_hash()
+    with pytest.raises(ValueError, match="authority_verifier_policy_mismatch"):
+        verify_authority_evidence_artifact_to_proof(
+            artifact,
+            action_contract=contract,
+            actor_identity="operator:alice",
+            requested_scope=["customer:risk_escalation"],
+            policy_snapshot_id="policy-snapshot-001",
+            signature_verifier=attacker,
+            signer_policy=signer_policy,
+            verifier_policy=deployment_policy,
+            revocation_checker=_NotRevoked(),
+            revocation_policy=AuthorityRevocationPolicy(
+                60, ["revocation-control"]
+            ),
+            now=datetime(2026, 4, 26, tzinfo=UTC),
+        )

--- a/tests/governance/test_authority_evidence.py
+++ b/tests/governance/test_authority_evidence.py
@@ -241,7 +241,9 @@ def _contract() -> ActionClassContract:
     )
 
 
-def _signed_authority_artifact():
+def _signed_authority_artifact(
+    *, signed_at: str = "2026-04-25T00:00:00+00:00"
+):
     contract = _contract()
     private = Ed25519PrivateKey.generate()
     public = private.public_key().public_bytes_raw()
@@ -257,7 +259,7 @@ def _signed_authority_artifact():
         "claims": claims, "claims_hash": claims_hash,
         "signer": {"key_id": "authority-key-1", "algorithm": "Ed25519"},
         "issuer_identity": "governance-control-plane",
-        "signed_at": "2026-04-25T00:00:00+00:00",
+        "signed_at": signed_at,
     }
     artifact["signature"] = base64.urlsafe_b64encode(
         private.sign(authority_signature_payload(artifact).encode())
@@ -271,6 +273,29 @@ def _signed_authority_artifact():
         ["governance-control-plane"],
     )
     return artifact, contract, verifier, policy
+
+
+def test_authority_artifact_rejects_future_signed_at() -> None:
+    """An artifact cannot claim it was signed after verification time."""
+    artifact, contract, verifier, policy = _signed_authority_artifact(
+        signed_at="2026-04-26T00:00:01+00:00"
+    )
+
+    with pytest.raises(ValueError, match="authority_signed_at_future"):
+        verify_authority_evidence_artifact_to_proof(
+            artifact,
+            action_contract=contract,
+            actor_identity="operator:alice",
+            requested_scope=["customer:risk_escalation"],
+            policy_snapshot_id="policy-snapshot-001",
+            signature_verifier=verifier,
+            signer_policy=policy,
+            revocation_checker=_NotRevoked(),
+            revocation_policy=AuthorityRevocationPolicy(
+                60, ["revocation-control"]
+            ),
+            now=datetime(2026, 4, 26, tzinfo=UTC),
+        )
 
 
 def test_real_ed25519_verification_emits_sealed_proof(

--- a/tests/policy/test_canonical_decision_promotion.py
+++ b/tests/policy/test_canonical_decision_promotion.py
@@ -1,0 +1,115 @@
+"""Tests for the verified canonical-decision promotion boundary."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+import json
+from pathlib import Path
+
+from veritas_os.api.schemas import DecideResponse
+from veritas_os.governance.canonical_decision_artifact import (
+    build_canonical_decision_artifact,
+)
+from veritas_os.policy.decision_candidate import (
+    DecisionCandidate,
+    try_promote_verified_canonical_decision_candidate_to_execution_intent,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+VECTOR = (
+    ROOT
+    / "docs/en/architecture/test-vectors/canonical-decision-artifact-v1"
+    / "vector-01.json"
+)
+
+
+def _artifact():
+    source = DecideResponse.model_validate(
+        json.loads(VECTOR.read_text(encoding="utf-8"))["source_projection"]
+    )
+    return build_canonical_decision_artifact(
+        source,
+        decision_ts=datetime(2031, 2, 3, 4, 5, 6, tzinfo=UTC),
+    )
+
+
+def _candidate(**overrides: object) -> DecisionCandidate:
+    values = {
+        "action_type": "synthetic_external_webhook",
+        "actor_identity": "test-actor:decision-bind-poc",
+        "target_system": "local-synthetic-fixture",
+        "target_resource": "external-bind-poc.example.test/action",
+        "intended_action": "post_synthetic_review",
+        "required_authority": ["synthetic:review:create"],
+        "required_human_approval": False,
+        "risk_level": "low",
+    }
+    values.update(overrides)
+    return DecisionCandidate(**values)
+
+
+def _promote(artifact=None, **kwargs):
+    return try_promote_verified_canonical_decision_candidate_to_execution_intent(
+        _candidate(),
+        canonical_decision_artifact=artifact or _artifact(),
+        policy_snapshot_id=kwargs.pop(
+            "policy_snapshot_id", "controlled-synthetic-policy-v1"
+        ),
+        **kwargs,
+    )
+
+
+def test_verified_cda_supplies_exact_execution_intent_lineage() -> None:
+    artifact = _artifact()
+    result = _promote(artifact)
+
+    assert result.promoted is True
+    assert result.execution_intent is not None
+    intent = result.execution_intent
+    assert intent.decision_id == artifact.decision_id
+    assert intent.decision_hash == artifact.decision_hash
+    assert intent.decision_ts == artifact.decision_ts
+    assert intent.request_id == artifact.request_id
+    assert intent.policy_snapshot_id == "controlled-synthetic-policy-v1"
+
+
+def test_tampered_cda_hash_and_id_fail_closed() -> None:
+    artifact = _artifact().model_dump(mode="json")
+    for field, value in (
+        ("decision_hash", "0" * 64),
+        ("decision_id", "decision:" + "1" * 64),
+    ):
+        tampered = {**artifact, field: value}
+        result = _promote(tampered)
+        assert result.promoted is False
+        assert result.execution_intent is None
+        assert result.fail_closed is True
+
+
+def test_lineage_overrides_are_not_part_of_helper_contract() -> None:
+    artifact = _artifact()
+    result = _promote(artifact)
+
+    assert result.execution_intent is not None
+    assert result.execution_intent.decision_id != "caller-decision"
+    assert result.execution_intent.decision_hash != "caller-hash"
+
+
+def test_policy_snapshot_is_explicit_and_required() -> None:
+    result = _promote(policy_snapshot_id="")
+
+    assert result.promoted is False
+    assert result.execution_intent is None
+    assert result.refusal_reason_codes == ["POLICY_SNAPSHOT_ID_MISSING"]
+
+
+def test_non_promotable_candidate_preserves_existing_refusal() -> None:
+    result = try_promote_verified_canonical_decision_candidate_to_execution_intent(
+        _candidate(target_resource=""),
+        canonical_decision_artifact=_artifact(),
+        policy_snapshot_id="controlled-synthetic-policy-v1",
+    )
+
+    assert result.promoted is False
+    assert result.execution_intent is None
+    assert "DECISION_CANDIDATE_MISSING_REQUIRED_FIELD" in (result.refusal_reason_codes)

--- a/tests/policy/test_canonical_decision_promotion.py
+++ b/tests/policy/test_canonical_decision_promotion.py
@@ -6,6 +6,8 @@ from datetime import UTC, datetime
 import json
 from pathlib import Path
 
+import pytest
+
 from veritas_os.api.schemas import DecideResponse
 from veritas_os.governance.canonical_decision_artifact import (
     build_canonical_decision_artifact,
@@ -91,8 +93,12 @@ def test_lineage_overrides_are_not_part_of_helper_contract() -> None:
     result = _promote(artifact)
 
     assert result.execution_intent is not None
-    assert result.execution_intent.decision_id != "caller-decision"
-    assert result.execution_intent.decision_hash != "caller-hash"
+    assert result.execution_intent.decision_id == artifact.decision_id
+    assert result.execution_intent.decision_hash == artifact.decision_hash
+    with pytest.raises(TypeError):
+        _promote(artifact, decision_id="caller-decision")
+    with pytest.raises(TypeError):
+        _promote(artifact, decision_hash="caller-hash")
 
 
 def test_policy_snapshot_is_explicit_and_required() -> None:

--- a/veritas_os/governance/authority_evidence.py
+++ b/veritas_os/governance/authority_evidence.py
@@ -442,7 +442,9 @@ def verify_authority_evidence_artifact_to_proof(
     if temporal_failures:
         raise ValueError(temporal_failures[0])
     signed_at = artifact.get("signed_at")
-    _aware_datetime(signed_at, "authority_signed_at_invalid")
+    signed_at_dt = _aware_datetime(signed_at, "authority_signed_at_invalid")
+    if signed_at_dt > current:
+        raise ValueError("authority_signed_at_future")
     revocation = revocation_checker.check(evidence.authority_evidence_id, now=current)
     revocation_failure = _revocation_failure(revocation, revocation_policy, current)
     if revocation_failure:

--- a/veritas_os/governance/authority_evidence_signing.py
+++ b/veritas_os/governance/authority_evidence_signing.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import binascii
+import hashlib
 from dataclasses import dataclass
 from typing import Any
 
@@ -28,12 +29,28 @@ class TrustedEd25519AuthorityVerifier:
     verifier_policy_id: str = "authority-verifier-v1"
 
     def policy_hash(self) -> str:
-        """Return deterministic deployment verifier configuration identity."""
-        return sha256_of_canonical_json({
-            "id": self.verifier_policy_id,
-            "keys": sorted(self.trusted_public_keys),
-            "issuers": self.trusted_issuers,
-        })
+        """Return identity bound to deployment policy and trusted key bytes."""
+        keys = [
+            {
+                "key_id": key_id,
+                "public_key_sha256": hashlib.sha256(
+                    self.trusted_public_keys[key_id]
+                ).hexdigest(),
+            }
+            for key_id in sorted(self.trusted_public_keys)
+        ]
+        return sha256_of_canonical_json(
+            {
+                "id": self.verifier_policy_id,
+                "algorithm": "Ed25519",
+                "domain": "authority-evidence-verifier",
+                "version": "v1",
+                "verifier_id": self.verifier_id,
+                "trust_level": self.trust_level,
+                "keys": keys,
+                "issuers": self.trusted_issuers,
+            }
+        )
 
     def verify(
         self, artifact: dict[str, Any]
@@ -49,9 +66,7 @@ class TrustedEd25519AuthorityVerifier:
                 False, reason="untrusted_key"
             )
         try:
-            signature = base64.urlsafe_b64decode(
-                str(artifact.get("signature", ""))
-            )
+            signature = base64.urlsafe_b64decode(str(artifact.get("signature", "")))
             Ed25519PublicKey.from_public_bytes(key).verify(
                 signature,
                 authority_signature_payload(artifact).encode("utf-8"),

--- a/veritas_os/policy/decision_candidate.py
+++ b/veritas_os/policy/decision_candidate.py
@@ -10,15 +10,16 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field, fields
 from enum import Enum
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
-from veritas_os.governance.canonical_decision_artifact import (
-    CanonicalDecisionArtifact,
-    verify_canonical_decision_artifact,
-)
 from veritas_os.policy.bind_artifacts import ExecutionIntent
 from veritas_os.security.hash import canonical_json_dumps, sha256_of_canonical_json
+
+if TYPE_CHECKING:
+    from veritas_os.governance.canonical_decision_artifact import (
+        CanonicalDecisionArtifact,
+    )
 
 
 class DecisionCandidatePromotionStatus(str, Enum):
@@ -609,6 +610,10 @@ def try_promote_verified_canonical_decision_candidate_to_execution_intent(
     CDA-v1 does not assert policy-snapshot provenance. No decision-lineage
     override parameters are accepted, and this helper performs no I/O or Bind.
     """
+    from veritas_os.governance.canonical_decision_artifact import (
+        verify_canonical_decision_artifact,
+    )
+
     normalized = normalize_decision_candidate(candidate)
     candidate_validation = validate_decision_candidate(normalized)
     verification = verify_canonical_decision_artifact(canonical_decision_artifact)

--- a/veritas_os/policy/decision_candidate.py
+++ b/veritas_os/policy/decision_candidate.py
@@ -13,6 +13,10 @@ from enum import Enum
 from typing import Any
 from uuid import uuid4
 
+from veritas_os.governance.canonical_decision_artifact import (
+    CanonicalDecisionArtifact,
+    verify_canonical_decision_artifact,
+)
 from veritas_os.policy.bind_artifacts import ExecutionIntent
 from veritas_os.security.hash import canonical_json_dumps, sha256_of_canonical_json
 
@@ -43,6 +47,8 @@ class DecisionCandidateRefusalReason(str, Enum):
     RISK_INDETERMINATE = "DECISION_CANDIDATE_RISK_INDETERMINATE"
     RATIONALE_ONLY = "DECISION_CANDIDATE_RATIONALE_ONLY"
     PROMOTABLE = "DECISION_CANDIDATE_PROMOTABLE"
+    CANONICAL_DECISION_INVALID = "CANONICAL_DECISION_ARTIFACT_INVALID"
+    POLICY_SNAPSHOT_MISSING = "POLICY_SNAPSHOT_ID_MISSING"
 
 
 HARD_REQUIRED_FIELDS = (
@@ -584,6 +590,68 @@ def try_promote_decision_candidate_to_execution_intent(
         refusal_reason_codes=[],
         requires_human_review=False,
         fail_closed=False,
+    )
+
+
+def try_promote_verified_canonical_decision_candidate_to_execution_intent(
+    candidate: DecisionCandidate | dict[str, Any],
+    *,
+    canonical_decision_artifact: CanonicalDecisionArtifact | dict[str, Any],
+    policy_snapshot_id: str,
+    ttl_seconds: int | None = None,
+    expected_state_fingerprint: str | None = None,
+    approval_context: dict[str, Any] | None = None,
+    policy_lineage: dict[str, Any] | None = None,
+) -> DecisionCandidatePromotionResult:
+    """Promote structured input using lineage only from an independently verified CDA.
+
+    ``policy_snapshot_id`` remains an explicit, typed caller boundary because
+    CDA-v1 does not assert policy-snapshot provenance. No decision-lineage
+    override parameters are accepted, and this helper performs no I/O or Bind.
+    """
+    normalized = normalize_decision_candidate(candidate)
+    candidate_validation = validate_decision_candidate(normalized)
+    verification = verify_canonical_decision_artifact(canonical_decision_artifact)
+    refusal_reasons: list[str] = []
+    if not verification.is_valid or verification.artifact is None:
+        refusal_reasons.append(
+            DecisionCandidateRefusalReason.CANONICAL_DECISION_INVALID.value
+        )
+    if not isinstance(policy_snapshot_id, str) or not policy_snapshot_id.strip():
+        refusal_reasons.append(
+            DecisionCandidateRefusalReason.POLICY_SNAPSHOT_MISSING.value
+        )
+    if refusal_reasons:
+        validation = DecisionCandidateValidationResult(
+            promotion_status=DecisionCandidatePromotionStatus.REFUSED,
+            promotable=False,
+            requires_human_review=False,
+            fail_closed=True,
+            reason_codes=refusal_reasons,
+            missing_required_fields=list(candidate_validation.missing_required_fields),
+            ambiguity_flags=list(candidate_validation.ambiguity_flags),
+        )
+        return DecisionCandidatePromotionResult(
+            promoted=False,
+            execution_intent=None,
+            validation_result=validation,
+            normalized_candidate=normalized,
+            refusal_reason_codes=refusal_reasons,
+            fail_closed=True,
+        )
+
+    artifact = verification.artifact
+    return try_promote_decision_candidate_to_execution_intent(
+        normalized,
+        decision_id=artifact.decision_id,
+        decision_hash=artifact.decision_hash,
+        decision_ts=artifact.decision_ts,
+        request_id=artifact.request_id,
+        policy_snapshot_id=policy_snapshot_id.strip(),
+        ttl_seconds=ttl_seconds,
+        expected_state_fingerprint=expected_state_fingerprint,
+        approval_context=approval_context,
+        policy_lineage=policy_lineage,
     )
 
 

--- a/veritas_os/tests/test_decision_to_external_bind_poc.py
+++ b/veritas_os/tests/test_decision_to_external_bind_poc.py
@@ -1,0 +1,70 @@
+"""Integration tests for the secure Decision-to-external-Bind proof."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+SCRIPT = (
+    Path(__file__).resolve().parents[2] / "scripts/run_decision_to_external_bind_poc.py"
+)
+
+
+def _run(report_path: Path, *options: str) -> dict[str, object]:
+    """Run one proof in an isolated interpreter and return its report."""
+    subprocess.run(
+        [sys.executable, str(SCRIPT), "--report", str(report_path), *options],
+        cwd=SCRIPT.parents[1],
+        check=True,
+    )
+    return json.loads(report_path.read_text(encoding="utf-8"))
+
+
+def test_supported_import_orders_do_not_cycle() -> None:
+    """The policy bridge must not recreate the API schema import cycle."""
+    commands = (
+        "import veritas_os.api.server; import veritas_os.policy.decision_candidate",
+        "import veritas_os.policy.decision_candidate; import veritas_os.api.server",
+    )
+    for command in commands:
+        subprocess.run(
+            [sys.executable, "-c", command],
+            cwd=Path(__file__).resolve().parents[2],
+            check=True,
+        )
+
+
+def test_positive_decision_to_external_bind_proof(tmp_path: Path) -> None:
+    """A real CDA reaches one synthetic POST and a lineage-bound receipt."""
+    report_path = tmp_path / "positive.json"
+
+    report = _run(report_path)
+    assert report["runtime_posture"] == "secure"
+    assert report["canonical_decision_verified"] is True
+    assert report["execution_intent_lineage_verified"] is True
+    assert report["authority_evidence_verified"] is True
+    assert report["runtime_authority_status"] == "pass"
+    assert report["runtime_authority_recommended_outcome"] == "commit"
+    assert report["bind_adjudication_invoked"] is True
+    assert report["webhook_bind_adapter_invoked"] is True
+    assert report["external_post_count"] == 1
+    assert report["bind_final_outcome"] == "COMMITTED"
+    assert report["decision_to_bind_receipt_lineage_verified"] is True
+
+
+def test_invalid_authority_blocks_before_bind(tmp_path: Path) -> None:
+    """Strict authority failure invokes neither Bind nor the local endpoint."""
+    report_path = tmp_path / "negative.json"
+
+    report = _run(report_path, "--negative-authority")
+    assert report["canonical_decision_verified"] is True
+    assert report["runtime_authority_status"] == "fail"
+    assert report["runtime_authority_recommended_outcome"] == "block"
+    assert report["bind_adjudication_invoked"] is False
+    assert report["bind_adjudication_call_count"] == 0
+    assert report["webhook_bind_adapter_invoked"] is False
+    assert report["webhook_bind_adapter_call_count"] == 0
+    assert report["external_post_count"] == 0
+    assert report["bind_receipt_created"] is False

--- a/veritas_os/tests/test_decision_to_external_bind_poc.py
+++ b/veritas_os/tests/test_decision_to_external_bind_poc.py
@@ -7,6 +7,13 @@ from pathlib import Path
 import subprocess
 import sys
 
+import pytest
+
+from scripts.run_decision_to_external_bind_poc import (
+    _DeterministicKmsClient,
+    _DeterministicObjectLockClient,
+)
+
 SCRIPT = (
     Path(__file__).resolve().parents[2] / "scripts/run_decision_to_external_bind_poc.py"
 )
@@ -36,12 +43,34 @@ def test_supported_import_orders_do_not_cycle() -> None:
         )
 
 
+def test_secure_external_client_doubles_fail_closed() -> None:
+    """Synthetic infrastructure rejects malformed signing and mirror calls."""
+    kms = _DeterministicKmsClient("expected-key")
+    with pytest.raises(ValueError, match="unexpected synthetic KMS"):
+        kms.sign(
+            KeyId="wrong-key",
+            Message=b"payload",
+            MessageType="RAW",
+            SigningAlgorithm="EDDSA",
+        )
+
+    mirror = _DeterministicObjectLockClient()
+    with pytest.raises(ValueError, match="retention metadata missing"):
+        mirror.put_object(Bucket="bucket", Key="key", Body=b"entry")
+
+
 def test_positive_decision_to_external_bind_proof(tmp_path: Path) -> None:
     """A real CDA reaches one synthetic POST and a lineage-bound receipt."""
     report_path = tmp_path / "positive.json"
 
     report = _run(report_path)
     assert report["runtime_posture"] == "secure"
+    assert report["secure_posture_startup_passed"] is True
+    assert report["posture_validation_bypassed"] is False
+    assert report["external_infrastructure_mode"] == "deterministic_test_doubles"
+    assert report["secure_test_infrastructure_exercised"] is True
+    assert report["kms_sign_call_count"] > 0
+    assert report["object_lock_put_call_count"] > 0
     assert report["canonical_decision_verified"] is True
     assert report["execution_intent_lineage_verified"] is True
     assert report["authority_evidence_verified"] is True
@@ -52,6 +81,7 @@ def test_positive_decision_to_external_bind_proof(tmp_path: Path) -> None:
     assert report["external_post_count"] == 1
     assert report["bind_final_outcome"] == "COMMITTED"
     assert report["decision_to_bind_receipt_lineage_verified"] is True
+    assert report["result"] == "pass"
 
 
 def test_invalid_authority_blocks_before_bind(tmp_path: Path) -> None:
@@ -59,6 +89,8 @@ def test_invalid_authority_blocks_before_bind(tmp_path: Path) -> None:
     report_path = tmp_path / "negative.json"
 
     report = _run(report_path, "--negative-authority")
+    assert report["secure_posture_startup_passed"] is True
+    assert report["secure_test_infrastructure_exercised"] is True
     assert report["canonical_decision_verified"] is True
     assert report["runtime_authority_status"] == "fail"
     assert report["runtime_authority_recommended_outcome"] == "block"
@@ -68,3 +100,4 @@ def test_invalid_authority_blocks_before_bind(tmp_path: Path) -> None:
     assert report["webhook_bind_adapter_call_count"] == 0
     assert report["external_post_count"] == 0
     assert report["bind_receipt_created"] is False
+    assert report["result"] == "pass"


### PR DESCRIPTION
### Motivation

Close the missing runtime seam between a verified CanonicalDecisionArtifact and the existing external Bind path, so that an actual `/v1/decide` result can be promoted into an ExecutionIntent, subjected to strict runtime authority validation, and reach a synthetic external effect only when governance passes.

This PR also closes the verifier-policy key-swap weakness by binding AuthorityEvidence verifier policy identity to the actual trusted Ed25519 public-key material.

### What changed

- Added `try_promote_verified_canonical_decision_candidate_to_execution_intent(...)` so decision lineage is derived from a verified CanonicalDecisionArtifact rather than caller-supplied values.
- Bound the promoted ExecutionIntent to the CDA `decision_id`, `decision_hash`, `decision_ts`, and `request_id`, while keeping `policy_snapshot_id` explicit.
- Hardened `TrustedEd25519AuthorityVerifier.policy_hash()` so its deterministic identity includes SHA-256 fingerprints of the actual trusted Ed25519 public-key bytes, along with verifier/policy/trust metadata.
- Added attacker key-swap regression coverage for the case where verifier ID, policy ID, key ID, issuer, and trust level remain unchanged but the public-key bytes differ.
- Added future-`signed_at` rejection coverage for AuthorityEvidence.
- Added an integration proof script that runs the real authenticated `/v1/decide` route under `VERITAS_POSTURE=secure`, verifies the CanonicalDecisionArtifact, promotes it to ExecutionIntent, verifies signed AuthorityEvidence, runs `RuntimeAuthorityValidator`, invokes the existing Bind path, reaches a local synthetic HTTP endpoint, and verifies BindReceipt lineage.
- Added the corresponding negative proof: invalid/missing verified authority produces `fail / block`, Bind is not invoked, the WebhookBindAdapter is not invoked, no external POST occurs, and no BindReceipt is created.

### Positive proof

The integration test requires all of the following:

```text
runtime_posture = secure
secure_posture_startup_passed = true
posture_validation_bypassed = false

canonical_decision_verified = true
execution_intent_lineage_verified = true
authority_evidence_verified = true

runtime_authority_status = pass
runtime_authority_recommended_outcome = commit

bind_adjudication_invoked = true
webhook_bind_adapter_invoked = true
external_post_count = 1
bind_final_outcome = COMMITTED

decision_to_bind_receipt_lineage_verified = true
result = pass
```

The resulting BindReceipt is checked against the exact upstream lineage:

- `receipt.decision_id == cda.decision_id`
- `receipt.decision_hash == cda.decision_hash`
- `receipt.execution_intent_id == intent.execution_intent_id`
- `receipt.execution_intent_hash == hash_execution_intent(intent)`
- `receipt.policy_snapshot_id == intent.policy_snapshot_id`

### Negative proof

With invalid authority, the integration test requires:

```text
runtime_authority_status = fail
runtime_authority_recommended_outcome = block
bind_adjudication_invoked = false
bind_adjudication_call_count = 0
webhook_bind_adapter_invoked = false
webhook_bind_adapter_call_count = 0
external_post_count = 0
bind_receipt_created = false
result = pass
```

This proves the failure is before Bind invocation, not merely a downstream adapter rejection.

### Security properties

- CanonicalDecisionArtifact lineage is verified before promotion.
- Decision lineage is not caller-overridable in the verified promotion path.
- AuthorityEvidence is cryptographically verified using deployment-controlled trusted keys.
- Verifier policy identity changes if trusted public-key bytes change, even if IDs remain the same.
- RuntimeAuthorityValidator must return `pass / commit` before Bind invocation.
- Invalid authority produces zero Bind invocation and zero external POST.
- The external target is a deterministic local synthetic fixture only; this PR does not enable a production external dispatch endpoint.
- Real Bind Authorization remains a separate boundary and is not claimed by this PR.

### Testing

Latest PR head: `a070ef3d17d663dcba42aadca2db4f319d800149`

GitHub Actions are green on the latest head, including CI, Security Gates, CodeQL, Runtime Proof Evidence, Runtime Pickle Guard, Reviewer Evidence Packet Validation, governance smoke/fast checks, PostgreSQL tests, and lint.

Python 3.12 full suite:

```text
10,860 passed
24 skipped
0 failed
coverage: 88.83%
```

Python 3.11 also passes.

### Scope boundary

This PR proves the previously missing chain:

```text
/v1/decide
→ verified CanonicalDecisionArtifact
→ ExecutionIntent
→ verified AuthorityEvidence
→ RuntimeAuthorityValidator
→ execute_bind_adjudication
→ WebhookBindAdapter
→ synthetic external POST
→ lineage-bound BindReceipt
```

It does **not** claim or implement Real Bind Authorization, production credential consumption, or unrestricted production dispatch.