### PR TITLE
feat(bind): add atomic authorization consumption and bind invocation gate v1

### DIFF
--- a/.github/workflows/bind-authorization-consumption-postgresql.yml
+++ b/.github/workflows/bind-authorization-consumption-postgresql.yml
@@ -1,0 +1,85 @@
+name: Bind Authorization Consumption PostgreSQL
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: bind-consumption-pg-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  consumption-contention:
+    name: bind-consumption-postgresql-contention
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: veritas
+          POSTGRES_PASSWORD: veritas_test
+          POSTGRES_DB: veritas_test
+        options: >-
+          --health-cmd "pg_isready -U veritas"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    env:
+      PYTHONUNBUFFERED: "1"
+      OPENAI_API_KEY: "DUMMY_FOR_CI"
+      VERITAS_API_KEY: "DUMMY_FOR_CI"
+      VERITAS_DATABASE_URL: "postgresql+psycopg://veritas:veritas_test@localhost:5432/veritas_test"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          set -euxo pipefail
+          python -m pip install --upgrade pip --retries 5 --timeout 60
+          python -m pip install --retries 5 --timeout 60 -r veritas_os/requirements.txt
+          python -m pip install --retries 5 --timeout 60 \
+            "psycopg[binary]" psycopg-pool alembic pytest pytest-asyncio
+
+      - name: Run Alembic migrations
+        run: |
+          set -euxo pipefail
+          alembic upgrade head
+
+      - name: Prove atomic consume-once on real PostgreSQL
+        run: |
+          set -euxo pipefail
+          mkdir -p test-reports
+          pytest -q \
+            veritas_os/tests/test_pg_bind_authorization_consumption_contention.py \
+            -m "postgresql and contention" \
+            -v \
+            --tb=short \
+            --durations=10 \
+            --junitxml=test-reports/bind-consumption-postgresql-contention.xml
+
+      - name: Upload contention report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bind-consumption-postgresql-contention-${{ github.run_id }}
+          path: test-reports/bind-consumption-postgresql-contention.xml
+          if-no-files-found: warn

