### PR TITLE
Include policy and selected-action evidence in CDA and enforce them during verified promotion

### DIFF
--- a/scripts/run_decision_to_external_bind_poc.py
+++ b/scripts/run_decision_to_external_bind_poc.py
@@ -74,7 +74,6 @@ from veritas_os.security.hash import sha256_of_canonical_json  # noqa: E402
 DEFAULT_REPORT = REPO_ROOT / "artifacts/decision-to-external-bind-poc/report.json"
 ACTOR = "test-actor:decision-bind-poc"
 SCOPE = ["synthetic:review:create"]
-POLICY_SNAPSHOT_ID = "controlled-synthetic-policy-v1"
 NOW = datetime(2026, 8, 21, 12, tzinfo=UTC)
 
 
@@ -187,9 +186,11 @@ def _action_contract() -> ActionClassContract:
 
 
 def _candidate() -> DecisionCandidate:
-    """Return explicit typed input; no model prose becomes authority."""
+    """Return the explicit typed candidate submitted to the real decision route."""
     return DecisionCandidate(
+        candidate_id="selected-decision-bind-candidate",
         source_model="CONTROLLED_STRUCTURED_SYNTHETIC_CANDIDATE",
+        source_trace_ref="decision-bind-poc-request-option",
         action_type="synthetic_external_webhook",
         actor_identity=ACTOR,
         target_system="local-synthetic-fixture",
@@ -198,19 +199,33 @@ def _candidate() -> DecisionCandidate:
         required_authority=list(SCOPE),
         required_human_approval=False,
         risk_level="low",
+        metadata={"synthetic_only": True},
     )
+
+
+def _decision_request_fixture() -> dict[str, Any]:
+    """Bind the structured execution candidate into the authenticated decision input."""
+    payload = _request_fixture()
+    selected = _candidate().to_dict()
+    selected.update(
+        {
+            "id": "synthetic-external-webhook",
+            "title": "Post one synthetic review",
+            "description": (
+                "Structured test-only action candidate for the local external Bind fixture."
+            ),
+            "score": 1.0,
+        }
+    )
+    payload["options"] = [selected]
+    return payload
 
 
 def _configure_secure_test_infrastructure(
     runtime_root: Path,
     api_secret: str,
 ) -> str:
