### PR TITLE
test(poc): prove secure PostgreSQL TLS real-bind runtime

### DIFF
--- a/.github/workflows/secure-real-bind-runtime-poc.yml
+++ b/.github/workflows/secure-real-bind-runtime-poc.yml
@@ -32,7 +32,7 @@ jobs:
           --health-timeout 5s
           --health-retries 20
     env:
-      VERITAS_DATABASE_URL: postgresql://veritas:veritas@127.0.0.1:5432/veritas_e2e
+      VERITAS_DATABASE_URL: postgresql+psycopg://veritas:veritas@127.0.0.1:5432/veritas_e2e
       VERITAS_E2E_BEARER_TOKEN: secure-e2e-controlled-token
       VERITAS_E2E_CA_FILE: /tmp/veritas-e2e-tls/ca.crt
       PYTHONUNBUFFERED: "1"
@@ -43,12 +43,15 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: pip
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -r requirements-dev.txt
+          set -euxo pipefail
+          python -m pip install --upgrade pip --retries 5 --timeout 60
+          python -m pip install --retries 5 --timeout 60 -r veritas_os/requirements.txt
+          python -m pip install --retries 5 --timeout 60 \
+            "psycopg[binary]" psycopg-pool alembic pytest pytest-asyncio httpx cryptography
 
       - name: Apply PostgreSQL migrations
         run: alembic upgrade head
@@ -92,13 +95,6 @@ jobs:
             >/tmp/veritas-e2e-fixture.log 2>&1 &
           echo $! >/tmp/veritas-e2e-fixture.pid
           for i in $(seq 1 20); do
-            if curl --silent --fail --cacert "$VERITAS_E2E_CA_FILE" \
-              -H "Authorization: Bearer $VERITAS_E2E_BEARER_TOKEN" \
-              https://api.example.invalid/v1/billing/effects/not-created \
-              >/dev/null 2>&1; then
-              break
-            fi
-            # A TLS HTTP 404 also proves the service is up; curl --fail returns non-zero.
             if curl --silent --cacert "$VERITAS_E2E_CA_FILE" \
               -H "Authorization: Bearer $VERITAS_E2E_BEARER_TOKEN" \
               https://api.example.invalid/v1/billing/effects/not-created \
@@ -132,7 +128,6 @@ jobs:
           assert report["initial_effect_state"] == "EFFECT_UNKNOWN"
           assert report["terminal_effect_state"] == "CONFIRMED_EFFECT"
           assert report["external_ack"]["status"] == "committed"
-          # Do not overclaim the next bridge.
           assert report["decision_lineage_proven"] is False
           PY
 

--- a/.github/workflows/secure-real-bind-runtime-poc.yml
+++ b/.github/workflows/secure-real-bind-runtime-poc.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Run secure real-boundary proof
         run: |
-          python scripts/run_secure_real_bind_runtime_poc.py \
+          PYTHONPATH=. python scripts/run_secure_real_bind_runtime_poc.py \
             --report artifacts/secure-real-bind-runtime-poc/report.json
 
       - name: Assert proof claims

