### PR TITLE
feat(bind): add effect unknown reconciliation v1

### DIFF
--- a/.github/workflows/bind-effect-state-postgresql.yml
+++ b/.github/workflows/bind-effect-state-postgresql.yml
@@ -1,0 +1,84 @@
+name: Bind Effect State PostgreSQL
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: bind-effect-state-pg-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  effect-state-contention:
+    name: bind-effect-state-postgresql-contention
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: veritas
+          POSTGRES_PASSWORD: veritas_test
+          POSTGRES_DB: veritas_test
+        options: >-
+          --health-cmd "pg_isready -U veritas"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    env:
+      PYTHONUNBUFFERED: "1"
+      OPENAI_API_KEY: "DUMMY_FOR_CI"
+      VERITAS_API_KEY: "DUMMY_FOR_CI"
+      VERITAS_DATABASE_URL: "postgresql+psycopg://veritas:veritas_test@localhost:5432/veritas_test"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          set -euxo pipefail
+          python -m pip install --upgrade pip --retries 5 --timeout 60
+          python -m pip install --retries 5 --timeout 60 -r veritas_os/requirements.txt
+          python -m pip install --retries 5 --timeout 60 \
+            "psycopg[binary]" psycopg-pool alembic pytest pytest-asyncio
+
+      - name: Run Alembic migrations
+        run: |
+          set -euxo pipefail
+          alembic upgrade head
+
+      - name: Prove effect-state compare-and-set
+        run: |
+          set -euxo pipefail
+          mkdir -p test-reports
+          pytest -q \
+            veritas_os/tests/test_pg_bind_effect_state_contention.py \
+            -m "postgresql and contention" \
+            -v \
+            --tb=short \
+            --junitxml=test-reports/bind-effect-state-postgresql.xml
+
+      - name: Upload contention report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bind-effect-state-postgresql-${{ github.run_id }}
+          path: test-reports/bind-effect-state-postgresql.xml
+          if-no-files-found: warn

