### PR TITLE
feat(bind): close bind outcome trustlog lineage v1

### DIFF
--- a/docs/en/architecture/bind-outcome-trustlog-lineage-v1.md
+++ b/docs/en/architecture/bind-outcome-trustlog-lineage-v1.md
@@ -1,0 +1,87 @@
+# Bind → Outcome → TrustLog Lineage v1
+
+## Purpose
+
+This boundary closes the post-bind evidence chain after a Real Bind Authorization has been atomically consumed.
+
+The chain is:
+
+`Real Bind Authorization → Authorization Consumption → Bind Core → BindReceipt → OutcomeReceipt → TrustLog`
+
+The implementation reuses the existing authorization-consumption gate, BindReceipt hashing/TrustLog helpers, and deterministic OutcomeReceipt artifact.
+
+## Exact lineage
+
+The final BindReceipt governance identity records non-secret references to:
+
+- Real Bind Authorization ID and hash;
+- authorization decision digest;
+- authorization issuer verifier-policy hash;
+- authorization consumption ID and hash;
+- consumption timestamp and idempotency key;
+- single-use enforcement status;
+- Bind-core invocation status;
+- adapter-apply-attempt status.
+
+The OutcomeReceipt then binds:
+
+- decision ID;
+- ExecutionIntent ID;
+- BindReceipt ID and hash;
+- BindReceipt TrustLog hash;
+- Real Bind Authorization ID/hash;
+- authorization consumption ID/hash;
+- bind-context hash;
+- idempotency key;
+- final Bind outcome;
+- pre/post state fingerprints when available;
+- rollback/failure information;
+- whether adapter apply was attempted.
+
+The OutcomeReceipt has its own deterministic `outcome_hash` and is appended to TrustLog after the linked BindReceipt.
+
+## Effect semantics
+
+A generic `BindAdapterContract.apply()` call is **not** sufficient evidence that an external effect occurred. An adapter may represent local memory, a database, a provider SDK, hardware, or a network request.
+
+Therefore this boundary preserves the distinction:
+
+- Authorization != Consumption
+- Consumption != Bind-core entry
+- Bind-core entry != Adapter apply
+- Adapter apply != Proven external effect
+- BindReceipt != OutcomeReceipt
+- OutcomeReceipt != External-system acknowledgement
+
+`observed_effects` records only the adapter-apply attempt unless a concrete adapter provides stronger effect evidence in a later boundary.
+
+## TrustLog ordering
+
+The composed path calls the authorization-consumption gate with Bind TrustLog writing disabled. This prevents a partially enriched BindReceipt from being logged. After Bind returns:
+
+1. ExecutionIntent is appended;
+2. the BindReceipt is enriched with authorization/consumption lineage and appended once;
+3. the OutcomeReceipt is created from that persisted BindReceipt;
+4. the OutcomeReceipt is appended.
+
+This yields an explicit evidence path from the consumed authorization to the post-bind outcome.
+
+## Important failure boundary
+
+TrustLog persistence happens after the Bind attempt. A storage failure can therefore occur after adapter apply has been attempted. The implementation raises `BOL_TRUSTLOG_PERSISTENCE_FAILED_AFTER_BIND_ATTEMPT` and does **not** pretend that no effect occurred. The consumed authorization remains consumed.
+
+This PR deliberately does not solve crash recovery or ambiguous external-effect state. Those belong to the next boundary:
+
+`IN_FLIGHT / EFFECT_UNKNOWN → reconciliation → terminal outcome`.
+
+## Non-claims
+
+This boundary does not claim:
+
+- exactly-once external effects;
+- proof that a generic adapter apply reached an external system;
+- recovery from process death between apply and TrustLog persistence;
+- external-system acknowledgement;
+- reconciliation of timeout/unknown outcomes.
+
+Those are separate runtime/reconciliation concerns and must not be inferred from a successful BindReceipt or OutcomeReceipt.

--- a/veritas_os/policy/bind_outcome_lineage.py
+++ b/veritas_os/policy/bind_outcome_lineage.py
@@ -1,7 +1,7 @@
 """Bind -> Outcome -> TrustLog lineage closure for one consumed authorization.
 
 This module composes the merged authorization-consumption gate with the
-existing BindReceipt and OutcomeReceipt artifacts.  It does not change Bind
+existing BindReceipt and OutcomeReceipt artifacts. It does not change Bind
 admissibility or authorization semantics; it makes the post-bind lineage
 explicit and auditable.
 """
