### PR TITLE
docs(proof): stop real Decision→Effect E2E and record reconciliation verifier blocker

### DIFF
--- a/artifacts/real-decision-to-effect-e2e/STOP.md
+++ b/artifacts/real-decision-to-effect-e2e/STOP.md
@@ -1,0 +1,64 @@
+# Real Decision-to-Effect E2E — Stop Report
+
+## Status
+
+The controlled real Decision-to-Effect E2E proof is **stopped** at base commit
+`e039496cefad9793f342f261940e4009806e5859` (merge commit for PR #2142).
+No passing `report.json` has been produced.
+
+## Missing production prerequisite
+
+The reconciliation boundary exposes only the
+`ReconciliationEvidenceVerifier` protocol. The repository has no reusable,
+non-test implementation that independently observes and authenticates an
+external acknowledgement before producing `VerifiedReconciliationEvidence`.
+
+`reconcile_effect_unknown(...)` accepts a verifier implementing that protocol,
+but it cannot itself establish that:
+
+- the acknowledgement came from the authorization-bound TLS endpoint;
+- the acknowledgement digest equals `external_ack_digest`;
+- the observation digest is derived from the independently retrieved response;
+- the external operation reference in the response matches the evidence; or
+- a deployment-controlled verifier policy approved the observation source.
+
+The existing controlled TLS runner fills this gap with the private
+`_HttpsReconciliationVerifier`. That runner-local implementation directly
+constructs `VerifiedReconciliationEvidence`; it is not a production verifier
+primitive and does not validate the evidence's acknowledgement or observation
+digests against the retrieved acknowledgement. Unit tests similarly use a
+private `_Verifier` that returns a verified object without external
+observation.
+
+Promoting either private implementation into the requested E2E would violate
+the requirements prohibiting test-only reconciliation trust and fake or
+mismatched acknowledgement acceptance.
+
+## Smallest prerequisite PR
+
+Add one production reconciliation verifier, with focused fail-closed tests,
+that:
+
+1. accepts deployment-controlled HTTPS endpoint trust and verifier-policy
+   configuration;
+2. performs certificate-validated, independent acknowledgement retrieval;
+3. canonicalizes the retrieved acknowledgement and verifies
+   `external_ack_digest` and `observation_digest`;
+4. binds operation, authorization, consumption, external reference, source,
+   and observation time;
+5. returns `VerifiedReconciliationEvidence` only after every binding passes;
+6. rejects endpoint substitution, malformed responses, mismatched digests,
+   mismatched operation references, and unapproved verifier policy; and
+7. never accepts bearer material through an artifact or emits it in evidence.
+
+After that prerequisite merges, the Decision-to-Effect composition can use
+the production verifier through `reconcile_effect_unknown(...)` and can
+legitimately derive `reconciliation_evidence_verified`,
+`terminal_effect_confirmed`, and the final E2E conjunction.
+
+## Security warning
+
+Claiming `CONFIRMED_EFFECT` with the current runner-local verifier would allow
+an acknowledgement/evidence digest mismatch to cross the reconciliation trust
+boundary. The final E2E claim must remain false until the missing verifier is
+implemented and independently tested.


### PR DESCRIPTION
### Motivation

- The Decision-to-Effect composition cannot be completed without a production-grade reconciliation verifier that independently retrieves and cryptographically validates external acknowledgements; the existing runner-local and test helpers are test-only and cannot be promoted.
- Rather than fabricate a passing machine-readable proof, record the STOP condition and the exact missing production prerequisite so reviewers can merge the smallest safe follow-up PR.
- Preserve security invariants by refusing to assert `CONFIRMED_EFFECT` or set any final proof booleans until the missing verifier is implemented and tested.

### Description

- Add `artifacts/real-decision-to-effect-e2e/STOP.md` that documents the blocker, explains why the private `_HttpsReconciliationVerifier` and test `_Verifier` are insufficient, and proposes the smallest production reconciliation verifier workitem and fail-closed tests.
- The document lists the exact verification properties required (certificate-validated acknowledgement retrieval, canonicalisation and digest checks, operation/authorization/consumption binding, verifier policy enforcement, and rejection modes).
- Include a clear security warning that claiming `CONFIRMED_EFFECT` with the current private verifiers would cross the reconciliation trust boundary and produce an unsafe proof.

### Testing

- Confirmed repository state includes the required post-#2142 baseline (PR #2142 merge is present) prior to making changes.
- Attempted focused test collection with `pytest` for reconciliation tests, but test collection failed due to missing runtime dependency (`pydantic`) in the environment (automated test run could not complete); this prevented end-to-end test execution in the current sandbox.
- Ran automated repository checks that completed: the bare-except security script succeeded, and `git diff --check` reported no whitespace/patch issues; those checks passed on the local change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8e6e15b2d483269908cbbbb90b8113)