--- a/alembic/versions/0005_bind_effect_states.py
+++ b/alembic/versions/0005_bind_effect_states.py
@@ -1,0 +1,45 @@
+"""bind effect execution and reconciliation states
+
+Revision ID: 0005
+Revises: 0004
+Create Date: 2026-08-24
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "0005"
+down_revision: str | None = "0004"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "bind_effect_states",
+        sa.Column("operation_id", sa.Text(), primary_key=True),
+        sa.Column("authorization_id", sa.Text(), nullable=False, unique=True),
+        sa.Column("consumption_id", sa.Text(), nullable=False, unique=True),
+        sa.Column("state", sa.Text(), nullable=False),
+        sa.Column("revision", sa.Integer(), nullable=False),
+        sa.Column("record_hash", sa.Text(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("record", sa.JSON(), nullable=False),
+        sa.CheckConstraint(
+            "state IN ('IN_FLIGHT','EFFECT_UNKNOWN','CONFIRMED_EFFECT','CONFIRMED_NO_EFFECT')",
+            name="ck_bind_effect_states_state",
+        ),
+        sa.CheckConstraint("revision >= 1", name="ck_bind_effect_states_revision"),
+    )
+    op.create_index(
+        "ix_bind_effect_states_state",
+        "bind_effect_states",
+        ["state"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_bind_effect_states_state", table_name="bind_effect_states")
+    op.drop_table("bind_effect_states")

--- a/docs/architecture/BIND_EFFECT_UNKNOWN_RECONCILIATION_V1.md
+++ b/docs/architecture/BIND_EFFECT_UNKNOWN_RECONCILIATION_V1.md
@@ -1,0 +1,36 @@
+# Bind EFFECT_UNKNOWN Reconciliation v1
+
+## Purpose
+
+This boundary prevents ambiguous external execution from being mislabeled as `NOT_EXECUTED`.
+
+The state flow is:
+
+`Authorization consumed → IN_FLIGHT → {CONFIRMED_NO_EFFECT | EFFECT_UNKNOWN}`
+
+and, when effect state is unknown:
+
+`EFFECT_UNKNOWN → verified reconciliation → {CONFIRMED_EFFECT | CONFIRMED_NO_EFFECT | EFFECT_UNKNOWN}`
+
+## Rules
+
+1. Successful authorization consumption creates `IN_FLIGHT` before credential access or adapter construction.
+2. If Bind completes without reaching adapter `apply`, the state may become `CONFIRMED_NO_EFFECT`.
+3. If adapter `apply` was attempted and there is no independently verified external acknowledgement, the state is `EFFECT_UNKNOWN` even if Bind itself returns a committed receipt.
+4. Unknown or unexpected interruption after consumption is never converted to `NOT_EXECUTED`.
+5. Reconciliation input is not trusted merely because a caller declares a result. A `ReconciliationEvidenceVerifier` must return sealed verified evidence.
+6. Reconciliation evidence must bind the exact operation ID, authorization ID, and consumption ID.
+7. Terminal `CONFIRMED_EFFECT` and `CONFIRMED_NO_EFFECT` states are immutable.
+8. The same Real Bind Authorization remains consumed throughout reconciliation and cannot be replayed.
+
+## Persistence
+
+`bind_effect_states` stores one current state per operation with optimistic compare-and-set semantics (`state` + `revision`). The production implementation uses PostgreSQL and the reference implementation includes a process-local in-memory store for deterministic tests.
+
+The PostgreSQL CI races 32 concurrent state transitions from the same `IN_FLIGHT` revision and requires exactly one winner.
+
+## Non-claims
+
+This boundary does not claim exactly-once delivery from an external provider. It provides exactly-once authorization consumption plus conservative effect-state accounting and verified reconciliation.
+
+A generic `adapter.apply()` call is never by itself proof that the external system committed an effect.

--- a/tests/policy/test_bind_effect_reconciliation.py
+++ b/tests/policy/test_bind_effect_reconciliation.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from veritas_os.policy.bind_effect_reconciliation import (
+    BindEffectStateError,
+    EffectExecutionState,
+    EffectStateTrackingConsumptionStore,
+    InMemoryAtomicEffectStateStore,
+    ReconciliationClaim,
+    ReconciliationEvidence,
+    VerifiedReconciliationEvidence,
+    classify_completed_bind_attempt,
+    reconcile_effect_unknown,
+)
+from veritas_os.policy.live_adapter_bind_authorization_consumption import (
+    BindAuthorizationConsumptionResult,
+)
+from veritas_os.policy.live_adapter_bind_authorization_consumption_store import (
+    InMemoryAtomicAuthorizationConsumptionStore,
+    build_authorization_consumption_record,
+)
+from veritas_os.security.hash import sha256_of_canonical_json
+
+
+@dataclass(frozen=True)
+class _Receipt:
+    pass
+
+
+class _Verifier:
+    async def verify(self, evidence: ReconciliationEvidence) -> VerifiedReconciliationEvidence:
+        return VerifiedReconciliationEvidence(
+            evidence=evidence,
+            verifier_id="fixture-verifier",
+            verifier_policy_hash="1" * 64,
+            verification_proof_hash="2" * 64,
+            verified_at="2026-08-24T00:00:02+00:00",
+        )
+
+
+def _consumption():
+    return build_authorization_consumption_record(
+        live_adapter_bind_authorization_id="auth-1",
+        live_adapter_bind_authorization_hash="a" * 64,
+        idempotency_key="idem-1",
+        bind_context_hash="b" * 64,
+        execution_intent_id="intent-1",
+        execution_intent_hash="c" * 64,
+        endpoint_identity_binding_digest="endpoint-digest",
+        credential_reference_digest="credential-digest",
+        credential_scope_binding_digest="scope-digest",
+        consumed_at="2026-08-24T00:00:00+00:00",
+    )
+
+
+@pytest.mark.asyncio
+async def test_consumption_creates_in_flight_before_effect_boundary() -> None:
+    base = InMemoryAtomicAuthorizationConsumptionStore()
+    effects = InMemoryAtomicEffectStateStore()
+    store = EffectStateTrackingConsumptionStore(base, effects)
+    record = _consumption()
+
+    assert await store.consume_once(record) is True
+    state = await effects.get(record.consumption_id)
+    assert state is not None
+    assert state.state == EffectExecutionState.IN_FLIGHT
+    assert await store.consume_once(record) is False
+
+
+@pytest.mark.asyncio
+async def test_apply_attempt_without_external_ack_becomes_effect_unknown() -> None:
+    base = InMemoryAtomicAuthorizationConsumptionStore()
+    effects = InMemoryAtomicEffectStateStore()
+    store = EffectStateTrackingConsumptionStore(base, effects)
+    record = _consumption()
+    assert await store.consume_once(record)
+
+    result = BindAuthorizationConsumptionResult(
+        consumption_record=record,
+        bind_receipt=_Receipt(),  # type: ignore[arg-type]
+        adapter_apply_attempted=True,
+    )
+    state = await classify_completed_bind_attempt(
+        result=result,
+        effect_store=effects,
+        updated_at="2026-08-24T00:00:01+00:00",
+    )
+    assert state.state == EffectExecutionState.EFFECT_UNKNOWN
+
+
+@pytest.mark.asyncio
+async def test_no_apply_is_confirmed_no_effect() -> None:
+    base = InMemoryAtomicAuthorizationConsumptionStore()
+    effects = InMemoryAtomicEffectStateStore()
+    store = EffectStateTrackingConsumptionStore(base, effects)
+    record = _consumption()
+    assert await store.consume_once(record)
+
+    result = BindAuthorizationConsumptionResult(
+        consumption_record=record,
+        bind_receipt=_Receipt(),  # type: ignore[arg-type]
+        adapter_apply_attempted=False,
+    )
+    state = await classify_completed_bind_attempt(
+        result=result,
+        effect_store=effects,
+        updated_at="2026-08-24T00:00:01+00:00",
+    )
+    assert state.state == EffectExecutionState.CONFIRMED_NO_EFFECT
+
+
+@pytest.mark.asyncio
+async def test_effect_unknown_requires_verified_reconciliation() -> None:
+    base = InMemoryAtomicAuthorizationConsumptionStore()
+    effects = InMemoryAtomicEffectStateStore()
+    store = EffectStateTrackingConsumptionStore(base, effects)
+    record = _consumption()
+    assert await store.consume_once(record)
+    result = BindAuthorizationConsumptionResult(
+        consumption_record=record,
+        bind_receipt=_Receipt(),  # type: ignore[arg-type]
+        adapter_apply_attempted=True,
+    )
+    await classify_completed_bind_attempt(
+        result=result,
+        effect_store=effects,
+        updated_at="2026-08-24T00:00:01+00:00",
+    )
+
+    observation = {
+        "operation_id": record.consumption_id,
+        "authorization_id": record.live_adapter_bind_authorization_id,
+        "consumption_id": record.consumption_id,
+        "claim": ReconciliationClaim.CONFIRMED_EFFECT,
+        "source_type": "external_api",
+        "source_identity": "fixture-ledger",
+        "observed_at": "2026-08-24T00:00:02+00:00",
+        "external_operation_reference": "ext-123",
+        "external_ack_digest": "d" * 64,
+    }
+    evidence = ReconciliationEvidence(
+        **observation,
+        observation_digest=sha256_of_canonical_json(observation),
+    )
+    terminal = await reconcile_effect_unknown(
+        operation_id=record.consumption_id,
+        evidence=evidence,
+        verifier=_Verifier(),
+        effect_store=effects,
+        updated_at="2026-08-24T00:00:03+00:00",
+    )
+    assert terminal.state == EffectExecutionState.CONFIRMED_EFFECT
+
+    with pytest.raises(BindEffectStateError, match="BES_TERMINAL_STATE_IMMUTABLE"):
+        await reconcile_effect_unknown(
+            operation_id=record.consumption_id,
+            evidence=evidence,
+            verifier=_Verifier(),
+            effect_store=effects,
+            updated_at="2026-08-24T00:00:04+00:00",
+        )
+
+
+@pytest.mark.asyncio
+async def test_reconciliation_lineage_mismatch_fails_closed() -> None:
+    base = InMemoryAtomicAuthorizationConsumptionStore()
+    effects = InMemoryAtomicEffectStateStore()
+    store = EffectStateTrackingConsumptionStore(base, effects)
+    record = _consumption()
+    assert await store.consume_once(record)
+    result = BindAuthorizationConsumptionResult(
+        consumption_record=record,
+        bind_receipt=_Receipt(),  # type: ignore[arg-type]
+        adapter_apply_attempted=True,
+    )
+    await classify_completed_bind_attempt(
+        result=result,
+        effect_store=effects,
+        updated_at="2026-08-24T00:00:01+00:00",
+    )
+    evidence = ReconciliationEvidence(
+        operation_id=record.consumption_id,
+        authorization_id="wrong-auth",
+        consumption_id=record.consumption_id,
+        claim=ReconciliationClaim.CONFIRMED_NO_EFFECT,
+        source_type="external_api",
+        source_identity="fixture-ledger",
+        observed_at="2026-08-24T00:00:02+00:00",
+        observation_digest="e" * 64,
+    )
+    with pytest.raises(BindEffectStateError, match="BES_RECONCILIATION_LINEAGE_MISMATCH"):
+        await reconcile_effect_unknown(
+            operation_id=record.consumption_id,
+            evidence=evidence,
+            verifier=_Verifier(),
+            effect_store=effects,
+            updated_at="2026-08-24T00:00:03+00:00",
+        )

--- a/veritas_os/policy/bind_effect_reconciliation.py
+++ b/veritas_os/policy/bind_effect_reconciliation.py
@@ -1,0 +1,482 @@
+"""Durable IN_FLIGHT / EFFECT_UNKNOWN reconciliation boundary.
+
+This module never infers an external effect from Bind-core success or generic
+adapter ``apply``. A consumed authorization enters IN_FLIGHT before credential
+access. If adapter apply may have happened without verified external evidence,
+the operation becomes EFFECT_UNKNOWN and requires reconciliation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any, Protocol
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from veritas_os.policy.live_adapter_bind_authorization_consumption import (
+    BindAuthorizationConsumptionResult,
+    LiveAdapterBindAuthorizationConsumptionError,
+)
+from veritas_os.policy.live_adapter_bind_authorization_consumption_store import (
+    AtomicAuthorizationConsumptionStore,
+    AuthorizationConsumptionRecord,
+    AuthorizationConsumptionStoreError,
+)
+from veritas_os.security.hash import sha256_of_canonical_json
+
+_HASH = r"^[0-9a-f]{64}$"
+
+
+class EffectExecutionState(StrEnum):
+    IN_FLIGHT = "IN_FLIGHT"
+    EFFECT_UNKNOWN = "EFFECT_UNKNOWN"
+    CONFIRMED_EFFECT = "CONFIRMED_EFFECT"
+    CONFIRMED_NO_EFFECT = "CONFIRMED_NO_EFFECT"
+
+
+class ReconciliationClaim(StrEnum):
+    CONFIRMED_EFFECT = "CONFIRMED_EFFECT"
+    CONFIRMED_NO_EFFECT = "CONFIRMED_NO_EFFECT"
+    STILL_UNKNOWN = "STILL_UNKNOWN"
+
+
+_TERMINAL = {
+    EffectExecutionState.CONFIRMED_EFFECT,
+    EffectExecutionState.CONFIRMED_NO_EFFECT,
+}
+
+
+class BindEffectStateError(RuntimeError):
+    """Fail-closed error for effect-state persistence or reconciliation."""
+
+
+class EffectStateRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    format_version: str = "bind-effect-state/v1"
+    operation_id: str = Field(min_length=1)
+    authorization_id: str = Field(min_length=1)
+    authorization_hash: str = Field(pattern=_HASH)
+    consumption_id: str = Field(min_length=1)
+    consumption_hash: str = Field(pattern=_HASH)
+    execution_intent_id: str = Field(min_length=1)
+    idempotency_key: str = Field(min_length=1)
+    state: EffectExecutionState
+    revision: int = Field(ge=1)
+    updated_at: str = Field(min_length=1)
+    reason_code: str = Field(min_length=1)
+    reconciliation_evidence_hash: str | None = Field(default=None, pattern=_HASH)
+    record_hash: str = Field(pattern=_HASH)
+
+
+class ReconciliationEvidence(BaseModel):
+    """External observation input. This object alone is not trusted evidence."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    format_version: str = "bind-effect-reconciliation-evidence/v1"
+    operation_id: str = Field(min_length=1)
+    authorization_id: str = Field(min_length=1)
+    consumption_id: str = Field(min_length=1)
+    claim: ReconciliationClaim
+    source_type: str = Field(min_length=1)
+    source_identity: str = Field(min_length=1)
+    observed_at: str = Field(min_length=1)
+    external_operation_reference: str | None = None
+    external_ack_digest: str | None = Field(default=None, pattern=_HASH)
+    observation_digest: str = Field(pattern=_HASH)
+
+
+class VerifiedReconciliationEvidence(BaseModel):
+    """Evidence after independent verifier validation."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    evidence: ReconciliationEvidence
+    verifier_id: str = Field(min_length=1)
+    verifier_policy_hash: str = Field(pattern=_HASH)
+    verification_proof_hash: str = Field(pattern=_HASH)
+    verified_at: str = Field(min_length=1)
+
+    def deterministic_digest(self) -> str:
+        return sha256_of_canonical_json(self.model_dump(mode="json"))
+
+
+class ReconciliationEvidenceVerifier(Protocol):
+    async def verify(
+        self, evidence: ReconciliationEvidence
+    ) -> VerifiedReconciliationEvidence:
+        ...
+
+
+class AtomicEffectStateStore(Protocol):
+    async def create_in_flight(self, record: EffectStateRecord) -> bool:
+        ...
+
+    async def transition(
+        self,
+        *,
+        operation_id: str,
+        expected_state: EffectExecutionState,
+        record: EffectStateRecord,
+    ) -> bool:
+        ...
+
+    async def get(self, operation_id: str) -> EffectStateRecord | None:
+        ...
+
+
+def _record_hash_payload(values: dict[str, Any]) -> dict[str, Any]:
+    payload = dict(values)
+    payload.pop("record_hash", None)
+    return payload
+
+
+def _build_record(
+    *,
+    consumption: AuthorizationConsumptionRecord,
+    state: EffectExecutionState,
+    revision: int,
+    updated_at: str,
+    reason_code: str,
+    reconciliation_evidence_hash: str | None = None,
+) -> EffectStateRecord:
+    values = {
+        "format_version": "bind-effect-state/v1",
+        "operation_id": consumption.consumption_id,
+        "authorization_id": consumption.live_adapter_bind_authorization_id,
+        "authorization_hash": consumption.live_adapter_bind_authorization_hash,
+        "consumption_id": consumption.consumption_id,
+        "consumption_hash": consumption.consumption_hash,
+        "execution_intent_id": consumption.execution_intent_id,
+        "idempotency_key": consumption.idempotency_key,
+        "state": state,
+        "revision": revision,
+        "updated_at": updated_at,
+        "reason_code": reason_code,
+        "reconciliation_evidence_hash": reconciliation_evidence_hash,
+    }
+    return EffectStateRecord(
+        **values,
+        record_hash=sha256_of_canonical_json(_record_hash_payload(values)),
+    )
+
+
+class InMemoryAtomicEffectStateStore:
+    production_safe = False
+
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        self._records: dict[str, EffectStateRecord] = {}
+
+    async def create_in_flight(self, record: EffectStateRecord) -> bool:
+        async with self._lock:
+            if record.operation_id in self._records:
+                return False
+            self._records[record.operation_id] = record
+            return True
+
+    async def transition(
+        self,
+        *,
+        operation_id: str,
+        expected_state: EffectExecutionState,
+        record: EffectStateRecord,
+    ) -> bool:
+        async with self._lock:
+            current = self._records.get(operation_id)
+            if current is None or current.state != expected_state:
+                return False
+            if record.revision != current.revision + 1:
+                return False
+            self._records[operation_id] = record
+            return True
+
+    async def get(self, operation_id: str) -> EffectStateRecord | None:
+        async with self._lock:
+            return self._records.get(operation_id)
+
+
+class PostgresAtomicEffectStateStore:
+    """Cross-process compare-and-set effect-state store."""
+
+    production_safe = True
+
+    async def create_in_flight(self, record: EffectStateRecord) -> bool:
+        try:
+            from psycopg.types.json import Jsonb
+            from veritas_os.storage.db import get_pool
+
+            pool = await get_pool()
+            async with pool.connection() as conn:
+                cur = await conn.execute(
+                    "INSERT INTO bind_effect_states "
+                    "(operation_id, authorization_id, consumption_id, state, revision, "
+                    "record_hash, updated_at, record) "
+                    "VALUES (%s, %s, %s, %s, %s, %s, %s, %s) "
+                    "ON CONFLICT DO NOTHING RETURNING operation_id",
+                    (
+                        record.operation_id,
+                        record.authorization_id,
+                        record.consumption_id,
+                        record.state.value,
+                        record.revision,
+                        record.record_hash,
+                        record.updated_at,
+                        Jsonb(record.model_dump(mode="json")),
+                    ),
+                )
+                return await cur.fetchone() is not None
+        except Exception:
+            raise BindEffectStateError("BES_POSTGRES_CREATE_FAILED") from None
+
+    async def transition(
+        self,
+        *,
+        operation_id: str,
+        expected_state: EffectExecutionState,
+        record: EffectStateRecord,
+    ) -> bool:
+        try:
+            from psycopg.types.json import Jsonb
+            from veritas_os.storage.db import get_pool
+
+            pool = await get_pool()
+            async with pool.connection() as conn:
+                cur = await conn.execute(
+                    "UPDATE bind_effect_states SET state=%s, revision=%s, record_hash=%s, "
+                    "updated_at=%s, record=%s WHERE operation_id=%s AND state=%s "
+                    "AND revision=%s RETURNING operation_id",
+                    (
+                        record.state.value,
+                        record.revision,
+                        record.record_hash,
+                        record.updated_at,
+                        Jsonb(record.model_dump(mode="json")),
+                        operation_id,
+                        expected_state.value,
+                        record.revision - 1,
+                    ),
+                )
+                return await cur.fetchone() is not None
+        except Exception:
+            raise BindEffectStateError("BES_POSTGRES_TRANSITION_FAILED") from None
+
+    async def get(self, operation_id: str) -> EffectStateRecord | None:
+        try:
+            from veritas_os.storage.db import get_pool
+
+            pool = await get_pool()
+            async with pool.connection() as conn:
+                cur = await conn.execute(
+                    "SELECT record FROM bind_effect_states WHERE operation_id=%s",
+                    (operation_id,),
+                )
+                row = await cur.fetchone()
+                if row is None:
+                    return None
+                return EffectStateRecord.model_validate(row[0])
+        except Exception:
+            raise BindEffectStateError("BES_POSTGRES_READ_FAILED") from None
+
+
+class EffectStateTrackingConsumptionStore:
+    """Decorates atomic authorization consumption with durable IN_FLIGHT creation."""
+
+    def __init__(
+        self,
+        delegate: AtomicAuthorizationConsumptionStore,
+        effect_store: AtomicEffectStateStore,
+    ) -> None:
+        self._delegate = delegate
+        self._effect_store = effect_store
+
+    async def consume_once(self, record: AuthorizationConsumptionRecord) -> bool:
+        claimed = await self._delegate.consume_once(record)
+        if not claimed:
+            return False
+        inflight = _build_record(
+            consumption=record,
+            state=EffectExecutionState.IN_FLIGHT,
+            revision=1,
+            updated_at=record.consumed_at,
+            reason_code="AUTHORIZATION_CONSUMED_BEFORE_EFFECT_BOUNDARY",
+        )
+        try:
+            created = await self._effect_store.create_in_flight(inflight)
+        except Exception:
+            raise AuthorizationConsumptionStoreError(
+                "BES_IN_FLIGHT_PERSISTENCE_FAILED_AFTER_CONSUMPTION"
+            ) from None
+        if not created:
+            raise AuthorizationConsumptionStoreError(
+                "BES_IN_FLIGHT_DUPLICATE_AFTER_CONSUMPTION"
+            )
+        return True
+
+
+_PRE_APPLY_FAILURES = {
+    "LABAC_CREDENTIAL_RESOLUTION_FAILED_AFTER_CONSUMPTION",
+    "LABAC_AUTHORIZATION_HEADER_CONSTRUCTION_FAILED_AFTER_CONSUMPTION",
+    "LABAC_ADAPTER_CONSTRUCTION_FAILED_AFTER_CONSUMPTION",
+    "LABAC_RESOLVED_CREDENTIAL_BINDING_MISMATCH",
+    "LABAC_AUTHORIZATION_HEADER_NAME_INVALID",
+    "LABAC_AUTHORIZATION_HEADER_VALUE_INVALID",
+    "LABAC_ADAPTER_BINDING_MISMATCH",
+}
+
+
+async def classify_completed_bind_attempt(
+    *,
+    result: BindAuthorizationConsumptionResult,
+    effect_store: AtomicEffectStateStore,
+    updated_at: str,
+) -> EffectStateRecord:
+    current = await effect_store.get(result.consumption_record.consumption_id)
+    if current is None or current.state != EffectExecutionState.IN_FLIGHT:
+        raise BindEffectStateError("BES_IN_FLIGHT_STATE_MISSING")
+    if result.adapter_apply_attempted:
+        next_state = EffectExecutionState.EFFECT_UNKNOWN
+        reason = "ADAPTER_APPLY_ATTEMPTED_WITHOUT_VERIFIED_EXTERNAL_ACK"
+    else:
+        next_state = EffectExecutionState.CONFIRMED_NO_EFFECT
+        reason = "BIND_COMPLETED_WITHOUT_ADAPTER_APPLY"
+    record = _build_record(
+        consumption=result.consumption_record,
+        state=next_state,
+        revision=current.revision + 1,
+        updated_at=updated_at,
+        reason_code=reason,
+    )
+    if not await effect_store.transition(
+        operation_id=current.operation_id,
+        expected_state=EffectExecutionState.IN_FLIGHT,
+        record=record,
+    ):
+        raise BindEffectStateError("BES_CLASSIFICATION_CAS_FAILED")
+    return record
+
+
+async def classify_bind_exception(
+    *,
+    consumption: AuthorizationConsumptionRecord,
+    error: Exception,
+    effect_store: AtomicEffectStateStore,
+    updated_at: str,
+) -> EffectStateRecord:
+    current = await effect_store.get(consumption.consumption_id)
+    if current is None or current.state != EffectExecutionState.IN_FLIGHT:
+        raise BindEffectStateError("BES_IN_FLIGHT_STATE_MISSING")
+    code = str(error)
+    if isinstance(error, LiveAdapterBindAuthorizationConsumptionError) and code in _PRE_APPLY_FAILURES:
+        state = EffectExecutionState.CONFIRMED_NO_EFFECT
+        reason = "KNOWN_PRE_APPLY_FAILURE"
+    else:
+        state = EffectExecutionState.EFFECT_UNKNOWN
+        reason = "EXECUTION_INTERRUPTED_EFFECT_CANNOT_BE_PROVEN"
+    record = _build_record(
+        consumption=consumption,
+        state=state,
+        revision=current.revision + 1,
+        updated_at=updated_at,
+        reason_code=reason,
+    )
+    if not await effect_store.transition(
+        operation_id=current.operation_id,
+        expected_state=EffectExecutionState.IN_FLIGHT,
+        record=record,
+    ):
+        raise BindEffectStateError("BES_EXCEPTION_CLASSIFICATION_CAS_FAILED")
+    return record
+
+
+async def reconcile_effect_unknown(
+    *,
+    operation_id: str,
+    evidence: ReconciliationEvidence,
+    verifier: ReconciliationEvidenceVerifier,
+    effect_store: AtomicEffectStateStore,
+    updated_at: str,
+) -> EffectStateRecord:
+    current = await effect_store.get(operation_id)
+    if current is None:
+        raise BindEffectStateError("BES_OPERATION_NOT_FOUND")
+    if current.state in _TERMINAL:
+        raise BindEffectStateError("BES_TERMINAL_STATE_IMMUTABLE")
+    if current.state != EffectExecutionState.EFFECT_UNKNOWN:
+        raise BindEffectStateError("BES_RECONCILIATION_REQUIRES_EFFECT_UNKNOWN")
+    if (
+        evidence.operation_id != current.operation_id
+        or evidence.authorization_id != current.authorization_id
+        or evidence.consumption_id != current.consumption_id
+    ):
+        raise BindEffectStateError("BES_RECONCILIATION_LINEAGE_MISMATCH")
+    try:
+        verified = await verifier.verify(evidence)
+    except Exception:
+        raise BindEffectStateError("BES_RECONCILIATION_VERIFICATION_FAILED") from None
+    if verified.evidence != evidence:
+        raise BindEffectStateError("BES_VERIFIED_EVIDENCE_SUBSTITUTION")
+    if evidence.claim == ReconciliationClaim.STILL_UNKNOWN:
+        state = EffectExecutionState.EFFECT_UNKNOWN
+        reason = "RECONCILIATION_STILL_UNKNOWN"
+    elif evidence.claim == ReconciliationClaim.CONFIRMED_EFFECT:
+        state = EffectExecutionState.CONFIRMED_EFFECT
+        reason = "VERIFIED_EXTERNAL_EFFECT_CONFIRMED"
+    else:
+        state = EffectExecutionState.CONFIRMED_NO_EFFECT
+        reason = "VERIFIED_EXTERNAL_NO_EFFECT_CONFIRMED"
+    record = _build_record(
+        consumption=AuthorizationConsumptionRecord(
+            consumption_id=current.consumption_id,
+            consumption_hash=current.consumption_hash,
+            live_adapter_bind_authorization_id=current.authorization_id,
+            live_adapter_bind_authorization_hash=current.authorization_hash,
+            idempotency_key=current.idempotency_key,
+            bind_context_hash="0" * 64,
+            execution_intent_id=current.execution_intent_id,
+            execution_intent_hash="0" * 64,
+            endpoint_identity_binding_digest="reconciliation",
+            credential_reference_digest="reconciliation",
+            credential_scope_binding_digest="reconciliation",
+            consumed_at=current.updated_at,
+        ),
+        state=state,
+        revision=current.revision + 1,
+        updated_at=updated_at,
+        reason_code=reason,
+        reconciliation_evidence_hash=verified.deterministic_digest(),
+    )
+    # Preserve original lineage hashes that are not carried by the compact state.
+    values = record.model_dump(mode="json")
+    values["authorization_hash"] = current.authorization_hash
+    values["consumption_hash"] = current.consumption_hash
+    values["record_hash"] = sha256_of_canonical_json(_record_hash_payload(values))
+    record = EffectStateRecord.model_validate(values)
+    if not await effect_store.transition(
+        operation_id=operation_id,
+        expected_state=EffectExecutionState.EFFECT_UNKNOWN,
+        record=record,
+    ):
+        raise BindEffectStateError("BES_RECONCILIATION_CAS_FAILED")
+    return record
+
+
+__all__ = [
+    "AtomicEffectStateStore",
+    "BindEffectStateError",
+    "EffectExecutionState",
+    "EffectStateRecord",
+    "EffectStateTrackingConsumptionStore",
+    "InMemoryAtomicEffectStateStore",
+    "PostgresAtomicEffectStateStore",
+    "ReconciliationClaim",
+    "ReconciliationEvidence",
+    "ReconciliationEvidenceVerifier",
+    "VerifiedReconciliationEvidence",
+    "classify_bind_exception",
+    "classify_completed_bind_attempt",
+    "reconcile_effect_unknown",
+]