--- a/alembic/versions/0004_bind_authorization_consumptions.py
+++ b/alembic/versions/0004_bind_authorization_consumptions.py
@@ -1,0 +1,59 @@
+"""bind authorization atomic consumption records
+
+Revision ID: 0004
+Revises: 0003
+Create Date: 2026-08-23
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "0004"
+down_revision: str | None = "0003"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "bind_authorization_consumptions",
+        sa.Column("consumption_id", sa.Text(), primary_key=True),
+        sa.Column("consumption_hash", sa.Text(), nullable=False),
+        sa.Column("authorization_id", sa.Text(), nullable=False, unique=True),
+        sa.Column("authorization_hash", sa.Text(), nullable=False),
+        sa.Column("idempotency_key", sa.Text(), nullable=False, unique=True),
+        sa.Column("bind_context_hash", sa.Text(), nullable=False),
+        sa.Column("execution_intent_id", sa.Text(), nullable=False),
+        sa.Column("execution_intent_hash", sa.Text(), nullable=False),
+        sa.Column("consumed_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("record", sa.JSON(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.CheckConstraint(
+            "btrim(authorization_id) <> ''",
+            name="ck_bind_authorization_consumptions_authorization_id_non_empty",
+        ),
+        sa.CheckConstraint(
+            "btrim(idempotency_key) <> ''",
+            name="ck_bind_authorization_consumptions_idempotency_key_non_empty",
+        ),
+    )
+    op.create_index(
+        "ix_bind_authorization_consumptions_execution_intent_id",
+        "bind_authorization_consumptions",
+        ["execution_intent_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_bind_authorization_consumptions_execution_intent_id",
+        table_name="bind_authorization_consumptions",
+    )
+    op.drop_table("bind_authorization_consumptions")

--- a/docs/en/architecture/live-adapter-bind-authorization-consumption-v1.md
+++ b/docs/en/architecture/live-adapter-bind-authorization-consumption-v1.md
@@ -1,0 +1,99 @@
+# Live Adapter Bind Authorization Consumption / Bind Invocation Gate v1
+
+## Purpose
+
+This boundary consumes the signed Real Bind Authorization produced by the
+preceding authorization layer and is the first layer permitted to access
+credential material or invoke Bind.
+
+The required ordering is:
+
+1. re-verify the complete Real Bind Authorization and its current validity;
+2. reconstruct and hash-check the exact ExecutionIntent;
+3. atomically consume the authorization exactly once;
+4. resolve only the credential reference bound by that authorization;
+5. construct the Authorization header in ephemeral memory;
+6. construct an adapter bound to the exact adapter, endpoint and credential
+   digests carried by the authorization;
+7. invoke the existing Bind adjudication core.
+
+No credential access, header construction, adapter construction or Bind call is
+allowed before atomic consumption succeeds.
+
+## Single-use semantics
+
+The authorization and its idempotency key are unique consumption keys.
+PostgreSQL enforces both using UNIQUE constraints and `INSERT ... ON CONFLICT
+DO NOTHING`, so concurrent processes cannot both consume the same grant.
+
+The in-memory store exists only for deterministic tests and reference use. It
+is process-local and explicitly marks itself `production_safe = False`.
+
+A downstream failure does **not** release an authorization. If credential
+resolution, header construction, adapter construction or Bind fails after the
+atomic consume step, that authorization remains consumed. A new authorization
+must be issued for a new attempt.
+
+## Secret boundary
+
+`AuthorizationConsumptionRecord` contains only non-secret lineage digests and
+identifiers. Resolved credential bytes and the constructed Authorization header
+are held only in ephemeral runtime objects whose repr is redacted. Neither is
+written into the consumption record or returned in the result.
+
+## Exact binding
+
+Before Bind invocation the gate checks the adapter factory output against the
+signed authorization for:
+
+- adapter contract ID and hash;
+- endpoint identity binding digest;
+- credential reference digest;
+- credential scope binding digest.
+
+The ExecutionIntent ID and canonical hash are also rechecked directly from the
+signed authorization.
+
+## Failure semantics
+
+These conditions fail closed before credential access:
+
+- invalid or tampered authorization;
+- expired/not-yet-valid authorization;
+- invalid ExecutionIntent binding;
+- already-consumed authorization;
+- consumption-store failure.
+
+These conditions fail closed after consumption and do not release it:
+
+- credential resolution failure or binding mismatch;
+- Authorization-header construction failure or invalid header value;
+- adapter construction failure or binding mismatch.
+
+## Relationship to Bind
+
+Real Bind Authorization is permission to attempt one exact future Bind.
+Atomic consumption converts that one-time permission into a single Bind
+attempt. It does not guarantee that Bind commits. The existing Bind core still
+performs live snapshot, authority, constraints, drift, risk, freshness,
+commit-boundary, postcondition and rollback/compensation checks and may return a
+blocked, escalated, failed, rolled-back or committed BindReceipt.
+
+Therefore:
+
+**Authorization != Consumption**
+
+**Consumption != Bind success**
+
+**Bind invocation != External effect success**
+
+**BindReceipt records the attempted bind outcome; it does not retroactively
+create authorization.**
+
+## Non-claims
+
+This work does not claim customer deployment, regulatory certification, or
+that every credential provider/authorization scheme has a production adapter.
+Credential resolution, header construction and adapter construction are
+injected contracts. PostgreSQL is the durable cross-process single-use backend
+provided by this version.

--- a/docs/en/architecture/live-adapter-bind-authorization-consumption-v1.md
+++ b/docs/en/architecture/live-adapter-bind-authorization-consumption-v1.md
@@ -4,7 +4,7 @@
 
 This boundary consumes the signed Real Bind Authorization produced by the
 preceding authorization layer and is the first layer permitted to access
-credential material or invoke Bind.
+credential material or enter the Bind adjudication path.
 
 The required ordering is:
 
@@ -15,10 +15,10 @@ The required ordering is:
 5. construct the Authorization header in ephemeral memory;
 6. construct an adapter bound to the exact adapter, endpoint and credential
    digests carried by the authorization;
-7. invoke the existing Bind adjudication core.
+7. enter the existing Bind adjudication core.
 
-No credential access, header construction, adapter construction or Bind call is
-allowed before atomic consumption succeeds.
+No credential access, header construction, adapter construction or Bind-core
+call is allowed before atomic consumption succeeds.
 
 ## Single-use semantics
 
@@ -30,9 +30,17 @@ The in-memory store exists only for deterministic tests and reference use. It
 is process-local and explicitly marks itself `production_safe = False`.
 
 A downstream failure does **not** release an authorization. If credential
-resolution, header construction, adapter construction or Bind fails after the
-atomic consume step, that authorization remains consumed. A new authorization
-must be issued for a new attempt.
+resolution, header construction, adapter construction or Bind processing fails
+after the atomic consume step, that authorization remains consumed. A new
+authorization must be issued for a new attempt.
+
+Real-PostgreSQL contention CI verifies both of these invariants directly
+against PostgreSQL 16:
+
+- many concurrent workers racing the same authorization yield exactly one
+  successful consumer;
+- different authorization IDs sharing one idempotency key still yield exactly
+  one successful consumer.
 
 ## Secret boundary
 
@@ -43,7 +51,7 @@ written into the consumption record or returned in the result.
 
 ## Exact binding
 
-Before Bind invocation the gate checks the adapter factory output against the
+Before Bind-core entry the gate checks the adapter factory output against the
 signed authorization for:
 
 - adapter contract ID and hash;
@@ -53,6 +61,28 @@ signed authorization for:
 
 The ExecutionIntent ID and canonical hash are also rechecked directly from the
 signed authorization.
+
+## Invocation semantics
+
+Entering the Bind adjudication core is not the same event as reaching the
+adapter's effect-bearing `apply` method.
+
+`BindAuthorizationConsumptionResult` therefore exposes separate facts:
+
+- `bind_core_invoked = True` means `execute_bind_adjudication()` was entered;
+- `adapter_apply_attempted = True` means the Bind core actually reached the
+  adapter `apply` boundary;
+- a blocked or escalated Bind can therefore have `bind_core_invoked = True`
+  while `adapter_apply_attempted = False`.
+
+The compatibility property `bind_invoked` maps only to `bind_core_invoked` and
+must never be interpreted as proof that adapter `apply` ran or that an external
+effect occurred.
+
+The gate does not claim a generic `external_effect_attempted` fact because
+`BindAdapterContract.apply()` may represent an in-memory, local, provider, or
+network action. External-effect semantics belong to the concrete adapter and
+its resulting BindReceipt/evidence.
 
 ## Failure semantics
 
@@ -73,19 +103,22 @@ These conditions fail closed after consumption and do not release it:
 ## Relationship to Bind
 
 Real Bind Authorization is permission to attempt one exact future Bind.
-Atomic consumption converts that one-time permission into a single Bind
-attempt. It does not guarantee that Bind commits. The existing Bind core still
-performs live snapshot, authority, constraints, drift, risk, freshness,
-commit-boundary, postcondition and rollback/compensation checks and may return a
-blocked, escalated, failed, rolled-back or committed BindReceipt.
+Atomic consumption converts that one-time permission into a single Bind-gate
+attempt. It does not guarantee that Bind commits and does not guarantee that
+adapter `apply` is reached. The existing Bind core still performs live
+snapshot, authority, constraints, drift, risk, freshness, commit-boundary,
+postcondition and rollback/compensation checks and may return a blocked,
+escalated, failed, rolled-back or committed BindReceipt.
 
 Therefore:
 
 **Authorization != Consumption**
 
-**Consumption != Bind success**
+**Consumption != Bind-core entry**
 
-**Bind invocation != External effect success**
+**Bind-core entry != Adapter apply**
+
+**Adapter apply != Successful external effect**
 
 **BindReceipt records the attempted bind outcome; it does not retroactively
 create authorization.**

--- a/schemas/live-adapter-bind-authorization-consumption-v1.schema.json
+++ b/schemas/live-adapter-bind-authorization-consumption-v1.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://veritas-os.example/schemas/live-adapter-bind-authorization-consumption-v1.schema.json",
+  "title": "Live Adapter Bind Authorization Consumption Record v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "format_version",
+    "consumption_id",
+    "consumption_hash",
+    "live_adapter_bind_authorization_id",
+    "live_adapter_bind_authorization_hash",
+    "idempotency_key",
+    "bind_context_hash",
+    "execution_intent_id",
+    "execution_intent_hash",
+    "endpoint_identity_binding_digest",
+    "credential_reference_digest",
+    "credential_scope_binding_digest",
+    "consumed_at",
+    "consumption_state",
+    "single_use_enforced"
+  ],
+  "properties": {
+    "format_version": {"const": "live-adapter-bind-authorization-consumption/v1"},
+    "consumption_id": {"type": "string", "pattern": "^labac:v1:sha256:[0-9a-f]{64}$"},
+    "consumption_hash": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "live_adapter_bind_authorization_id": {"type": "string", "minLength": 1},
+    "live_adapter_bind_authorization_hash": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "idempotency_key": {"type": "string", "minLength": 1},
+    "bind_context_hash": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "execution_intent_id": {"type": "string", "minLength": 1},
+    "execution_intent_hash": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "endpoint_identity_binding_digest": {"type": "string", "minLength": 1},
+    "credential_reference_digest": {"type": "string", "minLength": 1},
+    "credential_scope_binding_digest": {"type": "string", "minLength": 1},
+    "consumed_at": {"type": "string", "minLength": 1},
+    "consumption_state": {"const": "CONSUMED"},
+    "single_use_enforced": {"const": true}
+  }
+}

--- a/scripts/run_bind_authorization_consumption_poc.py
+++ b/scripts/run_bind_authorization_consumption_poc.py
@@ -1,0 +1,159 @@
+"""Deterministic proof runner for Authorization Consumption / Bind Invocation Gate.
+
+This runner intentionally uses the test/reference in-memory store and a
+non-network adapter. It proves ordering and single-use semantics, not production
+credential-provider deployment or external-network execution.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Mapping
+
+from veritas_os.policy.bind_artifacts import ExecutionIntent
+from veritas_os.policy.bind_core.contracts import BindAdapterContract
+from veritas_os.policy.live_adapter_bind_authorization_consumption import (
+    AuthorizedBindAdapterInstance,
+    ConstructedAuthorizationHeader,
+    ResolvedCredentialMaterial,
+    consume_live_adapter_bind_authorization_and_invoke_bind,
+)
+from veritas_os.policy.live_adapter_bind_authorization_consumption_store import (
+    InMemoryAtomicAuthorizationConsumptionStore,
+)
+from veritas_os.tests.test_live_adapter_bind_authorization import (
+    VERIFICATION_NOW,
+    _build,
+)
+
+
+class _Resolver:
+    async def resolve(
+        self,
+        credential_reference: Mapping[str, Any],
+        *,
+        credential_scope_binding: Mapping[str, Any],
+        live_adapter_bind_authorization_id: str,
+    ) -> ResolvedCredentialMaterial:
+        del credential_scope_binding, live_adapter_bind_authorization_id
+        return ResolvedCredentialMaterial(
+            credential_reference_id=str(
+                credential_reference["credential_reference_id"]
+            ),
+            credential_kind=str(credential_reference["credential_kind"]),
+            credential_provider_type=str(
+                credential_reference["credential_provider_type"]
+            ),
+            material=b"synthetic-secret",
+        )
+
+
+class _Header:
+    async def construct(
+        self,
+        credential: ResolvedCredentialMaterial,
+        *,
+        credential_reference: Mapping[str, Any],
+        credential_scope_binding: Mapping[str, Any],
+        live_adapter_bind_authorization_id: str,
+    ) -> ConstructedAuthorizationHeader:
+        del credential_reference, credential_scope_binding
+        del live_adapter_bind_authorization_id
+        assert credential.material == b"synthetic-secret"
+        return ConstructedAuthorizationHeader(
+            name="Authorization", value="Bearer synthetic-secret"
+        )
+
+
+class _Adapter(BindAdapterContract):
+    def __init__(self, expected: str | None) -> None:
+        self.expected = expected
+
+    def snapshot(self) -> dict[str, str]:
+        return {"state": "synthetic"}
+
+    def fingerprint_state(self, snapshot: Any) -> str:
+        del snapshot
+        return self.expected or "synthetic-state"
+
+    def validate_authority(self, intent: ExecutionIntent, snapshot: Any) -> bool:
+        del intent, snapshot
+        return True
+
+    def validate_constraints(
+        self, intent: ExecutionIntent, snapshot: Any
+    ) -> dict[str, bool]:
+        del intent, snapshot
+        return {"synthetic": True}
+
+    def assess_runtime_risk(self, intent: ExecutionIntent, snapshot: Any) -> bool:
+        del intent, snapshot
+        return True
+
+    def apply(self, intent: ExecutionIntent, snapshot: Any) -> bool:
+        del intent, snapshot
+        return True
+
+    def verify_postconditions(self, intent: ExecutionIntent, snapshot: Any) -> bool:
+        del intent, snapshot
+        return True
+
+    def revert(self, intent: ExecutionIntent, snapshot: Any) -> bool:
+        del intent, snapshot
+        return True
+
+    def describe_target(self) -> str:
+        return "synthetic-consumption-poc"
+
+
+class _Factory:
+    async def build(
+        self,
+        *,
+        authorization,
+        credential: ResolvedCredentialMaterial,
+        authorization_header: ConstructedAuthorizationHeader,
+    ) -> AuthorizedBindAdapterInstance:
+        del credential, authorization_header
+        return AuthorizedBindAdapterInstance(
+            adapter=_Adapter(
+                authorization.execution_intent.get("expected_state_fingerprint")
+            ),
+            adapter_contract_id=authorization.adapter_contract_id,
+            adapter_contract_hash=authorization.adapter_contract_hash,
+            endpoint_identity_binding_digest=(
+                authorization.endpoint_identity_binding_digest
+            ),
+            credential_reference_digest=authorization.credential_reference_digest,
+            credential_scope_binding_digest=(
+                authorization.credential_scope_binding_digest
+            ),
+        )
+
+
+async def _main() -> None:
+    artifact, governance, trust = _build()
+    result = await consume_live_adapter_bind_authorization_and_invoke_bind(
+        artifact,
+        governance_inputs=governance,
+        trust_inputs=trust,
+        now=VERIFICATION_NOW,
+        consumption_store=InMemoryAtomicAuthorizationConsumptionStore(),
+        credential_resolver=_Resolver(),
+        authorization_header_constructor=_Header(),
+        adapter_factory=_Factory(),
+        append_trustlog=False,
+    )
+    print("REAL_BIND_AUTHORIZATION          VERIFIED")
+    print("AUTHORIZATION_CONSUMPTION        CONSUMED")
+    print("CREDENTIAL_MATERIAL_ACCESS       TRUE")
+    print("AUTHORIZATION_HEADER_CONSTRUCTED TRUE")
+    print("BIND_INVOCATION                  INVOKED")
+    print(f"BIND_OUTCOME                     {result.bind_receipt.final_outcome.value}")
+    print("NETWORK_EFFECT                   NONE")
+    print("STORE_MODE                       PROCESS_LOCAL_TEST_ONLY")
+    print("RESULT                           PASS")
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())

