### PR TITLE
feat(governance): add promotion-native execution-intent readiness

### DIFF
--- a/veritas_os/policy/canonical_promotion_execution_intent_readiness.py
+++ b/veritas_os/policy/canonical_promotion_execution_intent_readiness.py
@@ -1,0 +1,311 @@
+"""Promotion-native readiness for one exact verified ``ExecutionIntent``.
+
+This boundary preserves the promoted intent without translating historical
+formation-readiness semantics.  It proves only pre-Bind source readiness and
+does not establish approval, authority, authorization, or an external effect.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime
+from typing import Any, Literal, Mapping
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from veritas_os.policy.bind_artifacts import ExecutionIntent, hash_execution_intent
+from veritas_os.policy.canonical_verified_decision_promotion import (
+    CanonicalVerifiedDecisionPromotionError,
+    CanonicalVerifiedDecisionPromotionPacket,
+    verify_canonical_verified_decision_promotion_packet,
+)
+
+FORMAT_VERSION = "canonical-promotion-execution-intent-readiness/v1"
+VERIFICATION_MECHANISM = (
+    "verify_canonical_verified_decision_promotion_for_pre_bind/v1"
+)
+MAPPING_DOMAIN = "veritas.promotion-execution-intent-readiness.mapping/v1"
+REQUIRED_FIELDS_DOMAIN = (
+    "veritas.promotion-execution-intent-readiness.required-fields/v1"
+)
+PACKET_DOMAIN = "veritas.promotion-execution-intent-readiness.packet/v1"
+EXECUTION_INTENT_REQUIRED_FIELDS = (
+    "execution_intent_id",
+    "decision_id",
+    "request_id",
+    "policy_snapshot_id",
+    "actor_identity",
+    "target_system",
+    "target_resource",
+    "intended_action",
+    "evidence_refs",
+    "decision_hash",
+    "decision_ts",
+    "ttl_seconds",
+    "expected_state_fingerprint",
+    "approval_context",
+    "policy_lineage",
+)
+SEMANTIC_FIELDS = EXECUTION_INTENT_REQUIRED_FIELDS[1:]
+REQUIRED_FIELD_PRESENCE = {
+    field: "verified_exact_value" for field in EXECUTION_INTENT_REQUIRED_FIELDS
+}
+SCOPE_LIMITATIONS = (
+    "NOT_EXECUTION_AUTHORITY",
+    "NOT_BIND_AUTHORIZATION",
+    "NOT_BIND_RECEIPT",
+    "NOT_HUMAN_APPROVAL_PROOF",
+    "NOT_AUTHORITY_EVIDENCE_PROOF",
+    "NOT_ADAPTER_SELECTION",
+    "NOT_EXTERNAL_EFFECT",
+    "NOT_TRUSTLOG_WRITE",
+)
+
+
+class CanonicalPromotionExecutionIntentReadinessError(ValueError):
+    """Fail-closed promotion-native readiness error."""
+
+
+class CanonicalPromotionExecutionIntentReadinessPacket(BaseModel):
+    """Immutable readiness binding to an independently verified promotion."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    format_version: Literal[
+        "canonical-promotion-execution-intent-readiness/v1"
+    ]
+    readiness_id: str = Field(pattern=r"^peir:v1:sha256:[0-9a-f]{64}$")
+    readiness_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    verification_mechanism: Literal[
+        "verify_canonical_verified_decision_promotion_for_pre_bind/v1"
+    ]
+    checked_at: str
+    source_promotion_id: str
+    source_promotion_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    source_promotion_packet: dict[str, Any]
+    execution_intent: dict[str, Any]
+    execution_intent_id: str
+    execution_intent_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    execution_intent_required_fields: tuple[str, ...]
+    required_field_presence: dict[str, str]
+    required_field_presence_digest: str = Field(pattern=r"^[0-9a-f]{64}$")
+    source_to_execution_intent_mapping: dict[str, Any]
+    mapping_value_digest: str = Field(pattern=r"^[0-9a-f]{64}$")
+    source_decision_identity: dict[str, Any]
+    candidate_identity: dict[str, Any]
+    selected_action_lineage: dict[str, Any]
+    policy_snapshot_lineage: dict[str, Any]
+    readiness_status: Literal["READY_FOR_PROMOTION_NATIVE_PRE_BIND"]
+    scope_limitations: tuple[str, ...]
+
+
+def _canonical_value(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        value = value.model_dump(mode="json")
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        if value != value or value in (float("inf"), float("-inf")):
+            raise CanonicalPromotionExecutionIntentReadinessError(
+                "PEIR_NON_CANONICAL_VALUE"
+            )
+        return value
+    if isinstance(value, (list, tuple)):
+        return [_canonical_value(item) for item in value]
+    if isinstance(value, Mapping):
+        if not all(isinstance(key, str) for key in value):
+            raise CanonicalPromotionExecutionIntentReadinessError(
+                "PEIR_NON_CANONICAL_VALUE"
+            )
+        return {key: _canonical_value(item) for key, item in value.items()}
+    raise CanonicalPromotionExecutionIntentReadinessError(
+        "PEIR_NON_CANONICAL_VALUE"
+    )
+
+
+def _digest(domain: str, value: Any) -> str:
+    payload = json.dumps(
+        {"domain": domain, "value": _canonical_value(value)},
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _aware_iso(value: Any) -> datetime:
+    try:
+        parsed = value if isinstance(value, datetime) else datetime.fromisoformat(value)
+    except (TypeError, ValueError) as exc:
+        raise CanonicalPromotionExecutionIntentReadinessError(
+            "PEIR_CHECKED_AT_INVALID"
+        ) from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise CanonicalPromotionExecutionIntentReadinessError(
+            "PEIR_CHECKED_AT_INVALID"
+        )
+    return parsed
+
+
+def _verify_promotion(value: Any) -> CanonicalVerifiedDecisionPromotionPacket:
+    try:
+        return verify_canonical_verified_decision_promotion_packet(value)
+    except (CanonicalVerifiedDecisionPromotionError, TypeError, ValueError) as exc:
+        raise CanonicalPromotionExecutionIntentReadinessError(
+            "PEIR_PROMOTION_INVALID"
+        ) from exc
+
+
+def _mapping(promotion: CanonicalVerifiedDecisionPromotionPacket) -> dict[str, Any]:
+    intent = promotion.exact_execution_intent
+    if set(intent) != set(EXECUTION_INTENT_REQUIRED_FIELDS):
+        raise CanonicalPromotionExecutionIntentReadinessError(
+            "PEIR_EXECUTION_INTENT_FIELDS_INVALID"
+        )
+    return {field: intent[field] for field in SEMANTIC_FIELDS}
+
+
+def _packet_hash(raw: dict[str, Any]) -> str:
+    value = {
+        key: item
+        for key, item in raw.items()
+        if key not in {"readiness_id", "readiness_hash"}
+    }
+    return _digest(PACKET_DOMAIN, value)
+
+
+def _source_lineage(
+    promotion: CanonicalVerifiedDecisionPromotionPacket,
+) -> dict[str, dict[str, Any]]:
+    return {
+        "source_decision_identity": promotion.source_decision_identity,
+        "candidate_identity": {
+            "candidate_id": promotion.candidate_id,
+            "candidate_hash": promotion.candidate_hash,
+        },
+        "selected_action_lineage": {
+            "selected_action_evidence": promotion.selected_action_evidence,
+            "selected_action_evidence_hash": (
+                promotion.selected_action_evidence_hash
+            ),
+        },
+        "policy_snapshot_lineage": {
+            "policy_snapshot_evidence": promotion.policy_snapshot_evidence,
+            "policy_snapshot_evidence_hash": (
+                promotion.policy_snapshot_evidence_hash
+            ),
+        },
+    }
+
+
+def build_canonical_promotion_execution_intent_readiness_packet(
+    promotion_packet: CanonicalVerifiedDecisionPromotionPacket | Mapping[str, Any],
+    *,
+    checked_at: datetime,
+) -> CanonicalPromotionExecutionIntentReadinessPacket:
+    """Build readiness solely from one independently verified promotion packet."""
+    checked = _aware_iso(checked_at)
+    promotion = _verify_promotion(_canonical_value(promotion_packet))
+    if checked < _aware_iso(promotion.promoted_at):
+        raise CanonicalPromotionExecutionIntentReadinessError(
+            "PEIR_CHECKED_BEFORE_PROMOTION"
+        )
+    mapping = _mapping(promotion)
+    presence = dict(REQUIRED_FIELD_PRESENCE)
+    raw = {
+        "format_version": FORMAT_VERSION,
+        "readiness_id": "peir:v1:sha256:" + "0" * 64,
+        "readiness_hash": "0" * 64,
+        "verification_mechanism": VERIFICATION_MECHANISM,
+        "checked_at": checked.isoformat(),
+        "source_promotion_id": promotion.promotion_id,
+        "source_promotion_hash": promotion.promotion_hash,
+        "source_promotion_packet": promotion.model_dump(mode="json"),
+        "execution_intent": promotion.exact_execution_intent,
+        "execution_intent_id": promotion.execution_intent_id,
+        "execution_intent_hash": promotion.execution_intent_hash,
+        "execution_intent_required_fields": EXECUTION_INTENT_REQUIRED_FIELDS,
+        "required_field_presence": presence,
+        "required_field_presence_digest": _digest(
+            REQUIRED_FIELDS_DOMAIN, presence
+        ),
+        "source_to_execution_intent_mapping": mapping,
+        "mapping_value_digest": _digest(MAPPING_DOMAIN, mapping),
+        **_source_lineage(promotion),
+        "readiness_status": "READY_FOR_PROMOTION_NATIVE_PRE_BIND",
+        "scope_limitations": SCOPE_LIMITATIONS,
+    }
+    digest = _packet_hash(raw)
+    raw.update(
+        readiness_hash=digest,
+        readiness_id=f"peir:v1:sha256:{digest}",
+    )
+    return verify_canonical_promotion_execution_intent_readiness_packet(raw)
+
+
+def verify_canonical_promotion_execution_intent_readiness_packet(
+    packet: CanonicalPromotionExecutionIntentReadinessPacket | Mapping[str, Any],
+) -> CanonicalPromotionExecutionIntentReadinessPacket:
+    """Strictly reconstruct every promotion, intent, lineage, and hash binding."""
+    try:
+        raw_input = _canonical_value(packet)
+        parsed = CanonicalPromotionExecutionIntentReadinessPacket.model_validate(
+            raw_input
+        )
+        raw = parsed.model_dump(mode="json")
+        checked = _aware_iso(parsed.checked_at)
+        promotion = _verify_promotion(parsed.source_promotion_packet)
+        if checked < _aware_iso(promotion.promoted_at):
+            raise CanonicalPromotionExecutionIntentReadinessError(
+                "PEIR_CHECKED_BEFORE_PROMOTION"
+            )
+        intent = ExecutionIntent(**promotion.exact_execution_intent)
+        mapping = _mapping(promotion)
+        lineage = _source_lineage(promotion)
+        if (
+            parsed.source_promotion_id != promotion.promotion_id
+            or parsed.source_promotion_hash != promotion.promotion_hash
+            or parsed.execution_intent != promotion.exact_execution_intent
+            or parsed.execution_intent_id != intent.execution_intent_id
+            or parsed.execution_intent_id != promotion.execution_intent_id
+            or parsed.execution_intent_hash != hash_execution_intent(intent)
+            or parsed.execution_intent_hash != promotion.execution_intent_hash
+            or parsed.source_to_execution_intent_mapping != mapping
+            or parsed.mapping_value_digest != _digest(MAPPING_DOMAIN, mapping)
+            or any(getattr(parsed, key) != value for key, value in lineage.items())
+        ):
+            raise CanonicalPromotionExecutionIntentReadinessError(
+                "PEIR_BINDING_MISMATCH"
+            )
+        if (
+            parsed.execution_intent_required_fields
+            != EXECUTION_INTENT_REQUIRED_FIELDS
+            or parsed.required_field_presence != REQUIRED_FIELD_PRESENCE
+            or parsed.required_field_presence_digest
+            != _digest(REQUIRED_FIELDS_DOMAIN, REQUIRED_FIELD_PRESENCE)
+        ):
+            raise CanonicalPromotionExecutionIntentReadinessError(
+                "PEIR_REQUIRED_FIELDS_MISMATCH"
+            )
+        if parsed.scope_limitations != SCOPE_LIMITATIONS:
+            raise CanonicalPromotionExecutionIntentReadinessError(
+                "PEIR_SCOPE_LIMITATIONS_MISMATCH"
+            )
+        digest = _packet_hash(raw)
+        if parsed.readiness_hash != digest:
+            raise CanonicalPromotionExecutionIntentReadinessError(
+                "PEIR_PACKET_HASH_MISMATCH"
+            )
+        if parsed.readiness_id != f"peir:v1:sha256:{digest}":
+            raise CanonicalPromotionExecutionIntentReadinessError(
+                "PEIR_PACKET_ID_MISMATCH"
+            )
+        return parsed
+    except CanonicalPromotionExecutionIntentReadinessError:
+        raise
+    except (TypeError, ValueError, ValidationError) as exc:
+        raise CanonicalPromotionExecutionIntentReadinessError(
+            "PEIR_PACKET_INVALID"
+        ) from exc

--- a/veritas_os/tests/test_canonical_promotion_execution_intent_readiness.py
+++ b/veritas_os/tests/test_canonical_promotion_execution_intent_readiness.py
@@ -1,0 +1,235 @@
+"""Fail-closed tests for promotion-native ExecutionIntent readiness."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from veritas_os.api.schemas import DecideResponse
+from veritas_os.governance.canonical_decision_artifact import (
+    build_canonical_decision_artifact,
+)
+from veritas_os.policy.canonical_promotion_execution_intent_readiness import (
+    CanonicalPromotionExecutionIntentReadinessError,
+    build_canonical_promotion_execution_intent_readiness_packet,
+    verify_canonical_promotion_execution_intent_readiness_packet,
+)
+from veritas_os.policy.canonical_verified_decision_promotion import (
+    build_canonical_verified_decision_promotion_packet,
+    verify_canonical_verified_decision_promotion_packet,
+)
+from veritas_os.policy.decision_candidate import DecisionCandidate
+
+ROOT = Path(__file__).resolve().parents[2]
+VECTOR = (
+    ROOT
+    / "docs/en/architecture/test-vectors/canonical-decision-artifact-v1/vector-01.json"
+)
+PROMOTED_AT = datetime(2026, 8, 27, 12, 0, tzinfo=UTC)
+CHECKED_AT = PROMOTED_AT + timedelta(seconds=1)
+SEMANTIC_FIELDS = (
+    "decision_id",
+    "request_id",
+    "policy_snapshot_id",
+    "actor_identity",
+    "target_system",
+    "target_resource",
+    "intended_action",
+    "evidence_refs",
+    "decision_hash",
+    "decision_ts",
+    "ttl_seconds",
+    "expected_state_fingerprint",
+    "approval_context",
+    "policy_lineage",
+)
+
+
+def _promotion(*, required_human_approval: bool = True):
+    candidate = DecisionCandidate(
+        candidate_id="candidate-one",
+        source_model="verified-planner",
+        action_type="update",
+        actor_identity="actor:one",
+        target_system="inventory",
+        target_resource="resource:one",
+        intended_action="set_state:one",
+        required_authority=["inventory:write"],
+        required_human_approval=required_human_approval,
+        risk_level="medium",
+        evidence_refs=["candidate-evidence:one"],
+        policy_context_refs=["policy-context:one"],
+    )
+    source = json.loads(VECTOR.read_text(encoding="utf-8"))["source_projection"]
+    source.update(
+        request_id="request-one",
+        chosen=candidate.to_dict(),
+        governance_identity={
+            "digest": "a" * 64,
+            "policy_version": "policy-one",
+            "signature_verified": True,
+            "signer_id": "signer:one",
+            "verified_at": (PROMOTED_AT - timedelta(seconds=30))
+            .isoformat()
+            .replace("+00:00", "Z"),
+        },
+    )
+    artifact = build_canonical_decision_artifact(
+        DecideResponse.model_validate(source),
+        decision_ts=PROMOTED_AT - timedelta(seconds=20),
+    )
+    return build_canonical_verified_decision_promotion_packet(
+        artifact,
+        candidate,
+        promoted_at=PROMOTED_AT,
+        ttl_seconds=120,
+        expected_state_fingerprint="state:one",
+    )
+
+
+def _readiness():
+    return build_canonical_promotion_execution_intent_readiness_packet(
+        _promotion(), checked_at=CHECKED_AT
+    )
+
+
+def _set_path(raw: dict, path: str, value: object) -> None:
+    target = raw
+    parts = path.split(".")
+    for part in parts[:-1]:
+        target = target[part]
+    target[parts[-1]] = value
+
+
+def test_exact_promoted_intent_and_native_shapes_are_preserved() -> None:
+    promotion = verify_canonical_verified_decision_promotion_packet(_promotion())
+    readiness = verify_canonical_promotion_execution_intent_readiness_packet(
+        build_canonical_promotion_execution_intent_readiness_packet(
+            promotion, checked_at=CHECKED_AT
+        )
+    )
+
+    assert readiness.execution_intent == promotion.exact_execution_intent
+    assert readiness.execution_intent_id == promotion.execution_intent_id
+    assert readiness.execution_intent_hash == promotion.execution_intent_hash
+    assert readiness.source_to_execution_intent_mapping == {
+        field: promotion.exact_execution_intent[field]
+        for field in SEMANTIC_FIELDS
+    }
+    approval = readiness.source_to_execution_intent_mapping["approval_context"]
+    assert approval == promotion.exact_execution_intent["approval_context"]
+    assert set(approval) == {
+        "required_human_approval",
+        "policy_context_refs",
+    }
+    policy = readiness.source_to_execution_intent_mapping["policy_lineage"]
+    assert policy == promotion.exact_execution_intent["policy_lineage"]
+    assert set(policy) == {
+        "version",
+        "semantic_digest",
+        "signer_id",
+        "verified_at",
+    }
+
+
+def test_human_approval_requirement_needs_no_pre_gate_receipt() -> None:
+    readiness = verify_canonical_promotion_execution_intent_readiness_packet(
+        build_canonical_promotion_execution_intent_readiness_packet(
+            _promotion(required_human_approval=True), checked_at=CHECKED_AT
+        )
+    )
+
+    approval = readiness.source_to_execution_intent_mapping["approval_context"]
+    assert approval["required_human_approval"] is True
+    assert "human_approval_receipt_ref" not in approval
+    assert "human_approval_receipt_hash" not in approval
+
+
+@pytest.mark.parametrize(
+    ("path", "value"),
+    [
+        ("source_promotion_packet.format_version", "malformed"),
+        ("source_promotion_packet.promotion_hash", "0" * 64),
+        ("source_decision_identity.decision_id", "decision:substituted"),
+        ("source_decision_identity.decision_hash", "0" * 64),
+        ("candidate_identity.candidate_id", "candidate-substituted"),
+        ("candidate_identity.candidate_hash", "0" * 64),
+        (
+            "selected_action_lineage.selected_action_evidence.candidate_hash",
+            "0" * 64,
+        ),
+        (
+            "selected_action_lineage.selected_action_evidence_hash",
+            "0" * 64,
+        ),
+        (
+            "policy_snapshot_lineage.policy_snapshot_evidence.snapshot_id",
+            "0" * 64,
+        ),
+        ("policy_snapshot_lineage.policy_snapshot_evidence_hash", "0" * 64),
+        ("execution_intent_id", "ei:v1:sha256:" + "0" * 64),
+        ("execution_intent_hash", "0" * 64),
+        ("execution_intent.actor_identity", "actor:substituted"),
+        ("execution_intent.target_system", "system:substituted"),
+        ("execution_intent.target_resource", "resource:substituted"),
+        ("execution_intent.intended_action", "action:substituted"),
+        ("execution_intent.evidence_refs", ["evidence:substituted"]),
+        (
+            "source_to_execution_intent_mapping.approval_context",
+            {"required_human_approval": False, "policy_context_refs": []},
+        ),
+        ("source_to_execution_intent_mapping.policy_lineage", {}),
+        (
+            (
+                "source_to_execution_intent_mapping.approval_context."
+                "required_human_approval"
+            ),
+            False,
+        ),
+        (
+            "source_to_execution_intent_mapping.approval_context.policy_context_refs",
+            [],
+        ),
+        (
+            "source_to_execution_intent_mapping.policy_lineage.signer_id",
+            "signer:substituted",
+        ),
+        (
+            "source_to_execution_intent_mapping.policy_lineage.verified_at",
+            "2026-08-27T11:00:00Z",
+        ),
+        ("source_promotion_id", "cvdp:v1:sha256:" + "0" * 64),
+        ("source_promotion_hash", "0" * 64),
+        ("readiness_hash", "0" * 64),
+        ("readiness_id", "peir:v1:sha256:" + "0" * 64),
+    ],
+)
+def test_readiness_tampering_fails_closed(path: str, value: object) -> None:
+    raw = deepcopy(_readiness().model_dump(mode="json"))
+    _set_path(raw, path, value)
+
+    with pytest.raises(CanonicalPromotionExecutionIntentReadinessError):
+        verify_canonical_promotion_execution_intent_readiness_packet(raw)
+
+
+@pytest.mark.parametrize(
+    ("path", "value"),
+    [
+        ("canonical_decision_id", "decision:substituted"),
+        ("candidate_id", "candidate-substituted"),
+        ("selected_action_evidence_hash", "0" * 64),
+        ("policy_snapshot_evidence_hash", "0" * 64),
+    ],
+)
+def test_embedded_promotion_lineage_tampering_fails_closed(
+    path: str, value: object
+) -> None:
+    raw = deepcopy(_readiness().model_dump(mode="json"))
+    _set_path(raw["source_promotion_packet"], path, value)
+
+    with pytest.raises(CanonicalPromotionExecutionIntentReadinessError):
+        verify_canonical_promotion_execution_intent_readiness_packet(raw)


### PR DESCRIPTION
### Motivation

- Introduce a new promotion-native readiness artifact that proves pre-Bind readiness directly from an independently verified `CanonicalVerifiedDecisionPromotionPacket` without translating or reinterpreting legacy v1 readiness semantics.
- Preserve all historical `canonical-execution-intent-formation-readiness/v1` behavior untouched while providing a separate production path for verified promotions.
- Require literal equality of the authoritative promoted `ExecutionIntent`, its `execution_intent_id`, and `execution_intent_hash` and preserve `approval_context` and `policy_lineage` shapes exactly as presented by the promotion packet.
- Security note: this is governance-sensitive pre-Bind verification code and requires human maintainer review; it does not claim Bind authority, human approval proof, or authority evidence proof.

### Description

- Added `veritas_os/policy/canonical_promotion_execution_intent_readiness.py` which defines `CanonicalPromotionExecutionIntentReadinessPacket` with format version `canonical-promotion-execution-intent-readiness/v1`, content-addressed `readiness_id` (`peir:v1:sha256:<digest>`), and a builder `build_canonical_promotion_execution_intent_readiness_packet()` plus verifier `verify_canonical_promotion_execution_intent_readiness_packet()`.
- The builder accepts exactly one authoritative input (`CanonicalVerifiedDecisionPromotionPacket`) and independently verifies it with `verify_canonical_verified_decision_promotion_packet()`, then copies `exact_execution_intent`, `execution_intent_id`, and `execution_intent_hash` verbatim into the readiness packet and constructs `source_to_execution_intent_mapping` as the exact promoted intent minus `execution_intent_id`.
- Defined a promotion-native required-field presence contract (fields marked `verified_exact_value`) and canonical JSON SHA-256 digests for mapping, required-field presence, and packet identity; explicitly declared scope limitations (e.g., `NOT_BIND_AUTHORIZATION`, `NOT_HUMAN_APPROVAL_PROOF`).
- Added focused tests in `veritas_os/tests/test_canonical_promotion_execution_intent_readiness.py` asserting exact ExecutionIntent equality, exact `execution_intent_id`/hash equality, preservation of `approval_context` and `policy_lineage` keys, mandatory-human-approval-without-pre-gate-receipt behavior, and extensive tamper/fail-closed negative cases; legacy readiness/v1 code was not modified.

### Testing

- Added unit tests: `veritas_os/tests/test_canonical_promotion_execution_intent_readiness.py` which includes equality, approval-shape, and negative tamper tests for fail-closed behavior.
- Static/compile checks passed: `python -m py_compile` for the new module and tests under `PYENV_VERSION=3.11.15` and `PYENV_VERSION=3.12.13` succeeded, and `scripts/architecture/check_responsibility_boundaries.py` passed.
- Full `pytest` runs were attempted but could not complete in the execution environment because `pydantic` and other runtime test dependencies were not available and network access for dependency resolution was blocked, so the new tests are present but not executed to completion here.
- Lint/line-fix adjustments were applied to satisfy style constraints during the rollout, and responsibility boundaries were verified to ensure no cross-component responsibility violation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a900b503c648326922af0d282ff0b03)