--- a/veritas_os/policy/bind_effect_runtime.py
+++ b/veritas_os/policy/bind_effect_runtime.py
@@ -1,0 +1,230 @@
+"""Runtime composition for Bind outcome lineage plus durable effect-state tracking.
+
+This module is the effect-aware orchestration boundary. It composes the merged
+Bind -> Outcome -> TrustLog path with the #2137 effect-state machine so that a
+real consumed authorization cannot execute without entering durable IN_FLIGHT
+tracking first.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from veritas_os.policy.bind_effect_reconciliation import (
+    AtomicEffectStateStore,
+    BindEffectStateError,
+    EffectExecutionState,
+    EffectStateRecord,
+    EffectStateTrackingConsumptionStore,
+    classify_bind_exception,
+    classify_completed_bind_attempt,
+)
+from veritas_os.policy.bind_outcome_lineage import (
+    BindOutcomeLineageResult,
+    consume_bind_and_record_outcome_lineage,
+)
+from veritas_os.policy.live_adapter_bind_authorization import (
+    BindAuthorizationTrustInputs,
+    RealBindAuthorizationGovernanceInputs,
+)
+from veritas_os.policy.live_adapter_bind_authorization_consumption import (
+    AuthorizationHeaderConstructor,
+    AuthorizedBindAdapterFactory,
+    CredentialMaterialResolver,
+)
+from veritas_os.policy.live_adapter_bind_authorization_consumption_store import (
+    AtomicAuthorizationConsumptionStore,
+    AuthorizationConsumptionRecord,
+)
+from veritas_os.security.hash import sha256_of_canonical_json
+
+
+class BindEffectRuntimeError(RuntimeError):
+    """Fail-closed runtime error after effect-state orchestration has taken over."""
+
+
+@dataclass(frozen=True)
+class BindEffectRuntimeResult:
+    lineage: BindOutcomeLineageResult
+    effect_state: EffectStateRecord
+
+
+class _CapturingConsumptionStore:
+    """Capture the exact non-secret record presented to the tracking store."""
+
+    def __init__(self, delegate: EffectStateTrackingConsumptionStore) -> None:
+        self._delegate = delegate
+        self.record: AuthorizationConsumptionRecord | None = None
+
+    async def consume_once(self, record: AuthorizationConsumptionRecord) -> bool:
+        self.record = record
+        return await self._delegate.consume_once(record)
+
+
+def _timestamp(value: datetime | str) -> str:
+    if isinstance(value, datetime):
+        parsed = value
+    else:
+        try:
+            parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        except (TypeError, ValueError):
+            raise BindEffectRuntimeError("BER_TIMESTAMP_INVALID") from None
+    if parsed.tzinfo is None:
+        raise BindEffectRuntimeError("BER_TIMESTAMP_NAIVE")
+    return parsed.astimezone(timezone.utc).isoformat()
+
+
+def _in_flight_record(
+    consumption: AuthorizationConsumptionRecord,
+    *,
+    updated_at: str,
+    reason_code: str,
+) -> EffectStateRecord:
+    values: dict[str, Any] = {
+        "format_version": "bind-effect-state/v1",
+        "operation_id": consumption.consumption_id,
+        "authorization_id": consumption.live_adapter_bind_authorization_id,
+        "authorization_hash": consumption.live_adapter_bind_authorization_hash,
+        "consumption_id": consumption.consumption_id,
+        "consumption_hash": consumption.consumption_hash,
+        "execution_intent_id": consumption.execution_intent_id,
+        "idempotency_key": consumption.idempotency_key,
+        "state": EffectExecutionState.IN_FLIGHT,
+        "revision": 1,
+        "updated_at": updated_at,
+        "reason_code": reason_code,
+        "reconciliation_evidence_hash": None,
+    }
+    values["record_hash"] = sha256_of_canonical_json(values)
+    return EffectStateRecord.model_validate(values)
+
+
+async def recover_in_flight_after_consumption(
+    *,
+    consumption: AuthorizationConsumptionRecord,
+    effect_store: AtomicEffectStateStore,
+    updated_at: datetime | str,
+) -> EffectStateRecord:
+    """Recover a missing IN_FLIGHT marker from an already-consumed record.
+
+    This never releases or re-consumes the authorization. Existing state must
+    match the exact authorization/consumption lineage; otherwise recovery fails
+    closed. The operation remains non-effectful: it only repairs durable state.
+    """
+    current = _timestamp(updated_at)
+    existing = await effect_store.get(consumption.consumption_id)
+    if existing is not None:
+        if (
+            existing.authorization_id != consumption.live_adapter_bind_authorization_id
+            or existing.authorization_hash != consumption.live_adapter_bind_authorization_hash
+            or existing.consumption_id != consumption.consumption_id
+            or existing.consumption_hash != consumption.consumption_hash
+        ):
+            raise BindEffectRuntimeError("BER_RECOVERY_LINEAGE_MISMATCH")
+        return existing
+
+    recovered = _in_flight_record(
+        consumption,
+        updated_at=current,
+        reason_code="RECOVERED_FROM_DURABLE_AUTHORIZATION_CONSUMPTION",
+    )
+    try:
+        created = await effect_store.create_in_flight(recovered)
+    except Exception:
+        raise BindEffectRuntimeError("BER_IN_FLIGHT_RECOVERY_STORE_FAILED") from None
+    if not created:
+        raced = await effect_store.get(consumption.consumption_id)
+        if raced is None:
+            raise BindEffectRuntimeError("BER_IN_FLIGHT_RECOVERY_CAS_FAILED")
+        if (
+            raced.authorization_id != consumption.live_adapter_bind_authorization_id
+            or raced.consumption_hash != consumption.consumption_hash
+        ):
+            raise BindEffectRuntimeError("BER_RECOVERY_LINEAGE_MISMATCH")
+        return raced
+    return recovered
+
+
+async def consume_bind_record_lineage_and_effect_state(
+    artifact: Any,
+    *,
+    governance_inputs: RealBindAuthorizationGovernanceInputs,
+    trust_inputs: BindAuthorizationTrustInputs,
+    now: datetime | str,
+    consumption_store: AtomicAuthorizationConsumptionStore,
+    effect_store: AtomicEffectStateStore,
+    credential_resolver: CredentialMaterialResolver,
+    authorization_header_constructor: AuthorizationHeaderConstructor,
+    adapter_factory: AuthorizedBindAdapterFactory,
+    bind_ts: str | None = None,
+) -> BindEffectRuntimeResult:
+    """Run the real Bind path with automatic durable effect classification.
+
+    Atomic authorization consumption is decorated so IN_FLIGHT is created
+    before credential access. A completed Bind is classified from the actual
+    adapter-apply observation. Any exception after consumption is classified
+    conservatively; post-apply/audit uncertainty becomes EFFECT_UNKNOWN.
+    """
+    current = _timestamp(now)
+    tracking = EffectStateTrackingConsumptionStore(consumption_store, effect_store)
+    capturing = _CapturingConsumptionStore(tracking)
+
+    try:
+        lineage = await consume_bind_and_record_outcome_lineage(
+            artifact,
+            governance_inputs=governance_inputs,
+            trust_inputs=trust_inputs,
+            now=current,
+            consumption_store=capturing,
+            credential_resolver=credential_resolver,
+            authorization_header_constructor=authorization_header_constructor,
+            adapter_factory=adapter_factory,
+            bind_ts=bind_ts,
+        )
+    except Exception as exc:
+        record = capturing.record
+        if record is None:
+            raise
+        state = await effect_store.get(record.consumption_id)
+        if state is None:
+            # Consumption may have committed while IN_FLIGHT persistence failed.
+            # Repair from the immutable consumption record; never retry dispatch.
+            state = await recover_in_flight_after_consumption(
+                consumption=record,
+                effect_store=effect_store,
+                updated_at=current,
+            )
+        if state.state == EffectExecutionState.IN_FLIGHT:
+            try:
+                await classify_bind_exception(
+                    consumption=record,
+                    error=exc,
+                    effect_store=effect_store,
+                    updated_at=current,
+                )
+            except BindEffectStateError as classify_exc:
+                raise BindEffectRuntimeError(
+                    "BER_EXCEPTION_EFFECT_CLASSIFICATION_FAILED"
+                ) from classify_exc
+        raise
+
+    try:
+        effect_state = await classify_completed_bind_attempt(
+            result=lineage.consumption_result,
+            effect_store=effect_store,
+            updated_at=current,
+        )
+    except BindEffectStateError as exc:
+        raise BindEffectRuntimeError("BER_COMPLETED_EFFECT_CLASSIFICATION_FAILED") from exc
+
+    return BindEffectRuntimeResult(lineage=lineage, effect_state=effect_state)
+
+
+__all__ = [
+    "BindEffectRuntimeError",
+    "BindEffectRuntimeResult",
+    "consume_bind_record_lineage_and_effect_state",
+    "recover_in_flight_after_consumption",
+]

--- a/veritas_os/tests/test_bind_effect_runtime.py
+++ b/veritas_os/tests/test_bind_effect_runtime.py
@@ -1,0 +1,163 @@
+"""Integration tests for the real Bind -> lineage -> effect-state runtime."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from veritas_os.policy.bind_artifacts import hash_bind_receipt
+from veritas_os.policy.bind_effect_reconciliation import (
+    EffectExecutionState,
+    InMemoryAtomicEffectStateStore,
+)
+from veritas_os.policy.bind_effect_runtime import (
+    consume_bind_record_lineage_and_effect_state,
+    recover_in_flight_after_consumption,
+)
+from veritas_os.policy.bind_outcome_lineage import BindOutcomeLineageError
+from veritas_os.policy.live_adapter_bind_authorization_consumption_store import (
+    InMemoryAtomicAuthorizationConsumptionStore,
+    build_authorization_consumption_record,
+)
+from veritas_os.tests.test_bind_outcome_lineage import _BlockedFactory
+from veritas_os.tests.test_live_adapter_bind_authorization import VERIFICATION_NOW, _build
+from veritas_os.tests.test_live_adapter_bind_authorization_consumption import (
+    _Factory,
+    _HeaderConstructor,
+    _Resolver,
+)
+
+
+def _install_fake_trustlog(monkeypatch) -> None:
+    import veritas_os.policy.bind_outcome_lineage as lineage
+
+    monkeypatch.setattr(
+        lineage,
+        "append_execution_intent_trustlog",
+        lambda intent: {"sha256": "a" * 64, "execution_intent_id": intent.execution_intent_id},
+    )
+
+    def _append_bind(receipt):
+        with_hash = replace(receipt, bind_receipt_hash=hash_bind_receipt(receipt))
+        return replace(with_hash, trustlog_hash="b" * 64)
+
+    monkeypatch.setattr(lineage, "append_bind_receipt_trustlog", _append_bind)
+    monkeypatch.setattr(lineage, "append_trust_log", lambda entry: {**entry, "sha256": "c" * 64})
+
+
+@pytest.mark.asyncio
+async def test_real_runtime_apply_attempt_automatically_becomes_effect_unknown(monkeypatch) -> None:
+    _install_fake_trustlog(monkeypatch)
+    artifact, governance, trust = _build()
+    effects = InMemoryAtomicEffectStateStore()
+
+    result = await consume_bind_record_lineage_and_effect_state(
+        artifact,
+        governance_inputs=governance,
+        trust_inputs=trust,
+        now=VERIFICATION_NOW,
+        consumption_store=InMemoryAtomicAuthorizationConsumptionStore(),
+        effect_store=effects,
+        credential_resolver=_Resolver(),
+        authorization_header_constructor=_HeaderConstructor(),
+        adapter_factory=_Factory(),
+    )
+
+    assert result.lineage.consumption_result.adapter_apply_attempted is True
+    assert result.effect_state.state == EffectExecutionState.EFFECT_UNKNOWN
+    assert result.effect_state.reason_code == "ADAPTER_APPLY_ATTEMPTED_WITHOUT_VERIFIED_EXTERNAL_ACK"
+    persisted = await effects.get(result.effect_state.operation_id)
+    assert persisted == result.effect_state
+
+
+@pytest.mark.asyncio
+async def test_real_runtime_block_before_apply_is_confirmed_no_effect(monkeypatch) -> None:
+    _install_fake_trustlog(monkeypatch)
+    artifact, governance, trust = _build()
+    effects = InMemoryAtomicEffectStateStore()
+
+    result = await consume_bind_record_lineage_and_effect_state(
+        artifact,
+        governance_inputs=governance,
+        trust_inputs=trust,
+        now=VERIFICATION_NOW,
+        consumption_store=InMemoryAtomicAuthorizationConsumptionStore(),
+        effect_store=effects,
+        credential_resolver=_Resolver(),
+        authorization_header_constructor=_HeaderConstructor(),
+        adapter_factory=_BlockedFactory(),
+    )
+
+    assert result.lineage.consumption_result.adapter_apply_attempted is False
+    assert result.effect_state.state == EffectExecutionState.CONFIRMED_NO_EFFECT
+    assert result.effect_state.reason_code == "BIND_COMPLETED_WITHOUT_ADAPTER_APPLY"
+
+
+@pytest.mark.asyncio
+async def test_trustlog_failure_after_real_apply_is_effect_unknown_and_not_reusable(monkeypatch) -> None:
+    import veritas_os.policy.bind_outcome_lineage as lineage
+
+    artifact, governance, trust = _build()
+    consumptions = InMemoryAtomicAuthorizationConsumptionStore()
+    effects = InMemoryAtomicEffectStateStore()
+
+    def _fail(_intent):
+        raise RuntimeError("audit-store-unavailable")
+
+    monkeypatch.setattr(lineage, "append_execution_intent_trustlog", _fail)
+
+    with pytest.raises(
+        BindOutcomeLineageError,
+        match="BOL_TRUSTLOG_PERSISTENCE_FAILED_AFTER_BIND_ATTEMPT",
+    ):
+        await consume_bind_record_lineage_and_effect_state(
+            artifact,
+            governance_inputs=governance,
+            trust_inputs=trust,
+            now=VERIFICATION_NOW,
+            consumption_store=consumptions,
+            effect_store=effects,
+            credential_resolver=_Resolver(),
+            authorization_header_constructor=_HeaderConstructor(),
+            adapter_factory=_Factory(),
+        )
+
+    consumed = await consumptions.get(artifact.live_adapter_bind_authorization_id)
+    assert consumed is not None
+    state = await effects.get(consumed.consumption_id)
+    assert state is not None
+    assert state.state == EffectExecutionState.EFFECT_UNKNOWN
+
+
+@pytest.mark.asyncio
+async def test_missing_in_flight_can_be_recovered_from_consumption_without_redispatch() -> None:
+    consumption = build_authorization_consumption_record(
+        live_adapter_bind_authorization_id="auth-recovery",
+        live_adapter_bind_authorization_hash="a" * 64,
+        idempotency_key="idem-recovery",
+        bind_context_hash="b" * 64,
+        execution_intent_id="intent-recovery",
+        execution_intent_hash="c" * 64,
+        endpoint_identity_binding_digest="endpoint",
+        credential_reference_digest="credential",
+        credential_scope_binding_digest="scope",
+        consumed_at="2026-08-24T00:00:00+00:00",
+    )
+    effects = InMemoryAtomicEffectStateStore()
+
+    recovered = await recover_in_flight_after_consumption(
+        consumption=consumption,
+        effect_store=effects,
+        updated_at="2026-08-24T00:00:01+00:00",
+    )
+
+    assert recovered.state == EffectExecutionState.IN_FLIGHT
+    assert recovered.consumption_hash == consumption.consumption_hash
+    assert recovered.reason_code == "RECOVERED_FROM_DURABLE_AUTHORIZATION_CONSUMPTION"
+    again = await recover_in_flight_after_consumption(
+        consumption=consumption,
+        effect_store=effects,
+        updated_at="2026-08-24T00:00:02+00:00",
+    )
+    assert again == recovered

