### PR TITLE
feat(governance): add trusted HTTPS reconciliation verifier

### DIFF
--- a/scripts/run_secure_real_bind_runtime_poc.py
+++ b/scripts/run_secure_real_bind_runtime_poc.py
@@ -180,12 +180,14 @@ class _HttpsEffectAdapter(BindAdapterContract):
         authorization_header: ConstructedAuthorizationHeader,
         ca_file: str,
         external_operation_reference: str,
+        authorization_id: str,
         expected_fingerprint: str | None,
     ) -> None:
         self.base_url = base_url
         self.authorization_header = authorization_header
         self.ca_file = ca_file
         self.external_operation_reference = external_operation_reference
+        self.authorization_id = authorization_id
         self.expected_fingerprint = expected_fingerprint
         self.last_ack: dict[str, Any] | None = None
 
@@ -216,7 +218,10 @@ class _HttpsEffectAdapter(BindAdapterContract):
     def apply(self, intent: ExecutionIntent, snapshot: Any) -> bool:
         del intent, snapshot
         body = json.dumps(
-            {"operation_id": self.external_operation_reference},
+            {
+                "external_operation_reference": self.external_operation_reference,
+                "authorization_id": self.authorization_id,
+            },
             sort_keys=True,
             separators=(",", ":"),
         ).encode("utf-8")
@@ -263,6 +268,7 @@ class _HttpsFactory:
             authorization_header=authorization_header,
             ca_file=self.ca_file,
             external_operation_reference=authorization.idempotency_key,
+            authorization_id=authorization.live_adapter_bind_authorization_id,
             expected_fingerprint=authorization.execution_intent.get(
                 "expected_state_fingerprint"
             ),
@@ -297,7 +303,7 @@ class _HttpsReconciliationVerifier:
         )
         with request.urlopen(req, context=context, timeout=10) as response:  # noqa: S310
             ack = json.loads(response.read().decode("utf-8"))
-        if ack.get("operation_id") != self.external_operation_reference:
+        if ack.get("external_operation_reference") != self.external_operation_reference:
             raise RuntimeError("ack operation mismatch")
         if ack.get("status") != "committed":
             raise RuntimeError("ack is not committed")

--- a/scripts/secure_e2e_https_fixture.py
+++ b/scripts/secure_e2e_https_fixture.py
@@ -48,20 +48,28 @@ class _Handler(BaseHTTPRequestHandler):
         try:
             length = int(self.headers.get("Content-Length", "0"))
             payload = json.loads(self.rfile.read(length) or b"{}")
-            operation_id = str(payload["operation_id"])
+            external_operation_reference = str(payload["external_operation_reference"])
+            authorization_id = str(payload["authorization_id"])
         except (ValueError, KeyError, TypeError, json.JSONDecodeError):
             self._json(400, {"error": "invalid_payload"})
             return
         with self.state.lock:
-            if operation_id in self.state.effects:
-                self._json(409, {"error": "duplicate_operation", "operation_id": operation_id})
+            if external_operation_reference in self.state.effects:
+                self._json(
+                    409,
+                    {
+                        "error": "duplicate_operation",
+                        "external_operation_reference": external_operation_reference,
+                    },
+                )
                 return
             effect = {
-                "operation_id": operation_id,
+                "external_operation_reference": external_operation_reference,
                 "status": "committed",
-                "effect_count": len(self.state.effects) + 1,
+                "source_identity": "api.example.invalid",
+                "authorization_id": authorization_id,
             }
-            self.state.effects[operation_id] = effect
+            self.state.effects[external_operation_reference] = effect
         self._json(201, effect)
 
     def do_GET(self) -> None:  # noqa: N802
@@ -73,11 +81,17 @@ class _Handler(BaseHTTPRequestHandler):
         if not parsed.path.startswith(prefix):
             self._json(404, {"error": "not_found"})
             return
-        operation_id = parsed.path[len(prefix):]
+        external_operation_reference = parsed.path[len(prefix) :]
         with self.state.lock:
-            effect = self.state.effects.get(operation_id)
+            effect = self.state.effects.get(external_operation_reference)
         if effect is None:
-            self._json(404, {"error": "effect_not_found", "operation_id": operation_id})
+            self._json(
+                404,
+                {
+                    "error": "effect_not_found",
+                    "external_operation_reference": external_operation_reference,
+                },
+            )
             return
         self._json(200, effect)
 

