### PR TITLE
Add Ed25519 human-approval signing backend, verifier, and tests

### DIFF
--- a/tests/governance/test_human_approval_receipt_signing.py
+++ b/tests/governance/test_human_approval_receipt_signing.py
@@ -1,0 +1,261 @@
+"""Tests for production Ed25519 Human Approval verification."""
+
+from __future__ import annotations
+
+import base64
+from copy import deepcopy
+from datetime import UTC, datetime
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from veritas_os.governance.human_approval_receipt import (
+    ApprovedHumanApprovalVerifier,
+    HumanApprovalReceipt,
+    HumanApprovalSignerPolicy,
+    HumanApprovalVerifierPolicy,
+    VerifiedHumanApprovalReceipt,
+    verify_human_approval_receipt_artifact_to_proof,
+)
+from veritas_os.governance.human_approval_receipt_signing import (
+    TrustedEd25519HumanApprovalVerifier,
+    human_approval_signature_payload,
+)
+
+NOW = datetime(2026, 5, 10, tzinfo=UTC)
+KEY_ID = "approval-key-1"
+IDENTITY = "operator:approver-1"
+ROLE = "risk_manager"
+
+
+def _receipt() -> HumanApprovalReceipt:
+    return HumanApprovalReceipt(
+        approval_receipt_id="har-001",
+        decision_id="decision-001",
+        execution_intent_id="intent-001",
+        approver_identity=IDENTITY,
+        approver_role=ROLE,
+        approved_action_class="wire_transfer",
+        approved_scope=["ledger:debit"],
+        approval_basis_refs=["policy:wire:v1"],
+        approved_at="2026-05-01T00:00:00+00:00",
+        expires_at="2026-06-01T00:00:00+00:00",
+        policy_snapshot_id="policy-001",
+        authority_evidence_id="aev-001",
+        approval_result="approved",
+        signature_verified=False,
+        receipt_hash="",
+        metadata={"purpose": "test"},
+    )
+
+
+def _verifier(
+    private_key: Ed25519PrivateKey,
+    **overrides: object,
+) -> TrustedEd25519HumanApprovalVerifier:
+    values = {
+        "trusted_public_keys": {
+            KEY_ID: private_key.public_key().public_bytes_raw()
+        },
+        "trusted_signer_identities": {KEY_ID: IDENTITY},
+        "trusted_signer_roles": {KEY_ID: ROLE},
+        "verifier_id": "trusted-human-approval-verifier",
+    }
+    values.update(overrides)
+    return TrustedEd25519HumanApprovalVerifier(**values)  # type: ignore[arg-type]
+
+
+def _artifact(private_key: Ed25519PrivateKey) -> dict[str, object]:
+    receipt_payload = _receipt().to_dict_for_hash()
+    receipt_payload["signature_verified"] = True
+    digest_payload = dict(receipt_payload)
+    digest_payload["signature_verified"] = False
+    digest_payload["receipt_hash"] = ""
+    receipt_hash = HumanApprovalReceipt(**digest_payload).deterministic_digest()
+    artifact: dict[str, object] = {
+        "artifact_type": "human_approval_receipt",
+        "artifact_version": "v1",
+        "receipt": receipt_payload,
+        "receipt_hash": receipt_hash,
+        "signer": {
+            "key_id": KEY_ID,
+            "algorithm": "Ed25519",
+            "identity": IDENTITY,
+            "role": ROLE,
+        },
+        "signed_at": "2026-05-01T00:00:00+00:00",
+    }
+    artifact["signature"] = base64.urlsafe_b64encode(
+        private_key.sign(human_approval_signature_payload(artifact).encode())
+    ).decode("ascii")
+    return artifact
+
+
+def _signer_policy(**overrides: object) -> HumanApprovalSignerPolicy:
+    values = {
+        "policy_id": "approval-signers-v1",
+        "allowed_key_ids": [KEY_ID],
+        "allowed_algorithms": ["Ed25519"],
+        "required_signer_identities": [IDENTITY],
+        "required_signer_roles": [ROLE],
+        "allowed_action_classes": ["wire_transfer"],
+        "allowed_policy_snapshot_ids": ["policy-001"],
+    }
+    values.update(overrides)
+    return HumanApprovalSignerPolicy(**values)  # type: ignore[arg-type]
+
+
+def _verifier_policy(
+    verifier: TrustedEd25519HumanApprovalVerifier,
+    **overrides: object,
+) -> HumanApprovalVerifierPolicy:
+    values = {
+        "verifier_id": verifier.verifier_id,
+        "trust_level": "production",
+        "verifier_key_id": KEY_ID,
+        "policy_id": verifier.verifier_policy_id,
+        "policy_hash": verifier.policy_hash(),
+    }
+    values.update(overrides)
+    return HumanApprovalVerifierPolicy(
+        [ApprovedHumanApprovalVerifier(**values)]  # type: ignore[arg-type]
+    )
+
+
+def _proof(
+    artifact: dict[str, object],
+    verifier: TrustedEd25519HumanApprovalVerifier,
+    *,
+    signer_policy: HumanApprovalSignerPolicy | None = None,
+    verifier_policy: HumanApprovalVerifierPolicy | None = None,
+) -> VerifiedHumanApprovalReceipt:
+    return verify_human_approval_receipt_artifact_to_proof(
+        artifact,  # type: ignore[arg-type]
+        verifier.verify,
+        requested_scope=["ledger:debit"],
+        action_class="wire_transfer",
+        policy_snapshot_id="policy-001",
+        now=NOW,
+        signer_policy=signer_policy or _signer_policy(),
+        verifier_policy=verifier_policy or _verifier_policy(verifier),
+        require_structured_signature_result=True,
+        require_production_verifier=True,
+    )
+
+
+def test_trusted_ed25519_verifier_produces_existing_verified_proof() -> None:
+    private_key = Ed25519PrivateKey.generate()
+    verifier = _verifier(private_key)
+
+    proof = _proof(_artifact(private_key), verifier)
+
+    assert proof.signer_identity == IDENTITY
+    assert proof.signer_role == ROLE
+    assert proof.signer_algorithm == "Ed25519"
+    assert proof.verifier_policy_hash == verifier.policy_hash()
+    assert proof.receipt.signature_verified is True
+
+
+@pytest.mark.parametrize(
+    ("mutation", "reason"),
+    [
+        ("invalid_signature", "invalid_signature"),
+        ("unknown_key", "untrusted_key"),
+        ("unsupported_algorithm", "unsupported_algorithm"),
+        ("malformed_base64", "malformed_signature"),
+        ("missing_signature", "missing_signature"),
+        ("malformed_envelope", "malformed_envelope"),
+    ],
+)
+def test_verifier_fails_closed_for_untrusted_envelopes(
+    mutation: str,
+    reason: str,
+) -> None:
+    private_key = Ed25519PrivateKey.generate()
+    verifier = _verifier(private_key)
+    artifact = _artifact(private_key)
+    if mutation == "invalid_signature":
+        artifact["signature"] = base64.urlsafe_b64encode(b"x" * 64).decode()
+    elif mutation == "unknown_key":
+        artifact["signer"]["key_id"] = "foreign"  # type: ignore[index]
+    elif mutation == "unsupported_algorithm":
+        artifact["signer"]["algorithm"] = "RSA"  # type: ignore[index]
+    elif mutation == "malformed_base64":
+        artifact["signature"] = "%%%"
+    elif mutation == "missing_signature":
+        artifact.pop("signature")
+    else:
+        artifact["receipt"] = "not-an-object"
+
+    result = verifier.verify(artifact)  # type: ignore[arg-type]
+
+    assert result.verified is False
+    assert result.reason == reason
+
+
+def test_malformed_trusted_public_key_fails_closed() -> None:
+    private_key = Ed25519PrivateKey.generate()
+    verifier = _verifier(private_key, trusted_public_keys={KEY_ID: b"short"})
+
+    result = verifier.verify(_artifact(private_key))
+
+    assert result.verified is False
+    assert result.reason == "malformed_signature"
+
+
+@pytest.mark.parametrize("field", ["identity", "role"])
+def test_artifact_signer_metadata_cannot_override_trusted_mapping(field: str) -> None:
+    private_key = Ed25519PrivateKey.generate()
+    verifier = _verifier(private_key)
+    artifact = _artifact(private_key)
+    artifact["signer"][field] = "foreign"  # type: ignore[index]
+    artifact["signature"] = base64.urlsafe_b64encode(
+        private_key.sign(human_approval_signature_payload(artifact).encode())
+    ).decode()
+
+    with pytest.raises(ValueError, match=f"signer_{field}_mismatch"):
+        _proof(artifact, verifier)
+
+
+def test_tampered_receipt_is_rejected() -> None:
+    private_key = Ed25519PrivateKey.generate()
+    verifier = _verifier(private_key)
+    artifact = deepcopy(_artifact(private_key))
+    artifact["receipt"]["approved_scope"] = ["ledger:admin"]  # type: ignore[index]
+
+    with pytest.raises(ValueError, match="receipt_hash_mismatch"):
+        _proof(artifact, verifier)
+
+
+@pytest.mark.parametrize(
+    ("policy_kind", "overrides", "reason"),
+    [
+        ("signer", {"allowed_key_ids": ["foreign"]}, "signer_key_not_allowed"),
+        ("signer", {"required_signer_identities": ["foreign"]}, "signer_identity_not_allowed"),
+        ("signer", {"required_signer_roles": ["foreign"]}, "signer_role_not_allowed"),
+        ("verifier", {"verifier_id": "foreign"}, "verifier_not_allowed"),
+        ("verifier", {"policy_id": "foreign"}, "verifier_policy_id_mismatch"),
+        ("verifier", {"policy_hash": "0" * 64}, "verifier_policy_hash_mismatch"),
+    ],
+)
+def test_existing_policies_reject_untrusted_signer_or_verifier(
+    policy_kind: str,
+    overrides: dict[str, object],
+    reason: str,
+) -> None:
+    private_key = Ed25519PrivateKey.generate()
+    verifier = _verifier(private_key)
+    signer_policy = _signer_policy(**overrides) if policy_kind == "signer" else None
+    verifier_policy = (
+        _verifier_policy(verifier, **overrides)
+        if policy_kind == "verifier"
+        else None
+    )
+
+    with pytest.raises(ValueError, match=reason):
+        _proof(
+            _artifact(private_key),
+            verifier,
+            signer_policy=signer_policy,
+            verifier_policy=verifier_policy,
+        )

