### PR TITLE
feat(governance): add promotion-native adapter dry-run fixture result

### DIFF
--- a/veritas_os/policy/adapter_dry_run_result.py
+++ b/veritas_os/policy/adapter_dry_run_result.py
@@ -317,27 +317,55 @@ def _fixture_results(
     supplied: Any,
     planned_steps: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
+    """Validate legacy fixture steps through the shared semantic validator."""
+    return validate_fixture_step_results(
+        supplied,
+        planned_steps,
+        value_domain=VALUE_DOMAIN,
+        result_limitations=RESULT_LIMITATIONS,
+        error_type=AdapterDryRunFixtureResultError,
+        error_code="ADR_FIXTURE_RESULTS_INVALID",
+        live_error_code="ADR_LIVE_RESULT_FORBIDDEN",
+        forbidden_error_code="ADR_FORBIDDEN_EXECUTION_RESULT",
+    )
+
+
+def validate_fixture_step_results(
+    supplied: Any,
+    planned_steps: list[dict[str, Any]],
+    *,
+    value_domain: str,
+    result_limitations: tuple[str, ...],
+    error_type: type[ValueError],
+    error_code: str,
+    live_error_code: str,
+    forbidden_error_code: str,
+) -> list[dict[str, Any]]:
+    """Validate the canonical seven no-effect fixture-step semantics.
+
+    Hash domains and refusal types remain caller-owned so legacy serialization
+    and hashes are unchanged while promotion-native packets share the exact
+    same closed set of fixture claims.
+    """
     raw_results = _json_value(supplied)
     if not isinstance(raw_results, list) or len(raw_results) != len(planned_steps):
-        raise AdapterDryRunFixtureResultError("ADR_FIXTURE_RESULTS_INVALID")
+        raise error_type(error_code)
     results = []
     for raw, step in zip(raw_results, planned_steps, strict=True):
         if not isinstance(raw, dict):
-            raise AdapterDryRunFixtureResultError("ADR_FIXTURE_RESULTS_INVALID")
+            raise error_type(error_code)
         value = dict(raw)
         if value.get("fixture_value_summary") != FIXTURE_VALUE_SUMMARY:
-            raise AdapterDryRunFixtureResultError("ADR_LIVE_RESULT_FORBIDDEN")
-        expected_digest = _digest(VALUE_DOMAIN, value.get("fixture_value_summary"))
+            raise error_type(live_error_code)
+        expected_digest = _digest(value_domain, value.get("fixture_value_summary"))
         supplied_digest = value.get("fixture_value_digest")
         if supplied_digest is not None and supplied_digest != expected_digest:
-            raise AdapterDryRunFixtureResultError("ADR_FIXTURE_RESULTS_INVALID")
+            raise error_type(error_code)
         value["fixture_value_digest"] = expected_digest
         try:
             result = AdapterDryRunFixtureStepResult.model_validate(value)
         except ValidationError as exc:
-            raise AdapterDryRunFixtureResultError(
-                "ADR_FIXTURE_RESULTS_INVALID"
-            ) from exc
+            raise error_type(error_code) from exc
         expected_id = (
             f"dry-run-fixture-result:v1:{step['ordinal']}:"
             f"{step['planned_adapter_method'].replace('_', '-')}"
@@ -349,14 +377,14 @@ def _fixture_results(
             or result.planned_adapter_method != step["planned_adapter_method"]
             or result.matched_expected_output_ref != step["expected_output_ref"]
             or result.refusal_if_missing_later != step["refusal_if_missing_later"]
-            or result.result_scope_limitations != RESULT_LIMITATIONS
+            or result.result_scope_limitations != result_limitations
         ):
-            raise AdapterDryRunFixtureResultError("ADR_FIXTURE_RESULTS_INVALID")
+            raise error_type(error_code)
         results.append(result.model_dump(mode="json"))
     if [item["planned_adapter_method"] for item in results] != list(
         PLANNED_METHODS
     ):
-        raise AdapterDryRunFixtureResultError("ADR_FORBIDDEN_EXECUTION_RESULT")
+        raise error_type(forbidden_error_code)
     return results
 
 

--- a/veritas_os/policy/canonical_promotion_adapter_dry_run_fixture_result.py
+++ b/veritas_os/policy/canonical_promotion_adapter_dry_run_fixture_result.py
@@ -1,0 +1,478 @@
+"""Record promotion-native adapter dry-run fixture evidence without effects.
+
+This boundary accepts only a verified promotion-native dry-run plan and inert
+fixture values.  It never creates or invokes an adapter, authorizes Bind,
+proves human approval, observes live state, or writes TrustLog.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime
+from typing import Any, Literal, Mapping
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from veritas_os.policy.adapter_dry_run_result import (
+    AdapterDryRunFixtureStepResult,
+    FIXTURE_VALUE_SUMMARY,
+    validate_fixture_step_results,
+)
+from veritas_os.policy.bind_adapter_contract_selection import (
+    BindAdapterContractSelectionError,
+    verify_bind_adapter_contract_descriptor,
+)
+from veritas_os.policy.bind_artifacts import ExecutionIntent, hash_execution_intent
+from veritas_os.policy.canonical_promotion_adapter_dry_run_plan import (
+    STEPS_DOMAIN as PLAN_STEPS_DOMAIN,
+    CanonicalPromotionAdapterDryRunPlanError,
+    CanonicalPromotionAdapterDryRunPlanPacket,
+    _digest as _plan_digest,
+    verify_canonical_promotion_adapter_dry_run_plan_packet,
+)
+
+FORMAT_VERSION = "canonical-promotion-adapter-dry-run-fixture-result/v1"
+RESULT_MECHANISM = (
+    "record_promotion_adapter_dry_run_fixture_result_without_invocation/v1"
+)
+VALUE_DOMAIN = "veritas.promotion-adapter-dry-run-fixture-result.value/v1"
+RESULTS_DOMAIN = "veritas.promotion-adapter-dry-run-fixture-result.results/v1"
+LOCAL_CHECKS_DOMAIN = (
+    "veritas.promotion-adapter-dry-run-fixture-result.local-checks/v1"
+)
+FUTURE_REQUIREMENTS_DOMAIN = (
+    "veritas.promotion-adapter-dry-run-fixture-result.future-requirements/v1"
+)
+PACKET_DOMAIN = "veritas.promotion-adapter-dry-run-fixture-result.packet/v1"
+RESULT_STATUS = "PROMOTION_NATIVE_ADAPTER_DRY_RUN_FIXTURE_RESULT_RECORDED_NO_EFFECT"
+
+RESULT_LIMITATIONS = (
+    "NOT_LIVE_RESULT",
+    "NOT_ADAPTER_INVOCATION",
+    "NOT_LIVE_STATE",
+    "NOT_AUTHORITY_REVALIDATION",
+    "NOT_CONSTRAINT_REVALIDATION",
+    "NOT_RUNTIME_RISK_ACCEPTANCE",
+    "NOT_BIND_AUTHORIZATION",
+    "NOT_BIND_RECEIPT",
+    "NOT_TRUSTLOG_WRITE",
+    "NOT_OPERATION_COMMIT",
+)
+SCOPE_LIMITATIONS = (
+    "NOT_EXECUTION_AUTHORITY",
+    "NOT_BIND_AUTHORIZATION",
+    "NOT_BIND_RECEIPT",
+    "NOT_BIND_INVOCATION",
+    "NOT_LIVE_ADAPTER_RESULT",
+    "NOT_LIVE_STATE_CHECK",
+    "NOT_HUMAN_APPROVAL_PROOF",
+    "NOT_AUTHORITY_EVIDENCE_PROOF",
+    "NOT_RUNTIME_RISK_ACCEPTANCE",
+    "NOT_EXTERNAL_EFFECT",
+    "NOT_OPERATION_COMMIT",
+    "NOT_TRUSTLOG_WRITE",
+)
+LOCAL_RESULT_CHECKS = {
+    key: True
+    for key in (
+        "promotion_adapter_dry_run_plan_verified",
+        "execution_intent_object_verified",
+        "execution_intent_id_verified",
+        "execution_intent_hash_verified",
+        "adapter_descriptor_verified",
+        "adapter_descriptor_target_verified",
+        "planned_steps_preserved",
+        "fixture_results_ordered",
+        "fixture_results_match_planned_steps",
+        "fixture_values_digest_verified",
+        "no_apply_result",
+        "no_postcondition_result",
+        "no_revert_result",
+        "resulted_after_plan",
+        "no_adapter_instance",
+        "no_adapter_invocation",
+        "no_network",
+        "no_filesystem",
+        "no_external_effect",
+        "no_live_state_claim",
+        "no_human_approval_proof",
+        "no_authority_evidence_proof",
+    )
+}
+FUTURE_REFERENCE_REHEARSAL_REQUIREMENTS = {
+    key: True
+    for key in (
+        "fresh_verified_source_gate_required",
+        "adapter_instance_required",
+        "all_seven_adapter_calls_required",
+        "live_result_packet_required",
+        "fixture_result_must_not_be_treated_as_live",
+        "human_approval_proof_still_deferred",
+        "authority_evidence_proof_still_deferred",
+        "trustlog_policy_still_deferred",
+        "bind_receipt_still_deferred",
+        "apply_still_forbidden",
+    )
+}
+
+
+class CanonicalPromotionAdapterDryRunFixtureResultError(ValueError):
+    """Stable fail-closed promotion fixture-result refusal."""
+
+
+class CanonicalPromotionAdapterDryRunFixtureResultPacket(BaseModel):
+    """Immutable promotion-native binding to seven inert fixture results."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    format_version: Literal[
+        "canonical-promotion-adapter-dry-run-fixture-result/v1"
+    ]
+    adapter_dry_run_fixture_result_id: str = Field(
+        pattern=r"^padr:v1:sha256:[0-9a-f]{64}$"
+    )
+    adapter_dry_run_fixture_result_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    result_mechanism: Literal[
+        "record_promotion_adapter_dry_run_fixture_result_without_invocation/v1"
+    ]
+    resulted_at: str
+    source_adapter_dry_run_plan_id: str
+    source_adapter_dry_run_plan_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    source_adapter_dry_run_plan_packet: dict[str, Any]
+    source_adapter_contract_selection_id: str
+    source_adapter_contract_selection_hash: str
+    source_bind_preflight_adjudication_id: str
+    source_bind_preflight_adjudication_hash: str
+    source_pre_bind_validation_id: str
+    source_pre_bind_validation_hash: str
+    source_readiness_id: str
+    source_readiness_hash: str
+    source_promotion_id: str
+    source_promotion_hash: str
+    source_decision_identity: dict[str, Any]
+    candidate_identity: dict[str, Any]
+    selected_action_lineage: dict[str, Any]
+    policy_snapshot_lineage: dict[str, Any]
+    execution_intent: dict[str, Any]
+    execution_intent_id: str
+    execution_intent_hash: str
+    adapter_contract_descriptor: dict[str, Any]
+    adapter_contract_id: str
+    adapter_contract_hash: str
+    adapter_contract_version: Literal["bind-adapter-contract/v1"]
+    approval_context: dict[str, Any]
+    policy_lineage: dict[str, Any]
+    planned_steps: tuple[dict[str, Any], ...]
+    planned_step_digest: str
+    fixture_step_results: tuple[AdapterDryRunFixtureStepResult, ...]
+    fixture_result_digest: str
+    local_result_checks: dict[str, bool]
+    local_result_checks_digest: str
+    future_reference_rehearsal_requirements: dict[str, bool]
+    future_reference_rehearsal_requirements_digest: str
+    dry_run_fixture_result_status: Literal[
+        "PROMOTION_NATIVE_ADAPTER_DRY_RUN_FIXTURE_RESULT_RECORDED_NO_EFFECT"
+    ]
+    ready_for_promotion_native_reference_rehearsal: Literal[True]
+    scope_limitations: tuple[str, ...]
+
+
+def _json_value(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        value = value.model_dump(mode="json")
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        if value != value or value in (float("inf"), float("-inf")):
+            raise CanonicalPromotionAdapterDryRunFixtureResultError(
+                "PADR_PACKET_INVALID"
+            )
+        return value
+    if isinstance(value, datetime):
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise CanonicalPromotionAdapterDryRunFixtureResultError(
+                "PADR_RESULTED_AT_INVALID"
+            )
+        return value.isoformat()
+    if isinstance(value, (list, tuple)):
+        return [_json_value(item) for item in value]
+    if isinstance(value, Mapping) and all(isinstance(key, str) for key in value):
+        return {key: _json_value(item) for key, item in value.items()}
+    raise CanonicalPromotionAdapterDryRunFixtureResultError("PADR_PACKET_INVALID")
+
+
+def _aware(value: Any, code: str) -> datetime:
+    try:
+        parsed = value if isinstance(value, datetime) else datetime.fromisoformat(value)
+    except (TypeError, ValueError) as exc:
+        raise CanonicalPromotionAdapterDryRunFixtureResultError(code) from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise CanonicalPromotionAdapterDryRunFixtureResultError(code)
+    return parsed
+
+
+def _digest(domain: str, value: Any) -> str:
+    encoded = json.dumps(
+        {"domain": domain, "value": _json_value(value)},
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _packet_hash(raw: dict[str, Any]) -> str:
+    return _digest(
+        PACKET_DOMAIN,
+        {
+            key: value
+            for key, value in raw.items()
+            if key
+            not in {
+                "adapter_dry_run_fixture_result_id",
+                "adapter_dry_run_fixture_result_hash",
+            }
+        },
+    )
+
+
+def _verified_plan(value: Any) -> CanonicalPromotionAdapterDryRunPlanPacket:
+    try:
+        return verify_canonical_promotion_adapter_dry_run_plan_packet(value)
+    except (CanonicalPromotionAdapterDryRunPlanError, TypeError, ValueError) as exc:
+        raise CanonicalPromotionAdapterDryRunFixtureResultError(
+            "PADR_SOURCE_PLAN_INVALID"
+        ) from exc
+
+
+def _intent(source: CanonicalPromotionAdapterDryRunPlanPacket) -> ExecutionIntent:
+    try:
+        intent = ExecutionIntent(**source.execution_intent)
+    except (TypeError, ValueError) as exc:
+        raise CanonicalPromotionAdapterDryRunFixtureResultError(
+            "PADR_EXECUTION_INTENT_INVALID"
+        ) from exc
+    if intent.to_dict() != source.execution_intent:
+        raise CanonicalPromotionAdapterDryRunFixtureResultError(
+            "PADR_EXECUTION_INTENT_OBJECT_MISMATCH"
+        )
+    if intent.execution_intent_id != source.execution_intent_id:
+        raise CanonicalPromotionAdapterDryRunFixtureResultError(
+            "PADR_EXECUTION_INTENT_ID_MISMATCH"
+        )
+    if hash_execution_intent(intent) != source.execution_intent_hash:
+        raise CanonicalPromotionAdapterDryRunFixtureResultError(
+            "PADR_EXECUTION_INTENT_HASH_MISMATCH"
+        )
+    return intent
+
+
+def _descriptor(source: CanonicalPromotionAdapterDryRunPlanPacket, intent: ExecutionIntent):
+    try:
+        descriptor = verify_bind_adapter_contract_descriptor(
+            source.adapter_contract_descriptor, intent
+        )
+    except (BindAdapterContractSelectionError, TypeError, ValueError) as exc:
+        raise CanonicalPromotionAdapterDryRunFixtureResultError(
+            "PADR_DESCRIPTOR_INVALID"
+        ) from exc
+    if (
+        descriptor.model_dump(mode="json") != source.adapter_contract_descriptor
+        or descriptor.adapter_contract_id != source.adapter_contract_id
+        or descriptor.adapter_contract_hash != source.adapter_contract_hash
+        or descriptor.adapter_contract_version != source.adapter_contract_version
+    ):
+        raise CanonicalPromotionAdapterDryRunFixtureResultError(
+            "PADR_DESCRIPTOR_MISMATCH"
+        )
+    return descriptor
+
+
+LINEAGE_FIELDS = (
+    "source_adapter_contract_selection_id",
+    "source_adapter_contract_selection_hash",
+    "source_bind_preflight_adjudication_id",
+    "source_bind_preflight_adjudication_hash",
+    "source_pre_bind_validation_id",
+    "source_pre_bind_validation_hash",
+    "source_readiness_id",
+    "source_readiness_hash",
+    "source_promotion_id",
+    "source_promotion_hash",
+    "source_decision_identity",
+    "candidate_identity",
+    "selected_action_lineage",
+    "policy_snapshot_lineage",
+    "approval_context",
+    "policy_lineage",
+)
+
+
+def _fixture_results(supplied: Any, steps: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return validate_fixture_step_results(
+        _json_value(supplied),
+        steps,
+        value_domain=VALUE_DOMAIN,
+        result_limitations=RESULT_LIMITATIONS,
+        error_type=CanonicalPromotionAdapterDryRunFixtureResultError,
+        error_code="PADR_FIXTURE_RESULTS_INVALID",
+        live_error_code="PADR_LIVE_RESULT_FORBIDDEN",
+        forbidden_error_code="PADR_EFFECT_RESULT_FORBIDDEN",
+    )
+
+
+def build_canonical_promotion_adapter_dry_run_fixture_result_packet(
+    adapter_dry_run_plan_packet: CanonicalPromotionAdapterDryRunPlanPacket
+    | Mapping[str, Any],
+    fixture_step_results: Any,
+    resulted_at: datetime,
+) -> CanonicalPromotionAdapterDryRunFixtureResultPacket:
+    """Build deterministic no-effect evidence from one verified native plan."""
+    resulted = _aware(resulted_at, "PADR_RESULTED_AT_INVALID")
+    source = _verified_plan(_json_value(adapter_dry_run_plan_packet))
+    if resulted < _aware(source.planned_at, "PADR_SOURCE_PLAN_INVALID"):
+        raise CanonicalPromotionAdapterDryRunFixtureResultError(
+            "PADR_RESULTED_BEFORE_PLAN"
+        )
+    intent = _intent(source)
+    _descriptor(source, intent)
+    steps = [step.model_dump(mode="json") for step in source.planned_steps]
+    if source.planned_step_digest != _plan_digest(PLAN_STEPS_DOMAIN, steps):
+        raise CanonicalPromotionAdapterDryRunFixtureResultError(
+            "PADR_PLANNED_STEP_DIGEST_MISMATCH"
+        )
+    results = _fixture_results(fixture_step_results, steps)
+    source_raw = source.model_dump(mode="json")
+    raw = {
+        "format_version": FORMAT_VERSION,
+        "result_mechanism": RESULT_MECHANISM,
+        "resulted_at": resulted.isoformat(),
+        "source_adapter_dry_run_plan_id": source.adapter_dry_run_plan_id,
+        "source_adapter_dry_run_plan_hash": source.adapter_dry_run_plan_hash,
+        "source_adapter_dry_run_plan_packet": source_raw,
+        **{field: source_raw[field] for field in LINEAGE_FIELDS},
+        "execution_intent": source.execution_intent,
+        "execution_intent_id": source.execution_intent_id,
+        "execution_intent_hash": source.execution_intent_hash,
+        "adapter_contract_descriptor": source.adapter_contract_descriptor,
+        "adapter_contract_id": source.adapter_contract_id,
+        "adapter_contract_hash": source.adapter_contract_hash,
+        "adapter_contract_version": source.adapter_contract_version,
+        "planned_steps": steps,
+        "planned_step_digest": source.planned_step_digest,
+        "fixture_step_results": results,
+        "fixture_result_digest": _digest(RESULTS_DOMAIN, results),
+        "local_result_checks": LOCAL_RESULT_CHECKS,
+        "local_result_checks_digest": _digest(
+            LOCAL_CHECKS_DOMAIN, LOCAL_RESULT_CHECKS
+        ),
+        "future_reference_rehearsal_requirements": (
+            FUTURE_REFERENCE_REHEARSAL_REQUIREMENTS
+        ),
+        "future_reference_rehearsal_requirements_digest": _digest(
+            FUTURE_REQUIREMENTS_DOMAIN, FUTURE_REFERENCE_REHEARSAL_REQUIREMENTS
+        ),
+        "dry_run_fixture_result_status": RESULT_STATUS,
+        "ready_for_promotion_native_reference_rehearsal": True,
+        "scope_limitations": SCOPE_LIMITATIONS,
+    }
+    digest = _packet_hash(raw)
+    raw["adapter_dry_run_fixture_result_hash"] = digest
+    raw["adapter_dry_run_fixture_result_id"] = f"padr:v1:sha256:{digest}"
+    return verify_canonical_promotion_adapter_dry_run_fixture_result_packet(raw)
+
+
+def verify_canonical_promotion_adapter_dry_run_fixture_result_packet(
+    packet: Any,
+) -> CanonicalPromotionAdapterDryRunFixtureResultPacket:
+    """Independently reverify every source, semantic, lineage, and digest."""
+    try:
+        value = _json_value(packet)
+        candidate = CanonicalPromotionAdapterDryRunFixtureResultPacket.model_validate(
+            value
+        )
+        raw = candidate.model_dump(mode="json")
+        source = _verified_plan(candidate.source_adapter_dry_run_plan_packet)
+        intent = _intent(source)
+        descriptor = _descriptor(source, intent)
+        if (
+            candidate.source_adapter_dry_run_plan_id != source.adapter_dry_run_plan_id
+            or candidate.source_adapter_dry_run_plan_hash
+            != source.adapter_dry_run_plan_hash
+            or any(
+                getattr(candidate, field) != getattr(source, field)
+                for field in LINEAGE_FIELDS
+            )
+            or candidate.execution_intent != source.execution_intent
+            or candidate.execution_intent != intent.to_dict()
+            or candidate.execution_intent_id != source.execution_intent_id
+            or candidate.execution_intent_id != intent.execution_intent_id
+            or candidate.execution_intent_hash != source.execution_intent_hash
+            or candidate.execution_intent_hash != hash_execution_intent(intent)
+            or candidate.adapter_contract_descriptor
+            != descriptor.model_dump(mode="json")
+            or candidate.adapter_contract_id != source.adapter_contract_id
+            or candidate.adapter_contract_hash != source.adapter_contract_hash
+            or candidate.adapter_contract_version != source.adapter_contract_version
+        ):
+            raise CanonicalPromotionAdapterDryRunFixtureResultError(
+                "PADR_SOURCE_BINDING_MISMATCH"
+            )
+        if _aware(candidate.resulted_at, "PADR_RESULTED_AT_INVALID") < _aware(
+            source.planned_at, "PADR_SOURCE_PLAN_INVALID"
+        ):
+            raise CanonicalPromotionAdapterDryRunFixtureResultError(
+                "PADR_RESULTED_BEFORE_PLAN"
+            )
+        steps = [step.model_dump(mode="json") for step in source.planned_steps]
+        if (
+            list(candidate.planned_steps) != steps
+            or candidate.planned_step_digest != source.planned_step_digest
+            or candidate.planned_step_digest
+            != _plan_digest(PLAN_STEPS_DOMAIN, steps)
+        ):
+            raise CanonicalPromotionAdapterDryRunFixtureResultError(
+                "PADR_PLANNED_STEPS_MISMATCH"
+            )
+        results = _fixture_results(
+            [item.model_dump(mode="json") for item in candidate.fixture_step_results],
+            steps,
+        )
+        if candidate.fixture_result_digest != _digest(RESULTS_DOMAIN, results):
+            raise CanonicalPromotionAdapterDryRunFixtureResultError(
+                "PADR_FIXTURE_RESULT_DIGEST_MISMATCH"
+            )
+        if (
+            candidate.local_result_checks != LOCAL_RESULT_CHECKS
+            or candidate.local_result_checks_digest
+            != _digest(LOCAL_CHECKS_DOMAIN, LOCAL_RESULT_CHECKS)
+            or candidate.future_reference_rehearsal_requirements
+            != FUTURE_REFERENCE_REHEARSAL_REQUIREMENTS
+            or candidate.future_reference_rehearsal_requirements_digest
+            != _digest(
+                FUTURE_REQUIREMENTS_DOMAIN,
+                FUTURE_REFERENCE_REHEARSAL_REQUIREMENTS,
+            )
+            or candidate.scope_limitations != SCOPE_LIMITATIONS
+        ):
+            raise CanonicalPromotionAdapterDryRunFixtureResultError(
+                "PADR_CANONICAL_CHECKS_MISMATCH"
+            )
+        digest = _packet_hash(raw)
+        if candidate.adapter_dry_run_fixture_result_hash != digest:
+            raise CanonicalPromotionAdapterDryRunFixtureResultError(
+                "PADR_PACKET_HASH_MISMATCH"
+            )
+        if candidate.adapter_dry_run_fixture_result_id != f"padr:v1:sha256:{digest}":
+            raise CanonicalPromotionAdapterDryRunFixtureResultError(
+                "PADR_PACKET_ID_MISMATCH"
+            )
+        return candidate
+    except CanonicalPromotionAdapterDryRunFixtureResultError:
+        raise
+    except (TypeError, ValueError, ValidationError) as exc:
+        raise CanonicalPromotionAdapterDryRunFixtureResultError(
+            "PADR_PACKET_INVALID"
+        ) from exc

--- a/veritas_os/tests/test_canonical_promotion_adapter_dry_run_fixture_result.py
+++ b/veritas_os/tests/test_canonical_promotion_adapter_dry_run_fixture_result.py
@@ -1,0 +1,229 @@
+"""Fail-closed tests for promotion-native no-effect fixture results."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import timedelta
+
+import pytest
+
+from veritas_os.policy.adapter_dry_run_result import (
+    RESULT_LIMITATIONS as LEGACY_RESULT_LIMITATIONS,
+    build_adapter_dry_run_fixture_result_packet,
+)
+from veritas_os.policy.bind_artifacts import ExecutionIntent, hash_execution_intent
+from veritas_os.policy.canonical_promotion_adapter_dry_run_fixture_result import (
+    RESULT_LIMITATIONS,
+    VALUE_DOMAIN,
+    CanonicalPromotionAdapterDryRunFixtureResultError,
+    _digest,
+    build_canonical_promotion_adapter_dry_run_fixture_result_packet,
+    verify_canonical_promotion_adapter_dry_run_fixture_result_packet,
+)
+from veritas_os.tests.test_adapter_dry_run_fixture_result import (
+    RESULTED_AT as LEGACY_RESULTED_AT,
+    _fixtures as legacy_fixtures,
+)
+from veritas_os.tests.test_adapter_dry_run_plan import _packet as legacy_plan
+from veritas_os.tests.test_canonical_promotion_adapter_dry_run_plan import (
+    PLANNED_AT,
+    _packet as promotion_plan,
+)
+
+RESULTED_AT = PLANNED_AT + timedelta(seconds=1)
+
+
+def _fixtures(plan=None):
+    plan = plan or promotion_plan()
+    return [
+        {
+            "step_result_id": (
+                f"dry-run-fixture-result:v1:{step.ordinal}:"
+                f"{step.planned_adapter_method.replace('_', '-')}"
+            ),
+            "planned_step_id": step.step_id,
+            "ordinal": step.ordinal,
+            "planned_adapter_method": step.planned_adapter_method,
+            "result_mode": "fixture_no_effect",
+            "result_source_kind": "unit_test_fixture",
+            "live_observed": False,
+            "adapter_instance_created": False,
+            "adapter_method_called": False,
+            "network_used": False,
+            "filesystem_used": False,
+            "external_effect_used": False,
+            "trustlog_written": False,
+            "bind_receipt_created": False,
+            "fixture_input_ref": f"fixture:{step.planned_adapter_method}",
+            "fixture_value_summary": {
+                "status": "FIXTURE_RESULT_AVAILABLE",
+                "semantic": "no_effect_fixture",
+                "live_system_claim": False,
+            },
+            "matched_expected_output_ref": step.expected_output_ref,
+            "refusal_if_missing_later": step.refusal_if_missing_later,
+            "result_scope_limitations": RESULT_LIMITATIONS,
+        }
+        for step in plan.planned_steps
+    ]
+
+
+def _packet():
+    plan = promotion_plan()
+    return build_canonical_promotion_adapter_dry_run_fixture_result_packet(
+        plan, _fixtures(plan), RESULTED_AT
+    )
+
+
+def _set_path(raw: dict, path: str, value: object) -> None:
+    target = raw
+    parts = path.split(".")
+    for part in parts[:-1]:
+        target = target[int(part)] if isinstance(target, list) else target[part]
+    if isinstance(target, list):
+        target[int(parts[-1])] = value
+    else:
+        target[parts[-1]] = value
+
+
+def test_full_chain_preserves_authoritative_intent_descriptor_and_no_effects() -> None:
+    source = promotion_plan()
+    packet = verify_canonical_promotion_adapter_dry_run_fixture_result_packet(
+        _packet()
+    )
+    intent = ExecutionIntent(**packet.execution_intent)
+
+    assert packet.execution_intent == source.execution_intent == intent.to_dict()
+    assert packet.execution_intent_id == source.execution_intent_id
+    assert packet.execution_intent_id == intent.execution_intent_id
+    assert packet.execution_intent_hash == source.execution_intent_hash
+    assert packet.execution_intent_hash == hash_execution_intent(intent)
+    assert packet.adapter_contract_descriptor == source.adapter_contract_descriptor
+    assert packet.adapter_contract_id == source.adapter_contract_id
+    assert packet.adapter_contract_hash == source.adapter_contract_hash
+    assert packet.approval_context["required_human_approval"] is True
+    assert len(packet.fixture_step_results) == 7
+    raw = packet.model_dump(mode="json")
+    forbidden = {
+        "source_formation_hash",
+        "source_eligibility_hash",
+        "source_handoff_hash",
+        "trusted_validation_context_hash",
+        "validation_result_hash",
+        "mapping_value_digest",
+        "replay_summary",
+        "human_approval_receipt_ref",
+        "human_approval_receipt_hash",
+        "apply",
+        "verify_postconditions",
+        "revert",
+    }
+    assert set(raw).isdisjoint(forbidden)
+    for result in packet.fixture_step_results:
+        assert result.live_observed is False
+        assert result.adapter_instance_created is False
+        assert result.adapter_method_called is False
+        assert result.network_used is False
+        assert result.filesystem_used is False
+        assert result.external_effect_used is False
+        assert result.fixture_value_digest == _digest(
+            VALUE_DOMAIN, result.fixture_value_summary
+        )
+
+
+def test_legacy_and_promotion_fixture_steps_have_equal_semantics() -> None:
+    legacy_source = legacy_plan()
+    legacy = build_adapter_dry_run_fixture_result_packet(
+        legacy_source, legacy_fixtures(legacy_source), LEGACY_RESULTED_AT
+    )
+    promotion = _packet()
+    fields = (
+        "ordinal",
+        "planned_adapter_method",
+        "result_mode",
+        "live_observed",
+        "adapter_instance_created",
+        "adapter_method_called",
+        "network_used",
+        "filesystem_used",
+        "external_effect_used",
+        "matched_expected_output_ref",
+        "refusal_if_missing_later",
+    )
+    assert [
+        tuple(getattr(item, field) for field in fields)
+        for item in promotion.fixture_step_results
+    ] == [
+        tuple(getattr(item, field) for field in fields)
+        for item in legacy.fixture_step_results
+    ]
+    assert all(
+        item.result_scope_limitations == RESULT_LIMITATIONS
+        for item in promotion.fixture_step_results
+    )
+    assert all(
+        item.result_scope_limitations == LEGACY_RESULT_LIMITATIONS
+        for item in legacy.fixture_step_results
+    )
+
+
+@pytest.mark.parametrize(
+    ("path", "value"),
+    [
+        ("source_adapter_dry_run_plan_id", "padp:v1:sha256:" + "0" * 64),
+        ("source_adapter_dry_run_plan_hash", "0" * 64),
+        ("source_adapter_contract_selection_hash", "0" * 64),
+        ("source_bind_preflight_adjudication_hash", "0" * 64),
+        ("source_pre_bind_validation_hash", "0" * 64),
+        ("source_readiness_hash", "0" * 64),
+        ("source_promotion_hash", "0" * 64),
+        ("execution_intent.actor_identity", "substitute"),
+        ("execution_intent_id", "ei:v1:sha256:" + "0" * 64),
+        ("execution_intent_hash", "0" * 64),
+        ("adapter_contract_descriptor.target_system", "substitute"),
+        ("adapter_contract_id", "adapter-contract:v1:sha256:" + "0" * 64),
+        ("adapter_contract_hash", "0" * 64),
+        ("planned_steps.0.ordinal", 2),
+        ("fixture_step_results.0.ordinal", 2),
+        ("fixture_step_results.0.planned_adapter_method", "snapshot"),
+        ("fixture_step_results.0.fixture_value_digest", "0" * 64),
+        ("fixture_step_results.0.live_observed", True),
+        ("fixture_step_results.0.adapter_method_called", True),
+        ("fixture_step_results.0.network_used", True),
+        ("fixture_step_results.0.filesystem_used", True),
+        ("fixture_step_results.0.external_effect_used", True),
+        ("fixture_step_results.0.result_scope_limitations", []),
+        ("approval_context.required_human_approval", False),
+        ("policy_lineage.version", "substitute"),
+        ("resulted_at", "2026-08-27T00:00:00+00:00"),
+        ("local_result_checks.no_adapter_invocation", False),
+        ("local_result_checks_digest", "0" * 64),
+        ("scope_limitations", []),
+        ("adapter_dry_run_fixture_result_hash", "0" * 64),
+        ("adapter_dry_run_fixture_result_id", "padr:v1:sha256:" + "0" * 64),
+    ],
+)
+def test_packet_tampering_fails_closed(path: str, value: object) -> None:
+    raw = deepcopy(_packet().model_dump(mode="json"))
+    _set_path(raw, path, value)
+    with pytest.raises(CanonicalPromotionAdapterDryRunFixtureResultError):
+        verify_canonical_promotion_adapter_dry_run_fixture_result_packet(raw)
+
+
+def test_result_count_order_effect_insertion_and_shortcuts_fail_closed() -> None:
+    for mutation in ("count", "order", "apply", "shortcut"):
+        raw = deepcopy(_packet().model_dump(mode="json"))
+        if mutation == "count":
+            raw["fixture_step_results"].pop()
+        elif mutation == "order":
+            raw["fixture_step_results"][0:2] = reversed(
+                raw["fixture_step_results"][0:2]
+            )
+        elif mutation == "apply":
+            result = deepcopy(raw["fixture_step_results"][0])
+            result["planned_adapter_method"] = "apply"
+            raw["fixture_step_results"].append(result)
+        else:
+            raw["human_approval_proven"] = True
+        with pytest.raises(CanonicalPromotionAdapterDryRunFixtureResultError):
+            verify_canonical_promotion_adapter_dry_run_fixture_result_packet(raw)


### PR DESCRIPTION
### Motivation

- Introduce a promotion-native, deterministic no-effect fixture-result artifact that consumes only the promotion-native dry-run plan and preserves authoritative plan/intent/descriptor lineage without fabricating legacy fields. 
- Reuse existing fixture-step semantics (seven no-effect steps) while preserving legacy `canonical-adapter-dry-run-fixture-result/v1` serialization and hashes. 
- Provide an independent verifier that is fail-closed for tampering, and add tests that cover positive and negative paths.

### Description

- Added a new promotion-native module `veritas_os/policy/canonical_promotion_adapter_dry_run_fixture_result.py` defining `CanonicalPromotionAdapterDryRunFixtureResultPacket` with format `canonical-promotion-adapter-dry-run-fixture-result/v1`, mechanism `record_promotion_adapter_dry_run_fixture_result_without_invocation/v1`, and ID prefix `padr:v1:sha256:`. The module implements `build_canonical_promotion_adapter_dry_run_fixture_result_packet(...)` and `verify_canonical_promotion_adapter_dry_run_fixture_result_packet(...)` which independently reverify the promotion-native plan, reconstruct the exact `ExecutionIntent`, verify the adapter contract descriptor, validate all seven planned steps and fixture results, compute content-addressed digests, and refuse live/effect claims. (`veritas_os/policy/canonical_promotion_adapter_dry_run_fixture_result.py`)
- Exposed a shared fixture-step validator `validate_fixture_step_results(...)` and wired legacy code to call it from `veritas_os/policy/adapter_dry_run_result.py` so legacy and promotion-native paths reuse identical fixture semantics while preserving legacy hash domains, error codes, and serialized output. (`veritas_os/policy/adapter_dry_run_result.py`) 
- Added fail-closed tests `veritas_os/tests/test_canonical_promotion_adapter_dry_run_fixture_result.py` that assert: exact `ExecutionIntent` object/ID/hash preservation, exact adapter descriptor equality, seven-step fixture semantic equality with legacy, absence of live/effect claims, promotion-native-only lineage fields, and numerous tamper/failure cases. (`veritas_os/tests/test_canonical_promotion_adapter_dry_run_fixture_result.py`)
- Preserved existing legacy entry points and behavior for `canonical-adapter-dry-run-fixture-result/v1` and its builder/verifier so historical behavior and hashes remain unchanged.
- Administrative: starting `main` SHA was `d5a659389dcaf564e6b9acb72dfb5712f79396f7`, commit created here `ff4f6bebd866fb99a349b491e944e048af8fda8c`, and no PR URL was created from this environment (no authenticated GitHub host).

### Testing

- Ran static checks and local validations: `py_compile` on changed files and `ruff` linting passed for the modified files (success).
- Ran architecture/security scripts: `scripts/architecture/check_responsibility_boundaries.py` and `scripts/security/check_subprocess_shell_usage.py` passed (success).
- Attempted unit tests: invoked `pytest` for `test_adapter_dry_run_fixture_result.py`, `test_canonical_promotion_adapter_dry_run_fixture_result.py`, and `test_canonical_promotion_adapter_dry_run_plan.py` but the execution environment lacked the `pydantic` dependency so full pytest runs were not completed here (warning). 
- Environment checks: attempted `uv` frozen run but runtime bootstrap failed due to network/runtime download issues; GitHub CLI unauthenticated so no PR was opened from this session (warning).

Notes and security warnings: this change touches governance/bind-path evidence and therefore requires human maintainer review and approval under the repository authority model, and the produced artifact is strictly fixture evidence only (it must not be treated as live adapter output, Bind authorization, human approval proof, authority evidence proof, or an acceptance of runtime risk).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a90f882631083268a1f64e0f41aee5e)