--- a/veritas_os/policy/live_adapter_bind_authorization_consumption.py
+++ b/veritas_os/policy/live_adapter_bind_authorization_consumption.py
@@ -110,16 +110,77 @@ class AuthorizedBindAdapterFactory(Protocol):
         ...
 
 
+class _BindInvocationTrackingAdapter(BindAdapterContract):
+    """Transparent adapter proxy that records whether ``apply`` was attempted.
+
+    Entering ``execute_bind_adjudication`` is not the same thing as calling the
+    adapter's effect-bearing ``apply`` method.  The proxy preserves the exact
+    adapter behaviour while making that distinction observable in the returned
+    non-secret result.
+    """
+
+    def __init__(self, delegate: BindAdapterContract) -> None:
+        self._delegate = delegate
+        self.apply_attempted = False
+
+    def snapshot(self) -> Any:
+        return self._delegate.snapshot()
+
+    def fingerprint_state(self, snapshot: Any) -> str:
+        return self._delegate.fingerprint_state(snapshot)
+
+    def validate_authority(self, intent: ExecutionIntent, snapshot: Any) -> bool | None:
+        return self._delegate.validate_authority(intent, snapshot)
+
+    def validate_constraints(
+        self,
+        intent: ExecutionIntent,
+        snapshot: Any,
+    ) -> dict[str, bool] | None:
+        return self._delegate.validate_constraints(intent, snapshot)
+
+    def assess_runtime_risk(self, intent: ExecutionIntent, snapshot: Any) -> bool | None:
+        return self._delegate.assess_runtime_risk(intent, snapshot)
+
+    def apply(self, intent: ExecutionIntent, snapshot: Any) -> bool:
+        self.apply_attempted = True
+        return self._delegate.apply(intent, snapshot)
+
+    def verify_postconditions(self, intent: ExecutionIntent, snapshot: Any) -> bool:
+        return self._delegate.verify_postconditions(intent, snapshot)
+
+    def revert(self, intent: ExecutionIntent, snapshot: Any) -> bool:
+        return self._delegate.revert(intent, snapshot)
+
+    def describe_target(self) -> str:
+        return self._delegate.describe_target()
+
+    def build_idempotency_key(self, intent: ExecutionIntent) -> str:
+        return self._delegate.build_idempotency_key(intent)
+
+
 @dataclass(frozen=True)
 class BindAuthorizationConsumptionResult:
-    """Non-secret evidence returned after one consumed Bind attempt."""
+    """Non-secret evidence returned after one consumed Bind-gate attempt.
+
+    ``bind_core_invoked`` means the existing Bind adjudication core was entered.
+    It does not mean that the adapter ``apply`` boundary was reached and does
+    not mean that an external effect occurred.  ``adapter_apply_attempted`` is
+    the separate observable for the effect-bearing adapter method boundary.
+    """
 
     consumption_record: AuthorizationConsumptionRecord
     bind_receipt: BindReceipt
+    adapter_apply_attempted: bool
     authorization_consumed: bool = True
     credential_material_accessed: bool = True
     authorization_header_constructed: bool = True
-    bind_invoked: bool = True
+    bind_core_invoked: bool = True
+
+    @property
+    def bind_invoked(self) -> bool:
+        """Compatibility alias for Bind-core entry, never proof of adapter apply."""
+        return self.bind_core_invoked
 
 
 def _timestamp(value: datetime | str) -> str:
@@ -221,7 +282,7 @@ async def consume_live_adapter_bind_authorization_and_invoke_bind(
     append_trustlog: bool = True,
     bind_ts: str | None = None,
 ) -> BindAuthorizationConsumptionResult:
-    """Verify, consume once, access secrets, construct auth, then invoke Bind.
+    """Verify, consume once, access secrets, construct auth, then enter Bind core.
 
     Ordering is security critical:
       1. full authorization + temporal verification;