--- a/veritas_os/tests/test_pg_bind_effect_state_contention.py
+++ b/veritas_os/tests/test_pg_bind_effect_state_contention.py
@@ -1,0 +1,83 @@
+"""Real-PostgreSQL contention tests for bind effect-state CAS semantics."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from uuid import uuid4
+
+import pytest
+
+from veritas_os.policy.bind_effect_reconciliation import (
+    EffectExecutionState,
+    PostgresAtomicEffectStateStore,
+    _build_record,
+)
+from veritas_os.policy.live_adapter_bind_authorization_consumption_store import (
+    build_authorization_consumption_record,
+)
+
+pytestmark = [pytest.mark.postgresql, pytest.mark.contention]
+
+
+def _require_real_postgresql() -> None:
+    if not os.getenv("VERITAS_DATABASE_URL", "").startswith("postgresql"):
+        pytest.skip("real PostgreSQL service container is required")
+
+
+def _consumption(token: str):
+    return build_authorization_consumption_record(
+        live_adapter_bind_authorization_id=f"auth-{token}",
+        live_adapter_bind_authorization_hash="a" * 64,
+        idempotency_key=f"idem-{token}",
+        bind_context_hash="b" * 64,
+        execution_intent_id=f"intent-{token}",
+        execution_intent_hash="c" * 64,
+        endpoint_identity_binding_digest="endpoint",
+        credential_reference_digest="credential",
+        credential_scope_binding_digest="scope",
+        consumed_at="2026-08-24T00:00:00+00:00",
+    )
+
+
+@pytest.mark.asyncio
+async def test_real_postgres_effect_state_transition_has_one_winner() -> None:
+    _require_real_postgresql()
+    token = uuid4().hex
+    consumption = _consumption(token)
+    store = PostgresAtomicEffectStateStore()
+    inflight = _build_record(
+        consumption=consumption,
+        state=EffectExecutionState.IN_FLIGHT,
+        revision=1,
+        updated_at="2026-08-24T00:00:00+00:00",
+        reason_code="TEST_IN_FLIGHT",
+    )
+    assert await store.create_in_flight(inflight)
+
+    candidates = [
+        _build_record(
+            consumption=consumption,
+            state=EffectExecutionState.EFFECT_UNKNOWN,
+            revision=2,
+            updated_at="2026-08-24T00:00:01+00:00",
+            reason_code=f"RACE_{index}",
+        )
+        for index in range(32)
+    ]
+    outcomes = await asyncio.gather(
+        *(
+            store.transition(
+                operation_id=consumption.consumption_id,
+                expected_state=EffectExecutionState.IN_FLIGHT,
+                record=candidate,
+            )
+            for candidate in candidates
+        )
+    )
+    assert outcomes.count(True) == 1
+    assert outcomes.count(False) == 31
+    stored = await store.get(consumption.consumption_id)
+    assert stored is not None
+    assert stored.state == EffectExecutionState.EFFECT_UNKNOWN
+    assert stored.revision == 2


### PR DESCRIPTION
### Motivation

Close the ambiguous post-dispatch state after merged #2136 without pretending that timeout/crash/audit uncertainty means `NOT_EXECUTED`.

### What this PR implements

- introduces durable Bind effect states: `IN_FLIGHT`, `EFFECT_UNKNOWN`, `CONFIRMED_EFFECT`, `CONFIRMED_NO_EFFECT`;
- decorates the atomic authorization consumption store so successful consumption creates `IN_FLIGHT` before credential access or adapter construction;
- classifies completed Bind attempts with no adapter apply as `CONFIRMED_NO_EFFECT`;
- classifies any adapter-apply attempt without independently verified external acknowledgement as `EFFECT_UNKNOWN`, even if Bind itself returned a committed receipt;
- classifies unexpected interruption after consumption conservatively as `EFFECT_UNKNOWN`;
- requires verified reconciliation evidence bound to exact operation / authorization / consumption lineage before resolving unknown state;
- keeps terminal `CONFIRMED_EFFECT` / `CONFIRMED_NO_EFFECT` immutable;
- adds PostgreSQL CAS persistence and migration `0005`;
- adds real PostgreSQL 32-worker contention proof for effect-state transitions;
- adds in-memory state-machine and attack-oriented reconciliation tests;
- documents non-claims: this is not exactly-once external delivery and generic adapter apply is not proof of external commit.

### State semantics

`Authorization consumed → IN_FLIGHT → {CONFIRMED_NO_EFFECT | EFFECT_UNKNOWN}`

`EFFECT_UNKNOWN → verified reconciliation → {CONFIRMED_EFFECT | CONFIRMED_NO_EFFECT | EFFECT_UNKNOWN}`

### Security invariants

- `EFFECT_UNKNOWN` is never mapped to `NOT_EXECUTED`.
- The consumed authorization is never released for retry.
- Caller-declared reconciliation evidence is not trusted by itself; a verifier proof is required.
- Reconciliation evidence must bind the exact operation ID, authorization ID and consumption ID.
- Terminal effect states cannot be rewritten.

### Base

Built directly on main after merged #2136 (`98a3995ecf0f9082ef18238ce58fb8e26deca618`).

DO NOT MERGE until fresh py3.11/py3.12, PostgreSQL, Security Gates, CodeQL, Runtime Proof, Runtime Pickle Guard, Reviewer Evidence and the dedicated Bind Effect State PostgreSQL contention workflow are green.