### PR TITLE
Add verified decision→bind-authorization issuance boundary and unit tests

### DIFF
--- a/veritas_os/policy/real_decision_bind_authorization.py
+++ b/veritas_os/policy/real_decision_bind_authorization.py
@@ -1,0 +1,174 @@
+"""Verified Canonical Decision to Real Bind Authorization issuance boundary.
+
+This module adds no authority or review primitive.  It composes the existing
+canonical decision, recursive gate-review, ExecutionIntent, and signed Real
+Bind Authorization verifiers and refuses issuance if any copy of the intent
+lineage differs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from veritas_os.governance.canonical_decision_artifact import (
+    CanonicalDecisionArtifact,
+    verify_canonical_decision_artifact,
+)
+from veritas_os.policy.bind_artifacts import ExecutionIntent, hash_execution_intent
+from veritas_os.policy.decision_candidate import (
+    DecisionCandidate,
+    try_promote_verified_canonical_decision_candidate_to_execution_intent,
+)
+from veritas_os.policy.live_adapter_bind_authorization import (
+    BindAuthorizationSigner,
+    BindAuthorizationTrustInputs,
+    CanonicalLiveAdapterBindAuthorizationArtifact,
+    RealBindAuthorizationGovernanceInputs,
+    build_live_adapter_bind_authorization_artifact,
+    verify_live_adapter_bind_authorization_artifact,
+)
+from veritas_os.policy.live_adapter_dry_run_bind_authorization_gate_review import (
+    verify_live_adapter_dry_run_bind_authorization_gate_review_packet,
+)
+
+
+class RealDecisionBindAuthorizationError(ValueError):
+    """Raised when independently verified decision lineage is not identical."""
+
+
+@dataclass(frozen=True)
+class VerifiedRealDecisionBindAuthorization:
+    """Result of the non-effecting, fail-closed issuance composition."""
+
+    canonical_decision_artifact: CanonicalDecisionArtifact
+    execution_intent: ExecutionIntent
+    execution_intent_hash: str
+    authorization: CanonicalLiveAdapterBindAuthorizationArtifact
+
+
+def _require_exact_intent(
+    expected: ExecutionIntent,
+    actual: Any,
+    actual_id: str,
+    actual_hash: str,
+    *,
+    boundary: str,
+) -> None:
+    """Require object, content-addressed identity, and digest equality."""
+    expected_raw = expected.to_dict()
+    actual_raw = (
+        actual.model_dump(mode="json")
+        if hasattr(actual, "model_dump")
+        else actual
+    )
+    expected_hash = hash_execution_intent(expected)
+    if (
+        actual_raw != expected_raw
+        or actual_id != expected.execution_intent_id
+        or actual_hash != expected_hash
+    ):
+        raise RealDecisionBindAuthorizationError(
+            f"RDBA_{boundary}_EXECUTION_INTENT_MISMATCH"
+        )
+
+
+def issue_verified_real_decision_bind_authorization(
+    *,
+    canonical_decision_artifact: CanonicalDecisionArtifact | dict[str, Any],
+    candidate: DecisionCandidate | dict[str, Any],
+    policy_snapshot_id: str,
+    source_gate_review_packet: Any,
+    signed_authorization_decision_artifact: Any,
+    valid_from: datetime | str,
+    valid_until: datetime | str,
+    governance_inputs: RealBindAuthorizationGovernanceInputs,
+    trust_inputs: BindAuthorizationTrustInputs,
+    authorization_issuer_signer: BindAuthorizationSigner,
+    ttl_seconds: int | None = None,
+    expected_state_fingerprint: str | None = None,
+    approval_context: dict[str, Any] | None = None,
+    policy_lineage: dict[str, Any] | None = None,
+) -> VerifiedRealDecisionBindAuthorization:
+    """Issue authorization only for one independently verified decision intent.
+
+    The function deliberately accepts no decision or ExecutionIntent identity
+    override.  The CDA verifier supplies decision lineage, the canonical
+    promotion helper derives the intent, and both the recursively verified
+    source packet and independently verified authorization must contain the
+    exact same intent object, identity, and content-derived hash.
+
+    Raises:
+        RealDecisionBindAuthorizationError: If verification or lineage differs.
+        LiveAdapterBindAuthorizationError: If existing governance fails closed.
+    """
+    cda_result = verify_canonical_decision_artifact(canonical_decision_artifact)
+    if not cda_result.is_valid or cda_result.artifact is None:
+        raise RealDecisionBindAuthorizationError("RDBA_CANONICAL_DECISION_INVALID")
+    cda = cda_result.artifact
+
+    promotion = try_promote_verified_canonical_decision_candidate_to_execution_intent(
+        candidate,
+        canonical_decision_artifact=cda,
+        policy_snapshot_id=policy_snapshot_id,
+        ttl_seconds=ttl_seconds,
+        expected_state_fingerprint=expected_state_fingerprint,
+        approval_context=approval_context,
+        policy_lineage=policy_lineage,
+    )
+    if not promotion.promoted or promotion.execution_intent is None:
+        raise RealDecisionBindAuthorizationError("RDBA_PROMOTION_REFUSED")
+    intent = promotion.execution_intent
+    if (
+        intent.decision_id != cda.decision_id
+        or intent.decision_hash != cda.decision_hash
+        or intent.decision_ts != cda.decision_ts
+        or intent.request_id != cda.request_id
+    ):
+        raise RealDecisionBindAuthorizationError("RDBA_DECISION_LINEAGE_MISMATCH")
+
+    source = verify_live_adapter_dry_run_bind_authorization_gate_review_packet(
+        source_gate_review_packet
+    )
+    _require_exact_intent(
+        intent,
+        source.execution_intent,
+        source.execution_intent_id,
+        source.execution_intent_hash,
+        boundary="SOURCE",
+    )
+    issued = build_live_adapter_bind_authorization_artifact(
+        source,
+        signed_authorization_decision_artifact,
+        valid_from,
+        valid_until,
+        governance_inputs=governance_inputs,
+        trust_inputs=trust_inputs,
+        authorization_issuer_signer=authorization_issuer_signer,
+    )
+    verified = verify_live_adapter_bind_authorization_artifact(
+        issued,
+        governance_inputs=governance_inputs,
+        trust_inputs=trust_inputs,
+    )
+    _require_exact_intent(
+        intent,
+        verified.execution_intent,
+        verified.execution_intent_id,
+        verified.execution_intent_hash,
+        boundary="AUTHORIZATION",
+    )
+    return VerifiedRealDecisionBindAuthorization(
+        canonical_decision_artifact=cda,
+        execution_intent=intent,
+        execution_intent_hash=hash_execution_intent(intent),
+        authorization=verified,
+    )
+
+
+__all__ = [
+    "RealDecisionBindAuthorizationError",
+    "VerifiedRealDecisionBindAuthorization",
+    "issue_verified_real_decision_bind_authorization",
+]

--- a/veritas_os/tests/test_real_decision_bind_authorization.py
+++ b/veritas_os/tests/test_real_decision_bind_authorization.py
@@ -1,0 +1,145 @@
+"""Tests for the verified decision-to-authorization composition boundary."""
+
+from __future__ import annotations
+
+import inspect
+from types import SimpleNamespace
+
+import pytest
+
+from veritas_os.policy.bind_artifacts import ExecutionIntent, hash_execution_intent
+from veritas_os.policy.real_decision_bind_authorization import (
+    RealDecisionBindAuthorizationError,
+    _require_exact_intent,
+    issue_verified_real_decision_bind_authorization,
+)
+
+
+def _intent(**changes: object) -> ExecutionIntent:
+    values = {
+        "execution_intent_id": "intent-live-decision",
+        "decision_id": "cda:v1:sha256:" + "a" * 64,
+        "request_id": "request-live-decision",
+        "policy_snapshot_id": "policy-live-v1",
+        "actor_identity": "operator:live",
+        "target_system": "billing",
+        "target_resource": "https://api.example.invalid/v1/billing",
+        "intended_action": "create_billing_effect",
+        "evidence_refs": ["authority:live"],
+        "decision_hash": "a" * 64,
+        "decision_ts": "2026-08-25T00:00:00.000000Z",
+    }
+    values.update(changes)
+    return ExecutionIntent(**values)
+
+
+def test_exact_intent_accepts_object_id_and_content_hash() -> None:
+    intent = _intent()
+    _require_exact_intent(
+        intent,
+        intent.to_dict(),
+        intent.execution_intent_id,
+        hash_execution_intent(intent),
+        boundary="SOURCE",
+    )
+
+
+@pytest.mark.parametrize(
+    ("actual", "actual_id", "actual_hash"),
+    [
+        (_intent(decision_hash="b" * 64).to_dict(), "intent-live-decision", None),
+        (_intent().to_dict(), "foreign-intent", None),
+        (_intent().to_dict(), "intent-live-decision", "0" * 64),
+        (
+            _intent(target_resource="https://foreign.invalid/effect").to_dict(),
+            "intent-live-decision",
+            None,
+        ),
+    ],
+)
+def test_exact_intent_rejects_foreign_or_tampered_lineage(
+    actual: dict[str, object],
+    actual_id: str,
+    actual_hash: str | None,
+) -> None:
+    expected = _intent()
+    with pytest.raises(
+        RealDecisionBindAuthorizationError,
+        match="RDBA_SOURCE_EXECUTION_INTENT_MISMATCH",
+    ):
+        _require_exact_intent(
+            expected,
+            actual,
+            actual_id,
+            actual_hash or hash_execution_intent(ExecutionIntent(**actual)),
+            boundary="SOURCE",
+        )
+
+
+def test_public_boundary_has_no_caller_lineage_override_parameters() -> None:
+    parameters = inspect.signature(
+        issue_verified_real_decision_bind_authorization
+    ).parameters
+    forbidden = {
+        "decision_id",
+        "decision_hash",
+        "decision_ts",
+        "request_id",
+        "execution_intent_id",
+        "execution_intent_hash",
+    }
+    assert forbidden.isdisjoint(parameters)
+
+
+def test_decision_lineage_mismatch_stops_before_source_verification(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cda = SimpleNamespace(
+        decision_id="cda:v1:sha256:" + "a" * 64,
+        decision_hash="a" * 64,
+        decision_ts="2026-08-25T00:00:00.000000Z",
+        request_id="request-live-decision",
+    )
+    foreign = _intent(decision_hash="b" * 64)
+    monkeypatch.setattr(
+        "veritas_os.policy.real_decision_bind_authorization."
+        "verify_canonical_decision_artifact",
+        lambda value: SimpleNamespace(is_valid=True, artifact=cda),
+    )
+    monkeypatch.setattr(
+        "veritas_os.policy.real_decision_bind_authorization."
+        "try_promote_verified_canonical_decision_candidate_to_execution_intent",
+        lambda *args, **kwargs: SimpleNamespace(
+            promoted=True,
+            execution_intent=foreign,
+        ),
+    )
+    source_called = False
+
+    def source_verifier(value: object) -> object:
+        nonlocal source_called
+        source_called = True
+        return value
+
+    monkeypatch.setattr(
+        "veritas_os.policy.real_decision_bind_authorization."
+        "verify_live_adapter_dry_run_bind_authorization_gate_review_packet",
+        source_verifier,
+    )
+    with pytest.raises(
+        RealDecisionBindAuthorizationError,
+        match="RDBA_DECISION_LINEAGE_MISMATCH",
+    ):
+        issue_verified_real_decision_bind_authorization(
+            canonical_decision_artifact={},
+            candidate={},
+            policy_snapshot_id="policy-live-v1",
+            source_gate_review_packet={},
+            signed_authorization_decision_artifact={},
+            valid_from="2026-08-25T00:00:00Z",
+            valid_until="2026-08-25T00:05:00Z",
+            governance_inputs=SimpleNamespace(),
+            trust_inputs=SimpleNamespace(),
+            authorization_issuer_signer=SimpleNamespace(),
+        )
+    assert source_called is False


### PR DESCRIPTION
### Motivation

- Establish a fail-closed composition boundary that issues a Real Bind Authorization only when an independently-verified canonical decision, promoted ExecutionIntent, source gate-review packet, and produced authorization artifact all contain the exact same intent lineage.  
- Prevent callers from overriding canonical decision or ExecutionIntent identity when requesting real authorizations.  
- Provide explicit error signaling for mismatches in intent, promotion refusal, or invalid canonical decision verification.

### Description

- Add `veritas_os.policy.real_decision_bind_authorization` which implements `issue_verified_real_decision_bind_authorization`, `VerifiedRealDecisionBindAuthorization`, `_require_exact_intent`, and `RealDecisionBindAuthorizationError`.  
- The new function verifies the `CanonicalDecisionArtifact` via `verify_canonical_decision_artifact`, promotes a `DecisionCandidate` to an `ExecutionIntent` using `try_promote_verified_canonical_decision_candidate_to_execution_intent`, enforces decision lineage equality, verifies the source gate-review packet, builds a live-adapter bind authorization with `build_live_adapter_bind_authorization_artifact`, verifies it, and ensures the produced authorization contains the identical intent.  
- Add defensive checks so the public API `issue_verified_real_decision_bind_authorization` exposes no parameters that allow callers to override `decision_id`, `decision_hash`, `decision_ts`, `request_id`, `execution_intent_id`, or `execution_intent_hash`.  
- Export the new types and helpers and raise `RealDecisionBindAuthorizationError` with distinct codes on different mismatch conditions.

### Testing

- Added `veritas_os/tests/test_real_decision_bind_authorization.py` containing unit tests for `_require_exact_intent` acceptance and rejection cases, API signature constraints, and the decision-lineage mismatch short-circuit behavior.  
- Ran the new tests with `pytest veritas_os/tests/test_real_decision_bind_authorization.py` and they passed.  
- The decision-lineage mismatch test uses `monkeypatch` to stub verifiers and asserts that source verification is not invoked when lineage already fails, and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8cfbb00e7c8326a2b6e12ec67156d9)