@@ -27,7 +27,9 @@ from veritas_os.policy.bind_artifacts import (
 from veritas_os.policy.bind_core.normalizers import normalize_execution_intent
 from veritas_os.policy.live_adapter_bind_authorization import (
     BindAuthorizationTrustInputs,
+    LiveAdapterBindAuthorizationError,
     RealBindAuthorizationGovernanceInputs,
+    validate_live_adapter_bind_authorization_temporal_validity,
 )
 from veritas_os.policy.live_adapter_bind_authorization_consumption import (
     AuthorizationHeaderConstructor,
@@ -231,19 +233,33 @@ async def consume_bind_and_record_outcome_lineage(
 ) -> BindOutcomeLineageResult:
     """Consume one authorization, invoke Bind, then persist Bind+Outcome lineage.
 
+    The raw input is first canonicalized through the same signed authorization
+    verification boundary used by the consumption gate. The canonical object is
+    then used for both Bind invocation and all post-bind lineage construction.
+
     The underlying consumption gate is invoked with ``append_trustlog=False`` so
     the BindReceipt is first enriched with authorization/consumption lineage and
-    then written exactly once in its final form.  Outcome evidence is appended
+    then written exactly once in its final form. Outcome evidence is appended
     after the linked BindReceipt.
 
     A TrustLog persistence failure can occur after adapter apply has been
     attempted; this function therefore raises rather than pretending the effect
-    did not happen.  Crash/unknown-effect reconciliation is intentionally a
+    did not happen. Crash/unknown-effect reconciliation is intentionally a
     separate boundary.
     """
     current = _now_iso(now)
+    try:
+        authorization = validate_live_adapter_bind_authorization_temporal_validity(
+            artifact,
+            now=current,
+            governance_inputs=governance_inputs,
+            trust_inputs=trust_inputs,
+        )
+    except LiveAdapterBindAuthorizationError:
+        raise BindOutcomeLineageError("BOL_AUTHORIZATION_VERIFICATION_FAILED") from None
+
     consumption = await consume_live_adapter_bind_authorization_and_invoke_bind(
-        artifact,
+        authorization,
         governance_inputs=governance_inputs,
         trust_inputs=trust_inputs,
         now=current,
@@ -255,7 +271,6 @@ async def consume_bind_and_record_outcome_lineage(
         bind_ts=bind_ts or current,
     )
 
-    authorization = artifact
     intent = normalize_execution_intent(authorization.execution_intent)
     enriched_receipt = replace(
         consumption.bind_receipt,

--- a/veritas_os/policy/bind_outcome_lineage.py
+++ b/veritas_os/policy/bind_outcome_lineage.py
@@ -1,0 +1,300 @@
+"""Bind -> Outcome -> TrustLog lineage closure for one consumed authorization.
+
+This module composes the merged authorization-consumption gate with the
+existing BindReceipt and OutcomeReceipt artifacts.  It does not change Bind
+admissibility or authorization semantics; it makes the post-bind lineage
+explicit and auditable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
+from typing import Any
+
+from veritas_os.governance.outcome_receipt import (
+    OutcomeReceipt,
+    build_outcome_receipt,
+    validate_outcome_receipt,
+)
+from veritas_os.logging.trust_log import append_trust_log
+from veritas_os.policy.bind_artifacts import (
+    BindReceipt,
+    FinalOutcome,
+    append_bind_receipt_trustlog,
+    append_execution_intent_trustlog,
+)
+from veritas_os.policy.bind_core.normalizers import normalize_execution_intent
+from veritas_os.policy.live_adapter_bind_authorization import (
+    BindAuthorizationTrustInputs,
+    RealBindAuthorizationGovernanceInputs,
+)
+from veritas_os.policy.live_adapter_bind_authorization_consumption import (
+    AuthorizationHeaderConstructor,
+    AuthorizedBindAdapterFactory,
+    BindAuthorizationConsumptionResult,
+    CredentialMaterialResolver,
+    consume_live_adapter_bind_authorization_and_invoke_bind,
+)
+from veritas_os.policy.live_adapter_bind_authorization_consumption_store import (
+    AtomicAuthorizationConsumptionStore,
+)
+
+
+class BindOutcomeLineageError(RuntimeError):
+    """Stable fail-closed error for post-bind lineage construction/persistence."""
+
+
+@dataclass(frozen=True)
+class BindOutcomeLineageResult:
+    """Complete non-secret lineage returned after one consumed Bind attempt."""
+
+    consumption_result: BindAuthorizationConsumptionResult
+    bind_receipt: BindReceipt
+    outcome_receipt: OutcomeReceipt
+    outcome_trustlog_hash: str
+
+
+def _now_iso(value: datetime | str) -> str:
+    if isinstance(value, datetime):
+        parsed = value
+    else:
+        try:
+            parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        except (TypeError, ValueError):
+            raise BindOutcomeLineageError("BOL_TIMESTAMP_INVALID") from None
+    if parsed.tzinfo is None:
+        raise BindOutcomeLineageError("BOL_TIMESTAMP_NAIVE")
+    return parsed.astimezone(timezone.utc).isoformat()
+
+
+def _requested_scope(authorization: Any) -> list[str]:
+    raw = authorization.authority_evidence_reference_bundle.get("bundle_scope")
+    if not isinstance(raw, list):
+        raise BindOutcomeLineageError("BOL_REQUESTED_SCOPE_MISSING")
+    values = [str(item).strip() for item in raw if str(item).strip()]
+    if not values or len(set(values)) != len(values):
+        raise BindOutcomeLineageError("BOL_REQUESTED_SCOPE_INVALID")
+    return values
+
+
+def _postcondition_status(receipt: BindReceipt) -> str:
+    if receipt.final_outcome == FinalOutcome.COMMITTED:
+        return "passed"
+    if receipt.final_outcome in {
+        FinalOutcome.APPLY_FAILED,
+        FinalOutcome.ROLLED_BACK,
+    }:
+        return "failed"
+    if receipt.final_outcome == FinalOutcome.ESCALATED:
+        return "indeterminate"
+    return "skipped"
+
+
+def _failure_reasons(receipt: BindReceipt) -> list[str]:
+    values = [
+        receipt.bind_failure_reason,
+        receipt.rollback_reason,
+        receipt.escalation_reason,
+    ]
+    return sorted({str(value) for value in values if value})
+
+
+def _lineage_identity(
+    *,
+    authorization: Any,
+    consumption_result: BindAuthorizationConsumptionResult,
+    receipt: BindReceipt,
+) -> dict[str, Any]:
+    current = dict(receipt.governance_identity or {})
+    current["real_bind_authorization"] = {
+        "live_adapter_bind_authorization_id": (
+            authorization.live_adapter_bind_authorization_id
+        ),
+        "live_adapter_bind_authorization_hash": (
+            authorization.live_adapter_bind_authorization_hash
+        ),
+        "authorization_decision_digest": authorization.authorization_decision_digest,
+        "authorization_issuer_verifier_policy_hash": (
+            authorization.authorization_issuer_verification.verifier_policy_hash
+        ),
+    }
+    current["authorization_consumption"] = {
+        "consumption_id": consumption_result.consumption_record.consumption_id,
+        "consumption_hash": consumption_result.consumption_record.consumption_hash,
+        "consumed_at": consumption_result.consumption_record.consumed_at,
+        "idempotency_key": consumption_result.consumption_record.idempotency_key,
+        "single_use_enforced": (
+            consumption_result.consumption_record.single_use_enforced
+        ),
+    }
+    current["bind_invocation"] = {
+        "bind_core_invoked": consumption_result.bind_core_invoked,
+        "adapter_apply_attempted": consumption_result.adapter_apply_attempted,
+    }
+    return current
+
+
+def _build_outcome(
+    *,
+    authorization: Any,
+    governance_inputs: RealBindAuthorizationGovernanceInputs,
+    consumption_result: BindAuthorizationConsumptionResult,
+    receipt: BindReceipt,
+    evaluated_at: str,
+) -> OutcomeReceipt:
+    intent = normalize_execution_intent(authorization.execution_intent)
+    metadata = {
+        "live_adapter_bind_authorization_id": (
+            authorization.live_adapter_bind_authorization_id
+        ),
+        "live_adapter_bind_authorization_hash": (
+            authorization.live_adapter_bind_authorization_hash
+        ),
+        "authorization_consumption_id": (
+            consumption_result.consumption_record.consumption_id
+        ),
+        "authorization_consumption_hash": (
+            consumption_result.consumption_record.consumption_hash
+        ),
+        "bind_receipt_hash": receipt.bind_receipt_hash,
+        "bind_trustlog_hash": receipt.trustlog_hash,
+        "bind_context_hash": authorization.bind_context_hash,
+        "idempotency_key": authorization.idempotency_key,
+        "bind_core_invoked": consumption_result.bind_core_invoked,
+        "adapter_apply_attempted": consumption_result.adapter_apply_attempted,
+        "external_effect_claim": "NOT_INFERRED_FROM_GENERIC_ADAPTER_APPLY",
+    }
+    outcome = build_outcome_receipt(
+        decision_id=intent.decision_id,
+        execution_intent_id=intent.execution_intent_id,
+        bind_receipt_id=receipt.bind_receipt_id,
+        operation_id=consumption_result.consumption_record.consumption_id,
+        action_class=governance_inputs.action_contract.action_class,
+        target_system=intent.target_system,
+        target_resource=intent.target_resource,
+        intended_action=intent.intended_action,
+        requested_scope=_requested_scope(authorization),
+        final_outcome=receipt.final_outcome.value,
+        pre_state_fingerprint=receipt.live_state_fingerprint_before or None,
+        post_state_fingerprint=receipt.live_state_fingerprint_after or None,
+        postcondition_status=_postcondition_status(receipt),
+        observed_effects=[
+            {
+                "kind": "adapter_apply_attempt",
+                "attempted": consumption_result.adapter_apply_attempted,
+                "external_effect_inferred": False,
+            }
+        ],
+        failure_reasons=_failure_reasons(receipt),
+        rollback_status=receipt.rollback_status,
+        evaluated_at=evaluated_at,
+        metadata=metadata,
+    )
+    validation = validate_outcome_receipt(outcome)
+    if not validation.is_valid or outcome.outcome_hash != outcome.deterministic_digest():
+        raise BindOutcomeLineageError("BOL_OUTCOME_RECEIPT_INVALID")
+    return outcome
+
+
+def append_outcome_receipt_trustlog(outcome: OutcomeReceipt) -> str:
+    """Append an OutcomeReceipt after its linked BindReceipt and return TrustLog hash."""
+    entry = append_trust_log(
+        {
+            "kind": "governance.outcome_receipt",
+            "request_id": outcome.decision_id,
+            "decision_id": outcome.decision_id,
+            "execution_intent_id": outcome.execution_intent_id,
+            "bind_receipt_id": outcome.bind_receipt_id,
+            "outcome_receipt_id": outcome.outcome_receipt_id,
+            "outcome_hash": outcome.outcome_hash,
+            "outcome_receipt": outcome.to_dict(),
+        }
+    )
+    value = str(entry.get("sha256") or "")
+    if not value:
+        raise BindOutcomeLineageError("BOL_OUTCOME_TRUSTLOG_HASH_MISSING")
+    return value
+
+
+async def consume_bind_and_record_outcome_lineage(
+    artifact: Any,
+    *,
+    governance_inputs: RealBindAuthorizationGovernanceInputs,
+    trust_inputs: BindAuthorizationTrustInputs,
+    now: datetime | str,
+    consumption_store: AtomicAuthorizationConsumptionStore,
+    credential_resolver: CredentialMaterialResolver,
+    authorization_header_constructor: AuthorizationHeaderConstructor,
+    adapter_factory: AuthorizedBindAdapterFactory,
+    bind_ts: str | None = None,
+) -> BindOutcomeLineageResult:
+    """Consume one authorization, invoke Bind, then persist Bind+Outcome lineage.
+
+    The underlying consumption gate is invoked with ``append_trustlog=False`` so
+    the BindReceipt is first enriched with authorization/consumption lineage and
+    then written exactly once in its final form.  Outcome evidence is appended
+    after the linked BindReceipt.
+
+    A TrustLog persistence failure can occur after adapter apply has been
+    attempted; this function therefore raises rather than pretending the effect
+    did not happen.  Crash/unknown-effect reconciliation is intentionally a
+    separate boundary.
+    """
+    current = _now_iso(now)
+    consumption = await consume_live_adapter_bind_authorization_and_invoke_bind(
+        artifact,
+        governance_inputs=governance_inputs,
+        trust_inputs=trust_inputs,
+        now=current,
+        consumption_store=consumption_store,
+        credential_resolver=credential_resolver,
+        authorization_header_constructor=authorization_header_constructor,
+        adapter_factory=adapter_factory,
+        append_trustlog=False,
+        bind_ts=bind_ts or current,
+    )
+
+    authorization = artifact
+    intent = normalize_execution_intent(authorization.execution_intent)
+    enriched_receipt = replace(
+        consumption.bind_receipt,
+        governance_identity=_lineage_identity(
+            authorization=authorization,
+            consumption_result=consumption,
+            receipt=consumption.bind_receipt,
+        ),
+    )
+
+    try:
+        append_execution_intent_trustlog(intent)
+        persisted_receipt = append_bind_receipt_trustlog(enriched_receipt)
+        outcome = _build_outcome(
+            authorization=authorization,
+            governance_inputs=governance_inputs,
+            consumption_result=consumption,
+            receipt=persisted_receipt,
+            evaluated_at=current,
+        )
+        outcome_trustlog_hash = append_outcome_receipt_trustlog(outcome)
+    except BindOutcomeLineageError:
+        raise
+    except Exception:
+        raise BindOutcomeLineageError(
+            "BOL_TRUSTLOG_PERSISTENCE_FAILED_AFTER_BIND_ATTEMPT"
+        ) from None
+
+    return BindOutcomeLineageResult(
+        consumption_result=consumption,
+        bind_receipt=persisted_receipt,
+        outcome_receipt=outcome,
+        outcome_trustlog_hash=outcome_trustlog_hash,
+    )
+
+
+__all__ = [
+    "BindOutcomeLineageError",
+    "BindOutcomeLineageResult",
+    "append_outcome_receipt_trustlog",
+    "consume_bind_and_record_outcome_lineage",
+]

--- a/veritas_os/tests/test_bind_outcome_lineage.py
+++ b/veritas_os/tests/test_bind_outcome_lineage.py
@@ -90,6 +90,33 @@ async def test_complete_lineage_binds_authorization_consumption_bind_and_outcome
     assert result.outcome_trustlog_hash == "c" * 64
 
 
+@pytest.mark.asyncio
+async def test_serialized_authorization_is_canonicalized_before_bind_and_lineage(monkeypatch) -> None:
+    _install_fake_trustlog(monkeypatch)
+    artifact, governance, trust = _build()
+    serialized = artifact.model_dump(mode="json")
+
+    result = await consume_bind_and_record_outcome_lineage(
+        serialized,
+        governance_inputs=governance,
+        trust_inputs=trust,
+        now=VERIFICATION_NOW,
+        consumption_store=InMemoryAtomicAuthorizationConsumptionStore(),
+        credential_resolver=_Resolver(),
+        authorization_header_constructor=_HeaderConstructor(),
+        adapter_factory=_Factory(),
+    )
+
+    identity = result.bind_receipt.governance_identity or {}
+    assert (
+        identity["real_bind_authorization"]["live_adapter_bind_authorization_id"]
+        == artifact.live_adapter_bind_authorization_id
+    )
+    assert result.outcome_receipt.bind_receipt_id == result.bind_receipt.bind_receipt_id
+    assert result.outcome_receipt.outcome_hash == result.outcome_receipt.deterministic_digest()
+    assert result.outcome_trustlog_hash == "c" * 64
+
+
 class _BlockedAdapter(_RecordingAdapter):
     def validate_authority(self, intent, snapshot):
         del intent, snapshot

--- a/veritas_os/tests/test_bind_outcome_lineage.py
+++ b/veritas_os/tests/test_bind_outcome_lineage.py
@@ -1,0 +1,168 @@
+"""Security and lineage tests for Bind -> Outcome -> TrustLog v1."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from veritas_os.policy.bind_artifacts import hash_bind_receipt
+from veritas_os.policy.bind_outcome_lineage import (
+    BindOutcomeLineageError,
+    consume_bind_and_record_outcome_lineage,
+)
+from veritas_os.policy.live_adapter_bind_authorization_consumption import (
+    AuthorizedBindAdapterInstance,
+)
+from veritas_os.policy.live_adapter_bind_authorization_consumption_store import (
+    InMemoryAtomicAuthorizationConsumptionStore,
+)
+from veritas_os.tests.test_live_adapter_bind_authorization import VERIFICATION_NOW, _build
+from veritas_os.tests.test_live_adapter_bind_authorization_consumption import (
+    _Factory,
+    _HeaderConstructor,
+    _RecordingAdapter,
+    _Resolver,
+)
+
+
+def _install_fake_trustlog(monkeypatch) -> None:
+    import veritas_os.policy.bind_outcome_lineage as lineage
+
+    monkeypatch.setattr(
+        lineage,
+        "append_execution_intent_trustlog",
+        lambda intent: {"sha256": "a" * 64, "execution_intent_id": intent.execution_intent_id},
+    )
+
+    def _append_bind(receipt):
+        with_hash = replace(receipt, bind_receipt_hash=hash_bind_receipt(receipt))
+        return replace(with_hash, trustlog_hash="b" * 64)
+
+    monkeypatch.setattr(lineage, "append_bind_receipt_trustlog", _append_bind)
+    monkeypatch.setattr(lineage, "append_trust_log", lambda entry: {**entry, "sha256": "c" * 64})
+
+
+@pytest.mark.asyncio
+async def test_complete_lineage_binds_authorization_consumption_bind_and_outcome(monkeypatch) -> None:
+    _install_fake_trustlog(monkeypatch)
+    artifact, governance, trust = _build()
+    store = InMemoryAtomicAuthorizationConsumptionStore()
+
+    result = await consume_bind_and_record_outcome_lineage(
+        artifact,
+        governance_inputs=governance,
+        trust_inputs=trust,
+        now=VERIFICATION_NOW,
+        consumption_store=store,
+        credential_resolver=_Resolver(),
+        authorization_header_constructor=_HeaderConstructor(),
+        adapter_factory=_Factory(),
+    )
+
+    identity = result.bind_receipt.governance_identity or {}
+    auth = identity["real_bind_authorization"]
+    consumption = identity["authorization_consumption"]
+    invocation = identity["bind_invocation"]
+
+    assert auth["live_adapter_bind_authorization_id"] == artifact.live_adapter_bind_authorization_id
+    assert auth["live_adapter_bind_authorization_hash"] == artifact.live_adapter_bind_authorization_hash
+    assert consumption["consumption_id"] == result.consumption_result.consumption_record.consumption_id
+    assert consumption["consumption_hash"] == result.consumption_result.consumption_record.consumption_hash
+    assert consumption["single_use_enforced"] is True
+    assert invocation["bind_core_invoked"] is True
+    assert invocation["adapter_apply_attempted"] is True
+
+    outcome = result.outcome_receipt
+    assert outcome.bind_receipt_id == result.bind_receipt.bind_receipt_id
+    assert outcome.outcome_hash == outcome.deterministic_digest()
+    assert outcome.metadata["bind_receipt_hash"] == result.bind_receipt.bind_receipt_hash
+    assert outcome.metadata["bind_trustlog_hash"] == "b" * 64
+    assert outcome.metadata["authorization_consumption_hash"] == consumption["consumption_hash"]
+    assert outcome.metadata["external_effect_claim"] == "NOT_INFERRED_FROM_GENERIC_ADAPTER_APPLY"
+    assert outcome.observed_effects == [
+        {
+            "kind": "adapter_apply_attempt",
+            "attempted": True,
+            "external_effect_inferred": False,
+        }
+    ]
+    assert result.outcome_trustlog_hash == "c" * 64
+
+
+class _BlockedAdapter(_RecordingAdapter):
+    def validate_authority(self, intent, snapshot):
+        del intent, snapshot
+        return False
+
+
+class _BlockedFactory(_Factory):
+    async def build(self, *, authorization, credential, authorization_header):
+        del credential, authorization_header
+        self.calls += 1
+        self.adapter = _BlockedAdapter(
+            authorization.execution_intent.get("expected_state_fingerprint")
+        )
+        return AuthorizedBindAdapterInstance(
+            adapter=self.adapter,
+            adapter_contract_id=authorization.adapter_contract_id,
+            adapter_contract_hash=authorization.adapter_contract_hash,
+            endpoint_identity_binding_digest=authorization.endpoint_identity_binding_digest,
+            credential_reference_digest=authorization.credential_reference_digest,
+            credential_scope_binding_digest=authorization.credential_scope_binding_digest,
+        )
+
+
+@pytest.mark.asyncio
+async def test_blocked_bind_records_core_entry_without_claiming_apply(monkeypatch) -> None:
+    _install_fake_trustlog(monkeypatch)
+    artifact, governance, trust = _build()
+
+    result = await consume_bind_and_record_outcome_lineage(
+        artifact,
+        governance_inputs=governance,
+        trust_inputs=trust,
+        now=VERIFICATION_NOW,
+        consumption_store=InMemoryAtomicAuthorizationConsumptionStore(),
+        credential_resolver=_Resolver(),
+        authorization_header_constructor=_HeaderConstructor(),
+        adapter_factory=_BlockedFactory(),
+    )
+
+    assert result.consumption_result.bind_core_invoked is True
+    assert result.consumption_result.adapter_apply_attempted is False
+    assert result.outcome_receipt.observed_effects[0]["attempted"] is False
+    assert result.outcome_receipt.observed_effects[0]["external_effect_inferred"] is False
+    assert result.outcome_receipt.blocked is True
+
+
+@pytest.mark.asyncio
+async def test_trustlog_failure_after_bind_attempt_is_explicit_and_authorization_stays_consumed(
+    monkeypatch,
+) -> None:
+    import veritas_os.policy.bind_outcome_lineage as lineage
+
+    artifact, governance, trust = _build()
+    store = InMemoryAtomicAuthorizationConsumptionStore()
+
+    def _fail(_intent):
+        raise RuntimeError("audit-store-unavailable")
+
+    monkeypatch.setattr(lineage, "append_execution_intent_trustlog", _fail)
+
+    with pytest.raises(
+        BindOutcomeLineageError,
+        match="BOL_TRUSTLOG_PERSISTENCE_FAILED_AFTER_BIND_ATTEMPT",
+    ):
+        await consume_bind_and_record_outcome_lineage(
+            artifact,
+            governance_inputs=governance,
+            trust_inputs=trust,
+            now=VERIFICATION_NOW,
+            consumption_store=store,
+            credential_resolver=_Resolver(),
+            authorization_header_constructor=_HeaderConstructor(),
+            adapter_factory=_Factory(),
+        )
+
+    assert await store.get(artifact.live_adapter_bind_authorization_id) is not None


### PR DESCRIPTION
### Motivation

Close the post-bind evidence chain after merged #2135 without adding another readiness layer.

### What this PR implements

- composes the signed Real Bind Authorization consumption gate with post-bind evidence persistence;
- invokes #2135 consumption with Bind TrustLog writing disabled so the BindReceipt can be enriched before its single final append;
- binds Real Bind Authorization ID/hash and authorization-decision/verifier-policy lineage into the BindReceipt governance identity;
- binds authorization-consumption ID/hash, consumed-at, idempotency key and single-use status into the BindReceipt;
- preserves the #2135 distinction between Bind-core entry and adapter-apply attempt;
- builds a deterministic OutcomeReceipt from the persisted BindReceipt;
- binds BindReceipt hash/TrustLog hash, authorization ID/hash, consumption ID/hash, bind-context hash and idempotency key into OutcomeReceipt metadata;
- appends OutcomeReceipt to TrustLog after the linked BindReceipt;
- explicitly refuses to infer an external effect from generic `BindAdapterContract.apply()`;
- fails explicitly if audit persistence fails after a Bind attempt while leaving the authorization consumed;
- adds tests for complete lineage, blocked-without-apply semantics, and TrustLog failure after a consumed Bind attempt.

### Evidence ordering

`Real Bind Authorization → atomic consumption → Bind core → enriched BindReceipt → TrustLog → OutcomeReceipt → TrustLog`

### Important semantics

- Authorization != Consumption
- Consumption != Bind-core entry
- Bind-core entry != Adapter apply
- Adapter apply != Proven external effect
- BindReceipt != OutcomeReceipt
- OutcomeReceipt != external-system acknowledgement

### Deliberate next boundary

This PR does **not** claim crash recovery, exactly-once external effects, or external acknowledgement. If the process or audit store fails after apply may have occurred, the system must not label the operation `NOT_EXECUTED`. The next boundary is explicit `IN_FLIGHT / EFFECT_UNKNOWN` state plus reconciliation.

### Base

Built directly on main after merged #2135 (`e2f2cb46a8c62c9c20907e3ce27a1d5027cbb218`).

DO NOT MERGE until fresh py3.11/py3.12, Security Gates, CodeQL, Runtime Proof, Runtime Pickle Guard and Reviewer Evidence checks are green.