--- a/tests/policy/test_trusted_https_reconciliation.py
+++ b/tests/policy/test_trusted_https_reconciliation.py
@@ -1,0 +1,323 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+import pytest
+
+from veritas_os.policy.bind_effect_reconciliation import (
+    BindEffectStateError,
+    EffectExecutionState,
+    EffectStateTrackingConsumptionStore,
+    InMemoryAtomicEffectStateStore,
+    ReconciliationClaim,
+    ReconciliationEvidence,
+    classify_completed_bind_attempt,
+    reconcile_effect_unknown,
+)
+from veritas_os.policy.live_adapter_bind_authorization_consumption import (
+    BindAuthorizationConsumptionResult,
+)
+from veritas_os.policy.live_adapter_bind_authorization_consumption_store import (
+    InMemoryAtomicAuthorizationConsumptionStore,
+    build_authorization_consumption_record,
+)
+from veritas_os.policy.trusted_https_reconciliation import (
+    ApprovedReconciliationVerifier,
+    ReconciliationVerifierPolicy,
+    TrustedHttpsReconciliationError,
+    TrustedHttpsReconciliationVerifier,
+    TrustedReconciliationEndpoint,
+    reconciliation_observation_digest,
+)
+from veritas_os.security.hash import sha256_of_canonical_json
+
+ACK = {
+    "operation_id": "consumption-1",
+    "external_operation_reference": "external-1",
+    "status": "committed",
+    "source_identity": "trusted-ledger",
+    "authorization_id": "authorization-1",
+    "consumption_id": "consumption-1",
+}
+
+
+class _Response:
+    def __init__(self, payload: Any = ACK, status_code: int = 200) -> None:
+        self._payload = payload
+        self.status_code = status_code
+        self.request = httpx.Request("GET", "https://ledger.example.test")
+
+    def json(self) -> Any:
+        if isinstance(self._payload, Exception):
+            raise self._payload
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError(
+                "failed",
+                request=self.request,
+                response=httpx.Response(self.status_code),
+            )
+
+
+class _Client:
+    response = _Response()
+    error: Exception | None = None
+    last_url = ""
+    kwargs: dict[str, Any] = {}
+
+    def __init__(self, **kwargs: Any) -> None:
+        type(self).kwargs = kwargs
+
+    async def __aenter__(self) -> _Client:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+    async def get(self, url: str, **kwargs: Any) -> _Response:
+        del kwargs
+        type(self).last_url = url
+        if self.error is not None:
+            raise self.error
+        return self.response
+
+
+@dataclass(frozen=True)
+class _Receipt:
+    pass
+
+
+def _endpoint(**changes: Any) -> TrustedReconciliationEndpoint:
+    values = {
+        "scheme": "https",
+        "host": "ledger.example.test",
+        "port": 8443,
+        "path_prefix": "/v1/effects",
+        "source_type": "external_https_api",
+        "source_identity": "trusted-ledger",
+    }
+    values.update(changes)
+    return TrustedReconciliationEndpoint(**values)
+
+
+def _verifier(
+    *, endpoint: TrustedReconciliationEndpoint | None = None, approved: bool = True
+) -> TrustedHttpsReconciliationVerifier:
+    endpoint = endpoint or _endpoint()
+    policy_hash = TrustedHttpsReconciliationVerifier.policy_hash_for_config(
+        endpoint=endpoint, verifier_id="reconciliation-verifier-1"
+    )
+    if not approved:
+        policy_hash = "0" * 64
+    return TrustedHttpsReconciliationVerifier(
+        endpoint=endpoint,
+        verifier_id="reconciliation-verifier-1",
+        verifier_policy=ReconciliationVerifierPolicy(
+            (ApprovedReconciliationVerifier("reconciliation-verifier-1", policy_hash),)
+        ),
+    )
+
+
+def _evidence(**changes: Any) -> ReconciliationEvidence:
+    values = {
+        "operation_id": "consumption-1",
+        "authorization_id": "authorization-1",
+        "consumption_id": "consumption-1",
+        "claim": ReconciliationClaim.CONFIRMED_EFFECT,
+        "source_type": "external_https_api",
+        "source_identity": "trusted-ledger",
+        "observed_at": "2026-08-26T12:00:00+00:00",
+        "external_operation_reference": "external-1",
+        "external_ack_digest": sha256_of_canonical_json(ACK),
+        "observation_digest": "0" * 64,
+    }
+    values.update(changes)
+    provisional = ReconciliationEvidence(**values)
+    if "observation_digest" not in changes:
+        values["observation_digest"] = reconciliation_observation_digest(provisional)
+    return ReconciliationEvidence(**values)
+
+
+@pytest.fixture(autouse=True)
+def _http_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    _Client.response = _Response()
+    _Client.error = None
+    _Client.last_url = ""
+    monkeypatch.setattr(
+        "veritas_os.policy.trusted_https_reconciliation.httpx.AsyncClient", _Client
+    )
+
+
+@pytest.mark.asyncio
+async def test_valid_acknowledgement_is_independently_verified() -> None:
+    evidence = _evidence()
+    verified = await _verifier().verify(evidence)
+
+    assert verified.evidence == evidence
+    assert verified.verifier_id == "reconciliation-verifier-1"
+    assert _Client.last_url == (
+        "https://ledger.example.test:8443/v1/effects/external-1"
+    )
+    assert _Client.kwargs["follow_redirects"] is False
+    context = _Client.kwargs["verify"]
+    assert context.check_hostname is True
+    assert context.verify_mode.name == "CERT_REQUIRED"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("changes", "message"),
+    [
+        ({"external_operation_reference": "wrong"}, "OPERATION_REFERENCE"),
+        ({"external_ack_digest": "a" * 64}, "ACK_DIGEST"),
+        ({"observation_digest": "b" * 64}, "OBSERVATION_DIGEST"),
+        ({"source_identity": "attacker"}, "SOURCE_IDENTITY"),
+        ({"source_type": "caller_object"}, "SOURCE_TYPE"),
+        ({"observed_at": "not-a-time"}, "OBSERVED_AT"),
+        ({"observed_at": "2026-08-26T12:00:00"}, "OBSERVED_AT"),
+    ],
+)
+async def test_untrusted_evidence_fails_closed(
+    changes: dict[str, Any], message: str
+) -> None:
+    with pytest.raises(TrustedHttpsReconciliationError, match=message):
+        await _verifier().verify(_evidence(**changes))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ({"malformed": True}, "ACK_RETRIEVAL"),
+        ({**ACK, "external_operation_reference": "wrong"}, "OPERATION_REFERENCE"),
+        ({**ACK, "source_identity": "wrong"}, "SOURCE_IDENTITY"),
+        ({**ACK, "status": "invented"}, "STATUS_UNSUPPORTED"),
+        ({**ACK, "status": "rejected"}, "CLAIM_CONTRADICTED"),
+        ({**ACK, "authorization_id": "wrong"}, "AUTHORIZATION_LINEAGE"),
+        ({**ACK, "consumption_id": "wrong"}, "CONSUMPTION_LINEAGE"),
+    ],
+)
+async def test_untrusted_acknowledgement_fails_closed(
+    payload: dict[str, Any], message: str
+) -> None:
+    _Client.response = _Response(payload)
+    with pytest.raises(TrustedHttpsReconciliationError, match=message):
+        await _verifier().verify(_evidence())
+
+
+@pytest.mark.asyncio
+async def test_tls_or_network_failure_fails_closed() -> None:
+    request = httpx.Request("GET", "https://ledger.example.test")
+    _Client.error = httpx.ConnectError("certificate verify failed", request=request)
+    with pytest.raises(TrustedHttpsReconciliationError, match="ACK_RETRIEVAL"):
+        await _verifier().verify(_evidence())
+
+
+def test_endpoint_substitution_and_unapproved_policy_fail_closed() -> None:
+    with pytest.raises(TrustedHttpsReconciliationError, match="ENDPOINT_INVALID"):
+        _verifier(endpoint=_endpoint(scheme="http"))
+    with pytest.raises(TrustedHttpsReconciliationError, match="ENDPOINT_INVALID"):
+        _verifier(endpoint=_endpoint(host="trusted.test@attacker.test"))
+    with pytest.raises(TrustedHttpsReconciliationError, match="VERIFIER_NOT_APPROVED"):
+        _verifier(approved=False)
+
+
+@pytest.mark.asyncio
+async def test_production_verifier_reconciles_effect_unknown() -> None:
+    consumption = build_authorization_consumption_record(
+        live_adapter_bind_authorization_id="authorization-1",
+        live_adapter_bind_authorization_hash="a" * 64,
+        idempotency_key="idem-1",
+        bind_context_hash="b" * 64,
+        execution_intent_id="intent-1",
+        execution_intent_hash="c" * 64,
+        endpoint_identity_binding_digest="endpoint",
+        credential_reference_digest="credential",
+        credential_scope_binding_digest="scope",
+        consumed_at="2026-08-26T11:59:00+00:00",
+    )
+    authorization_store = InMemoryAtomicAuthorizationConsumptionStore()
+    effect_store = InMemoryAtomicEffectStateStore()
+    tracking_store = EffectStateTrackingConsumptionStore(
+        authorization_store, effect_store
+    )
+    assert await tracking_store.consume_once(consumption)
+    await classify_completed_bind_attempt(
+        result=BindAuthorizationConsumptionResult(
+            consumption_record=consumption,
+            bind_receipt=_Receipt(),  # type: ignore[arg-type]
+            adapter_apply_attempted=True,
+        ),
+        effect_store=effect_store,
+        updated_at="2026-08-26T12:00:00+00:00",
+    )
+
+    acknowledgement = {
+        **ACK,
+        "operation_id": consumption.consumption_id,
+        "consumption_id": consumption.consumption_id,
+    }
+    _Client.response = _Response(acknowledgement)
+
+    terminal = await reconcile_effect_unknown(
+        operation_id=consumption.consumption_id,
+        evidence=_evidence(
+            operation_id=consumption.consumption_id,
+            consumption_id=consumption.consumption_id,
+            external_ack_digest=sha256_of_canonical_json(acknowledgement),
+        ),
+        verifier=_verifier(),
+        effect_store=effect_store,
+        updated_at="2026-08-26T12:01:00+00:00",
+    )
+    assert terminal.state == EffectExecutionState.CONFIRMED_EFFECT
+
+
+@pytest.mark.asyncio
+async def test_failed_verification_cannot_confirm_effect() -> None:
+    consumption = build_authorization_consumption_record(
+        live_adapter_bind_authorization_id="authorization-1",
+        live_adapter_bind_authorization_hash="a" * 64,
+        idempotency_key="idem-2",
+        bind_context_hash="b" * 64,
+        execution_intent_id="intent-1",
+        execution_intent_hash="c" * 64,
+        endpoint_identity_binding_digest="endpoint",
+        credential_reference_digest="credential",
+        credential_scope_binding_digest="scope",
+        consumed_at="2026-08-26T11:59:00+00:00",
+    )
+    effect_store = InMemoryAtomicEffectStateStore()
+    tracking_store = EffectStateTrackingConsumptionStore(
+        InMemoryAtomicAuthorizationConsumptionStore(), effect_store
+    )
+    assert await tracking_store.consume_once(consumption)
+    await classify_completed_bind_attempt(
+        result=BindAuthorizationConsumptionResult(
+            consumption_record=consumption,
+            bind_receipt=_Receipt(),  # type: ignore[arg-type]
+            adapter_apply_attempted=True,
+        ),
+        effect_store=effect_store,
+        updated_at="2026-08-26T12:00:00+00:00",
+    )
+    evidence = _evidence(
+        operation_id=consumption.consumption_id,
+        consumption_id=consumption.consumption_id,
+        observation_digest="f" * 64,
+    )
+    with pytest.raises(BindEffectStateError, match="VERIFICATION_FAILED"):
+        await reconcile_effect_unknown(
+            operation_id=consumption.consumption_id,
+            evidence=evidence,
+            verifier=_verifier(),
+            effect_store=effect_store,
+            updated_at="2026-08-26T12:01:00+00:00",
+        )
+    state = await effect_store.get(consumption.consumption_id)
+    assert state is not None
+    assert state.state == EffectExecutionState.EFFECT_UNKNOWN