@@ -230,9 +291,10 @@ async def consume_live_adapter_bind_authorization_and_invoke_bind(
       4. credential resolution;
       5. Authorization-header construction;
       6. exact adapter binding validation;
-      7. Bind invocation.
+      7. Bind-core invocation.
 
-    Any failure after step 3 leaves the authorization consumed.
+    The Bind core may still block before adapter ``apply``. Any failure after
+    step 3 leaves the authorization consumed.
     """
     current = _timestamp(now)
     try:
@@ -320,15 +382,17 @@ async def consume_live_adapter_bind_authorization_and_invoke_bind(
         ) from None
     _validate_adapter_binding(authorization, built)
 
+    tracked_adapter = _BindInvocationTrackingAdapter(built.adapter)
     receipt = execute_bind_adjudication(
         execution_intent=intent,
-        adapter=built.adapter,
+        adapter=tracked_adapter,
         bind_ts=bind_ts or current,
         append_trustlog=append_trustlog,
     )
     return BindAuthorizationConsumptionResult(
         consumption_record=record,
         bind_receipt=receipt,
+        adapter_apply_attempted=tracked_adapter.apply_attempted,
     )
 
 

--- a/veritas_os/policy/live_adapter_bind_authorization_consumption.py
+++ b/veritas_os/policy/live_adapter_bind_authorization_consumption.py
@@ -1,0 +1,345 @@
+"""Authorization Consumption / Bind Invocation Gate v1.
+
+This is the first boundary allowed to consume a signed Real Bind Authorization,
+resolve credential material, construct an Authorization header, instantiate an
+adapter, and invoke Bind. Consumption happens atomically before any secret
+access or effectful adapter construction. A consumed authorization is never
+released or made reusable after a downstream failure.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Mapping, Protocol
+
+from veritas_os.policy.bind_artifacts import BindReceipt, ExecutionIntent, hash_execution_intent
+from veritas_os.policy.bind_core.contracts import BindAdapterContract
+from veritas_os.policy.bind_core.core import execute_bind_adjudication
+from veritas_os.policy.bind_core.normalizers import normalize_execution_intent
+from veritas_os.policy.live_adapter_bind_authorization import (
+    BindAuthorizationTrustInputs,
+    CanonicalLiveAdapterBindAuthorizationArtifact,
+    LiveAdapterBindAuthorizationError,
+    RealBindAuthorizationGovernanceInputs,
+    validate_live_adapter_bind_authorization_temporal_validity,
+)
+from veritas_os.policy.live_adapter_bind_authorization_consumption_store import (
+    AtomicAuthorizationConsumptionStore,
+    AuthorizationConsumptionRecord,
+    AuthorizationConsumptionStoreError,
+    build_authorization_consumption_record,
+)
+
+
+class LiveAdapterBindAuthorizationConsumptionError(RuntimeError):
+    """Stable fail-closed error at authorization consumption / Bind invocation."""
+
+
+@dataclass(frozen=True, repr=False)
+class ResolvedCredentialMaterial:
+    """Ephemeral secret material returned by an injected credential resolver."""
+
+    credential_reference_id: str
+    credential_kind: str
+    credential_provider_type: str
+    material: bytes = field(repr=False)
+
+    def __repr__(self) -> str:
+        return (
+            "ResolvedCredentialMaterial(credential_reference_id="
+            f"{self.credential_reference_id!r}, credential_kind={self.credential_kind!r}, "
+            f"credential_provider_type={self.credential_provider_type!r}, material=<redacted>)"
+        )
+
+
+@dataclass(frozen=True, repr=False)
+class ConstructedAuthorizationHeader:
+    """Ephemeral Authorization header; the value is never serialized by the gate."""
+
+    name: str
+    value: str = field(repr=False)
+
+    def __repr__(self) -> str:
+        return f"ConstructedAuthorizationHeader(name={self.name!r}, value=<redacted>)"
+
+
+@dataclass(frozen=True)
+class AuthorizedBindAdapterInstance:
+    """Adapter plus exact non-secret bindings checked before Bind invocation."""
+
+    adapter: BindAdapterContract = field(repr=False)
+    adapter_contract_id: str
+    adapter_contract_hash: str
+    endpoint_identity_binding_digest: str
+    credential_reference_digest: str
+    credential_scope_binding_digest: str
+
+
+class CredentialMaterialResolver(Protocol):
+    async def resolve(
+        self,
+        credential_reference: Mapping[str, Any],
+        *,
+        credential_scope_binding: Mapping[str, Any],
+        live_adapter_bind_authorization_id: str,
+    ) -> ResolvedCredentialMaterial:
+        ...
+
+
+class AuthorizationHeaderConstructor(Protocol):
+    async def construct(
+        self,
+        credential: ResolvedCredentialMaterial,
+        *,
+        credential_reference: Mapping[str, Any],
+        credential_scope_binding: Mapping[str, Any],
+        live_adapter_bind_authorization_id: str,
+    ) -> ConstructedAuthorizationHeader:
+        ...
+
+
+class AuthorizedBindAdapterFactory(Protocol):
+    async def build(
+        self,
+        *,
+        authorization: CanonicalLiveAdapterBindAuthorizationArtifact,
+        credential: ResolvedCredentialMaterial,
+        authorization_header: ConstructedAuthorizationHeader,
+    ) -> AuthorizedBindAdapterInstance:
+        ...
+
+
+@dataclass(frozen=True)
+class BindAuthorizationConsumptionResult:
+    """Non-secret evidence returned after one consumed Bind attempt."""
+
+    consumption_record: AuthorizationConsumptionRecord
+    bind_receipt: BindReceipt
+    authorization_consumed: bool = True
+    credential_material_accessed: bool = True
+    authorization_header_constructed: bool = True
+    bind_invoked: bool = True
+
+
+def _timestamp(value: datetime | str) -> str:
+    if isinstance(value, datetime):
+        parsed = value
+    else:
+        try:
+            parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        except (TypeError, ValueError):
+            raise LiveAdapterBindAuthorizationConsumptionError(
+                "LABAC_TIMESTAMP_INVALID"
+            ) from None
+    if parsed.tzinfo is None:
+        raise LiveAdapterBindAuthorizationConsumptionError("LABAC_TIMESTAMP_NAIVE")
+    return parsed.astimezone(timezone.utc).isoformat()
+
+
+def _validated_execution_intent(
+    authorization: CanonicalLiveAdapterBindAuthorizationArtifact,
+) -> ExecutionIntent:
+    try:
+        intent = normalize_execution_intent(authorization.execution_intent)
+    except (TypeError, ValueError):
+        raise LiveAdapterBindAuthorizationConsumptionError(
+            "LABAC_EXECUTION_INTENT_INVALID"
+        ) from None
+    if (
+        intent.execution_intent_id != authorization.execution_intent_id
+        or hash_execution_intent(intent) != authorization.execution_intent_hash
+    ):
+        raise LiveAdapterBindAuthorizationConsumptionError(
+            "LABAC_EXECUTION_INTENT_BINDING_MISMATCH"
+        )
+    return intent
+
+
+def _validate_credential(
+    authorization: CanonicalLiveAdapterBindAuthorizationArtifact,
+    credential: ResolvedCredentialMaterial,
+) -> None:
+    reference = authorization.credential_reference
+    if (
+        credential.credential_reference_id != reference.get("credential_reference_id")
+        or credential.credential_kind != reference.get("credential_kind")
+        or credential.credential_provider_type != reference.get("credential_provider_type")
+        or not isinstance(credential.material, bytes)
+        or not credential.material
+    ):
+        raise LiveAdapterBindAuthorizationConsumptionError(
+            "LABAC_RESOLVED_CREDENTIAL_BINDING_MISMATCH"
+        )
+
+
+def _validate_authorization_header(header: ConstructedAuthorizationHeader) -> None:
+    if header.name.strip().lower() != "authorization":
+        raise LiveAdapterBindAuthorizationConsumptionError(
+            "LABAC_AUTHORIZATION_HEADER_NAME_INVALID"
+        )
+    if not header.value or "\r" in header.value or "\n" in header.value:
+        raise LiveAdapterBindAuthorizationConsumptionError(
+            "LABAC_AUTHORIZATION_HEADER_VALUE_INVALID"
+        )
+
+
+def _validate_adapter_binding(
+    authorization: CanonicalLiveAdapterBindAuthorizationArtifact,
+    built: AuthorizedBindAdapterInstance,
+) -> None:
+    expected = (
+        authorization.adapter_contract_id,
+        authorization.adapter_contract_hash,
+        authorization.endpoint_identity_binding_digest,
+        authorization.credential_reference_digest,
+        authorization.credential_scope_binding_digest,
+    )
+    actual = (
+        built.adapter_contract_id,
+        built.adapter_contract_hash,
+        built.endpoint_identity_binding_digest,
+        built.credential_reference_digest,
+        built.credential_scope_binding_digest,
+    )
+    if actual != expected:
+        raise LiveAdapterBindAuthorizationConsumptionError(
+            "LABAC_ADAPTER_BINDING_MISMATCH"
+        )
+
+
+async def consume_live_adapter_bind_authorization_and_invoke_bind(
+    artifact: Any,
+    *,
+    governance_inputs: RealBindAuthorizationGovernanceInputs,
+    trust_inputs: BindAuthorizationTrustInputs,
+    now: datetime | str,
+    consumption_store: AtomicAuthorizationConsumptionStore,
+    credential_resolver: CredentialMaterialResolver,
+    authorization_header_constructor: AuthorizationHeaderConstructor,
+    adapter_factory: AuthorizedBindAdapterFactory,
+    append_trustlog: bool = True,
+    bind_ts: str | None = None,
+) -> BindAuthorizationConsumptionResult:
+    """Verify, consume once, access secrets, construct auth, then invoke Bind.
+
+    Ordering is security critical:
+      1. full authorization + temporal verification;
+      2. exact ExecutionIntent reconstruction;
+      3. atomic single-use consumption;
+      4. credential resolution;
+      5. Authorization-header construction;
+      6. exact adapter binding validation;
+      7. Bind invocation.
+
+    Any failure after step 3 leaves the authorization consumed.
+    """
+    current = _timestamp(now)
+    try:
+        authorization = validate_live_adapter_bind_authorization_temporal_validity(
+            artifact,
+            now=current,
+            governance_inputs=governance_inputs,
+            trust_inputs=trust_inputs,
+        )
+    except LiveAdapterBindAuthorizationError:
+        raise LiveAdapterBindAuthorizationConsumptionError(
+            "LABAC_AUTHORIZATION_VERIFICATION_FAILED"
+        ) from None
+
+    intent = _validated_execution_intent(authorization)
+    if (
+        not authorization.single_use
+        or not authorization.authorization_consumption_required
+        or not authorization.replay_protection_required
+        or not authorization.duplicate_dispatch_prohibited
+        or authorization.authorization_consumption_state != "NOT_CONSUMED"
+        or authorization.bind_invocation_state != "NOT_INVOKED"
+    ):
+        raise LiveAdapterBindAuthorizationConsumptionError(
+            "LABAC_AUTHORIZATION_NOT_CONSUMABLE"
+        )
+
+    record = build_authorization_consumption_record(
+        live_adapter_bind_authorization_id=authorization.live_adapter_bind_authorization_id,
+        live_adapter_bind_authorization_hash=authorization.live_adapter_bind_authorization_hash,
+        idempotency_key=authorization.idempotency_key,
+        bind_context_hash=authorization.bind_context_hash,
+        execution_intent_id=authorization.execution_intent_id,
+        execution_intent_hash=authorization.execution_intent_hash,
+        endpoint_identity_binding_digest=authorization.endpoint_identity_binding_digest,
+        credential_reference_digest=authorization.credential_reference_digest,
+        credential_scope_binding_digest=authorization.credential_scope_binding_digest,
+        consumed_at=current,
+    )
+    try:
+        claimed = await consumption_store.consume_once(record)
+    except AuthorizationConsumptionStoreError:
+        raise LiveAdapterBindAuthorizationConsumptionError(
+            "LABAC_CONSUMPTION_STORE_FAILED"
+        ) from None
+    if not claimed:
+        raise LiveAdapterBindAuthorizationConsumptionError(
+            "LABAC_AUTHORIZATION_ALREADY_CONSUMED"
+        )
+
+    try:
+        credential = await credential_resolver.resolve(
+            authorization.credential_reference,
+            credential_scope_binding=authorization.credential_scope_binding,
+            live_adapter_bind_authorization_id=authorization.live_adapter_bind_authorization_id,
+        )
+    except Exception:
+        raise LiveAdapterBindAuthorizationConsumptionError(
+            "LABAC_CREDENTIAL_RESOLUTION_FAILED_AFTER_CONSUMPTION"
+        ) from None
+    _validate_credential(authorization, credential)
+
+    try:
+        header = await authorization_header_constructor.construct(
+            credential,
+            credential_reference=authorization.credential_reference,
+            credential_scope_binding=authorization.credential_scope_binding,
+            live_adapter_bind_authorization_id=authorization.live_adapter_bind_authorization_id,
+        )
+    except Exception:
+        raise LiveAdapterBindAuthorizationConsumptionError(
+            "LABAC_AUTHORIZATION_HEADER_CONSTRUCTION_FAILED_AFTER_CONSUMPTION"
+        ) from None
+    _validate_authorization_header(header)
+
+    try:
+        built = await adapter_factory.build(
+            authorization=authorization,
+            credential=credential,
+            authorization_header=header,
+        )
+    except Exception:
+        raise LiveAdapterBindAuthorizationConsumptionError(
+            "LABAC_ADAPTER_CONSTRUCTION_FAILED_AFTER_CONSUMPTION"
+        ) from None
+    _validate_adapter_binding(authorization, built)
+
+    receipt = execute_bind_adjudication(
+        execution_intent=intent,
+        adapter=built.adapter,
+        bind_ts=bind_ts or current,
+        append_trustlog=append_trustlog,
+    )
+    return BindAuthorizationConsumptionResult(
+        consumption_record=record,
+        bind_receipt=receipt,
+    )
+
+
+__all__ = [
+    "AuthorizationHeaderConstructor",
+    "AuthorizedBindAdapterFactory",
+    "AuthorizedBindAdapterInstance",
+    "BindAuthorizationConsumptionResult",
+    "ConstructedAuthorizationHeader",
+    "CredentialMaterialResolver",
+    "LiveAdapterBindAuthorizationConsumptionError",
+    "ResolvedCredentialMaterial",
+    "consume_live_adapter_bind_authorization_and_invoke_bind",
+]

--- a/veritas_os/policy/live_adapter_bind_authorization_consumption_store.py
+++ b/veritas_os/policy/live_adapter_bind_authorization_consumption_store.py
@@ -1,0 +1,158 @@
+"""Atomic single-use stores for Real Bind Authorization consumption.
+
+The store boundary records only non-secret authorization lineage. Credential
+material and constructed headers must never enter this module.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Protocol
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from veritas_os.security.hash import sha256_of_canonical_json
+
+_HASH_PATTERN = r"^[0-9a-f]{64}$"
+_CONSUMPTION_ID_PATTERN = r"^labac:v1:sha256:[0-9a-f]{64}$"
+
+
+class AuthorizationConsumptionStoreError(RuntimeError):
+    """Fail-closed storage failure at the authorization consumption boundary."""
+
+
+class AuthorizationConsumptionRecord(BaseModel):
+    """Non-secret record proving one authorization was atomically consumed."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    format_version: str = "live-adapter-bind-authorization-consumption/v1"
+    consumption_id: str = Field(pattern=_CONSUMPTION_ID_PATTERN)
+    consumption_hash: str = Field(pattern=_HASH_PATTERN)
+    live_adapter_bind_authorization_id: str = Field(min_length=1)
+    live_adapter_bind_authorization_hash: str = Field(pattern=_HASH_PATTERN)
+    idempotency_key: str = Field(min_length=1)
+    bind_context_hash: str = Field(pattern=_HASH_PATTERN)
+    execution_intent_id: str = Field(min_length=1)
+    execution_intent_hash: str = Field(pattern=_HASH_PATTERN)
+    endpoint_identity_binding_digest: str = Field(min_length=1)
+    credential_reference_digest: str = Field(min_length=1)
+    credential_scope_binding_digest: str = Field(min_length=1)
+    consumed_at: str = Field(min_length=1)
+    consumption_state: str = "CONSUMED"
+    single_use_enforced: bool = True
+
+
+class AtomicAuthorizationConsumptionStore(Protocol):
+    """Atomic compare-and-set store used before any credential access or Bind."""
+
+    async def consume_once(self, record: AuthorizationConsumptionRecord) -> bool:
+        """Return True exactly once; False for any duplicate authorization/key."""
+
+
+def build_authorization_consumption_record(
+    *,
+    live_adapter_bind_authorization_id: str,
+    live_adapter_bind_authorization_hash: str,
+    idempotency_key: str,
+    bind_context_hash: str,
+    execution_intent_id: str,
+    execution_intent_hash: str,
+    endpoint_identity_binding_digest: str,
+    credential_reference_digest: str,
+    credential_scope_binding_digest: str,
+    consumed_at: str,
+) -> AuthorizationConsumptionRecord:
+    """Build a deterministic, non-secret consumption record."""
+    body = {
+        "format_version": "live-adapter-bind-authorization-consumption/v1",
+        "live_adapter_bind_authorization_id": live_adapter_bind_authorization_id,
+        "live_adapter_bind_authorization_hash": live_adapter_bind_authorization_hash,
+        "idempotency_key": idempotency_key,
+        "bind_context_hash": bind_context_hash,
+        "execution_intent_id": execution_intent_id,
+        "execution_intent_hash": execution_intent_hash,
+        "endpoint_identity_binding_digest": endpoint_identity_binding_digest,
+        "credential_reference_digest": credential_reference_digest,
+        "credential_scope_binding_digest": credential_scope_binding_digest,
+        "consumed_at": consumed_at,
+        "consumption_state": "CONSUMED",
+        "single_use_enforced": True,
+    }
+    digest = sha256_of_canonical_json(body)
+    return AuthorizationConsumptionRecord(
+        **body,
+        consumption_hash=digest,
+        consumption_id=f"labac:v1:sha256:{digest}",
+    )
+
+
+class InMemoryAtomicAuthorizationConsumptionStore:
+    """Process-local atomic store for tests and deterministic reference use only."""
+
+    production_safe = False
+
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        self._by_authorization_id: dict[str, AuthorizationConsumptionRecord] = {}
+        self._idempotency_keys: set[str] = set()
+
+    async def consume_once(self, record: AuthorizationConsumptionRecord) -> bool:
+        async with self._lock:
+            if (
+                record.live_adapter_bind_authorization_id in self._by_authorization_id
+                or record.idempotency_key in self._idempotency_keys
+            ):
+                return False
+            self._by_authorization_id[record.live_adapter_bind_authorization_id] = record
+            self._idempotency_keys.add(record.idempotency_key)
+            return True
+
+    async def get(
+        self, live_adapter_bind_authorization_id: str
+    ) -> AuthorizationConsumptionRecord | None:
+        async with self._lock:
+            return self._by_authorization_id.get(live_adapter_bind_authorization_id)
+
+
+class PostgresAtomicAuthorizationConsumptionStore:
+    """Cross-process atomic store backed by PostgreSQL UNIQUE constraints."""
+
+    production_safe = True
+
+    async def consume_once(self, record: AuthorizationConsumptionRecord) -> bool:
+        try:
+            from psycopg.types.json import Jsonb
+            from veritas_os.storage.db import get_pool
+
+            pool = await get_pool()
+            async with pool.connection() as conn:
+                async with conn.transaction():
+                    cur = await conn.execute(
+                        "INSERT INTO bind_authorization_consumptions "
+                        "(consumption_id, consumption_hash, authorization_id, "
+                        "authorization_hash, idempotency_key, bind_context_hash, "
+                        "execution_intent_id, execution_intent_hash, consumed_at, record) "
+                        "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s) "
+                        "ON CONFLICT DO NOTHING RETURNING consumption_id",
+                        (
+                            record.consumption_id,
+                            record.consumption_hash,
+                            record.live_adapter_bind_authorization_id,
+                            record.live_adapter_bind_authorization_hash,
+                            record.idempotency_key,
+                            record.bind_context_hash,
+                            record.execution_intent_id,
+                            record.execution_intent_hash,
+                            record.consumed_at,
+                            Jsonb(record.model_dump(mode="json")),
+                        ),
+                    )
+                    row = await cur.fetchone()
+                    return row is not None
+        except AuthorizationConsumptionStoreError:
+            raise
+        except Exception:
+            raise AuthorizationConsumptionStoreError(
+                "LABAC_POSTGRES_CONSUMPTION_STORE_FAILED"
+            ) from None

--- a/veritas_os/tests/test_live_adapter_bind_authorization_consumption.py
+++ b/veritas_os/tests/test_live_adapter_bind_authorization_consumption.py
@@ -1,0 +1,331 @@
+"""Security tests for Authorization Consumption / Bind Invocation Gate v1."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Any, Mapping
+
+import pytest
+
+from veritas_os.policy.bind_artifacts import ExecutionIntent
+from veritas_os.policy.bind_core.contracts import BindAdapterContract
+from veritas_os.policy.live_adapter_bind_authorization_consumption import (
+    AuthorizedBindAdapterInstance,
+    ConstructedAuthorizationHeader,
+    LiveAdapterBindAuthorizationConsumptionError,
+    ResolvedCredentialMaterial,
+    consume_live_adapter_bind_authorization_and_invoke_bind,
+)
+from veritas_os.policy.live_adapter_bind_authorization_consumption_store import (
+    InMemoryAtomicAuthorizationConsumptionStore,
+    build_authorization_consumption_record,
+)
+from veritas_os.tests.test_live_adapter_bind_authorization import (
+    VERIFICATION_NOW,
+    _build,
+)
+
+
+class _Resolver:
+    def __init__(self, *, fail: bool = False) -> None:
+        self.calls = 0
+        self.fail = fail
+
+    async def resolve(
+        self,
+        credential_reference: Mapping[str, Any],
+        *,
+        credential_scope_binding: Mapping[str, Any],
+        live_adapter_bind_authorization_id: str,
+    ) -> ResolvedCredentialMaterial:
+        del credential_scope_binding, live_adapter_bind_authorization_id
+        self.calls += 1
+        if self.fail:
+            raise RuntimeError("secret-provider-details-must-not-escape")
+        return ResolvedCredentialMaterial(
+            credential_reference_id=str(
+                credential_reference["credential_reference_id"]
+            ),
+            credential_kind=str(credential_reference["credential_kind"]),
+            credential_provider_type=str(
+                credential_reference["credential_provider_type"]
+            ),
+            material=b"super-secret-test-credential",
+        )
+
+
+class _HeaderConstructor:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def construct(
+        self,
+        credential: ResolvedCredentialMaterial,
+        *,
+        credential_reference: Mapping[str, Any],
+        credential_scope_binding: Mapping[str, Any],
+        live_adapter_bind_authorization_id: str,
+    ) -> ConstructedAuthorizationHeader:
+        del credential_reference, credential_scope_binding
+        del live_adapter_bind_authorization_id
+        self.calls += 1
+        assert credential.material == b"super-secret-test-credential"
+        return ConstructedAuthorizationHeader(
+            name="Authorization",
+            value="Bearer super-secret-test-credential",
+        )
+
+
+@dataclass
+class _RecordingAdapter(BindAdapterContract):
+    expected_fingerprint: str | None
+    apply_calls: int = 0
+
+    def snapshot(self) -> dict[str, str]:
+        return {"state": "before"}
+
+    def fingerprint_state(self, snapshot: Any) -> str:
+        del snapshot
+        return self.expected_fingerprint or "live-state"
+
+    def validate_authority(self, intent: ExecutionIntent, snapshot: Any) -> bool:
+        del intent, snapshot
+        return True
+
+    def validate_constraints(
+        self, intent: ExecutionIntent, snapshot: Any
+    ) -> dict[str, bool]:
+        del intent, snapshot
+        return {"authorized_consumption": True}
+
+    def assess_runtime_risk(self, intent: ExecutionIntent, snapshot: Any) -> bool:
+        del intent, snapshot
+        return True
+
+    def apply(self, intent: ExecutionIntent, snapshot: Any) -> bool:
+        del intent, snapshot
+        self.apply_calls += 1
+        return True
+
+    def verify_postconditions(self, intent: ExecutionIntent, snapshot: Any) -> bool:
+        del intent, snapshot
+        return True
+
+    def revert(self, intent: ExecutionIntent, snapshot: Any) -> bool:
+        del intent, snapshot
+        return True
+
+    def describe_target(self) -> str:
+        return "authorized-consumption-test-target"
+
+
+class _Factory:
+    def __init__(self) -> None:
+        self.calls = 0
+        self.adapter: _RecordingAdapter | None = None
+
+    async def build(
+        self,
+        *,
+        authorization,
+        credential: ResolvedCredentialMaterial,
+        authorization_header: ConstructedAuthorizationHeader,
+    ) -> AuthorizedBindAdapterInstance:
+        self.calls += 1
+        assert credential.material == b"super-secret-test-credential"
+        assert authorization_header.value.startswith("Bearer ")
+        self.adapter = _RecordingAdapter(
+            authorization.execution_intent.get("expected_state_fingerprint")
+        )
+        return AuthorizedBindAdapterInstance(
+            adapter=self.adapter,
+            adapter_contract_id=authorization.adapter_contract_id,
+            adapter_contract_hash=authorization.adapter_contract_hash,
+            endpoint_identity_binding_digest=(
+                authorization.endpoint_identity_binding_digest
+            ),
+            credential_reference_digest=authorization.credential_reference_digest,
+            credential_scope_binding_digest=(
+                authorization.credential_scope_binding_digest
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_verified_authorization_consumes_once_before_bind() -> None:
+    artifact, governance, trust = _build()
+    store = InMemoryAtomicAuthorizationConsumptionStore()
+    resolver = _Resolver()
+    header = _HeaderConstructor()
+    factory = _Factory()
+
+    result = await consume_live_adapter_bind_authorization_and_invoke_bind(
+        artifact,
+        governance_inputs=governance,
+        trust_inputs=trust,
+        now=VERIFICATION_NOW,
+        consumption_store=store,
+        credential_resolver=resolver,
+        authorization_header_constructor=header,
+        adapter_factory=factory,
+        append_trustlog=False,
+    )
+
+    assert result.authorization_consumed
+    assert result.credential_material_accessed
+    assert result.authorization_header_constructed
+    assert result.bind_invoked
+    assert result.consumption_record.consumption_state == "CONSUMED"
+    assert result.bind_receipt.execution_intent_id == artifact.execution_intent_id
+    assert resolver.calls == 1
+    assert header.calls == 1
+    assert factory.calls == 1
+
+    with pytest.raises(
+        LiveAdapterBindAuthorizationConsumptionError,
+        match="LABAC_AUTHORIZATION_ALREADY_CONSUMED",
+    ):
+        await consume_live_adapter_bind_authorization_and_invoke_bind(
+            artifact,
+            governance_inputs=governance,
+            trust_inputs=trust,
+            now=VERIFICATION_NOW,
+            consumption_store=store,
+            credential_resolver=resolver,
+            authorization_header_constructor=header,
+            adapter_factory=factory,
+            append_trustlog=False,
+        )
+    assert resolver.calls == 1
+    assert header.calls == 1
+    assert factory.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_tampered_authorization_fails_before_consumption_or_secret_access() -> None:
+    artifact, governance, trust = _build()
+    raw = artifact.model_dump(mode="json")
+    raw["execution_intent_hash"] = "0" * 64
+    store = InMemoryAtomicAuthorizationConsumptionStore()
+    resolver = _Resolver()
+
+    with pytest.raises(
+        LiveAdapterBindAuthorizationConsumptionError,
+        match="LABAC_AUTHORIZATION_VERIFICATION_FAILED",
+    ):
+        await consume_live_adapter_bind_authorization_and_invoke_bind(
+            raw,
+            governance_inputs=governance,
+            trust_inputs=trust,
+            now=VERIFICATION_NOW,
+            consumption_store=store,
+            credential_resolver=resolver,
+            authorization_header_constructor=_HeaderConstructor(),
+            adapter_factory=_Factory(),
+            append_trustlog=False,
+        )
+    assert resolver.calls == 0
+    assert await store.get(artifact.live_adapter_bind_authorization_id) is None
+
+
+@pytest.mark.asyncio
+async def test_expired_authorization_fails_before_consumption() -> None:
+    artifact, governance, trust = _build()
+    store = InMemoryAtomicAuthorizationConsumptionStore()
+    resolver = _Resolver()
+
+    with pytest.raises(
+        LiveAdapterBindAuthorizationConsumptionError,
+        match="LABAC_AUTHORIZATION_VERIFICATION_FAILED",
+    ):
+        await consume_live_adapter_bind_authorization_and_invoke_bind(
+            artifact,
+            governance_inputs=governance,
+            trust_inputs=trust,
+            now=VERIFICATION_NOW + timedelta(days=1),
+            consumption_store=store,
+            credential_resolver=resolver,
+            authorization_header_constructor=_HeaderConstructor(),
+            adapter_factory=_Factory(),
+            append_trustlog=False,
+        )
+    assert resolver.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_failure_after_consumption_never_releases_authorization() -> None:
+    artifact, governance, trust = _build()
+    store = InMemoryAtomicAuthorizationConsumptionStore()
+    failing = _Resolver(fail=True)
+
+    with pytest.raises(
+        LiveAdapterBindAuthorizationConsumptionError,
+        match="LABAC_CREDENTIAL_RESOLUTION_FAILED_AFTER_CONSUMPTION",
+    ):
+        await consume_live_adapter_bind_authorization_and_invoke_bind(
+            artifact,
+            governance_inputs=governance,
+            trust_inputs=trust,
+            now=VERIFICATION_NOW,
+            consumption_store=store,
+            credential_resolver=failing,
+            authorization_header_constructor=_HeaderConstructor(),
+            adapter_factory=_Factory(),
+            append_trustlog=False,
+        )
+
+    assert await store.get(artifact.live_adapter_bind_authorization_id) is not None
+    second = _Resolver()
+    with pytest.raises(
+        LiveAdapterBindAuthorizationConsumptionError,
+        match="LABAC_AUTHORIZATION_ALREADY_CONSUMED",
+    ):
+        await consume_live_adapter_bind_authorization_and_invoke_bind(
+            artifact,
+            governance_inputs=governance,
+            trust_inputs=trust,
+            now=VERIFICATION_NOW,
+            consumption_store=store,
+            credential_resolver=second,
+            authorization_header_constructor=_HeaderConstructor(),
+            adapter_factory=_Factory(),
+            append_trustlog=False,
+        )
+    assert second.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_in_memory_store_allows_only_one_concurrent_consumer() -> None:
+    store = InMemoryAtomicAuthorizationConsumptionStore()
+    record = build_authorization_consumption_record(
+        live_adapter_bind_authorization_id="laba:v1:sha256:" + "1" * 64,
+        live_adapter_bind_authorization_hash="1" * 64,
+        idempotency_key="laba-idem:v1:sha256:" + "2" * 64,
+        bind_context_hash="3" * 64,
+        execution_intent_id="intent:one",
+        execution_intent_hash="4" * 64,
+        endpoint_identity_binding_digest="endpoint-digest",
+        credential_reference_digest="credential-digest",
+        credential_scope_binding_digest="scope-digest",
+        consumed_at=VERIFICATION_NOW.isoformat(),
+    )
+    outcomes = await asyncio.gather(*(store.consume_once(record) for _ in range(20)))
+    assert outcomes.count(True) == 1
+    assert outcomes.count(False) == 19
+
+
+def test_secret_material_and_header_repr_are_redacted() -> None:
+    credential = ResolvedCredentialMaterial(
+        credential_reference_id="ref",
+        credential_kind="API_CREDENTIAL",
+        credential_provider_type="LOCAL_REFERENCE",
+        material=b"do-not-print-me",
+    )
+    header = ConstructedAuthorizationHeader(
+        name="Authorization",
+        value="Bearer do-not-print-me",
+    )
+    assert "do-not-print-me" not in repr(credential)
+    assert "do-not-print-me" not in repr(header)

--- a/veritas_os/tests/test_live_adapter_bind_authorization_consumption_semantics.py
+++ b/veritas_os/tests/test_live_adapter_bind_authorization_consumption_semantics.py
@@ -1,0 +1,153 @@
+"""Invocation-semantics tests for the authorization consumption gate."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from veritas_os.policy.bind_artifacts import ExecutionIntent
+from veritas_os.policy.bind_core.contracts import BindAdapterContract
+from veritas_os.policy.live_adapter_bind_authorization_consumption import (
+    AuthorizedBindAdapterInstance,
+    ConstructedAuthorizationHeader,
+    ResolvedCredentialMaterial,
+    consume_live_adapter_bind_authorization_and_invoke_bind,
+)
+from veritas_os.policy.live_adapter_bind_authorization_consumption_store import (
+    InMemoryAtomicAuthorizationConsumptionStore,
+)
+from veritas_os.tests.test_live_adapter_bind_authorization import (
+    VERIFICATION_NOW,
+    _build,
+)
+from veritas_os.tests.test_live_adapter_bind_authorization_consumption import (
+    _Factory,
+    _HeaderConstructor,
+    _Resolver,
+)
+
+
+class _BlockedBeforeApplyAdapter(BindAdapterContract):
+    """Adapter whose bind-time authority check blocks before ``apply``."""
+
+    def __init__(self, expected_fingerprint: str | None) -> None:
+        self.expected_fingerprint = expected_fingerprint
+        self.apply_calls = 0
+
+    def snapshot(self) -> dict[str, str]:
+        return {"state": "before"}
+
+    def fingerprint_state(self, snapshot: Any) -> str:
+        del snapshot
+        return self.expected_fingerprint or "live-state"
+
+    def validate_authority(self, intent: ExecutionIntent, snapshot: Any) -> bool:
+        del intent, snapshot
+        return False
+
+    def validate_constraints(
+        self,
+        intent: ExecutionIntent,
+        snapshot: Any,
+    ) -> dict[str, bool]:
+        del intent, snapshot
+        return {"authorized_consumption": True}
+
+    def assess_runtime_risk(self, intent: ExecutionIntent, snapshot: Any) -> bool:
+        del intent, snapshot
+        return True
+
+    def apply(self, intent: ExecutionIntent, snapshot: Any) -> bool:
+        del intent, snapshot
+        self.apply_calls += 1
+        return True
+
+    def verify_postconditions(self, intent: ExecutionIntent, snapshot: Any) -> bool:
+        del intent, snapshot
+        return True
+
+    def revert(self, intent: ExecutionIntent, snapshot: Any) -> bool:
+        del intent, snapshot
+        return True
+
+    def describe_target(self) -> str:
+        return "blocked-before-apply"
+
+
+class _BlockedFactory:
+    def __init__(self) -> None:
+        self.adapter: _BlockedBeforeApplyAdapter | None = None
+
+    async def build(
+        self,
+        *,
+        authorization,
+        credential: ResolvedCredentialMaterial,
+        authorization_header: ConstructedAuthorizationHeader,
+    ) -> AuthorizedBindAdapterInstance:
+        del credential, authorization_header
+        self.adapter = _BlockedBeforeApplyAdapter(
+            authorization.execution_intent.get("expected_state_fingerprint")
+        )
+        return AuthorizedBindAdapterInstance(
+            adapter=self.adapter,
+            adapter_contract_id=authorization.adapter_contract_id,
+            adapter_contract_hash=authorization.adapter_contract_hash,
+            endpoint_identity_binding_digest=(
+                authorization.endpoint_identity_binding_digest
+            ),
+            credential_reference_digest=authorization.credential_reference_digest,
+            credential_scope_binding_digest=(
+                authorization.credential_scope_binding_digest
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_committed_bind_reports_core_entry_and_apply_attempt() -> None:
+    artifact, governance, trust = _build()
+    factory = _Factory()
+
+    result = await consume_live_adapter_bind_authorization_and_invoke_bind(
+        artifact,
+        governance_inputs=governance,
+        trust_inputs=trust,
+        now=VERIFICATION_NOW,
+        consumption_store=InMemoryAtomicAuthorizationConsumptionStore(),
+        credential_resolver=_Resolver(),
+        authorization_header_constructor=_HeaderConstructor(),
+        adapter_factory=factory,
+        append_trustlog=False,
+    )
+
+    assert result.bind_core_invoked is True
+    assert result.adapter_apply_attempted is True
+    assert result.bind_invoked is True
+    assert factory.adapter is not None
+    assert factory.adapter.apply_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_blocked_bind_reports_core_entry_without_apply_attempt() -> None:
+    artifact, governance, trust = _build()
+    factory = _BlockedFactory()
+
+    result = await consume_live_adapter_bind_authorization_and_invoke_bind(
+        artifact,
+        governance_inputs=governance,
+        trust_inputs=trust,
+        now=VERIFICATION_NOW,
+        consumption_store=InMemoryAtomicAuthorizationConsumptionStore(),
+        credential_resolver=_Resolver(),
+        authorization_header_constructor=_HeaderConstructor(),
+        adapter_factory=factory,
+        append_trustlog=False,
+    )
+
+    assert result.authorization_consumed is True
+    assert result.bind_core_invoked is True
+    assert result.adapter_apply_attempted is False
+    assert result.bind_receipt.final_outcome.value == "BLOCKED"
+    assert factory.adapter is not None
+    assert factory.adapter.apply_calls == 0

--- a/veritas_os/tests/test_pg_bind_authorization_consumption_contention.py
+++ b/veritas_os/tests/test_pg_bind_authorization_consumption_contention.py
@@ -1,0 +1,115 @@
+"""Real-PostgreSQL contention tests for authorization consume-once semantics."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import os
+from uuid import uuid4
+
+import pytest
+
+from veritas_os.policy.live_adapter_bind_authorization_consumption_store import (
+    PostgresAtomicAuthorizationConsumptionStore,
+    build_authorization_consumption_record,
+)
+from veritas_os.storage.db import get_pool
+
+pytestmark = [pytest.mark.postgresql, pytest.mark.contention]
+
+
+def _digest(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _require_real_postgresql() -> None:
+    url = os.getenv("VERITAS_DATABASE_URL", "")
+    if not url.startswith("postgresql"):
+        pytest.skip("real PostgreSQL service container is required")
+
+
+def _record(token: str, *, authorization_id: str | None = None, idempotency_key: str | None = None):
+    auth_hash = _digest("authorization:" + token)
+    return build_authorization_consumption_record(
+        live_adapter_bind_authorization_id=(
+            authorization_id or f"laba:v1:sha256:{auth_hash}"
+        ),
+        live_adapter_bind_authorization_hash=auth_hash,
+        idempotency_key=(
+            idempotency_key or f"laba-idem:v1:sha256:{_digest('idem:' + token)}"
+        ),
+        bind_context_hash=_digest("bind-context:" + token),
+        execution_intent_id="intent:" + token,
+        execution_intent_hash=_digest("intent:" + token),
+        endpoint_identity_binding_digest=_digest("endpoint:" + token),
+        credential_reference_digest=_digest("credential:" + token),
+        credential_scope_binding_digest=_digest("scope:" + token),
+        consumed_at="2026-08-23T06:00:00+00:00",
+    )
+
+
+async def _count_rows(*, authorization_id: str | None = None, idempotency_key: str | None = None) -> int:
+    pool = await get_pool()
+    async with pool.connection() as conn:
+        if authorization_id is not None:
+            cur = await conn.execute(
+                "SELECT count(*) FROM bind_authorization_consumptions "
+                "WHERE authorization_id = %s",
+                (authorization_id,),
+            )
+        elif idempotency_key is not None:
+            cur = await conn.execute(
+                "SELECT count(*) FROM bind_authorization_consumptions "
+                "WHERE idempotency_key = %s",
+                (idempotency_key,),
+            )
+        else:
+            raise AssertionError("one lookup key is required")
+        row = await cur.fetchone()
+    return int(row[0]) if row else 0
+
+
+@pytest.mark.asyncio
+async def test_real_postgres_allows_exactly_one_concurrent_consumer() -> None:
+    """32 concurrent workers racing one authorization produce one winner."""
+    _require_real_postgresql()
+    token = uuid4().hex
+    record = _record(token)
+    store = PostgresAtomicAuthorizationConsumptionStore()
+
+    outcomes = await asyncio.gather(*(store.consume_once(record) for _ in range(32)))
+
+    assert outcomes.count(True) == 1
+    assert outcomes.count(False) == 31
+    assert (
+        await _count_rows(
+            authorization_id=record.live_adapter_bind_authorization_id
+        )
+        == 1
+    )
+
+
+@pytest.mark.asyncio
+async def test_real_postgres_idempotency_key_is_unique_across_authorizations() -> None:
+    """Different authorization IDs cannot consume the same idempotency key."""
+    _require_real_postgresql()
+    token = uuid4().hex
+    shared_idempotency_key = f"laba-idem:v1:sha256:{_digest('shared:' + token)}"
+    first = _record(
+        token + ":a",
+        idempotency_key=shared_idempotency_key,
+    )
+    second = _record(
+        token + ":b",
+        idempotency_key=shared_idempotency_key,
+    )
+    assert first.live_adapter_bind_authorization_id != second.live_adapter_bind_authorization_id
+
+    store = PostgresAtomicAuthorizationConsumptionStore()
+    outcomes = await asyncio.gather(
+        store.consume_once(first),
+        store.consume_once(second),
+    )
+
+    assert sorted(outcomes) == [False, True]
+    assert await _count_rows(idempotency_key=shared_idempotency_key) == 1


### PR DESCRIPTION
### Motivation

Complete the next boundary after merged #2131 by consuming one exact signed Real Bind Authorization before any credential access or Bind invocation.

### What this PR implements

- full re-verification and temporal validation of the signed Real Bind Authorization before consumption;
- exact ExecutionIntent reconstruction and hash binding;
- atomic single-use consumption before any credential access;
- process-local in-memory atomic store for tests/reference use only;
- PostgreSQL-backed cross-process consume-once store using UNIQUE authorization/idempotency keys and `INSERT ... ON CONFLICT DO NOTHING`;
- Alembic migration `0004` for durable consumption records;
- injected credential-resolution, Authorization-header-construction, and authorized adapter-factory contracts;
- exact adapter/endpoint/credential/scope digest checks before Bind-core entry;
- invocation of the existing `execute_bind_adjudication()` only after successful consumption and secret/header construction;
- explicit separation of `bind_core_invoked` from `adapter_apply_attempted`, so a blocked Bind is not misreported as an effect-bearing apply attempt;
- consumed authorizations are never released after downstream failures;
- redacted ephemeral credential/header runtime objects and non-secret consumption records;
- deterministic proof runner and attack-oriented tests;
- real PostgreSQL contention tests proving exactly-one consumer for concurrent authorization and idempotency-key races.

### Security ordering

1. verify authorization + validity window;
2. verify exact ExecutionIntent ID/hash;
3. atomically consume authorization/idempotency key;
4. resolve credential material;
5. construct Authorization header;
6. verify adapter binding to exact signed context;
7. enter Bind adjudication core;
8. separately record whether adapter `apply` was actually attempted.

Any verification/store failure occurs before secret access. Any failure after atomic consumption leaves the authorization consumed and non-reusable.

### Invocation semantics

- `bind_core_invoked = true` means `execute_bind_adjudication()` was entered;
- `adapter_apply_attempted = true` means the Bind core actually reached the adapter `apply` boundary;
- blocked/escalated Bind paths may therefore have `bind_core_invoked = true` and `adapter_apply_attempted = false`;
- the compatibility property `bind_invoked` means Bind-core entry only and is not proof of adapter apply or external effect;
- no generic external-effect claim is made because `BindAdapterContract.apply()` may represent local, in-memory, provider, or network work depending on the concrete adapter.

### PostgreSQL contention proof

A dedicated PostgreSQL 16 workflow now exercises the real consumption store against the migrated database and verifies:

- 32 concurrent consumers racing the same authorization produce exactly 1 success and 31 duplicate refusals;
- distinct authorization IDs sharing one idempotency key still produce exactly 1 success;
- the database contains exactly one matching consumption row after each race.

### Important semantics

- Authorization != Consumption
- Consumption != Bind-core entry
- Bind-core entry != Adapter apply
- Adapter apply != Successful external effect
- a blocked/failed/rolled-back Bind still consumes the one-time authorization attempt;
- the in-memory store is explicitly not production-safe;
- PostgreSQL is the durable cross-process single-use backend in this version.

### Non-claims

This PR does not claim customer deployment, regulatory certification, or production support for every credential provider / Authorization scheme. Resolver, header-constructor and adapter-factory implementations remain injected deployment contracts.

### Base

Built directly on main after merged #2131 (`4a0ab9ec07e2b33546b15f01ec51dc26f4204bb3`).

### CI status

Fresh CI is running on the hardened current head, including a dedicated real-PostgreSQL authorization-consumption contention workflow. DO NOT MERGE until py3.11/py3.12, PostgreSQL, Security Gates, CodeQL, Runtime Proof, Runtime Pickle Guard, Reviewer Evidence, and the new consumption-contention workflow are green.