--- a/.github/workflows/secure-real-bind-runtime-poc.yml
+++ b/.github/workflows/secure-real-bind-runtime-poc.yml
@@ -1,0 +1,147 @@
+name: Secure Real Bind Runtime PoC
+
+on:
+  pull_request:
+    paths:
+      - "scripts/run_secure_real_bind_runtime_poc.py"
+      - "scripts/secure_e2e_https_fixture.py"
+      - "veritas_os/policy/**"
+      - "alembic/**"
+      - ".github/workflows/secure-real-bind-runtime-poc.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  secure-real-bind-runtime:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: veritas
+          POSTGRES_PASSWORD: veritas
+          POSTGRES_DB: veritas_e2e
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U veritas -d veritas_e2e"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    env:
+      VERITAS_DATABASE_URL: postgresql://veritas:veritas@127.0.0.1:5432/veritas_e2e
+      VERITAS_E2E_BEARER_TOKEN: secure-e2e-controlled-token
+      VERITAS_E2E_CA_FILE: /tmp/veritas-e2e-tls/ca.crt
+      PYTHONUNBUFFERED: "1"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+
+      - name: Apply PostgreSQL migrations
+        run: alembic upgrade head
+
+      - name: Create controlled CA and endpoint certificate
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/veritas-e2e-tls
+          openssl req -x509 -newkey rsa:2048 -nodes -days 1 \
+            -keyout /tmp/veritas-e2e-tls/ca.key \
+            -out /tmp/veritas-e2e-tls/ca.crt \
+            -subj "/CN=VERITAS Secure E2E Test CA"
+          openssl req -newkey rsa:2048 -nodes \
+            -keyout /tmp/veritas-e2e-tls/server.key \
+            -out /tmp/veritas-e2e-tls/server.csr \
+            -subj "/CN=api.example.invalid"
+          cat >/tmp/veritas-e2e-tls/ext.cnf <<'EOF'
+          subjectAltName=DNS:api.example.invalid
+          extendedKeyUsage=serverAuth
+          EOF
+          openssl x509 -req -days 1 \
+            -in /tmp/veritas-e2e-tls/server.csr \
+            -CA /tmp/veritas-e2e-tls/ca.crt \
+            -CAkey /tmp/veritas-e2e-tls/ca.key \
+            -CAcreateserial \
+            -out /tmp/veritas-e2e-tls/server.crt \
+            -extfile /tmp/veritas-e2e-tls/ext.cnf
+
+      - name: Bind authorized hostname to loopback
+        run: echo "127.0.0.1 api.example.invalid" | sudo tee -a /etc/hosts
+
+      - name: Start independent HTTPS effect fixture on authorized endpoint
+        run: |
+          set -euo pipefail
+          sudo -E python scripts/secure_e2e_https_fixture.py \
+            --host 0.0.0.0 \
+            --port 443 \
+            --cert /tmp/veritas-e2e-tls/server.crt \
+            --key /tmp/veritas-e2e-tls/server.key \
+            --token "$VERITAS_E2E_BEARER_TOKEN" \
+            >/tmp/veritas-e2e-fixture.log 2>&1 &
+          echo $! >/tmp/veritas-e2e-fixture.pid
+          for i in $(seq 1 20); do
+            if curl --silent --fail --cacert "$VERITAS_E2E_CA_FILE" \
+              -H "Authorization: Bearer $VERITAS_E2E_BEARER_TOKEN" \
+              https://api.example.invalid/v1/billing/effects/not-created \
+              >/dev/null 2>&1; then
+              break
+            fi
+            # A TLS HTTP 404 also proves the service is up; curl --fail returns non-zero.
+            if curl --silent --cacert "$VERITAS_E2E_CA_FILE" \
+              -H "Authorization: Bearer $VERITAS_E2E_BEARER_TOKEN" \
+              https://api.example.invalid/v1/billing/effects/not-created \
+              | grep -q effect_not_found; then
+              break
+            fi
+            sleep 0.5
+          done
+          curl --silent --cacert "$VERITAS_E2E_CA_FILE" \
+            -H "Authorization: Bearer $VERITAS_E2E_BEARER_TOKEN" \
+            https://api.example.invalid/v1/billing/effects/not-created \
+            | grep -q effect_not_found
+
+      - name: Run secure real-boundary proof
+        run: |
+          python scripts/run_secure_real_bind_runtime_poc.py \
+            --report artifacts/secure-real-bind-runtime-poc/report.json
+
+      - name: Assert proof claims
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          report = json.loads(Path("artifacts/secure-real-bind-runtime-poc/report.json").read_text())
+          assert report["result"] == "PASS"
+          assert report["proof"] == "REAL_BIND_RUNTIME_NETWORK_DB_E2E"
+          assert report["posture"] == "secure"
+          assert report["postgresql_consumption"] is True
+          assert report["postgresql_effect_state"] is True
+          assert report["adapter_apply_attempted"] is True
+          assert report["initial_effect_state"] == "EFFECT_UNKNOWN"
+          assert report["terminal_effect_state"] == "CONFIRMED_EFFECT"
+          assert report["external_ack"]["status"] == "committed"
+          # Do not overclaim the next bridge.
+          assert report["decision_lineage_proven"] is False
+          PY
+
+      - name: Upload proof report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: secure-real-bind-runtime-poc-report
+          path: |
+            artifacts/secure-real-bind-runtime-poc/report.json
+            /tmp/veritas-e2e-fixture.log
+          if-no-files-found: warn

--- a/scripts/run_secure_real_bind_runtime_poc.py
+++ b/scripts/run_secure_real_bind_runtime_poc.py
@@ -74,23 +74,57 @@ EXPECTED_PORT = 443
 EXPECTED_PREFIX = "/v1/billing"
 
 
-def _binding_dict(authorization: Any) -> dict[str, Any]:
-    value = authorization.endpoint_identity_binding
+def _as_dict(value: Any, *, label: str) -> dict[str, Any]:
     if hasattr(value, "model_dump"):
         value = value.model_dump(mode="json")
     if not isinstance(value, dict):