--- a/tests/policy/test_trusted_https_reconciliation.py
+++ b/tests/policy/test_trusted_https_reconciliation.py
@@ -1,10 +1,21 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from datetime import UTC, datetime, timedelta
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import ipaddress
+import json
+from pathlib import Path
+import ssl
+from threading import Thread
+from typing import Any, Mapping
 
 import httpx
 import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
 
 from veritas_os.policy.bind_effect_reconciliation import (
     BindEffectStateError,
@@ -34,7 +45,7 @@ from veritas_os.policy.trusted_https_reconciliation import (
 from veritas_os.security.hash import sha256_of_canonical_json
 
 ACK = {
-    "operation_id": "consumption-1",
+    "veritas_operation_id": "consumption-1",
     "external_operation_reference": "external-1",
     "status": "committed",
     "source_identity": "trusted-ledger",
@@ -89,6 +100,14 @@ class _Client:
 @dataclass(frozen=True)
 class _Receipt:
     pass
+
+
+@dataclass(frozen=True)
+class _Headers:
+    values: Mapping[str, str]
+
+    async def authorization_headers(self) -> Mapping[str, str]:
+        return self.values
 
 
 def _endpoint(**changes: Any) -> TrustedReconciliationEndpoint:
@@ -169,6 +188,20 @@ async def test_valid_acknowledgement_is_independently_verified() -> None:
 
 
 @pytest.mark.asyncio
+async def test_format_version_is_bound_by_observation_digest() -> None:
+    evidence = _evidence()
+    substituted = evidence.model_copy(
+        update={"format_version": "bind-effect-reconciliation-evidence/v2"}
+    )
+
+    assert reconciliation_observation_digest(substituted) != (
+        reconciliation_observation_digest(evidence)
+    )
+    with pytest.raises(TrustedHttpsReconciliationError, match="FORMAT_VERSION"):
+        await _verifier().verify(substituted)
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("changes", "message"),
     [
@@ -227,6 +260,183 @@ def test_endpoint_substitution_and_unapproved_policy_fail_closed() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "header_name",
+    ["Host", "HOST", "content-length", "Connection", "Transfer-Encoding"],
+)
+async def test_credential_provider_cannot_override_transport_headers(
+    header_name: str,
+) -> None:
+    endpoint = _endpoint()
+    policy_hash = TrustedHttpsReconciliationVerifier.policy_hash_for_config(
+        endpoint=endpoint, verifier_id="reconciliation-verifier-1"
+    )
+    verifier = TrustedHttpsReconciliationVerifier(
+        endpoint=endpoint,
+        verifier_id="reconciliation-verifier-1",
+        verifier_policy=ReconciliationVerifierPolicy(
+            (ApprovedReconciliationVerifier("reconciliation-verifier-1", policy_hash),)
+        ),
+        credential_provider=_Headers({header_name: "attacker-controlled"}),
+    )
+
+    with pytest.raises(TrustedHttpsReconciliationError, match="CREDENTIAL_FAILED"):
+        await verifier.verify(_evidence())
+
+
+def _write_test_certificates(
+    directory: Path, *, certificate_name: str, hostname: str
+) -> tuple[Path, Path, Path]:
+    """Create an ephemeral CA and server certificate for local TLS tests."""
+    now = datetime.now(UTC)
+    ca_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    ca_name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "Test CA")])
+    ca_cert = (
+        x509.CertificateBuilder()
+        .subject_name(ca_name)
+        .issuer_name(ca_name)
+        .public_key(ca_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - timedelta(minutes=1))
+        .not_valid_after(now + timedelta(days=1))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .sign(ca_key, hashes.SHA256())
+    )
+    server_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    server_name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, hostname)])
+    try:
+        san: x509.GeneralName = x509.IPAddress(ipaddress.ip_address(hostname))
+    except ValueError:
+        san = x509.DNSName(hostname)
+    server_cert = (
+        x509.CertificateBuilder()
+        .subject_name(server_name)
+        .issuer_name(ca_cert.subject)
+        .public_key(server_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - timedelta(minutes=1))
+        .not_valid_after(now + timedelta(days=1))
+        .add_extension(x509.SubjectAlternativeName([san]), critical=False)
+        .add_extension(
+            x509.ExtendedKeyUsage([x509.oid.ExtendedKeyUsageOID.SERVER_AUTH]),
+            critical=False,
+        )
+        .sign(ca_key, hashes.SHA256())
+    )
+    ca_path = directory / f"{certificate_name}-ca.pem"
+    cert_path = directory / f"{certificate_name}-server.pem"
+    key_path = directory / f"{certificate_name}-server-key.pem"
+    ca_path.write_bytes(ca_cert.public_bytes(serialization.Encoding.PEM))
+    cert_path.write_bytes(server_cert.public_bytes(serialization.Encoding.PEM))
+    key_path.write_bytes(
+        server_key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        )
+    )
+    return ca_path, cert_path, key_path
+
+
+def _start_https_server(
+    cert_path: Path, key_path: Path, acknowledgement: dict[str, Any]
+) -> tuple[ThreadingHTTPServer, Thread]:
+    """Start a real loopback TLS server returning one acknowledgement."""
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802
+            body = json.dumps(
+                acknowledgement, sort_keys=True, separators=(",", ":")
+            ).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format: str, *args: object) -> None:
+            del format, args
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.load_cert_chain(cert_path, key_path)
+    server.socket = context.wrap_socket(server.socket, server_side=True)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, thread
+
+
+@pytest.mark.asyncio
+async def test_real_tls_handshake_and_certificate_failures(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Exercise real OpenSSL success, foreign-CA, and hostname failures."""
+    monkeypatch.undo()
+    acknowledgement = {
+        "veritas_operation_id": "internal-operation-1",
+        "external_operation_reference": "provider-operation-9",
+        "status": "committed",
+        "source_identity": "local-trusted-ledger",
+        "authorization_id": "authorization-1",
+        "consumption_id": "consumption-1",
+    }
+    trusted_ca, cert, key = _write_test_certificates(
+        tmp_path, certificate_name="trusted", hostname="127.0.0.1"
+    )
+    foreign_ca, _, _ = _write_test_certificates(
+        tmp_path, certificate_name="foreign", hostname="127.0.0.1"
+    )
+    mismatch_ca, mismatch_cert, mismatch_key = _write_test_certificates(
+        tmp_path, certificate_name="mismatch", hostname="localhost"
+    )
+    trusted_server, trusted_thread = _start_https_server(cert, key, acknowledgement)
+    mismatch_server, mismatch_thread = _start_https_server(
+        mismatch_cert, mismatch_key, acknowledgement
+    )
+
+    def verifier(port: int, ca_file: Path) -> TrustedHttpsReconciliationVerifier:
+        endpoint = _endpoint(
+            host="127.0.0.1",
+            port=port,
+            source_identity="local-trusted-ledger",
+            ca_file=str(ca_file),
+        )
+        policy_hash = TrustedHttpsReconciliationVerifier.policy_hash_for_config(
+            endpoint=endpoint, verifier_id="real-tls-verifier"
+        )
+        return TrustedHttpsReconciliationVerifier(
+            endpoint=endpoint,
+            verifier_id="real-tls-verifier",
+            verifier_policy=ReconciliationVerifierPolicy(
+                (ApprovedReconciliationVerifier("real-tls-verifier", policy_hash),)
+            ),
+        )
+
+    evidence = _evidence(
+        operation_id="internal-operation-1",
+        external_operation_reference="provider-operation-9",
+        source_identity="local-trusted-ledger",
+        external_ack_digest=sha256_of_canonical_json(acknowledgement),
+    )
+    try:
+        verified = await verifier(trusted_server.server_port, trusted_ca).verify(
+            evidence
+        )
+        assert verified.evidence == evidence
+        with pytest.raises(TrustedHttpsReconciliationError, match="ACK_RETRIEVAL"):
+            await verifier(trusted_server.server_port, foreign_ca).verify(evidence)
+        with pytest.raises(TrustedHttpsReconciliationError, match="ACK_RETRIEVAL"):
+            await verifier(mismatch_server.server_port, mismatch_ca).verify(evidence)
+    finally:
+        trusted_server.shutdown()
+        mismatch_server.shutdown()
+        trusted_server.server_close()
+        mismatch_server.server_close()
+        trusted_thread.join(timeout=2)
+        mismatch_thread.join(timeout=2)
+
+
+@pytest.mark.asyncio
 async def test_production_verifier_reconciles_effect_unknown() -> None:
     consumption = build_authorization_consumption_record(
         live_adapter_bind_authorization_id="authorization-1",
@@ -258,7 +468,7 @@ async def test_production_verifier_reconciles_effect_unknown() -> None:
 
     acknowledgement = {
         **ACK,
-        "operation_id": consumption.consumption_id,
+        "veritas_operation_id": consumption.consumption_id,
         "consumption_id": consumption.consumption_id,
     }
     _Client.response = _Response(acknowledgement)

--- a/tests/policy/test_trusted_https_reconciliation.py
+++ b/tests/policy/test_trusted_https_reconciliation.py
@@ -359,6 +359,7 @@ def _start_https_server(
 
     server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
     context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.minimum_version = ssl.TLSVersion.TLSv1_2
     context.load_cert_chain(cert_path, key_path)
     server.socket = context.wrap_socket(server.socket, server_side=True)
     thread = Thread(target=server.serve_forever, daemon=True)

--- a/veritas_os/policy/trusted_https_reconciliation.py
+++ b/veritas_os/policy/trusted_https_reconciliation.py
@@ -1,0 +1,357 @@
+"""Production HTTPS verification for external effect reconciliation.
+
+The verifier in this module treats reconciliation evidence as an untrusted
+claim.  It retrieves a fresh acknowledgement from one deployment-controlled
+HTTPS origin and validates its integrity, lineage, and interpretation before
+creating :class:`VerifiedReconciliationEvidence`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import ssl
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Mapping, Protocol
+from urllib.parse import quote, urlsplit
+
+import httpx
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from veritas_os.policy.bind_effect_reconciliation import (
+    ReconciliationClaim,
+    ReconciliationEvidence,
+    VerifiedReconciliationEvidence,
+)
+from veritas_os.security.hash import sha256_of_canonical_json
+
+
+class TrustedHttpsReconciliationError(RuntimeError):
+    """Stable fail-closed error for acknowledgement verification failures."""
+
+
+class ReconciliationCredentialProvider(Protocol):
+    """Deployment credential boundary used only when making the HTTPS request."""
+
+    async def authorization_headers(self) -> Mapping[str, str]:
+        """Return secret request headers without persisting them in evidence."""
+
+
+@dataclass(frozen=True)
+class TrustedReconciliationEndpoint:
+    """Deployment-controlled origin and acknowledgement path configuration."""
+
+    scheme: str
+    host: str
+    port: int
+    path_prefix: str
+    source_type: str
+    source_identity: str
+    ca_file: str | None = None
+
+    def validate(self) -> None:
+        """Reject malformed or insecure endpoint trust configuration."""
+        if self.scheme != "https" or not self.host or not (1 <= self.port <= 65535):
+            raise TrustedHttpsReconciliationError("RHRV_ENDPOINT_INVALID")
+        if (
+            not self.path_prefix.startswith("/")
+            or self.path_prefix.endswith("/")
+            or "?" in self.path_prefix
+            or "#" in self.path_prefix
+            or not self.source_type
+            or not self.source_identity
+        ):
+            raise TrustedHttpsReconciliationError("RHRV_ENDPOINT_INVALID")
+        parsed = urlsplit(f"https://{self.host}:{self.port}{self.path_prefix}")
+        if parsed.hostname != self.host or parsed.port != self.port:
+            raise TrustedHttpsReconciliationError("RHRV_ENDPOINT_INVALID")
+        if self.ca_file is not None and not Path(self.ca_file).is_file():
+            raise TrustedHttpsReconciliationError("RHRV_CA_TRUST_INVALID")
+
+
+@dataclass(frozen=True)
+class ApprovedReconciliationVerifier:
+    """Deployment-owned approval for an exact verifier policy hash."""
+
+    verifier_id: str
+    verifier_policy_hash: str
+
+
+@dataclass(frozen=True)
+class ReconciliationVerifierPolicy:
+    """Deployment-controlled allowlist of reconciliation verifier provenance."""
+
+    approved_verifiers: tuple[ApprovedReconciliationVerifier, ...]
+
+    def approves(self, verifier_id: str, policy_hash: str) -> bool:
+        """Return whether the exact verifier identity and policy are approved."""
+        return any(
+            item.verifier_id == verifier_id
+            and item.verifier_policy_hash == policy_hash
+            and _is_hash(item.verifier_policy_hash)
+            for item in self.approved_verifiers
+        )
+
+
+class _Acknowledgement(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    operation_id: str = Field(min_length=1)
+    external_operation_reference: str = Field(min_length=1)
+    status: str = Field(min_length=1)
+    source_identity: str = Field(min_length=1)
+    authorization_id: str | None = None
+    consumption_id: str | None = None
+
+
+def reconciliation_observation_digest(evidence: ReconciliationEvidence) -> str:
+    """Hash the canonical observation while excluding its digest field."""
+    payload = evidence.model_dump(mode="json")
+    payload.pop("observation_digest")
+    # format_version is a model envelope, not part of the established v1
+    # observation preimage used by existing reconciliation producers.
+    payload.pop("format_version")
+    return sha256_of_canonical_json(payload)
+
+
+def _is_hash(value: str) -> bool:
+    return len(value) == 64 and all(
+        character in "0123456789abcdef" for character in value
+    )
+
+
+class TrustedHttpsReconciliationVerifier:
+    """Independently verify reconciliation through certificate-validated HTTPS.
+
+    Endpoint, CA roots, status semantics, credentials, verifier identity, and
+    verifier approval are deployment inputs. Redirects are disabled and the
+    untrusted operation reference is encoded as one path segment.
+    """
+
+    def __init__(
+        self,
+        *,
+        endpoint: TrustedReconciliationEndpoint,
+        verifier_id: str,
+        verifier_policy: ReconciliationVerifierPolicy,
+        credential_provider: ReconciliationCredentialProvider | None = None,
+        committed_statuses: tuple[str, ...] = ("committed",),
+        no_effect_statuses: tuple[str, ...] = ("rejected", "not_applied"),
+        unknown_statuses: tuple[str, ...] = ("pending", "unknown"),
+        timeout_seconds: float = 10.0,
+        interpretation_version: str = "https-acknowledgement/v1",
+    ) -> None:
+        endpoint.validate()
+        if (
+            not verifier_id
+            or timeout_seconds <= 0
+            or not interpretation_version
+            or not committed_statuses
+            or set(committed_statuses) & set(no_effect_statuses)
+            or set(committed_statuses) & set(unknown_statuses)
+            or set(no_effect_statuses) & set(unknown_statuses)
+        ):
+            raise TrustedHttpsReconciliationError("RHRV_POLICY_INVALID")
+        self._endpoint = endpoint
+        self._verifier_id = verifier_id
+        self._verifier_policy = verifier_policy
+        self._credential_provider = credential_provider
+        self._committed_statuses = tuple(sorted(committed_statuses))
+        self._no_effect_statuses = tuple(sorted(no_effect_statuses))
+        self._unknown_statuses = tuple(sorted(unknown_statuses))
+        self._timeout_seconds = timeout_seconds
+        self._interpretation_version = interpretation_version
+        if not self._verifier_policy.approves(verifier_id, self.policy_hash()):
+            raise TrustedHttpsReconciliationError("RHRV_VERIFIER_NOT_APPROVED")
+
+    @staticmethod
+    def policy_hash_for_config(
+        *,
+        endpoint: TrustedReconciliationEndpoint,
+        verifier_id: str,
+        committed_statuses: tuple[str, ...] = ("committed",),
+        no_effect_statuses: tuple[str, ...] = ("rejected", "not_applied"),
+        unknown_statuses: tuple[str, ...] = ("pending", "unknown"),
+        interpretation_version: str = "https-acknowledgement/v1",
+    ) -> str:
+        """Calculate the policy hash used in a deployment approval entry."""
+        ca_digest = None
+        if endpoint.ca_file:
+            try:
+                ca_digest = hashlib.sha256(
+                    Path(endpoint.ca_file).read_bytes()
+                ).hexdigest()
+            except OSError:
+                raise TrustedHttpsReconciliationError("RHRV_CA_TRUST_INVALID") from None
+        return sha256_of_canonical_json(
+            {
+                "policy_version": "trusted-https-reconciliation-verifier/v1",
+                "verifier_id": verifier_id,
+                "scheme": endpoint.scheme,
+                "host": endpoint.host,
+                "port": endpoint.port,
+                "path_prefix": endpoint.path_prefix,
+                "source_type": endpoint.source_type,
+                "source_identity": endpoint.source_identity,
+                "ca_trust": "deployment_custom" if endpoint.ca_file else "system",
+                "ca_bundle_sha256": ca_digest,
+                "interpretation_version": interpretation_version,
+                "committed_statuses": tuple(sorted(committed_statuses)),
+                "no_effect_statuses": tuple(sorted(no_effect_statuses)),
+                "unknown_statuses": tuple(sorted(unknown_statuses)),
+            }
+        )
+
+    def policy_hash(self) -> str:
+        """Return a stable hash of all non-secret security policy inputs."""
+        return self.policy_hash_for_config(
+            endpoint=self._endpoint,
+            verifier_id=self._verifier_id,
+            committed_statuses=self._committed_statuses,
+            no_effect_statuses=self._no_effect_statuses,
+            unknown_statuses=self._unknown_statuses,
+            interpretation_version=self._interpretation_version,
+        )
+
+    async def verify(
+        self, evidence: ReconciliationEvidence
+    ) -> VerifiedReconciliationEvidence:
+        """Fetch and validate an acknowledgement, failing closed on any error."""
+        policy_hash = self.policy_hash()
+        if not self._verifier_policy.approves(self._verifier_id, policy_hash):
+            raise TrustedHttpsReconciliationError("RHRV_VERIFIER_NOT_APPROVED")
+        self._validate_evidence(evidence)
+        acknowledgement = await self._retrieve(
+            evidence.external_operation_reference or ""
+        )
+        self._validate_acknowledgement(evidence, acknowledgement)
+        ack_payload = acknowledgement.model_dump(mode="json", exclude_none=True)
+        ack_digest = sha256_of_canonical_json(ack_payload)
+        if evidence.external_ack_digest != ack_digest:
+            raise TrustedHttpsReconciliationError("RHRV_ACK_DIGEST_MISMATCH")
+        proof_hash = sha256_of_canonical_json(
+            {
+                "acknowledgement_digest": ack_digest,
+                "observation_digest": evidence.observation_digest,
+                "operation_id": evidence.operation_id,
+                "external_operation_reference": evidence.external_operation_reference,
+                "source_identity": evidence.source_identity,
+                "verifier_id": self._verifier_id,
+                "verifier_policy_hash": policy_hash,
+                "verified_claim": evidence.claim.value,
+                "verified_status": acknowledgement.status,
+            }
+        )
+        return VerifiedReconciliationEvidence(
+            evidence=evidence,
+            verifier_id=self._verifier_id,
+            verifier_policy_hash=policy_hash,
+            verification_proof_hash=proof_hash,
+            verified_at=datetime.now(UTC).isoformat(),
+        )
+
+    def _validate_evidence(self, evidence: ReconciliationEvidence) -> None:
+        endpoint = self._endpoint
+        if evidence.source_type != endpoint.source_type:
+            raise TrustedHttpsReconciliationError("RHRV_SOURCE_TYPE_UNSUPPORTED")
+        if evidence.source_identity != endpoint.source_identity:
+            raise TrustedHttpsReconciliationError("RHRV_SOURCE_IDENTITY_MISMATCH")
+        if (
+            not evidence.external_operation_reference
+            or not evidence.external_ack_digest
+        ):
+            raise TrustedHttpsReconciliationError("RHRV_ACK_BINDING_MISSING")
+        try:
+            observed_at = datetime.fromisoformat(evidence.observed_at)
+        except ValueError:
+            raise TrustedHttpsReconciliationError("RHRV_OBSERVED_AT_INVALID") from None
+        if observed_at.tzinfo is None or observed_at.utcoffset() is None:
+            raise TrustedHttpsReconciliationError("RHRV_OBSERVED_AT_INVALID")
+        if reconciliation_observation_digest(evidence) != evidence.observation_digest:
+            raise TrustedHttpsReconciliationError("RHRV_OBSERVATION_DIGEST_MISMATCH")
+
+    async def _retrieve(self, operation_reference: str) -> _Acknowledgement:
+        headers: Mapping[str, str] = {}
+        if self._credential_provider is not None:
+            try:
+                headers = await self._credential_provider.authorization_headers()
+            except Exception:
+                raise TrustedHttpsReconciliationError(
+                    "RHRV_CREDENTIAL_FAILED"
+                ) from None
+        if any(
+            not key or "\n" in key or "\r" in key or "\n" in value or "\r" in value
+            for key, value in headers.items()
+        ):
+            raise TrustedHttpsReconciliationError("RHRV_CREDENTIAL_FAILED")
+        endpoint = self._endpoint
+        url = (
+            f"https://{endpoint.host}:{endpoint.port}{endpoint.path_prefix}/"
+            f"{quote(operation_reference, safe='')}"
+        )
+        context = ssl.create_default_context(cafile=endpoint.ca_file)
+        context.check_hostname = True
+        context.verify_mode = ssl.CERT_REQUIRED
+        try:
+            async with httpx.AsyncClient(
+                verify=context,
+                timeout=self._timeout_seconds,
+                follow_redirects=False,
+            ) as client:
+                response = await client.get(url, headers=dict(headers))
+            response.raise_for_status()
+            payload = response.json()
+            if not isinstance(payload, dict):
+                raise ValueError
+            return _Acknowledgement.model_validate(payload)
+        except (httpx.HTTPError, ValueError, ValidationError):
+            raise TrustedHttpsReconciliationError("RHRV_ACK_RETRIEVAL_FAILED") from None
+
+    def _validate_acknowledgement(
+        self,
+        evidence: ReconciliationEvidence,
+        acknowledgement: _Acknowledgement,
+    ) -> None:
+        if (
+            acknowledgement.external_operation_reference
+            != evidence.external_operation_reference
+        ):
+            raise TrustedHttpsReconciliationError("RHRV_OPERATION_REFERENCE_MISMATCH")
+        if acknowledgement.operation_id != evidence.operation_id:
+            raise TrustedHttpsReconciliationError("RHRV_OPERATION_ID_MISMATCH")
+        if acknowledgement.source_identity != evidence.source_identity:
+            raise TrustedHttpsReconciliationError("RHRV_SOURCE_IDENTITY_MISMATCH")
+        if (
+            acknowledgement.authorization_id is not None
+            and acknowledgement.authorization_id != evidence.authorization_id
+        ):
+            raise TrustedHttpsReconciliationError("RHRV_AUTHORIZATION_LINEAGE_MISMATCH")
+        if (
+            acknowledgement.consumption_id is not None
+            and acknowledgement.consumption_id != evidence.consumption_id
+        ):
+            raise TrustedHttpsReconciliationError("RHRV_CONSUMPTION_LINEAGE_MISMATCH")
+        expected_statuses = {
+            ReconciliationClaim.CONFIRMED_EFFECT: self._committed_statuses,
+            ReconciliationClaim.CONFIRMED_NO_EFFECT: self._no_effect_statuses,
+            ReconciliationClaim.STILL_UNKNOWN: self._unknown_statuses,
+        }[evidence.claim]
+        all_statuses = (
+            self._committed_statuses + self._no_effect_statuses + self._unknown_statuses
+        )
+        if acknowledgement.status not in all_statuses:
+            raise TrustedHttpsReconciliationError("RHRV_STATUS_UNSUPPORTED")
+        if acknowledgement.status not in expected_statuses:
+            raise TrustedHttpsReconciliationError("RHRV_CLAIM_CONTRADICTED")
+
+
+__all__ = [
+    "ApprovedReconciliationVerifier",
+    "ReconciliationCredentialProvider",
+    "ReconciliationVerifierPolicy",
+    "TrustedHttpsReconciliationError",
+    "TrustedHttpsReconciliationVerifier",
+    "TrustedReconciliationEndpoint",
+    "reconciliation_observation_digest",
+]

--- a/veritas_os/policy/trusted_https_reconciliation.py
+++ b/veritas_os/policy/trusted_https_reconciliation.py
@@ -97,21 +97,18 @@ class ReconciliationVerifierPolicy:
 class _Acknowledgement(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    operation_id: str = Field(min_length=1)
     external_operation_reference: str = Field(min_length=1)
     status: str = Field(min_length=1)
     source_identity: str = Field(min_length=1)
+    veritas_operation_id: str | None = None
     authorization_id: str | None = None
     consumption_id: str | None = None
 
 
 def reconciliation_observation_digest(evidence: ReconciliationEvidence) -> str:
-    """Hash the canonical observation while excluding its digest field."""
+    """Hash all v1 observation fields except ``observation_digest`` itself."""
     payload = evidence.model_dump(mode="json")
     payload.pop("observation_digest")
-    # format_version is a model envelope, not part of the established v1
-    # observation preimage used by existing reconciliation producers.
-    payload.pop("format_version")
     return sha256_of_canonical_json(payload)
 
 
@@ -253,6 +250,8 @@ class TrustedHttpsReconciliationVerifier:
 
     def _validate_evidence(self, evidence: ReconciliationEvidence) -> None:
         endpoint = self._endpoint
+        if evidence.format_version != "bind-effect-reconciliation-evidence/v1":
+            raise TrustedHttpsReconciliationError("RHRV_FORMAT_VERSION_UNSUPPORTED")
         if evidence.source_type != endpoint.source_type:
             raise TrustedHttpsReconciliationError("RHRV_SOURCE_TYPE_UNSUPPORTED")
         if evidence.source_identity != endpoint.source_identity:
@@ -281,7 +280,13 @@ class TrustedHttpsReconciliationVerifier:
                     "RHRV_CREDENTIAL_FAILED"
                 ) from None
         if any(
-            not key or "\n" in key or "\r" in key or "\n" in value or "\r" in value
+            not key
+            or key.lower()
+            in {"host", "content-length", "connection", "transfer-encoding"}
+            or "\n" in key
+            or "\r" in key
+            or "\n" in value
+            or "\r" in value
             for key, value in headers.items()
         ):
             raise TrustedHttpsReconciliationError("RHRV_CREDENTIAL_FAILED")
@@ -318,7 +323,10 @@ class TrustedHttpsReconciliationVerifier:
             != evidence.external_operation_reference
         ):
             raise TrustedHttpsReconciliationError("RHRV_OPERATION_REFERENCE_MISMATCH")
-        if acknowledgement.operation_id != evidence.operation_id:
+        if (
+            acknowledgement.veritas_operation_id is not None
+            and acknowledgement.veritas_operation_id != evidence.operation_id
+        ):
             raise TrustedHttpsReconciliationError("RHRV_OPERATION_ID_MISMATCH")
         if acknowledgement.source_identity != evidence.source_identity:
             raise TrustedHttpsReconciliationError("RHRV_SOURCE_IDENTITY_MISMATCH")


### PR DESCRIPTION
### Motivation
- Close the blocker that prevented producing production-grade reconciliation verification by adding a reusable, deployment-controlled HTTPS verifier for ReconciliationEvidence (addressing the missing primitive identified by #2143). 
- Preserve the EFFECT_UNKNOWN invariant by requiring independent, certificate-validated acknowledgement retrieval and strict verification before producing VerifiedReconciliationEvidence. 

### Description
- Add a production module `veritas_os/policy/trusted_https_reconciliation.py` implementing `TrustedHttpsReconciliationVerifier`, deployment-controlled `TrustedReconciliationEndpoint`, verifier policy (`ReconciliationVerifierPolicy` / `ApprovedReconciliationVerifier`), and a credential-provider protocol; all inputs are validated and malformed or insecure configuration fails closed. 
- Perform independent acknowledgement retrieval over HTTPS using a real TLS context (`ssl.create_default_context`) with hostname verification, disabled redirects, injectable credential headers (never persisted), Pydantic-backed acknowledgement parsing, deterministic canonicalisation, and recomputation of `external_ack_digest` and `observation_digest`. 
- Require exact deployment approval of verifier provenance by matching `verifier_id` plus a deterministic `policy_hash` that binds trusted host/port/path/prefix/source identity and optional CA bundle digest; compute `verification_proof_hash` from non-secret verified evidence only. 
- Preserve existing reconciliation boundary semantics by integrating with `reconcile_effect_unknown(...)` without changing the state-transition model; verification failures remain fail-closed and leave state at `EFFECT_UNKNOWN`. 

### Testing
- Added focused unit/integration tests at `tests/policy/test_trusted_https_reconciliation.py` covering positive verification, digest/timestamp/lineage mismatches, endpoint substitution, unapproved policy, malformed acknowledgements, TLS/network failures, and integration with `reconcile_effect_unknown(...)`. 
- Ran formatting and lint checks (`ruff format` / `ruff check`) and `py_compile` on the new module and test file (all passed). 
- Attempted to run the focused pytest matrix locally but test collection/execution was blocked by missing runtime dependencies and a restricted network proxy in the environment, so full pytest, PostgreSQL-backed, and CI matrix runs are pending in CI and must be executed there. 

Security note: This is governance-sensitive code; a human maintainer review is required and deployment owners must approve verifier policy hashes and protect any credential-provider outputs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8e969b51888326a4dfcbffcb4fe689)