-    """Configure secure posture while isolating external network clients.
-
-    The production AWS KMS signer and S3 Object Lock mirror remain selected.
-    Only their client boundary is replaced during the PoC with implementations
-    that perform Ed25519 signing and enforce retention metadata.
-    """
+    """Configure secure posture while isolating external network clients."""
     kms_key_id = "arn:aws:kms:us-east-1:000000000000:key/decision-bind-poc"
     os.environ.update(
         {
@@ -240,10 +255,10 @@ def _configure_secure_test_infrastructure(
     return kms_key_id
 
 
-def _verified_authority() -> tuple[
-    Any, AuthorityEvidenceVerifierPolicy, AuthorityRevocationPolicy
-]:
-    """Create and cryptographically verify ephemeral AuthorityEvidence."""
+def _verified_authority(
+    policy_snapshot_id: str,
+) -> tuple[Any, AuthorityEvidenceVerifierPolicy, AuthorityRevocationPolicy]:
+    """Create AuthorityEvidence bound to the verified CDA policy snapshot."""
     contract = _action_contract()
     private_key = Ed25519PrivateKey.generate()
     public_key = private_key.public_key().public_bytes_raw()
@@ -269,7 +284,7 @@ def _verified_authority() -> tuple[
         valid_from=issued_at,
         valid_until=valid_until,
         revalidated_at=NOW.isoformat(),
-        policy_snapshot_id=POLICY_SNAPSHOT_ID,
+        policy_snapshot_id=policy_snapshot_id,
         evidence_hash="",
         verification_result=VerificationResult.INDETERMINATE,
         failure_reasons=[],
@@ -321,7 +336,7 @@ def _verified_authority() -> tuple[
         action_contract=contract,
         actor_identity=ACTOR,
         requested_scope=list(SCOPE),
-        policy_snapshot_id=POLICY_SNAPSHOT_ID,
+        policy_snapshot_id=policy_snapshot_id,
         signature_verifier=verifier,
         signer_policy=signer_policy,
         verifier_policy=verifier_policy,
@@ -358,7 +373,6 @@ def _decide(
         name: str,
         package: str | None = None,
     ) -> Any:
-        """Substitute only boto3 while preserving normal dynamic imports."""
         if name == "boto3":
             return aws_clients
         return real_import_module(name, package)
@@ -366,16 +380,13 @@ def _decide(
     with (
         patch.object(llm_client, "chat", controlled_chat),
         patch.object(decision_kernel, "decide", observed),
-        patch(
-            "importlib.import_module",
-            side_effect=controlled_import_module,
-        ),
+        patch("importlib.import_module", side_effect=controlled_import_module),
     ):
         with TestClient(server.app) as client:
             response = client.post(
                 "/v1/decide",
                 headers={"X-API-Key": os.environ["VERITAS_API_KEY"]},
-                json=_request_fixture(),
+                json=_decision_request_fixture(),
             )
     response.raise_for_status()
     return (
@@ -398,10 +409,7 @@ def run_proof(report_path: Path, *, invalid_authority: bool = False) -> int:
     ) as temporary:
         runtime_root = Path(temporary)
         _configure_environment(runtime_root, api_key, encryption_key)
-        kms_key_id = _configure_secure_test_infrastructure(
-            runtime_root,
-            api_secret,
-        )
+        kms_key_id = _configure_secure_test_infrastructure(runtime_root, api_secret)
         if os.environ.get("VERITAS_POSTURE") != "secure":
             raise RuntimeError("integrated proof requires secure posture")
 
@@ -415,25 +423,38 @@ def run_proof(report_path: Path, *, invalid_authority: bool = False) -> int:
         if not cda_verification.is_valid or cda_verification.artifact is None:
             raise RuntimeError("HTTP response canonical decision failed verification")
         cda: CanonicalDecisionArtifact = cda_verification.artifact
-        promotion = (
-            try_promote_verified_canonical_decision_candidate_to_execution_intent(
-                _candidate(),
-                canonical_decision_artifact=cda,
-                policy_snapshot_id=POLICY_SNAPSHOT_ID,
-                expected_state_fingerprint=sha256_of_canonical_json(SNAPSHOT),
-                approval_context={"external_webhook_action_approved": True},
-            )
+        policy_evidence = cda.decision.policy_snapshot_evidence
+        action_evidence = cda.decision.selected_action_evidence
+        if policy_evidence is None:
+            raise RuntimeError("verified canonical decision has no policy snapshot evidence")
+        if action_evidence is None:
+            raise RuntimeError("verified canonical decision has no selected-action evidence")
+        selected_candidate = response.get("chosen")
+        if not isinstance(selected_candidate, dict):
+            raise RuntimeError("HTTP response chosen value is not a structured candidate")
+        policy_snapshot_id = policy_evidence.snapshot_id
+        promotion = try_promote_verified_canonical_decision_candidate_to_execution_intent(
+            selected_candidate,
+            canonical_decision_artifact=cda,
+            policy_snapshot_id=policy_snapshot_id,
+            expected_state_fingerprint=sha256_of_canonical_json(SNAPSHOT),
+            approval_context={"external_webhook_action_approved": True},
         )
         if not promotion.promoted or promotion.execution_intent is None:
-            raise RuntimeError("verified canonical decision was not promoted")
+            reasons = ",".join(promotion.refusal_reason_codes)
+            raise RuntimeError(f"verified canonical decision was not promoted: {reasons}")
         intent = promotion.execution_intent
         lineage_ok = (
             intent.decision_id == cda.decision_id
             and intent.decision_hash == cda.decision_hash
             and intent.decision_ts == cda.decision_ts
             and intent.request_id == cda.request_id
+            and intent.policy_snapshot_id == policy_snapshot_id
+            and intent.actor_identity == ACTOR
         )
-        proof, verifier_policy, revocation_policy = _verified_authority()
+        proof, verifier_policy, revocation_policy = _verified_authority(
+            policy_snapshot_id
+        )
         runtime_result = RuntimeAuthorityValidator().validate(
             action_contract=_action_contract(),
             authority_evidence=None,
@@ -442,8 +463,8 @@ def run_proof(report_path: Path, *, invalid_authority: bool = False) -> int:
             authority_revocation_policy=revocation_policy,
             requested_scope=list(SCOPE),
             required_evidence_metadata={},
-            policy_snapshot_id=POLICY_SNAPSHOT_ID,
-            actor_identity=ACTOR,
+            policy_snapshot_id=policy_snapshot_id,
+            actor_identity=intent.actor_identity,
             human_approval_state={"approved": False},
             execution_intent_id=intent.execution_intent_id,
             bind_context_metadata={"proof": "decision-to-external-bind-poc"},
@@ -539,9 +560,10 @@ def run_proof(report_path: Path, *, invalid_authority: bool = False) -> int:
             "decision_hash": cda.decision_hash,
             "decision_ts": cda.decision_ts,
             "request_id": cda.request_id,
-            "decision_candidate_source": "CONTROLLED_STRUCTURED_SYNTHETIC_CANDIDATE",
-            "policy_snapshot_id": POLICY_SNAPSHOT_ID,
-            "policy_snapshot_source": "CONTROLLED_SYNTHETIC_POLICY_FIXTURE",
+            "decision_candidate_source": selected_candidate.get("source_model"),
+            "selected_action_lineage_verified": action_evidence is not None,
+            "policy_snapshot_id": policy_snapshot_id,
+            "policy_snapshot_source": "VERIFIED_CDA_GOVERNANCE_IDENTITY",
             "execution_intent_created": True,
             "execution_intent_id": intent.execution_intent_id,
             "execution_intent_hash": hash_execution_intent(intent),
@@ -551,9 +573,7 @@ def run_proof(report_path: Path, *, invalid_authority: bool = False) -> int:
             "authority_revocation_verified": not invalid_authority,
             "human_approval_state": "NOT_REQUIRED",
             "runtime_authority_status": runtime_result.status,
-            "runtime_authority_recommended_outcome": (
-                runtime_result.recommended_outcome
-            ),
+            "runtime_authority_recommended_outcome": runtime_result.recommended_outcome,
             "bind_adjudication_invoked": bind_invoked,
             "bind_adjudication_call_count": int(bind_invoked),
             "webhook_bind_adapter_invoked": bind_invoked,
@@ -592,9 +612,7 @@ def run_proof(report_path: Path, *, invalid_authority: bool = False) -> int:
             ),
         }
         serialized = json.dumps(report, sort_keys=True, separators=(",", ":"))
-        if any(
-            secret in serialized for secret in (api_key, api_secret, encryption_key)
-        ):
+        if any(secret in serialized for secret in (api_key, api_secret, encryption_key)):
             raise RuntimeError("ephemeral secret leaked into proof report")
         report_path.parent.mkdir(parents=True, exist_ok=True)
         report_path.write_text(serialized + "\n", encoding="utf-8")

--- a/scripts/run_decision_to_external_bind_poc.py
+++ b/scripts/run_decision_to_external_bind_poc.py
@@ -65,6 +65,7 @@ from veritas_os.policy.bind_artifacts import (  # noqa: E402
     hash_execution_intent,
 )
 from veritas_os.policy.bind_core import execute_bind_adjudication  # noqa: E402
+from veritas_os.policy.compiler import compile_policy_to_bundle  # noqa: E402
 from veritas_os.policy.decision_candidate import (  # noqa: E402
     DecisionCandidate,
     try_promote_verified_canonical_decision_candidate_to_execution_intent,
@@ -72,6 +73,7 @@ from veritas_os.policy.decision_candidate import (  # noqa: E402
 from veritas_os.security.hash import sha256_of_canonical_json  # noqa: E402
 
 DEFAULT_REPORT = REPO_ROOT / "artifacts/decision-to-external-bind-poc/report.json"
+POLICY_SOURCE = REPO_ROOT / "policies/examples/low_risk_route_allow.yaml"
 ACTOR = "test-actor:decision-bind-poc"
 SCOPE = ["synthetic:review:create"]
 NOW = datetime(2026, 8, 21, 12, tzinfo=UTC)
@@ -203,9 +205,24 @@ def _candidate() -> DecisionCandidate:
     )
 
 
-def _decision_request_fixture() -> dict[str, Any]:
-    """Bind the structured execution candidate into the authenticated decision input."""
+def _decision_request_fixture(policy_bundle_dir: Path) -> dict[str, Any]:
+    """Bind the structured execution candidate and verified policy into /v1/decide."""
     payload = _request_fixture()
+    context = dict(payload.get("context") or {})
+    context.update(
+        {
+            "compiled_policy_bundle_dir": policy_bundle_dir.as_posix(),
+            "policy_runtime_enforce": True,
+            "domain": "governance",
+            "route": "/api/decide",
+            "actor": "kernel",
+            "risk": {"level": "low"},
+            "runtime": {"auto_execute": True},
+            "evidence": {"available": ["risk_assessment"]},
+            "approvals": {"approved_by": ["governance_officer"]},
+        }
+    )
+    payload["context"] = context
     selected = _candidate().to_dict()
     selected.update(
         {
@@ -253,6 +270,35 @@ def _configure_secure_test_infrastructure(
         }
     )
     return kms_key_id
+
+
+def _configure_verified_policy_bundle(runtime_root: Path) -> Path:
+    """Create and configure an Ed25519-verified policy bundle for the real pipeline."""
+    private_key = Ed25519PrivateKey.generate()
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_pem = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    verify_key_path = runtime_root / "policy-verify-key.pem"
+    verify_key_path.write_bytes(public_pem)
+    compiled = compile_policy_to_bundle(
+        POLICY_SOURCE,
+        runtime_root / "policy-bundle",
+        compiled_at=NOW.isoformat().replace("+00:00", "Z"),
+        signing_key=private_pem,
+    )
+    os.environ.update(
+        {
+            "VERITAS_POLICY_VERIFY_KEY": str(verify_key_path),
+            "VERITAS_POLICY_REQUIRE_ED25519": "1",
+        }
+    )
+    return compiled.bundle_dir
 
 
 def _verified_authority(
@@ -350,6 +396,7 @@ def _verified_authority(
 def _decide(
     *,
     aws_clients: _DeterministicAwsClients,
+    policy_bundle_dir: Path,
 ) -> tuple[dict[str, Any], bool, dict[str, int]]:
     """Cross the authenticated real HTTP route with controlled provider output."""
     from veritas_os.api import server
@@ -386,7 +433,7 @@ def _decide(
             response = client.post(
                 "/v1/decide",
                 headers={"X-API-Key": os.environ["VERITAS_API_KEY"]},
-                json=_decision_request_fixture(),
+                json=_decision_request_fixture(policy_bundle_dir),
             )
     response.raise_for_status()
     return (
@@ -412,11 +459,13 @@ def run_proof(report_path: Path, *, invalid_authority: bool = False) -> int:
         kms_key_id = _configure_secure_test_infrastructure(runtime_root, api_secret)
         if os.environ.get("VERITAS_POSTURE") != "secure":
             raise RuntimeError("integrated proof requires secure posture")
+        policy_bundle_dir = _configure_verified_policy_bundle(runtime_root)
 
         kms_client = _DeterministicKmsClient(kms_key_id)
         s3_client = _DeterministicObjectLockClient()
         response, pipeline_ok, infrastructure_calls = _decide(
-            aws_clients=_DeterministicAwsClients(kms_client, s3_client)
+            aws_clients=_DeterministicAwsClients(kms_client, s3_client),
+            policy_bundle_dir=policy_bundle_dir,
         )
         raw_cda = response.get("canonical_decision_artifact")
         cda_verification = verify_canonical_decision_artifact(raw_cda)
@@ -535,6 +584,7 @@ def run_proof(report_path: Path, *, invalid_authority: bool = False) -> int:
             "real_runtime_components": [
                 "FastAPI POST /v1/decide",
                 "decision pipeline and kernel",
+                "compiled policy runtime Ed25519 verification",
                 "CanonicalDecisionArtifact verification",
                 "DecisionCandidate promotion",
                 "AuthorityEvidence Ed25519 verification",
@@ -546,6 +596,7 @@ def run_proof(report_path: Path, *, invalid_authority: bool = False) -> int:
             ],
             "controlled_components": [
                 "model provider output",
+                "ephemeral policy signing key",
                 "runtime-injected API secret",
                 "AWS KMS network client",
                 "S3 Object Lock network client",
@@ -563,6 +614,9 @@ def run_proof(report_path: Path, *, invalid_authority: bool = False) -> int:
             "decision_candidate_source": selected_candidate.get("source_model"),
             "selected_action_lineage_verified": action_evidence is not None,
             "policy_snapshot_id": policy_snapshot_id,
+            "policy_snapshot_version": policy_evidence.version,
+            "policy_snapshot_signer_id": policy_evidence.signer_id,
+            "policy_snapshot_signature_verified": policy_evidence.signature_verified,
             "policy_snapshot_source": "VERIFIED_CDA_GOVERNANCE_IDENTITY",
             "execution_intent_created": True,
             "execution_intent_id": intent.execution_intent_id,

--- a/tests/policy/test_canonical_decision_promotion.py
+++ b/tests/policy/test_canonical_decision_promotion.py
@@ -1,8 +1,8 @@
-"""Tests for the verified canonical-decision promotion boundary."""
+"""Tests for authenticated CDA-to-ExecutionIntent promotion."""
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 import json
 from pathlib import Path
 
@@ -10,12 +10,17 @@ import pytest
 
 from veritas_os.api.schemas import DecideResponse
 from veritas_os.governance.canonical_decision_artifact import (
+    CDA_DECISION_ID_PREFIX,
     build_canonical_decision_artifact,
+    canonical_decision_preimage,
+    strict_canonical_json_bytes,
 )
 from veritas_os.policy.decision_candidate import (
     DecisionCandidate,
     try_promote_verified_canonical_decision_candidate_to_execution_intent,
+    verified_canonical_promotion_proof_report,
 )
+from veritas_os.security.hash import sha256_hex
 
 ROOT = Path(__file__).resolve().parents[2]
 VECTOR = (
@@ -23,20 +28,13 @@ VECTOR = (
     / "docs/en/architecture/test-vectors/canonical-decision-artifact-v1"
     / "vector-01.json"
 )
-
-
-def _artifact():
-    source = DecideResponse.model_validate(
-        json.loads(VECTOR.read_text(encoding="utf-8"))["source_projection"]
-    )
-    return build_canonical_decision_artifact(
-        source,
-        decision_ts=datetime(2031, 2, 3, 4, 5, 6, tzinfo=UTC),
-    )
+NOW = datetime(2031, 2, 3, 4, 5, 6, tzinfo=UTC)
+POLICY_DIGEST = "a" * 64
 
 
 def _candidate(**overrides: object) -> DecisionCandidate:
     values = {
+        "candidate_id": "selected-candidate-1",
         "action_type": "synthetic_external_webhook",
         "actor_identity": "test-actor:decision-bind-poc",
         "target_system": "local-synthetic-fixture",
@@ -50,20 +48,44 @@ def _candidate(**overrides: object) -> DecisionCandidate:
     return DecisionCandidate(**values)
 
 
-def _promote(artifact=None, **kwargs):
+def _artifact(
+    *,
+    candidate: DecisionCandidate | None = None,
+    verified_at: datetime = NOW,
+    signature_verified: bool = True,
+    include_selected_action: bool = True,
+):
+    source_payload = json.loads(VECTOR.read_text(encoding="utf-8"))[
+        "source_projection"
+    ]
+    source_payload["chosen"] = (
+        (candidate or _candidate()).to_dict()
+        if include_selected_action
+        else {"id": "not-a-structured-action"}
+    )
+    source_payload["governance_identity"] = {
+        "policy_version": "synthetic-v7",
+        "digest": POLICY_DIGEST,
+        "signature_verified": signature_verified,
+        "signer_id": "policy-root-1",
+        "verified_at": verified_at.isoformat().replace("+00:00", "Z"),
+    }
+    source = DecideResponse.model_validate(source_payload)
+    return build_canonical_decision_artifact(source, decision_ts=NOW)
+
+
+def _promote(candidate: DecisionCandidate | None = None, artifact=None, **kwargs):
     return try_promote_verified_canonical_decision_candidate_to_execution_intent(
-        _candidate(),
+        candidate or _candidate(),
         canonical_decision_artifact=artifact or _artifact(),
-        policy_snapshot_id=kwargs.pop(
-            "policy_snapshot_id", "controlled-synthetic-policy-v1"
-        ),
+        now=kwargs.pop("now", NOW),
         **kwargs,
     )
 
 
-def test_verified_cda_supplies_exact_execution_intent_lineage() -> None:
+def test_verified_evidence_supplies_all_execution_intent_lineage() -> None:
     artifact = _artifact()
-    result = _promote(artifact)
+    result = _promote(artifact=artifact)
 
     assert result.promoted is True
     assert result.execution_intent is not None
@@ -72,50 +94,102 @@ def test_verified_cda_supplies_exact_execution_intent_lineage() -> None:
     assert intent.decision_hash == artifact.decision_hash
     assert intent.decision_ts == artifact.decision_ts
     assert intent.request_id == artifact.request_id
-    assert intent.policy_snapshot_id == "controlled-synthetic-policy-v1"
+    assert intent.policy_snapshot_id == POLICY_DIGEST
+    assert intent.policy_lineage == {
+        "version": "synthetic-v7",
+        "semantic_digest": POLICY_DIGEST,
+        "signer_id": "policy-root-1",
+        "verified_at": "2031-02-03T04:05:06Z",
+    }
+    assert verified_canonical_promotion_proof_report(result, artifact) == {
+        "policy_snapshot_lineage_proven": True,
+        "selected_action_lineage_proven": True,
+        "decision_lineage_proven": True,
+        "execution_intent_lineage_proven": True,
+    }
 
 
-def test_tampered_cda_hash_and_id_fail_closed() -> None:
-    artifact = _artifact().model_dump(mode="json")
-    for field, value in (
-        ("decision_hash", "0" * 64),
-        ("decision_id", "decision:" + "1" * 64),
-    ):
-        tampered = {**artifact, field: value}
-        result = _promote(tampered)
-        assert result.promoted is False
-        assert result.execution_intent is None
-        assert result.fail_closed is True
-
-
-def test_lineage_overrides_are_not_part_of_helper_contract() -> None:
-    artifact = _artifact()
-    result = _promote(artifact)
-
-    assert result.execution_intent is not None
-    assert result.execution_intent.decision_id == artifact.decision_id
-    assert result.execution_intent.decision_hash == artifact.decision_hash
-    with pytest.raises(TypeError):
-        _promote(artifact, decision_id="caller-decision")
-    with pytest.raises(TypeError):
-        _promote(artifact, decision_hash="caller-hash")
-
-
-def test_policy_snapshot_is_explicit_and_required() -> None:
-    result = _promote(policy_snapshot_id="")
+def test_foreign_caller_policy_snapshot_is_rejected() -> None:
+    result = _promote(policy_snapshot_id="b" * 64)
 
     assert result.promoted is False
-    assert result.execution_intent is None
-    assert result.refusal_reason_codes == ["POLICY_SNAPSHOT_ID_MISSING"]
+    assert result.refusal_reason_codes == ["POLICY_SNAPSHOT_ID_MISMATCH"]
 
 
-def test_non_promotable_candidate_preserves_existing_refusal() -> None:
-    result = try_promote_verified_canonical_decision_candidate_to_execution_intent(
-        _candidate(target_resource=""),
-        canonical_decision_artifact=_artifact(),
-        policy_snapshot_id="controlled-synthetic-policy-v1",
+@pytest.mark.parametrize(
+    ("artifact", "reason"),
+    [
+        (
+            _artifact(verified_at=NOW - timedelta(seconds=301)),
+            "POLICY_SNAPSHOT_PROVENANCE_STALE",
+        ),
+        (
+            _artifact(signature_verified=False),
+            "POLICY_SNAPSHOT_PROVENANCE_INVALID",
+        ),
+    ],
+)
+def test_stale_or_unverifiable_policy_snapshot_is_rejected(
+    artifact, reason: str
+) -> None:
+    result = _promote(artifact=artifact)
+
+    assert result.promoted is False
+    assert reason in result.refusal_reason_codes
+
+
+@pytest.mark.parametrize(
+    "candidate",
+    [
+        _candidate(candidate_id="foreign-candidate"),
+        _candidate(intended_action="tampered_after_decision"),
+    ],
+)
+def test_candidate_different_from_selected_action_is_rejected(
+    candidate: DecisionCandidate,
+) -> None:
+    result = _promote(candidate=candidate)
+
+    assert result.promoted is False
+    assert result.refusal_reason_codes == ["SELECTED_ACTION_BINDING_MISMATCH"]
+
+
+def test_chosen_binding_hash_tampering_is_rejected() -> None:
+    raw = _artifact().model_dump(mode="json")
+    raw["decision"]["chosen_binding"]["sha256"] = "0" * 64
+    provisional = type(_artifact()).model_validate(raw)
+    decision_hash = sha256_hex(
+        strict_canonical_json_bytes(canonical_decision_preimage(provisional))
+    )
+    raw["decision_hash"] = decision_hash
+    raw["decision_id"] = CDA_DECISION_ID_PREFIX + decision_hash
+
+    result = _promote(artifact=raw)
+
+    assert result.promoted is False
+    assert result.refusal_reason_codes == ["SELECTED_ACTION_BINDING_MISMATCH"]
+
+
+def test_missing_selected_action_evidence_is_rejected() -> None:
+    result = _promote(artifact=_artifact(include_selected_action=False))
+
+    assert result.promoted is False
+    assert result.refusal_reason_codes == ["SELECTED_ACTION_EVIDENCE_MISSING"]
+
+
+def test_caller_cannot_override_verified_policy_lineage() -> None:
+    result = _promote(
+        policy_snapshot_id=POLICY_DIGEST,
+        policy_lineage={"version": "attacker-version"},
     )
 
     assert result.promoted is False
     assert result.execution_intent is None
-    assert "DECISION_CANDIDATE_MISSING_REQUIRED_FIELD" in (result.refusal_reason_codes)
+    assert result.refusal_reason_codes == [
+        "POLICY_SNAPSHOT_LINEAGE_OVERRIDE_REFUSED"
+    ]
+
+
+def test_decision_lineage_override_is_not_part_of_contract() -> None:
+    with pytest.raises(TypeError):
+        _promote(decision_hash="caller-hash")

--- a/veritas_os/governance/canonical_decision_artifact.py
+++ b/veritas_os/governance/canonical_decision_artifact.py
@@ -329,7 +329,7 @@ def canonical_decision_preimage(
         "request_id": artifact.request_id,
         "decision_ts": artifact.decision_ts,
         "source_contract": artifact.source_contract.model_dump(mode="json"),
-        "decision": artifact.decision.model_dump(mode="json", exclude_none=True),
+        "decision": artifact.decision.model_dump(mode="json"),
     }
 
 
@@ -395,7 +395,7 @@ def build_canonical_decision_artifact(
             "request_id": request_id,
             "decision_ts": normalized_ts,
             "source_contract": provisional["source_contract"].model_dump(mode="json"),
-            "decision": decision.model_dump(mode="json", exclude_none=True),
+            "decision": decision.model_dump(mode="json"),
         }
         decision_hash = sha256_hex(strict_canonical_json_bytes(preimage))
         return CanonicalDecisionArtifact(

--- a/veritas_os/governance/canonical_decision_artifact.py
+++ b/veritas_os/governance/canonical_decision_artifact.py
@@ -479,9 +479,6 @@ def _validated_source_projection(source: DecideResponse) -> dict[str, Any]:
             CanonicalDecisionArtifactBuildReason.NON_CANONICAL_JSON_VALUE
         ) from exc
     try:
-        # JSON-mode dumping can coerce non-finite floats under Pydantic's
-        # serialization policy.  Inspect the Python projection first so no
-        # hash-relevant non-finite or unsupported value can be laundered.
         python_projection = source.model_dump(mode="python", include=_SOURCE_FIELDS)
     except (TypeError, ValueError) as exc:
         raise CanonicalDecisionArtifactBuildError(
@@ -513,19 +510,7 @@ def _validated_source_projection(source: DecideResponse) -> dict[str, Any]:
 
 
 def _validate_canonical_json_value(value: Any) -> None:
-    """Recursively require exact CDA-v1 canonical JSON value families.
-
-    Python containers and objects that ``json.dumps`` or Pydantic might coerce
-    are deliberately rejected rather than converted into canonical identity.
-
-    Args:
-        value: Candidate value to validate without normalization.
-
-    Raises:
-        TypeError: If a value, container, or mapping key is not an exact JSON
-            family supported by CDA v1.
-        ValueError: If a floating-point value is non-finite.
-    """
+    """Recursively require exact CDA-v1 canonical JSON value families."""
     value_type = type(value)
     if value is None or value_type is bool or value_type is int or value_type is str:
         return
@@ -550,21 +535,7 @@ def _validate_typed_source_model(
     value: BaseModel | None,
     expected_type: type[BaseModel],
 ) -> None:
-    """Validate raw contents of one explicitly allowed typed source model.
-
-    Only the declared top-level Pydantic source model may cross this boundary.
-    Its known fields and Pydantic extras are inspected before ``model_dump`` so
-    nested Python objects cannot be normalized into a CDA binding.
-
-    Args:
-        value: Current raw source-model value, or ``None``.
-        expected_type: Exact Pydantic model type allowed for this source field.
-
-    Raises:
-        TypeError: If the top-level type is unexpected or any contained value
-            is not an exact canonical JSON family.
-        ValueError: If a contained floating-point value is non-finite.
-    """
+    """Validate raw contents of one explicitly allowed typed source model."""
     if value is None:
         return
     if type(value) is not expected_type:
@@ -662,7 +633,7 @@ def _build_projection(source: dict[str, Any]) -> CanonicalDecisionProjection:
 
 
 def _selected_action_evidence(value: Any) -> CanonicalSelectedActionEvidence | None:
-    """Derive selected-action evidence only from a complete candidate payload."""
+    """Bind a promotable candidate to the exact decision-selected value."""
     if not isinstance(value, dict):
         return None
     try:
@@ -679,9 +650,7 @@ def _selected_action_evidence(value: Any) -> CanonicalSelectedActionEvidence | N
         return None
     return CanonicalSelectedActionEvidence(
         candidate_hash=hash_decision_candidate(candidate),
-        chosen_binding_sha256=_binding_digest(
-            CDA_CHOSEN_BINDING_PROFILE, candidate.to_dict()
-        ),
+        chosen_binding_sha256=_binding_digest(CDA_CHOSEN_BINDING_PROFILE, value),
     )
 
 

--- a/veritas_os/governance/canonical_decision_artifact.py
+++ b/veritas_os/governance/canonical_decision_artifact.py
@@ -14,7 +14,15 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Literal, Mapping
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    SerializerFunctionWrapHandler,
+    ValidationError,
+    model_serializer,
+    model_validator,
+)
 
 from veritas_os.api.schemas import (
     DecideResponse,
@@ -174,11 +182,31 @@ class CanonicalDecisionTransitionRefusalBinding(_FrozenModel):
     sha256: str = Field(pattern=_DIGEST_PATTERN)
 
 
+class CanonicalSelectedActionEvidence(_FrozenModel):
+    """Content address of a normalized structured execution candidate."""
+
+    candidate_hash: str = Field(pattern=_DIGEST_PATTERN)
+    chosen_binding_sha256: str = Field(pattern=_DIGEST_PATTERN)
+
+
+class CanonicalPolicySnapshotEvidence(_FrozenModel):
+    """Policy identity already authenticated by the decision pipeline."""
+
+    snapshot_id: str = Field(pattern=_DIGEST_PATTERN)
+    version: str = Field(min_length=1)
+    semantic_digest: str = Field(pattern=_DIGEST_PATTERN)
+    signature_verified: Literal[True]
+    signer_id: str = Field(min_length=1)
+    verified_at: str = Field(min_length=1)
+
+
 class CanonicalDecisionProjection(_FrozenModel):
     """Exact closed v1 decision projection."""
 
     formation_status: Literal["COMPLETE", "INCOMPLETE"]
     chosen_binding: CanonicalDecisionChosenBinding
+    selected_action_evidence: CanonicalSelectedActionEvidence | None = None
+    policy_snapshot_evidence: CanonicalPolicySnapshotEvidence | None = None
     decision_status: Literal["allow", "modify", "rejected", "block", "abstain"]
     rejection_reason: str | None
     gate_decision: Literal["proceed", "hold", "block", "human_review_required"]
@@ -210,6 +238,18 @@ class CanonicalDecisionProjection(_FrozenModel):
     governance_identity_binding: CanonicalDecisionGovernanceIdentityBinding | None
     lineage_promotability_binding: CanonicalDecisionLineagePromotabilityBinding | None
     transition_refusal_binding: CanonicalDecisionTransitionRefusalBinding | None
+
+    @model_serializer(mode="wrap")
+    def _serialize_optional_evidence(
+        self, handler: SerializerFunctionWrapHandler
+    ) -> dict[str, Any]:
+        """Keep legacy CDA-v1 JSON exact when new evidence is unavailable."""
+        serialized = handler(self)
+        if self.selected_action_evidence is None:
+            serialized.pop("selected_action_evidence", None)
+        if self.policy_snapshot_evidence is None:
+            serialized.pop("policy_snapshot_evidence", None)
+        return serialized
 
     @model_validator(mode="after")
     def _validate_semantics(self) -> "CanonicalDecisionProjection":
@@ -289,7 +329,7 @@ def canonical_decision_preimage(
         "request_id": artifact.request_id,
         "decision_ts": artifact.decision_ts,
         "source_contract": artifact.source_contract.model_dump(mode="json"),
-        "decision": artifact.decision.model_dump(mode="json"),
+        "decision": artifact.decision.model_dump(mode="json", exclude_none=True),
     }
 
 
@@ -355,7 +395,7 @@ def build_canonical_decision_artifact(
             "request_id": request_id,
             "decision_ts": normalized_ts,
             "source_contract": provisional["source_contract"].model_dump(mode="json"),
-            "decision": decision.model_dump(mode="json"),
+            "decision": decision.model_dump(mode="json", exclude_none=True),
         }
         decision_hash = sha256_hex(strict_canonical_json_bytes(preimage))
         return CanonicalDecisionArtifact(
@@ -567,6 +607,8 @@ def _binding_digest(profile: str, value: Any) -> str:
 
 def _build_projection(source: dict[str, Any]) -> CanonicalDecisionProjection:
     governance = source["governance_identity"]
+    selected_action_evidence = _selected_action_evidence(source["chosen"])
+    policy_snapshot_evidence = _policy_snapshot_evidence(governance)
     common = {
         field: source[field]
         for field in (
@@ -593,6 +635,8 @@ def _build_projection(source: dict[str, Any]) -> CanonicalDecisionProjection:
             profile=CDA_CHOSEN_BINDING_PROFILE,
             sha256=_binding_digest(CDA_CHOSEN_BINDING_PROFILE, source["chosen"]),
         ),
+        selected_action_evidence=selected_action_evidence,
+        policy_snapshot_evidence=policy_snapshot_evidence,
         governance_identity_binding=(
             CanonicalDecisionGovernanceIdentityBinding(
                 profile=CDA_GOVERNANCE_IDENTITY_BINDING_PROFILE,
@@ -615,6 +659,49 @@ def _build_projection(source: dict[str, Any]) -> CanonicalDecisionProjection:
         ),
         **common,
     )
+
+
+def _selected_action_evidence(value: Any) -> CanonicalSelectedActionEvidence | None:
+    """Derive selected-action evidence only from a complete candidate payload."""
+    if not isinstance(value, dict):
+        return None
+    try:
+        from veritas_os.policy.decision_candidate import (
+            hash_decision_candidate,
+            normalize_decision_candidate,
+            validate_decision_candidate,
+        )
+
+        candidate = normalize_decision_candidate(value)
+        if not validate_decision_candidate(candidate).promotable:
+            return None
+    except (TypeError, ValueError):
+        return None
+    return CanonicalSelectedActionEvidence(
+        candidate_hash=hash_decision_candidate(candidate),
+        chosen_binding_sha256=_binding_digest(
+            CDA_CHOSEN_BINDING_PROFILE, candidate.to_dict()
+        ),
+    )
+
+
+def _policy_snapshot_evidence(
+    value: Any,
+) -> CanonicalPolicySnapshotEvidence | None:
+    """Project the existing signed governance identity without inventing trust."""
+    if not isinstance(value, dict):
+        return None
+    try:
+        return CanonicalPolicySnapshotEvidence(
+            snapshot_id=value["digest"],
+            version=value["policy_version"],
+            semantic_digest=value["digest"],
+            signature_verified=value["signature_verified"],
+            signer_id=value["signer_id"],
+            verified_at=value["verified_at"],
+        )
+    except (KeyError, TypeError, ValueError, ValidationError):
+        return None
 
 
 def _optional_binding(model: type[_FrozenModel], profile: str, value: Any) -> Any:

--- a/veritas_os/policy/__init__.py
+++ b/veritas_os/policy/__init__.py
@@ -65,7 +65,9 @@ from .decision_candidate import (
     promote_decision_candidate_to_execution_intent,
     try_build_decision_candidate_refusal_artifact,
     try_promote_decision_candidate_to_execution_intent,
+    try_promote_verified_canonical_decision_candidate_to_execution_intent,
     validate_decision_candidate,
+    verified_canonical_promotion_proof_report,
 )
 from .bind_revalidation import (
     replay_bind_receipt_admissibility,
@@ -149,6 +151,8 @@ __all__ = [
     "canonical_decision_candidate_json",
     "canonical_decision_candidate_refusal_artifact_json",
     "canonical_decision_candidate_refusal_reviewer_export_json",
+    "try_promote_verified_canonical_decision_candidate_to_execution_intent",
+    "verified_canonical_promotion_proof_report",
     "canonical_bind_receipt_json",
     "compile_policy_to_bundle",
     "build_generated_test_cases",

--- a/veritas_os/policy/decision_candidate.py
+++ b/veritas_os/policy/decision_candidate.py
@@ -9,6 +9,7 @@ append TrustLog entries, or adjudicate bind eligibility.
 from __future__ import annotations
 
 from dataclasses import dataclass, field, fields
+from datetime import UTC, datetime, timedelta
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
@@ -50,6 +51,12 @@ class DecisionCandidateRefusalReason(str, Enum):
     PROMOTABLE = "DECISION_CANDIDATE_PROMOTABLE"
     CANONICAL_DECISION_INVALID = "CANONICAL_DECISION_ARTIFACT_INVALID"
     POLICY_SNAPSHOT_MISSING = "POLICY_SNAPSHOT_ID_MISSING"
+    POLICY_SNAPSHOT_INVALID = "POLICY_SNAPSHOT_PROVENANCE_INVALID"
+    POLICY_SNAPSHOT_STALE = "POLICY_SNAPSHOT_PROVENANCE_STALE"
+    POLICY_SNAPSHOT_MISMATCH = "POLICY_SNAPSHOT_ID_MISMATCH"
+    POLICY_LINEAGE_OVERRIDE = "POLICY_SNAPSHOT_LINEAGE_OVERRIDE_REFUSED"
+    SELECTED_ACTION_MISSING = "SELECTED_ACTION_EVIDENCE_MISSING"
+    SELECTED_ACTION_MISMATCH = "SELECTED_ACTION_BINDING_MISMATCH"
 
 
 HARD_REQUIRED_FIELDS = (
@@ -88,6 +95,7 @@ HUMAN_APPROVAL_TRUE_VALUES = {"true", "yes", "approved", "required"}
 HUMAN_APPROVAL_FALSE_VALUES = {"false", "no", "not_required", "none"}
 REGULATED_TRUE_VALUES = {"true", "yes", "high", "regulated"}
 REGULATED_FALSE_VALUES = {"false", "no", "none"}
+POLICY_SNAPSHOT_MAX_AGE_SECONDS = 300
 
 
 REVIEWER_REDACTION_PROFILE = "reviewer_safe_v1"
@@ -598,7 +606,8 @@ def try_promote_verified_canonical_decision_candidate_to_execution_intent(
     candidate: DecisionCandidate | dict[str, Any],
     *,
     canonical_decision_artifact: CanonicalDecisionArtifact | dict[str, Any],
-    policy_snapshot_id: str,
+    policy_snapshot_id: str | None = None,
+    now: datetime | None = None,
     ttl_seconds: int | None = None,
     expected_state_fingerprint: str | None = None,
     approval_context: dict[str, Any] | None = None,
@@ -606,9 +615,9 @@ def try_promote_verified_canonical_decision_candidate_to_execution_intent(
 ) -> DecisionCandidatePromotionResult:
     """Promote structured input using lineage only from an independently verified CDA.
 
-    ``policy_snapshot_id`` remains an explicit, typed caller boundary because
-    CDA-v1 does not assert policy-snapshot provenance. No decision-lineage
-    override parameters are accepted, and this helper performs no I/O or Bind.
+    The policy identity and selected action are derived exclusively from the
+    independently verified CDA. ``policy_snapshot_id`` is only an optional
+    assertion and can never supply lineage.
     """
     from veritas_os.governance.canonical_decision_artifact import (
         verify_canonical_decision_artifact,
@@ -622,9 +631,64 @@ def try_promote_verified_canonical_decision_candidate_to_execution_intent(
         refusal_reasons.append(
             DecisionCandidateRefusalReason.CANONICAL_DECISION_INVALID.value
         )
-    if not isinstance(policy_snapshot_id, str) or not policy_snapshot_id.strip():
+    artifact = verification.artifact
+    policy_evidence = (
+        artifact.decision.policy_snapshot_evidence if artifact else None
+    )
+    action_evidence = (
+        artifact.decision.selected_action_evidence if artifact else None
+    )
+    if policy_evidence is None:
         refusal_reasons.append(
-            DecisionCandidateRefusalReason.POLICY_SNAPSHOT_MISSING.value
+            DecisionCandidateRefusalReason.POLICY_SNAPSHOT_INVALID.value
+        )
+    if policy_lineage is not None:
+        refusal_reasons.append(
+            DecisionCandidateRefusalReason.POLICY_LINEAGE_OVERRIDE.value
+        )
+    if (
+        policy_evidence is not None
+        and policy_snapshot_id is not None
+        and (
+            not isinstance(policy_snapshot_id, str)
+            or policy_snapshot_id.strip() != policy_evidence.snapshot_id
+        )
+    ):
+        refusal_reasons.append(
+            DecisionCandidateRefusalReason.POLICY_SNAPSHOT_MISMATCH.value
+        )
+    if policy_evidence is not None:
+        try:
+            verified_at = datetime.fromisoformat(
+                policy_evidence.verified_at.replace("Z", "+00:00")
+            )
+            current = now or datetime.now(UTC)
+            if (
+                verified_at.tzinfo is None
+                or verified_at > current
+                or current - verified_at
+                > timedelta(seconds=POLICY_SNAPSHOT_MAX_AGE_SECONDS)
+            ):
+                refusal_reasons.append(
+                    DecisionCandidateRefusalReason.POLICY_SNAPSHOT_STALE.value
+                )
+        except (TypeError, ValueError, OverflowError):
+            refusal_reasons.append(
+                DecisionCandidateRefusalReason.POLICY_SNAPSHOT_INVALID.value
+            )
+    if action_evidence is None:
+        refusal_reasons.append(
+            DecisionCandidateRefusalReason.SELECTED_ACTION_MISSING.value
+        )
+    elif hash_decision_candidate(normalized) != action_evidence.candidate_hash:
+        refusal_reasons.append(
+            DecisionCandidateRefusalReason.SELECTED_ACTION_MISMATCH.value
+        )
+    elif action_evidence.chosen_binding_sha256 != (
+        artifact.decision.chosen_binding.sha256
+    ):
+        refusal_reasons.append(
+            DecisionCandidateRefusalReason.SELECTED_ACTION_MISMATCH.value
         )
     if refusal_reasons:
         validation = DecisionCandidateValidationResult(
@@ -645,18 +709,24 @@ def try_promote_verified_canonical_decision_candidate_to_execution_intent(
             fail_closed=True,
         )
 
-    artifact = verification.artifact
+    assert artifact is not None
+    assert policy_evidence is not None
     return try_promote_decision_candidate_to_execution_intent(
         normalized,
         decision_id=artifact.decision_id,
         decision_hash=artifact.decision_hash,
         decision_ts=artifact.decision_ts,
         request_id=artifact.request_id,
-        policy_snapshot_id=policy_snapshot_id.strip(),
+        policy_snapshot_id=policy_evidence.snapshot_id,
         ttl_seconds=ttl_seconds,
         expected_state_fingerprint=expected_state_fingerprint,
         approval_context=approval_context,
-        policy_lineage=policy_lineage,
+        policy_lineage={
+            "version": policy_evidence.version,
+            "semantic_digest": policy_evidence.semantic_digest,
+            "signer_id": policy_evidence.signer_id,
+            "verified_at": policy_evidence.verified_at,
+        },
     )
 
 
@@ -814,6 +884,64 @@ def canonical_decision_candidate_json(
 def hash_decision_candidate(candidate: DecisionCandidate | dict[str, Any]) -> str:
     """Compute SHA-256 over canonical ``DecisionCandidate`` payload."""
     return sha256_of_canonical_json(normalize_decision_candidate(candidate).to_dict())
+
+
+def verified_canonical_promotion_proof_report(
+    result: DecisionCandidatePromotionResult,
+    canonical_decision_artifact: CanonicalDecisionArtifact | dict[str, Any],
+) -> dict[str, bool]:
+    """Derive narrow, machine-readable claims for a completed promotion.
+
+    Each claim is computed from its own verified relationship. This report
+    makes no Bind, dispatch, effect, or production-readiness claim.
+    """
+    from veritas_os.governance.canonical_decision_artifact import (
+        verify_canonical_decision_artifact,
+    )
+
+    verification = verify_canonical_decision_artifact(canonical_decision_artifact)
+    artifact = verification.artifact
+    intent = result.execution_intent
+    policy = artifact.decision.policy_snapshot_evidence if artifact else None
+    action = artifact.decision.selected_action_evidence if artifact else None
+    decision_lineage = bool(
+        verification.is_valid
+        and artifact
+        and intent
+        and intent.decision_id == artifact.decision_id
+        and intent.decision_hash == artifact.decision_hash
+        and intent.decision_ts == artifact.decision_ts
+        and intent.request_id == artifact.request_id
+    )
+    policy_lineage = bool(
+        intent
+        and policy
+        and intent.policy_snapshot_id == policy.snapshot_id
+        and intent.policy_lineage
+        and intent.policy_lineage.get("version") == policy.version
+        and intent.policy_lineage.get("semantic_digest")
+        == policy.semantic_digest
+    )
+    selected_action_lineage = bool(
+        action
+        and action.candidate_hash
+        == hash_decision_candidate(result.normalized_candidate)
+        and artifact
+        and action.chosen_binding_sha256
+        == artifact.decision.chosen_binding.sha256
+    )
+    return {
+        "policy_snapshot_lineage_proven": policy_lineage,
+        "selected_action_lineage_proven": selected_action_lineage,
+        "decision_lineage_proven": decision_lineage,
+        "execution_intent_lineage_proven": bool(
+            result.promoted
+            and intent
+            and decision_lineage
+            and policy_lineage
+            and selected_action_lineage
+        ),
+    }
 
 
 def canonical_decision_candidate_refusal_artifact_json(


### PR DESCRIPTION
### Motivation

- Ensure `ExecutionIntent` lineage is derived from an independently verified Canonical Decision Artifact (CDA), rather than caller-supplied decision or policy lineage.
- Bind a promotable structured `DecisionCandidate` to the exact decision-selected `chosen` value, while preserving legacy CDA-v1 hashes when the new optional evidence is absent.
- Prevent caller overrides, stale policy provenance, and selected-action substitution during verified promotion.

### Description

- Added `CanonicalSelectedActionEvidence` and `CanonicalPolicySnapshotEvidence` to the CDA decision projection as optional evidence.
- Legacy CDA-v1 serialization remains stable when those fields are unavailable: the model serializer omits only the new optional evidence fields; the existing preimage does not globally drop historical `None` fields.
- Selected-action evidence now records both the normalized `DecisionCandidate` hash and a binding to the exact `DecideResponse.chosen` value. This permits presentation metadata on a selected option without weakening the exact chosen-value binding.
- Policy snapshot evidence is projected from the decision pipeline governance identity and verified promotion derives `policy_snapshot_id` / `policy_lineage` from that CDA evidence.
- `try_promote_verified_canonical_decision_candidate_to_execution_intent` independently verifies the CDA, rejects caller policy-lineage overrides, rejects mismatching/stale policy snapshots, and rejects missing or mismatching selected-action evidence.
- The Decision-to-external-Bind PoC now submits the synthetic structured execution candidate through the authenticated `POST /v1/decide` input, promotes the actual selected `response.chosen`, and carries the CDA-derived policy snapshot digest into AuthorityEvidence and `RuntimeAuthorityValidator` instead of using a post-hoc candidate or a fixed synthetic policy ID.
- No Real Bind Authorization or authorization-consumption claim is added; the external effect remains synthetic/local and production credentials are not used.

### Testing / CI

- Focused canonical promotion coverage includes successful verified promotion, foreign/stale policy rejection, selected-action substitution rejection, missing evidence, and policy-lineage override refusal.
- The prior legacy CDA-v1 hash regressions are fixed on this branch.
- Fresh CI is running on the current head; merge should wait for the required Python 3.11 and 3.12 full-test jobs to complete successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8d7d1ce3a88326a41fdb4b93a81741)