--- a/tests/governance/test_human_approval_receipt_signing.py
+++ b/tests/governance/test_human_approval_receipt_signing.py
@@ -152,6 +152,7 @@ def test_trusted_ed25519_verifier_produces_existing_verified_proof() -> None:
     assert proof.signer_identity == IDENTITY
     assert proof.signer_role == ROLE
     assert proof.signer_algorithm == "Ed25519"
+    assert proof.verifier_key_id == KEY_ID
     assert proof.verifier_policy_hash == verifier.policy_hash()
     assert proof.receipt.signature_verified is True
 

--- a/veritas_os/governance/human_approval_receipt.py
+++ b/veritas_os/governance/human_approval_receipt.py
@@ -558,9 +558,16 @@ def _validate_production_verifier_policy(
         and result.verifier_key_id != approved.verifier_key_id
     ):
         raise ValueError("human_approval_verifier_key_mismatch")
-    if approved.policy_hash is not None and result.verifier_policy_hash is not None:
-        if result.verifier_policy_hash != approved.policy_hash:
-            raise ValueError("human_approval_verifier_policy_hash_mismatch")
+    if (
+        approved.policy_id is not None
+        and result.verifier_policy_id != approved.policy_id
+    ):
+        raise ValueError("human_approval_verifier_policy_id_mismatch")
+    if (
+        approved.policy_hash is not None
+        and result.verifier_policy_hash != approved.policy_hash
+    ):
+        raise ValueError("human_approval_verifier_policy_hash_mismatch")
 
 
 def _validate_signer_policy(

--- a/veritas_os/governance/human_approval_receipt_signing.py
+++ b/veritas_os/governance/human_approval_receipt_signing.py
@@ -1,0 +1,158 @@
+"""Ed25519 signing preimage and trusted Human Approval verification backend."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+from dataclasses import dataclass
+from typing import Any
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+from veritas_os.governance.human_approval_receipt import (
+    HumanApprovalSignatureVerificationResult,
+)
+from veritas_os.security.hash import canonical_json_dumps, sha256_of_canonical_json
+
+SIGNATURE_DOMAIN = "VERITAS:human-approval-receipt:ed25519:v1"
+
+
+def human_approval_signature_payload(artifact: dict[str, Any]) -> str:
+    """Return the canonical, security-relevant Human Approval envelope.
+
+    Verifier-derived fields are deliberately excluded. The signed envelope
+    binds the immutable artifact identity, exact receipt, receipt hash, signer
+    declarations, and signing time without creating another receipt model.
+    """
+    if not isinstance(artifact, dict):
+        raise ValueError("human_approval_signature_envelope_invalid")
+    signer = artifact.get("signer")
+    receipt = artifact.get("receipt")
+    if not isinstance(signer, dict) or not isinstance(receipt, dict):
+        raise ValueError("human_approval_signature_envelope_invalid")
+    required = (
+        "artifact_type",
+        "artifact_version",
+        "receipt_hash",
+        "signed_at",
+    )
+    if any(not isinstance(artifact.get(field), str) for field in required):
+        raise ValueError("human_approval_signature_envelope_invalid")
+    return canonical_json_dumps(
+        {
+            "domain": SIGNATURE_DOMAIN,
+            "artifact_type": artifact["artifact_type"],
+            "artifact_version": artifact["artifact_version"],
+            "receipt_hash": artifact["receipt_hash"],
+            "receipt": receipt,
+            "signer": signer,
+            "signed_at": artifact["signed_at"],
+        }
+    )
+
+
+@dataclass(frozen=True)
+class TrustedEd25519HumanApprovalVerifier:
+    """Verify Human Approval signatures against deployment-controlled trust."""
+
+    trusted_public_keys: dict[str, bytes]
+    trusted_signer_identities: dict[str, str]
+    trusted_signer_roles: dict[str, str]
+    verifier_id: str
+    trust_level: str = "production"
+    verifier_policy_id: str = "human-approval-ed25519-verifier-v1"
+
+    def policy_hash(self) -> str:
+        """Return a stable identity for keys and trusted signer mappings."""
+        keys = [
+            {
+                "key_id": key_id,
+                "public_key_sha256": hashlib.sha256(
+                    self.trusted_public_keys[key_id]
+                ).hexdigest(),
+                "signer_identity": self.trusted_signer_identities.get(key_id),
+                "signer_role": self.trusted_signer_roles.get(key_id),
+            }
+            for key_id in sorted(self.trusted_public_keys)
+        ]
+        return sha256_of_canonical_json(
+            {
+                "id": self.verifier_policy_id,
+                "algorithm": "Ed25519",
+                "domain": "human-approval-ed25519-verifier",
+                "version": "v1",
+                "verifier_id": self.verifier_id,
+                "trust_level": self.trust_level,
+                "keys": keys,
+            }
+        )
+
+    def verify(
+        self,
+        artifact: dict[str, Any],
+    ) -> HumanApprovalSignatureVerificationResult:
+        """Cryptographically verify the envelope and return trusted metadata."""
+        if not isinstance(artifact, dict):
+            return self._failure("malformed_envelope")
+        signer = artifact.get("signer")
+        if not isinstance(signer, dict):
+            return self._failure("malformed_envelope")
+        key_id = signer.get("key_id")
+        algorithm = signer.get("algorithm")
+        if not isinstance(key_id, str) or not key_id:
+            return self._failure("untrusted_key")
+        if algorithm != "Ed25519":
+            return self._failure("unsupported_algorithm")
+        key = self.trusted_public_keys.get(key_id)
+        identity = self.trusted_signer_identities.get(key_id)
+        role = self.trusted_signer_roles.get(key_id)
+        if key is None or identity is None or role is None:
+            return self._failure("untrusted_key")
+        signature_value = artifact.get("signature")
+        if not isinstance(signature_value, str) or not signature_value:
+            return self._failure("missing_signature")
+        try:
+            signature = base64.b64decode(
+                signature_value.encode("ascii"), altchars=b"-_", validate=True
+            )
+            public_key = Ed25519PublicKey.from_public_bytes(key)
+            public_key.verify(
+                signature,
+                human_approval_signature_payload(artifact).encode("utf-8"),
+            )
+        except (ValueError, TypeError, UnicodeEncodeError, binascii.Error):
+            return self._failure("malformed_signature")
+        except InvalidSignature:
+            return self._failure("invalid_signature")
+        return HumanApprovalSignatureVerificationResult(
+            verified=True,
+            key_id=key_id,
+            algorithm="Ed25519",
+            signer_identity=identity,
+            signer_role=role,
+            reason="signature_valid",
+            verifier_trust_level=self.trust_level,
+            verifier_id=self.verifier_id,
+            verifier_key_id=key_id,
+            verifier_policy_id=self.verifier_policy_id,
+            verifier_policy_hash=self.policy_hash(),
+        )
+
+    def _failure(self, reason: str) -> HumanApprovalSignatureVerificationResult:
+        """Return a non-verifying result without trusting artifact metadata."""
+        return HumanApprovalSignatureVerificationResult(
+            verified=False,
+            reason=reason,
+            verifier_trust_level=self.trust_level,
+            verifier_id=self.verifier_id,
+            verifier_policy_id=self.verifier_policy_id,
+            verifier_policy_hash=self.policy_hash(),
+        )
+
+
+__all__ = [
+    "TrustedEd25519HumanApprovalVerifier",
+    "human_approval_signature_payload",
+]

--- a/veritas_os/governance/human_approval_receipt_signing.py
+++ b/veritas_os/governance/human_approval_receipt_signing.py
@@ -114,14 +114,15 @@ class TrustedEd25519HumanApprovalVerifier:
         if not isinstance(signature_value, str) or not signature_value:
             return self._failure("missing_signature")
         try:
+            payload = human_approval_signature_payload(artifact).encode("utf-8")
+        except (ValueError, TypeError):
+            return self._failure("malformed_envelope")
+        try:
             signature = base64.b64decode(
                 signature_value.encode("ascii"), altchars=b"-_", validate=True
             )
             public_key = Ed25519PublicKey.from_public_bytes(key)
-            public_key.verify(
-                signature,
-                human_approval_signature_payload(artifact).encode("utf-8"),
-            )
+            public_key.verify(signature, payload)
         except (ValueError, TypeError, UnicodeEncodeError, binascii.Error):
             return self._failure("malformed_signature")
         except InvalidSignature:

--- a/veritas_os/tests/test_live_adapter_bind_authorization.py
+++ b/veritas_os/tests/test_live_adapter_bind_authorization.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import base64
-import hashlib
 from copy import deepcopy
 from dataclasses import dataclass
 from datetime import timedelta
@@ -11,11 +10,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from cryptography.exceptions import InvalidSignature
-from cryptography.hazmat.primitives.asymmetric.ed25519 import (
-    Ed25519PrivateKey,
-    Ed25519PublicKey,
-)
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
 from veritas_os.governance.action_contracts import ActionClassContract
 from veritas_os.governance.authority_evidence import (
@@ -34,9 +29,12 @@ from veritas_os.governance.authority_evidence_signing import (
 from veritas_os.governance.human_approval_receipt import (
     ApprovedHumanApprovalVerifier,
     HumanApprovalReceipt,
-    HumanApprovalSignatureVerificationResult,
     HumanApprovalSignerPolicy,
     HumanApprovalVerifierPolicy,
+)
+from veritas_os.governance.human_approval_receipt_signing import (
+    TrustedEd25519HumanApprovalVerifier,
+    human_approval_signature_payload,
 )
 from veritas_os.policy.live_adapter_bind_authorization import (
     ACKNOWLEDGEMENTS,
@@ -61,7 +59,7 @@ from veritas_os.policy.live_adapter_bind_authorization import (
 from veritas_os.policy.live_adapter_bind_authorization_signing import (
     TrustedEd25519BindAuthorizationVerifier,
 )
-from veritas_os.security.hash import canonical_json_dumps, sha256_of_canonical_json
+from veritas_os.security.hash import sha256_of_canonical_json
 from veritas_os.tests.test_live_adapter_dry_run_bind_authorization_gate_review import (
     RECORDED_AT as SOURCE_RECORDED_AT,
     _decision as gate_decision,
@@ -100,80 +98,6 @@ class _Ed25519Signer:
 
     def sign(self, payload: bytes) -> bytes:
         return self.private_key.sign(payload)
-
-
-def _human_approval_signature_payload(artifact: dict[str, Any]) -> str:
-    return canonical_json_dumps(
-        {
-            "domain": "VERITAS:test-human-approval-ed25519:v1:",
-            "artifact_type": artifact.get("artifact_type"),
-            "artifact_version": artifact.get("artifact_version"),
-            "receipt_hash": artifact.get("receipt_hash"),
-            "receipt": artifact.get("receipt"),
-            "signer": artifact.get("signer"),
-            "signed_at": artifact.get("signed_at"),
-        }
-    )
-
-
-class _Ed25519HumanApprovalVerifier:
-    production_verifier = True
-
-    def __init__(
-        self,
-        *,
-        public_key: bytes,
-        key_id: str,
-        signer_identity: str,
-        signer_role: str,
-    ) -> None:
-        self.public_key = public_key
-        self.key_id = key_id
-        self.signer_identity = signer_identity
-        self.signer_role = signer_role
-        self.verifier_id = "human-approval-ed25519-verifier"
-        self.verifier_key_id = key_id
-        self.verifier_policy_id = "human-approval-ed25519-policy-v1"
-        self.verifier_trust_level = "production"
-
-    def policy_hash(self) -> str:
-        return sha256_of_canonical_json(
-            {
-                "id": self.verifier_policy_id,
-                "algorithm": "Ed25519",
-                "domain": "human-approval-test-verifier",
-                "version": "v1",
-                "verifier_id": self.verifier_id,
-                "public_key_sha256": hashlib.sha256(self.public_key).hexdigest(),
-                "signer_identity": self.signer_identity,
-                "signer_role": self.signer_role,
-            }
-        )
-
-    def verify(self, artifact: dict[str, Any]) -> HumanApprovalSignatureVerificationResult:
-        try:
-            signature = base64.urlsafe_b64decode(str(artifact.get("signature", "")))
-            Ed25519PublicKey.from_public_bytes(self.public_key).verify(
-                signature,
-                _human_approval_signature_payload(artifact).encode("utf-8"),
-            )
-        except (ValueError, TypeError, InvalidSignature):
-            return HumanApprovalSignatureVerificationResult(
-                verified=False, reason="bad_signature"
-            )
-        return HumanApprovalSignatureVerificationResult(
-            verified=True,
-            key_id=self.key_id,
-            algorithm="Ed25519",
-            signer_identity=self.signer_identity,
-            signer_role=self.signer_role,
-            reason="signature_valid",
-            verifier_trust_level="production",
-            verifier_id=self.verifier_id,
-            verifier_key_id=self.verifier_key_id,
-            verifier_policy_id=self.verifier_policy_id,
-            verifier_policy_hash=self.policy_hash(),
-        )
 
 
 def _contract(*, human_required: bool = False, required_evidence: list[str] | None = None):
@@ -345,13 +269,16 @@ def _signed_human_approval(contract: ActionClassContract):
         "signed_at": SOURCE_RECORDED_AT.isoformat(),
     }
     artifact["signature"] = base64.urlsafe_b64encode(
-        private_key.sign(_human_approval_signature_payload(artifact).encode("utf-8"))
+        private_key.sign(human_approval_signature_payload(artifact).encode("utf-8"))
     ).decode("ascii")
-    verifier = _Ed25519HumanApprovalVerifier(
-        public_key=public_key,
-        key_id="human-approval-key",
-        signer_identity=ref["approver_id"],
-        signer_role=ref["approver_role"],
+    verifier = TrustedEd25519HumanApprovalVerifier(
+        trusted_public_keys={"human-approval-key": public_key},
+        trusted_signer_identities={
+            "human-approval-key": ref["approver_id"]
+        },
+        trusted_signer_roles={"human-approval-key": ref["approver_role"]},
+        verifier_id="human-approval-ed25519-verifier",
+        verifier_policy_id="human-approval-ed25519-policy-v1",
     )
     signer_policy = HumanApprovalSignerPolicy(
         policy_id="human-approval-signer-policy",

--- a/veritas_os/tests/test_live_adapter_bind_authorization.py
+++ b/veritas_os/tests/test_live_adapter_bind_authorization.py
@@ -221,6 +221,7 @@ def _authority_bundle(contract: ActionClassContract):
 
 def _signed_human_approval(contract: ActionClassContract):
     source = source_packet()
+    approval_key_id = "human-approval-key"
     ref = source.human_approval_reference_bundle["human_approval_references"][0]
     authority_ref = source.authority_evidence_reference_bundle[
         "authority_evidence_references"
@@ -261,7 +262,7 @@ def _signed_human_approval(contract: ActionClassContract):
         "receipt": receipt_payload,
         "receipt_hash": expected_hash,
         "signer": {
-            "key_id": "human-approval-key",
+            "key_id": approval_key_id,
             "algorithm": "Ed25519",
             "identity": ref["approver_id"],
             "role": ref["approver_role"],
@@ -272,17 +273,17 @@ def _signed_human_approval(contract: ActionClassContract):
         private_key.sign(human_approval_signature_payload(artifact).encode("utf-8"))
     ).decode("ascii")
     verifier = TrustedEd25519HumanApprovalVerifier(
-        trusted_public_keys={"human-approval-key": public_key},
+        trusted_public_keys={approval_key_id: public_key},
         trusted_signer_identities={
-            "human-approval-key": ref["approver_id"]
+            approval_key_id: ref["approver_id"]
         },
-        trusted_signer_roles={"human-approval-key": ref["approver_role"]},
+        trusted_signer_roles={approval_key_id: ref["approver_role"]},
         verifier_id="human-approval-ed25519-verifier",
         verifier_policy_id="human-approval-ed25519-policy-v1",
     )
     signer_policy = HumanApprovalSignerPolicy(
         policy_id="human-approval-signer-policy",
-        allowed_key_ids=["human-approval-key"],
+        allowed_key_ids=[approval_key_id],
         allowed_algorithms=["Ed25519"],
         required_signer_roles=[ref["approver_role"]],
         required_signer_identities=[ref["approver_id"]],
@@ -294,7 +295,7 @@ def _signed_human_approval(contract: ActionClassContract):
             ApprovedHumanApprovalVerifier(
                 verifier_id=verifier.verifier_id,
                 trust_level="production",
-                verifier_key_id=verifier.verifier_key_id,
+                verifier_key_id=approval_key_id,
                 policy_id=verifier.verifier_policy_id,
                 policy_hash=verifier.policy_hash(),
             )


### PR DESCRIPTION
### Motivation
- Centralize and standardize Ed25519 signing preimage and trusted verifier logic for Human Approval receipts to enable consistent, deployment-controlled verification.

### Description
- Add `veritas_os/governance/human_approval_receipt_signing.py` which implements `human_approval_signature_payload` and `TrustedEd25519HumanApprovalVerifier` with a stable `policy_hash()` and robust envelope/signature validation.
- Tighten production verifier validation in `veritas_os/governance/human_approval_receipt.py` to explicitly verify `verifier_policy_id` before checking `verifier_policy_hash`, and raise clearer mismatch errors.
- Add comprehensive unit tests in `tests/governance/test_human_approval_receipt_signing.py` exercising valid verification, various failure modes, signer/verifier policy checks, and receipt tampering detection.
- Update `veritas_os/tests/test_live_adapter_bind_authorization.py` to use the new verifier and signing helpers and remove duplicated test verifier code and helpers.

### Testing
- Ran `pytest tests/governance/test_human_approval_receipt_signing.py` which exercises the new verifier behavior and signature envelope validation, and it passed.
- Ran `pytest veritas_os/tests/test_live_adapter_bind_authorization.py` after updating imports to use the new signing/verifier utilities, and it passed.
- Ran the updated unit test suite for the modified governance files (`pytest`), and the affected tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8e3eecd7a4832686ff2f77c90ad0e8)