-        raise RuntimeError("endpoint identity binding is not an object")
+        raise RuntimeError(f"{label} is not an object")
     return value
 
 
 def _exact_endpoint(authorization: Any) -> str:
-    binding = _binding_dict(authorization)
-    scheme = str(binding.get("endpoint_scheme") or binding.get("scheme") or "").lower()
-    host = str(binding.get("endpoint_host") or binding.get("host") or "").lower()
-    port = int(binding.get("endpoint_port") or binding.get("port") or 0)
-    prefix = str(
-        binding.get("endpoint_path_prefix") or binding.get("path_prefix") or ""
-    ).rstrip("/")
+    """Resolve only the exact endpoint carried by the verified authorization.
+
+    The endpoint coordinates live in ``endpoint_candidate``.  The separate
+    ``endpoint_identity_binding`` binds that candidate identity to the adapter
+    and allowlist context; it is not itself a URL descriptor.  Never infer a
+    target from the binding object or substitute a different endpoint.
+    """
+
+    candidate = _as_dict(authorization.endpoint_candidate, label="endpoint candidate")
+    binding = _as_dict(
+        authorization.endpoint_identity_binding,
+        label="endpoint identity binding",
+    )
+
+    candidate_id = str(candidate.get("endpoint_candidate_id") or "")
+    adapter_contract_id = str(candidate.get("adapter_contract_id") or "")
+    if not candidate_id or not adapter_contract_id:
+        raise RuntimeError("signed authorization endpoint candidate is incomplete")
+
+    if str(binding.get("endpoint_candidate_id") or "") != candidate_id:
+        raise RuntimeError("endpoint identity binding does not bind the signed candidate")
+    if str(binding.get("adapter_contract_id") or "") != adapter_contract_id:
+        raise RuntimeError("endpoint identity binding does not bind the signed adapter")
+    if adapter_contract_id != str(authorization.adapter_contract_id):
+        raise RuntimeError("endpoint candidate adapter does not match authorization adapter")
+
+    source = _as_dict(
+        authorization.source_gate_review_packet,
+        label="source gate review packet",
+    )
+    if source.get("endpoint_candidate_digest") != authorization.endpoint_candidate_digest:
+        raise RuntimeError("endpoint candidate digest diverged from signed source lineage")
+    if (
+        source.get("endpoint_identity_binding_digest")
+        != authorization.endpoint_identity_binding_digest
+    ):
+        raise RuntimeError("endpoint identity binding digest diverged from signed source lineage")
+
+    scheme = str(candidate.get("endpoint_scheme") or "").lower()
+    host = str(candidate.get("endpoint_host") or "").lower()
+    port = int(candidate.get("endpoint_port") or 0)
+    prefix = str(candidate.get("endpoint_path_prefix") or "").rstrip("/")
     if (scheme, host, port, prefix) != (
         "https",
         EXPECTED_HOST,
@@ -324,7 +358,6 @@ def _configure_secure_posture() -> tuple[_DeterministicAwsClients, str]:
 async def _run(report_path: Path) -> int:
     aws_clients, ca_file = _configure_secure_posture()
     artifact, governance, trust = _build()
-    base_url = _exact_endpoint(artifact)
     token = os.environ["VERITAS_E2E_BEARER_TOKEN"]
     factory = _HttpsFactory(ca_file)
     real_import = importlib.import_module
@@ -351,6 +384,9 @@ async def _run(report_path: Path) -> int:
         raise RuntimeError(
             "generic HTTPS apply must remain EFFECT_UNKNOWN until independent acknowledgement"
         )
+    if factory.adapter is None:
+        raise RuntimeError("authorized HTTPS adapter was not constructed")
+    base_url = factory.adapter.base_url
     consumption = runtime.lineage.consumption_result.consumption_record
     observation = {
         "format_version": "bind-effect-reconciliation-evidence/v1",

--- a/scripts/run_secure_real_bind_runtime_poc.py
+++ b/scripts/run_secure_real_bind_runtime_poc.py
@@ -1,0 +1,428 @@
+#!/usr/bin/env python3
+"""Secure real-boundary PoC for the merged #2131-#2137 Bind runtime.
+
+This proof deliberately uses:
+- VERITAS_POSTURE=secure;
+- real PostgreSQL stores for authorization consumption and effect state;
+- a real TLS socket at the exact endpoint already bound into the signed
+  authorization fixture (api.example.invalid:443/v1/billing);
+- an Authorization header constructed from ephemeral secret material;
+- the merged Bind -> Outcome -> TrustLog -> EFFECT_UNKNOWN runtime; and
+- an independent HTTPS acknowledgement lookup before reconciliation.
+
+The authorization source is still the deterministic authenticated reference
+fixture used by the Real Bind Authorization tests. Therefore this runner proves
+REAL_BIND_RUNTIME_NETWORK_DB_E2E, not yet REAL_DECISION_TO_EFFECT_E2E.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+from dataclasses import dataclass
+from datetime import UTC, datetime
+import importlib
+import json
+import os
+from pathlib import Path
+import ssl
+from typing import Any, Mapping
+from unittest.mock import patch
+from urllib import request
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from scripts.run_decision_to_external_bind_poc import (
+    _DeterministicAwsClients,
+    _DeterministicKmsClient,
+    _DeterministicObjectLockClient,
+)
+from veritas_os.policy.bind_artifacts import ExecutionIntent
+from veritas_os.policy.bind_core.contracts import BindAdapterContract
+from veritas_os.policy.bind_effect_reconciliation import (
+    EffectExecutionState,
+    PostgresAtomicEffectStateStore,
+    ReconciliationClaim,
+    ReconciliationEvidence,
+    VerifiedReconciliationEvidence,
+    reconcile_effect_unknown,
+)
+from veritas_os.policy.bind_effect_runtime import (
+    consume_bind_record_lineage_and_effect_state,
+)
+from veritas_os.policy.live_adapter_bind_authorization_consumption import (
+    AuthorizedBindAdapterInstance,
+    ConstructedAuthorizationHeader,
+    ResolvedCredentialMaterial,
+)
+from veritas_os.policy.live_adapter_bind_authorization_consumption_store import (
+    PostgresAtomicAuthorizationConsumptionStore,
+)
+from veritas_os.security.hash import sha256_of_canonical_json
+from veritas_os.security.trustlog_production_posture import (
+    check_trustlog_production_posture,
+)
+from veritas_os.tests.test_live_adapter_bind_authorization import (
+    VERIFICATION_NOW,
+    _build,
+)
+
+
+EXPECTED_HOST = "api.example.invalid"
+EXPECTED_PORT = 443
+EXPECTED_PREFIX = "/v1/billing"
+
+
+def _binding_dict(authorization: Any) -> dict[str, Any]:
+    value = authorization.endpoint_identity_binding
+    if hasattr(value, "model_dump"):
+        value = value.model_dump(mode="json")
+    if not isinstance(value, dict):
+        raise RuntimeError("endpoint identity binding is not an object")
+    return value
+
+
+def _exact_endpoint(authorization: Any) -> str:
+    binding = _binding_dict(authorization)
+    scheme = str(binding.get("endpoint_scheme") or binding.get("scheme") or "").lower()
+    host = str(binding.get("endpoint_host") or binding.get("host") or "").lower()
+    port = int(binding.get("endpoint_port") or binding.get("port") or 0)
+    prefix = str(
+        binding.get("endpoint_path_prefix") or binding.get("path_prefix") or ""
+    ).rstrip("/")
+    if (scheme, host, port, prefix) != (
+        "https",
+        EXPECTED_HOST,
+        EXPECTED_PORT,
+        EXPECTED_PREFIX,
+    ):
+        raise RuntimeError(
+            "signed authorization endpoint does not match the controlled TLS fixture: "
+            f"{scheme}://{host}:{port}{prefix}"
+        )
+    return f"https://{host}:{port}{prefix}"
+
+
+class _EnvResolver:
+    async def resolve(
+        self,
+        credential_reference: Mapping[str, Any],
+        *,
+        credential_scope_binding: Mapping[str, Any],
+        live_adapter_bind_authorization_id: str,
+    ) -> ResolvedCredentialMaterial:
+        del credential_scope_binding, live_adapter_bind_authorization_id
+        token = os.environ.get("VERITAS_E2E_BEARER_TOKEN", "")
+        if not token:
+            raise RuntimeError("VERITAS_E2E_BEARER_TOKEN is required")
+        return ResolvedCredentialMaterial(
+            credential_reference_id=str(credential_reference["credential_reference_id"]),
+            credential_kind=str(credential_reference["credential_kind"]),
+            credential_provider_type=str(credential_reference["credential_provider_type"]),
+            material=token.encode("utf-8"),
+        )
+
+
+class _BearerHeader:
+    async def construct(
+        self,
+        credential: ResolvedCredentialMaterial,
+        *,
+        credential_reference: Mapping[str, Any],
+        credential_scope_binding: Mapping[str, Any],
+        live_adapter_bind_authorization_id: str,
+    ) -> ConstructedAuthorizationHeader:
+        del credential_reference, credential_scope_binding, live_adapter_bind_authorization_id
+        token = credential.material.decode("utf-8")
+        return ConstructedAuthorizationHeader(name="Authorization", value=f"Bearer {token}")
+
+
+class _HttpsEffectAdapter(BindAdapterContract):
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        authorization_header: ConstructedAuthorizationHeader,
+        ca_file: str,
+        external_operation_reference: str,
+        expected_fingerprint: str | None,
+    ) -> None:
+        self.base_url = base_url
+        self.authorization_header = authorization_header
+        self.ca_file = ca_file
+        self.external_operation_reference = external_operation_reference
+        self.expected_fingerprint = expected_fingerprint
+        self.last_ack: dict[str, Any] | None = None
+
+    def _open(self, req: request.Request) -> dict[str, Any]:
+        context = ssl.create_default_context(cafile=self.ca_file)
+        with request.urlopen(req, context=context, timeout=10) as response:  # noqa: S310
+            return json.loads(response.read().decode("utf-8"))
+
+    def snapshot(self) -> dict[str, str]:
+        return {"target": self.base_url, "state": "pre-effect"}
+
+    def fingerprint_state(self, snapshot: Any) -> str:
+        del snapshot
+        return self.expected_fingerprint or "secure-e2e-pre-state"
+
+    def validate_authority(self, intent: ExecutionIntent, snapshot: Any) -> bool:
+        del intent, snapshot
+        return True
+
+    def validate_constraints(self, intent: ExecutionIntent, snapshot: Any) -> dict[str, bool]:
+        del intent, snapshot
+        return {"exact_tls_endpoint_binding": True}
+
+    def assess_runtime_risk(self, intent: ExecutionIntent, snapshot: Any) -> bool:
+        del intent, snapshot
+        return True
+
+    def apply(self, intent: ExecutionIntent, snapshot: Any) -> bool:
+        del intent, snapshot
+        body = json.dumps(
+            {"operation_id": self.external_operation_reference},
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        req = request.Request(
+            f"{self.base_url}/effects",
+            data=body,
+            method="POST",
+            headers={
+                self.authorization_header.name: self.authorization_header.value,
+                "Content-Type": "application/json",
+            },
+        )
+        self.last_ack = self._open(req)
+        return self.last_ack.get("status") == "committed"
+
+    def verify_postconditions(self, intent: ExecutionIntent, snapshot: Any) -> bool:
+        del intent, snapshot
+        return bool(self.last_ack and self.last_ack.get("status") == "committed")
+
+    def revert(self, intent: ExecutionIntent, snapshot: Any) -> bool:
+        del intent, snapshot
+        return False
+
+    def describe_target(self) -> str:
+        return self.base_url
+
+
+class _HttpsFactory:
+    def __init__(self, ca_file: str) -> None:
+        self.ca_file = ca_file
+        self.adapter: _HttpsEffectAdapter | None = None
+
+    async def build(
+        self,
+        *,
+        authorization: Any,
+        credential: ResolvedCredentialMaterial,
+        authorization_header: ConstructedAuthorizationHeader,
+    ) -> AuthorizedBindAdapterInstance:
+        del credential
+        base_url = _exact_endpoint(authorization)
+        self.adapter = _HttpsEffectAdapter(
+            base_url=base_url,
+            authorization_header=authorization_header,
+            ca_file=self.ca_file,
+            external_operation_reference=authorization.idempotency_key,
+            expected_fingerprint=authorization.execution_intent.get(
+                "expected_state_fingerprint"
+            ),
+        )
+        return AuthorizedBindAdapterInstance(
+            adapter=self.adapter,
+            adapter_contract_id=authorization.adapter_contract_id,
+            adapter_contract_hash=authorization.adapter_contract_hash,
+            endpoint_identity_binding_digest=authorization.endpoint_identity_binding_digest,
+            credential_reference_digest=authorization.credential_reference_digest,
+            credential_scope_binding_digest=authorization.credential_scope_binding_digest,
+        )
+
+
+@dataclass(frozen=True)
+class _HttpsReconciliationVerifier:
+    base_url: str
+    token: str
+    ca_file: str
+    external_operation_reference: str
+
+    async def verify(
+        self, evidence: ReconciliationEvidence
+    ) -> VerifiedReconciliationEvidence:
+        if evidence.external_operation_reference != self.external_operation_reference:
+            raise RuntimeError("external operation reference mismatch")
+        context = ssl.create_default_context(cafile=self.ca_file)
+        req = request.Request(
+            f"{self.base_url}/effects/{self.external_operation_reference}",
+            method="GET",
+            headers={"Authorization": f"Bearer {self.token}"},
+        )
+        with request.urlopen(req, context=context, timeout=10) as response:  # noqa: S310
+            ack = json.loads(response.read().decode("utf-8"))
+        if ack.get("operation_id") != self.external_operation_reference:
+            raise RuntimeError("ack operation mismatch")
+        if ack.get("status") != "committed":
+            raise RuntimeError("ack is not committed")
+        proof_hash = sha256_of_canonical_json(ack)
+        return VerifiedReconciliationEvidence(
+            evidence=evidence,
+            verifier_id="secure-e2e-https-ack-verifier",
+            verifier_policy_hash=sha256_of_canonical_json(
+                {
+                    "scheme": "https",
+                    "host": EXPECTED_HOST,
+                    "port": EXPECTED_PORT,
+                    "path_prefix": EXPECTED_PREFIX,
+                    "mode": "independent_get_ack",
+                }
+            ),
+            verification_proof_hash=proof_hash,
+            verified_at=datetime.now(UTC).isoformat(),
+        )
+
+
+def _configure_secure_posture() -> tuple[_DeterministicAwsClients, str]:
+    database_url = os.environ.get("VERITAS_DATABASE_URL", "")
+    ca_file = os.environ.get("VERITAS_E2E_CA_FILE", "")
+    token = os.environ.get("VERITAS_E2E_BEARER_TOKEN", "")
+    if not database_url or not ca_file or not token:
+        raise RuntimeError(
+            "VERITAS_DATABASE_URL, VERITAS_E2E_CA_FILE and VERITAS_E2E_BEARER_TOKEN are required"
+        )
+    encryption_key = os.environ.get("VERITAS_ENCRYPTION_KEY") or base64.urlsafe_b64encode(
+        os.urandom(32)
+    ).decode("ascii")
+    kms_key_id = "arn:aws:kms:us-east-1:000000000000:key/secure-real-bind-poc"
+    os.environ.update(
+        {
+            "VERITAS_POSTURE": "secure",
+            "VERITAS_TRUSTLOG_BACKEND": "postgresql",
+            "VERITAS_ENCRYPTION_KEY": encryption_key,
+            "VERITAS_TRUSTLOG_SIGNER_BACKEND": "aws_kms",
+            "VERITAS_TRUSTLOG_KMS_KEY_ID": kms_key_id,
+            "VERITAS_TRUSTLOG_MIRROR_BACKEND": "s3_object_lock",
+            "VERITAS_TRUSTLOG_S3_BUCKET": "secure-real-bind-poc",
+            "VERITAS_TRUSTLOG_S3_PREFIX": "trustlog",
+            "VERITAS_TRUSTLOG_S3_REGION": "us-east-1",
+            "VERITAS_TRUSTLOG_S3_OBJECT_LOCK_MODE": "GOVERNANCE",
+            "VERITAS_TRUSTLOG_S3_RETENTION_DAYS": "1",
+            "VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED": "0",
+        }
+    )
+    posture = check_trustlog_production_posture()
+    if not posture.passed:
+        raise RuntimeError("secure TrustLog posture failed: " + "; ".join(posture.failures))
+    kms = _DeterministicKmsClient(kms_key_id)
+    s3 = _DeterministicObjectLockClient()
+    return _DeterministicAwsClients(kms, s3), ca_file
+
+
+async def _run(report_path: Path) -> int:
+    aws_clients, ca_file = _configure_secure_posture()
+    artifact, governance, trust = _build()
+    base_url = _exact_endpoint(artifact)
+    token = os.environ["VERITAS_E2E_BEARER_TOKEN"]
+    factory = _HttpsFactory(ca_file)
+    real_import = importlib.import_module
+
+    def _controlled_import(name: str, package: str | None = None) -> Any:
+        if name == "boto3":
+            return aws_clients
+        return real_import(name, package)
+
+    with patch("importlib.import_module", side_effect=_controlled_import):
+        runtime = await consume_bind_record_lineage_and_effect_state(
+            artifact,
+            governance_inputs=governance,
+            trust_inputs=trust,
+            now=VERIFICATION_NOW,
+            consumption_store=PostgresAtomicAuthorizationConsumptionStore(),
+            effect_store=PostgresAtomicEffectStateStore(),
+            credential_resolver=_EnvResolver(),
+            authorization_header_constructor=_BearerHeader(),
+            adapter_factory=factory,
+        )
+
+    if runtime.effect_state.state != EffectExecutionState.EFFECT_UNKNOWN:
+        raise RuntimeError(
+            "generic HTTPS apply must remain EFFECT_UNKNOWN until independent acknowledgement"
+        )
+    consumption = runtime.lineage.consumption_result.consumption_record
+    observation = {
+        "format_version": "bind-effect-reconciliation-evidence/v1",
+        "operation_id": consumption.consumption_id,
+        "authorization_id": artifact.live_adapter_bind_authorization_id,
+        "consumption_id": consumption.consumption_id,
+        "claim": ReconciliationClaim.CONFIRMED_EFFECT,
+        "source_type": "https_ack_lookup",
+        "source_identity": EXPECTED_HOST,
+        "observed_at": datetime.now(UTC).isoformat(),
+        "external_operation_reference": artifact.idempotency_key,
+        "external_ack_digest": sha256_of_canonical_json(factory.adapter.last_ack or {}),
+    }
+    evidence = ReconciliationEvidence(
+        **observation,
+        observation_digest=sha256_of_canonical_json(observation),
+    )
+    terminal = await reconcile_effect_unknown(
+        operation_id=consumption.consumption_id,
+        evidence=evidence,
+        verifier=_HttpsReconciliationVerifier(
+            base_url=base_url,
+            token=token,
+            ca_file=ca_file,
+            external_operation_reference=artifact.idempotency_key,
+        ),
+        effect_store=PostgresAtomicEffectStateStore(),
+        updated_at=datetime.now(UTC).isoformat(),
+    )
+    if terminal.state != EffectExecutionState.CONFIRMED_EFFECT:
+        raise RuntimeError("verified acknowledgement did not produce CONFIRMED_EFFECT")
+
+    report = {
+        "proof": "REAL_BIND_RUNTIME_NETWORK_DB_E2E",
+        "decision_lineage_proven": False,
+        "decision_lineage_note": (
+            "Authorization source is the authenticated deterministic Real Bind Authorization "
+            "reference fixture; real /v1/decide lineage is the next bridge."
+        ),
+        "posture": os.environ.get("VERITAS_POSTURE"),
+        "postgresql_consumption": True,
+        "postgresql_effect_state": True,
+        "tls_endpoint": base_url,
+        "authorization_consumed": True,
+        "bind_core_invoked": runtime.lineage.consumption_result.bind_core_invoked,
+        "adapter_apply_attempted": runtime.lineage.consumption_result.adapter_apply_attempted,
+        "initial_effect_state": EffectExecutionState.EFFECT_UNKNOWN.value,
+        "terminal_effect_state": terminal.state.value,
+        "external_ack": factory.adapter.last_ack if factory.adapter else None,
+        "bind_receipt_hash": runtime.lineage.bind_receipt.bind_receipt_hash,
+        "outcome_hash": runtime.lineage.outcome_receipt.outcome_hash,
+        "outcome_trustlog_hash": runtime.lineage.outcome_trustlog_hash,
+        "authorization_id": artifact.live_adapter_bind_authorization_id,
+        "consumption_id": consumption.consumption_id,
+        "result": "PASS",
+    }
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--report",
+        type=Path,
+        default=Path("artifacts/secure-real-bind-runtime-poc/report.json"),
+    )
+    args = parser.parse_args()
+    return asyncio.run(_run(args.report))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/secure_e2e_https_fixture.py
+++ b/scripts/secure_e2e_https_fixture.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Minimal HTTPS effect fixture for the secure real-bind PoC.
+
+The fixture is intentionally a separate TLS socket/process. It requires a
+Bearer token, records one POST effect in memory, and exposes a GET endpoint for
+independent acknowledgement lookup. It is a local integration target, not a
+mocked adapter call and not a public Internet service.
+"""
+
+from __future__ import annotations
+
+import argparse
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import json
+import ssl
+from threading import Lock
+from urllib.parse import urlparse
+
+
+class _State:
+    def __init__(self, token: str) -> None:
+        self.token = token
+        self.lock = Lock()
+        self.effects: dict[str, dict[str, object]] = {}
+
+
+class _Handler(BaseHTTPRequestHandler):
+    state: _State
+
+    def _json(self, status: int, payload: dict[str, object]) -> None:
+        raw = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def _authorized(self) -> bool:
+        return self.headers.get("Authorization", "") == f"Bearer {self.state.token}"
+
+    def do_POST(self) -> None:  # noqa: N802
+        if not self._authorized():
+            self._json(401, {"error": "unauthorized"})
+            return
+        if self.path != "/v1/billing/effects":
+            self._json(404, {"error": "not_found"})
+            return
+        try:
+            length = int(self.headers.get("Content-Length", "0"))
+            payload = json.loads(self.rfile.read(length) or b"{}")
+            operation_id = str(payload["operation_id"])
+        except (ValueError, KeyError, TypeError, json.JSONDecodeError):
+            self._json(400, {"error": "invalid_payload"})
+            return
+        with self.state.lock:
+            if operation_id in self.state.effects:
+                self._json(409, {"error": "duplicate_operation", "operation_id": operation_id})
+                return
+            effect = {
+                "operation_id": operation_id,
+                "status": "committed",
+                "effect_count": len(self.state.effects) + 1,
+            }
+            self.state.effects[operation_id] = effect
+        self._json(201, effect)
+
+    def do_GET(self) -> None:  # noqa: N802
+        if not self._authorized():
+            self._json(401, {"error": "unauthorized"})
+            return
+        parsed = urlparse(self.path)
+        prefix = "/v1/billing/effects/"
+        if not parsed.path.startswith(prefix):
+            self._json(404, {"error": "not_found"})
+            return
+        operation_id = parsed.path[len(prefix):]
+        with self.state.lock:
+            effect = self.state.effects.get(operation_id)
+        if effect is None:
+            self._json(404, {"error": "effect_not_found", "operation_id": operation_id})
+            return
+        self._json(200, effect)
+
+    def log_message(self, format: str, *args: object) -> None:
+        del format, args
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=443)
+    parser.add_argument("--cert", required=True)
+    parser.add_argument("--key", required=True)
+    parser.add_argument("--token", required=True)
+    args = parser.parse_args()
+
+    _Handler.state = _State(args.token)
+    server = ThreadingHTTPServer((args.host, args.port), _Handler)
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.load_cert_chain(args.cert, args.key)
+    server.socket = context.wrap_socket(server.socket, server_side=True)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/secure_e2e_https_fixture.py
+++ b/scripts/secure_e2e_https_fixture.py
@@ -97,6 +97,7 @@ def main() -> None:
     _Handler.state = _State(args.token)
     server = ThreadingHTTPServer((args.host, args.port), _Handler)
     context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.minimum_version = ssl.TLSVersion.TLSv1_2
     context.load_cert_chain(args.cert, args.key)
     server.socket = context.wrap_socket(server.socket, server_side=True)
     server.serve_forever()


### PR DESCRIPTION
### Goal

Prove the merged #2131-#2137 Real Bind runtime across real process/network/database boundaries before claiming full Decision-to-effect E2E.

### What this PR proves

- `VERITAS_POSTURE=secure` is enforced.
- PostgreSQL 16 is used for atomic authorization consumption and durable effect state.
- The signed authorization's existing exact endpoint binding (`https://api.example.invalid:443/v1/billing`) is preserved; CI maps that hostname to loopback rather than changing the authorization.
- A separate TLS server process receives the real HTTPS POST.
- Bearer credential material is resolved ephemerally and used to construct the real Authorization header.
- The merged Bind -> Outcome -> TrustLog -> effect-state runtime is used.
- Generic adapter apply first becomes `EFFECT_UNKNOWN`.
- An independent HTTPS GET acknowledgement lookup is required before reconciliation can produce `CONFIRMED_EFFECT`.
- Proof output is uploaded as a CI artifact.

### Explicit non-claim

This PR does **not** yet claim `REAL_DECISION_TO_EFFECT_E2E`. The Real Bind Authorization source is still the authenticated deterministic reference fixture used by the existing authorization security tests. The report contains `decision_lineage_proven: false` and CI asserts that value so this stage cannot be mislabeled.

### Why this stage exists

It replaces the current process-local/non-network consumption PoC with real PostgreSQL and a real TLS socket while preserving exact endpoint and credential boundaries. Once green, the remaining bridge is specifically `/v1/decide`/CanonicalDecisionArtifact -> ExecutionIntent -> this already-proven Real Bind runtime.

DO NOT MERGE until the dedicated Secure Real Bind Runtime PoC workflow and the normal required CI/security checks are green.