### PR TITLE
feat(governance): add promotion-native reference adapter rehearsal

### DIFF
--- a/veritas_os/policy/canonical_promotion_reference_adapter_rehearsal.py
+++ b/veritas_os/policy/canonical_promotion_reference_adapter_rehearsal.py
@@ -347,7 +347,7 @@ def _results(source, fixture: dict[str, Any]) -> list[dict[str, Any]]:
         method = step_raw["planned_adapter_method"]
         ordinal = step_raw["ordinal"]
         summary = adapter.rehearse(method, ordinal)
-        results.append({
+        raw_result = {
             "rehearsal_step_result_id": (
                 f"promotion-reference-rehearsal-result:v1:{ordinal}:"
                 f"{method.replace('_', '-')}"
@@ -373,7 +373,12 @@ def _results(source, fixture: dict[str, Any]) -> list[dict[str, Any]]:
             "output_digest": _digest(OUTPUT_DOMAIN, summary),
             "matched_expected_output_ref": step_raw["expected_output_ref"],
             "rehearsal_scope_limitations": STEP_LIMITATIONS,
-        })
+        }
+        results.append(
+            PromotionReferenceAdapterStepResult.model_validate(
+                raw_result
+            ).model_dump(mode="json")
+        )
     return results
 
 

--- a/veritas_os/policy/canonical_promotion_reference_adapter_rehearsal.py
+++ b/veritas_os/policy/canonical_promotion_reference_adapter_rehearsal.py
@@ -1,0 +1,492 @@
+"""Promotion-native deterministic reference-adapter rehearsal boundary.
+
+The boundary invokes only the shared seven-method in-memory rehearsal adapter.
+It independently binds a verified promotion-native fixture-result packet and
+cannot perform Bind, live adapter calls, I/O, or external effects.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime
+from typing import Any, Literal, Mapping
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from veritas_os.policy.bind_adapter_contract_selection import (
+    BindAdapterContractSelectionError,
+    verify_bind_adapter_contract_descriptor,
+)
+from veritas_os.policy.bind_artifacts import ExecutionIntent, hash_execution_intent
+from veritas_os.policy.canonical_promotion_adapter_dry_run_fixture_result import (
+    RESULTS_DOMAIN as FIXTURE_RESULTS_DOMAIN,
+    CanonicalPromotionAdapterDryRunFixtureResultError,
+    CanonicalPromotionAdapterDryRunFixtureResultPacket,
+    _digest as fixture_digest,
+    verify_canonical_promotion_adapter_dry_run_fixture_result_packet,
+)
+from veritas_os.policy.canonical_promotion_adapter_dry_run_plan import (
+    STEPS_DOMAIN,
+    _digest as plan_digest,
+)
+from veritas_os.policy.reference_adapter_rehearsal import (
+    InMemoryReferenceRehearsalAdapter,
+    PLANNED_METHODS,
+)
+
+FORMAT_VERSION = "canonical-promotion-reference-adapter-in-memory-rehearsal/v1"
+REHEARSAL_MECHANISM = (
+    "run_promotion_reference_adapter_in_memory_rehearsal_without_bind/v1"
+)
+OUTPUT_DOMAIN = "veritas.promotion-reference-adapter-rehearsal.output/v1"
+RESULTS_DOMAIN = "veritas.promotion-reference-adapter-rehearsal.results/v1"
+LOCAL_CHECKS_DOMAIN = "veritas.promotion-reference-adapter-rehearsal.local-checks/v1"
+FUTURE_REQUIREMENTS_DOMAIN = (
+    "veritas.promotion-reference-adapter-rehearsal.future-requirements/v1"
+)
+PACKET_DOMAIN = "veritas.promotion-reference-adapter-rehearsal.packet/v1"
+STATUS = "PROMOTION_NATIVE_REFERENCE_ADAPTER_IN_MEMORY_REHEARSAL_COMPLETED_NO_EFFECT"
+STEP_LIMITATIONS = (
+    "NOT_LIVE_ADAPTER_RESULT",
+    "NOT_LIVE_STATE",
+    "NOT_LIVE_AUTHORITY_REVALIDATION",
+    "NOT_LIVE_CONSTRAINT_REVALIDATION",
+    "NOT_RUNTIME_RISK_ACCEPTANCE",
+    "NOT_BIND_AUTHORIZATION",
+    "NOT_BIND_RECEIPT",
+    "NOT_TRUSTLOG_WRITE",
+    "NOT_OPERATION_COMMIT",
+    "NOT_AUTHORITY_EVIDENCE_PROOF",
+    "NOT_HUMAN_APPROVAL_PROOF",
+)
+SCOPE_LIMITATIONS = (
+    "NOT_EXECUTION_AUTHORITY",
+    "NOT_BIND_AUTHORIZATION",
+    "NOT_BIND_RECEIPT",
+    "NOT_BIND_INVOCATION",
+    "NOT_LIVE_ADAPTER_INSTANCE",
+    "NOT_LIVE_ADAPTER_INVOCATION",
+    "NOT_LIVE_ADAPTER_RESULT",
+    "NOT_EXTERNAL_EFFECT",
+    "NOT_OPERATION_COMMIT",
+    "NOT_TRUSTLOG_WRITE",
+    "NOT_LIVE_STATE_CHECK",
+    "NOT_RUNTIME_RISK_ACCEPTANCE",
+    "NOT_LIVE_AUTHORITY_REVALIDATION",
+    "NOT_LIVE_CONSTRAINT_REVALIDATION",
+    "NOT_POSTCONDITION_VERIFICATION",
+    "NOT_ROLLBACK_PROOF",
+    "NOT_AUTHORITY_EVIDENCE_PROOF",
+    "NOT_HUMAN_APPROVAL_PROOF",
+)
+LOCAL_CHECKS = {
+    key: True
+    for key in (
+        "promotion_fixture_result_verified",
+        "execution_intent_object_verified",
+        "execution_intent_id_verified",
+        "execution_intent_hash_verified",
+        "adapter_descriptor_verified",
+        "adapter_descriptor_target_verified",
+        "planned_steps_verified",
+        "fixture_results_verified",
+        "seven_reference_methods_called",
+        "rehearsal_outputs_reconstructed",
+        "no_apply_rehearsal",
+        "no_postcondition_rehearsal",
+        "no_revert_rehearsal",
+        "no_live_adapter_instance",
+        "no_live_adapter_invocation",
+        "no_network",
+        "no_filesystem",
+        "no_external_effect",
+        "no_bind_invocation",
+        "no_bind_receipt",
+        "no_trustlog_write",
+        "no_authority_evidence_proof",
+        "no_human_approval_proof",
+        "rehearsed_after_fixture_result",
+    )
+}
+FUTURE_REQUIREMENTS = {
+    key: True
+    for key in (
+        "fresh_verified_source_gate_required",
+        "live_adapter_dry_run_request_required",
+        "live_authority_revalidation_required",
+        "live_constraint_revalidation_required",
+        "runtime_risk_acceptance_required",
+        "human_approval_proof_still_deferred",
+        "authority_evidence_proof_still_deferred",
+        "bind_authorization_still_deferred",
+        "trustlog_policy_still_deferred",
+        "apply_still_forbidden",
+    )
+}
+LINEAGE_FIELDS = (
+    "source_adapter_dry_run_plan_id",
+    "source_adapter_dry_run_plan_hash",
+    "source_adapter_contract_selection_id",
+    "source_adapter_contract_selection_hash",
+    "source_bind_preflight_adjudication_id",
+    "source_bind_preflight_adjudication_hash",
+    "source_pre_bind_validation_id",
+    "source_pre_bind_validation_hash",
+    "source_readiness_id",
+    "source_readiness_hash",
+    "source_promotion_id",
+    "source_promotion_hash",
+    "source_decision_identity",
+    "candidate_identity",
+    "selected_action_lineage",
+    "policy_snapshot_lineage",
+    "approval_context",
+    "policy_lineage",
+)
+
+
+class CanonicalPromotionReferenceAdapterRehearsalError(ValueError):
+    """Stable fail-closed refusal for promotion-native rehearsal packets."""
+
+
+class PromotionReferenceAdapterStepResult(BaseModel):
+    """Immutable evidence for one allowlisted local adapter call."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    rehearsal_step_result_id: str = Field(
+        pattern=r"^promotion-reference-rehearsal-result:v1:[1-9][0-9]*:[a-z0-9-]+$"
+    )
+    planned_step_id: str
+    fixture_step_result_id: str
+    ordinal: int = Field(ge=1)
+    planned_adapter_method: Literal[
+        "describe_target", "build_idempotency_key", "snapshot",
+        "fingerprint_state", "validate_authority", "validate_constraints",
+        "assess_runtime_risk",
+    ]
+    rehearsal_mode: Literal["reference_in_memory_no_effect"]
+    reference_adapter_instance_created: Literal[True]
+    reference_adapter_method_called: Literal[True]
+    live_adapter_instance_created: Literal[False]
+    live_adapter_method_called: Literal[False]
+    network_used: Literal[False]
+    filesystem_used: Literal[False]
+    external_effect_used: Literal[False]
+    trustlog_written: Literal[False]
+    bind_receipt_created: Literal[False]
+    bind_invoked: Literal[False]
+    authority_evidence_proven: Literal[False]
+    human_approval_proven: Literal[False]
+    output_summary: dict[str, Any]
+    output_digest: str = Field(pattern=r"^[0-9a-f]{64}$")
+    matched_expected_output_ref: str
+    rehearsal_scope_limitations: tuple[str, ...]
+
+
+class CanonicalPromotionReferenceAdapterInMemoryRehearsalPacket(BaseModel):
+    """Content-addressed promotion-native in-memory rehearsal evidence."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    format_version: Literal[
+        "canonical-promotion-reference-adapter-in-memory-rehearsal/v1"
+    ]
+    promotion_reference_rehearsal_id: str = Field(
+        pattern=r"^prar:v1:sha256:[0-9a-f]{64}$"
+    )
+    promotion_reference_rehearsal_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    rehearsal_mechanism: Literal[
+        "run_promotion_reference_adapter_in_memory_rehearsal_without_bind/v1"
+    ]
+    rehearsed_at: str
+    reference_rehearsal_fixture: dict[str, Any]
+    source_adapter_dry_run_fixture_result_id: str
+    source_adapter_dry_run_fixture_result_hash: str
+    source_adapter_dry_run_fixture_result_packet: dict[str, Any]
+    source_adapter_dry_run_plan_id: str
+    source_adapter_dry_run_plan_hash: str
+    source_adapter_contract_selection_id: str
+    source_adapter_contract_selection_hash: str
+    source_bind_preflight_adjudication_id: str
+    source_bind_preflight_adjudication_hash: str
+    source_pre_bind_validation_id: str
+    source_pre_bind_validation_hash: str
+    source_readiness_id: str
+    source_readiness_hash: str
+    source_promotion_id: str
+    source_promotion_hash: str
+    source_decision_identity: dict[str, Any]
+    candidate_identity: dict[str, Any]
+    selected_action_lineage: dict[str, Any]
+    policy_snapshot_lineage: dict[str, Any]
+    approval_context: dict[str, Any]
+    policy_lineage: dict[str, Any]
+    execution_intent: dict[str, Any]
+    execution_intent_id: str
+    execution_intent_hash: str
+    adapter_contract_descriptor: dict[str, Any]
+    adapter_contract_id: str
+    adapter_contract_hash: str
+    adapter_contract_version: Literal["bind-adapter-contract/v1"]
+    planned_steps: tuple[dict[str, Any], ...]
+    planned_step_digest: str
+    fixture_step_results: tuple[dict[str, Any], ...]
+    fixture_result_digest: str
+    reference_rehearsal_results: tuple[PromotionReferenceAdapterStepResult, ...]
+    reference_rehearsal_result_digest: str
+    local_rehearsal_checks: dict[str, bool]
+    local_rehearsal_checks_digest: str
+    future_requirements: dict[str, bool]
+    future_requirements_digest: str
+    reference_rehearsal_status: Literal[
+        "PROMOTION_NATIVE_REFERENCE_ADAPTER_IN_MEMORY_REHEARSAL_COMPLETED_NO_EFFECT"
+    ]
+    ready_for_promotion_native_live_adapter_dry_run_request: Literal[True]
+    scope_limitations: tuple[str, ...]
+
+
+def _json(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        value = value.model_dump(mode="json")
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float) and value == value and value not in (
+        float("inf"), float("-inf")
+    ):
+        return value
+    if isinstance(value, datetime):
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise CanonicalPromotionReferenceAdapterRehearsalError(
+                "PRAR_REHEARSED_AT_INVALID"
+            )
+        return value.isoformat()
+    if isinstance(value, (list, tuple)):
+        return [_json(item) for item in value]
+    if isinstance(value, Mapping) and all(isinstance(key, str) for key in value):
+        return {key: _json(item) for key, item in value.items()}
+    raise CanonicalPromotionReferenceAdapterRehearsalError("PRAR_PACKET_INVALID")
+
+
+def _digest(domain: str, value: Any) -> str:
+    encoded = json.dumps(
+        {"domain": domain, "value": _json(value)}, allow_nan=False,
+        ensure_ascii=False, separators=(",", ":"), sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _aware(value: Any, code: str) -> datetime:
+    try:
+        parsed = value if isinstance(value, datetime) else datetime.fromisoformat(value)
+    except (TypeError, ValueError) as exc:
+        raise CanonicalPromotionReferenceAdapterRehearsalError(code) from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise CanonicalPromotionReferenceAdapterRehearsalError(code)
+    return parsed
+
+
+def _packet_hash(raw: dict[str, Any]) -> str:
+    return _digest(PACKET_DOMAIN, {key: value for key, value in raw.items() if key not in {
+        "promotion_reference_rehearsal_id", "promotion_reference_rehearsal_hash"
+    }})
+
+
+def _source(value: Any) -> CanonicalPromotionAdapterDryRunFixtureResultPacket:
+    try:
+        return verify_canonical_promotion_adapter_dry_run_fixture_result_packet(value)
+    except (CanonicalPromotionAdapterDryRunFixtureResultError, TypeError, ValueError) as exc:
+        raise CanonicalPromotionReferenceAdapterRehearsalError(
+            "PRAR_SOURCE_FIXTURE_RESULT_INVALID"
+        ) from exc
+
+
+def _intent(source: CanonicalPromotionAdapterDryRunFixtureResultPacket) -> ExecutionIntent:
+    try:
+        intent = ExecutionIntent(**source.execution_intent)
+    except (TypeError, ValueError) as exc:
+        raise CanonicalPromotionReferenceAdapterRehearsalError(
+            "PRAR_EXECUTION_INTENT_INVALID"
+        ) from exc
+    if (intent.to_dict() != source.execution_intent
+            or intent.execution_intent_id != source.execution_intent_id
+            or hash_execution_intent(intent) != source.execution_intent_hash):
+        raise CanonicalPromotionReferenceAdapterRehearsalError(
+            "PRAR_EXECUTION_INTENT_MISMATCH"
+        )
+    return intent
+
+
+def _descriptor(source, intent: ExecutionIntent) -> None:
+    try:
+        descriptor = verify_bind_adapter_contract_descriptor(
+            source.adapter_contract_descriptor, intent
+        )
+    except (BindAdapterContractSelectionError, TypeError, ValueError) as exc:
+        raise CanonicalPromotionReferenceAdapterRehearsalError(
+            "PRAR_DESCRIPTOR_INVALID"
+        ) from exc
+    if (descriptor.model_dump(mode="json") != source.adapter_contract_descriptor
+            or descriptor.adapter_contract_id != source.adapter_contract_id
+            or descriptor.adapter_contract_hash != source.adapter_contract_hash
+            or descriptor.adapter_contract_version != source.adapter_contract_version):
+        raise CanonicalPromotionReferenceAdapterRehearsalError(
+            "PRAR_DESCRIPTOR_MISMATCH"
+        )
+
+
+def _results(source, fixture: dict[str, Any]) -> list[dict[str, Any]]:
+    adapter = InMemoryReferenceRehearsalAdapter(
+        _intent(source), fixture, output_domain=OUTPUT_DOMAIN
+    )
+    results = []
+    for step, fixture_result in zip(
+        source.planned_steps, source.fixture_step_results, strict=True
+    ):
+        step_raw = _json(step)
+        fixture_raw = _json(fixture_result)
+        method = step_raw["planned_adapter_method"]
+        ordinal = step_raw["ordinal"]
+        summary = adapter.rehearse(method, ordinal)
+        results.append({
+            "rehearsal_step_result_id": (
+                f"promotion-reference-rehearsal-result:v1:{ordinal}:"
+                f"{method.replace('_', '-')}"
+            ),
+            "planned_step_id": step_raw["step_id"],
+            "fixture_step_result_id": fixture_raw["step_result_id"],
+            "ordinal": ordinal,
+            "planned_adapter_method": method,
+            "rehearsal_mode": "reference_in_memory_no_effect",
+            "reference_adapter_instance_created": True,
+            "reference_adapter_method_called": True,
+            "live_adapter_instance_created": False,
+            "live_adapter_method_called": False,
+            "network_used": False,
+            "filesystem_used": False,
+            "external_effect_used": False,
+            "trustlog_written": False,
+            "bind_receipt_created": False,
+            "bind_invoked": False,
+            "authority_evidence_proven": False,
+            "human_approval_proven": False,
+            "output_summary": summary,
+            "output_digest": _digest(OUTPUT_DOMAIN, summary),
+            "matched_expected_output_ref": step_raw["expected_output_ref"],
+            "rehearsal_scope_limitations": STEP_LIMITATIONS,
+        })
+    return results
+
+
+def build_canonical_promotion_reference_adapter_in_memory_rehearsal_packet(
+    adapter_dry_run_fixture_result_packet: CanonicalPromotionAdapterDryRunFixtureResultPacket | Mapping[str, Any],
+    reference_rehearsal_fixture: Any,
+    rehearsed_at: datetime,
+) -> CanonicalPromotionReferenceAdapterInMemoryRehearsalPacket:
+    """Build and independently reverify one promotion-native rehearsal packet."""
+    source = _source(_json(adapter_dry_run_fixture_result_packet))
+    fixture = _json(reference_rehearsal_fixture)
+    if not isinstance(fixture, dict):
+        raise CanonicalPromotionReferenceAdapterRehearsalError("PRAR_FIXTURE_INVALID")
+    rehearsed = _aware(rehearsed_at, "PRAR_REHEARSED_AT_INVALID")
+    if rehearsed < _aware(source.resulted_at, "PRAR_SOURCE_FIXTURE_RESULT_INVALID"):
+        raise CanonicalPromotionReferenceAdapterRehearsalError(
+            "PRAR_REHEARSED_BEFORE_RESULT"
+        )
+    intent = _intent(source)
+    _descriptor(source, intent)
+    source_raw = source.model_dump(mode="json")
+    steps = [_json(item) for item in source.planned_steps]
+    fixtures = [_json(item) for item in source.fixture_step_results]
+    results = _results(source, fixture)
+    raw = {
+        "format_version": FORMAT_VERSION,
+        "rehearsal_mechanism": REHEARSAL_MECHANISM,
+        "rehearsed_at": rehearsed.isoformat(),
+        "reference_rehearsal_fixture": fixture,
+        "source_adapter_dry_run_fixture_result_id": source.adapter_dry_run_fixture_result_id,
+        "source_adapter_dry_run_fixture_result_hash": source.adapter_dry_run_fixture_result_hash,
+        "source_adapter_dry_run_fixture_result_packet": source_raw,
+        **{field: source_raw[field] for field in LINEAGE_FIELDS},
+        "execution_intent": source.execution_intent,
+        "execution_intent_id": source.execution_intent_id,
+        "execution_intent_hash": source.execution_intent_hash,
+        "adapter_contract_descriptor": source.adapter_contract_descriptor,
+        "adapter_contract_id": source.adapter_contract_id,
+        "adapter_contract_hash": source.adapter_contract_hash,
+        "adapter_contract_version": source.adapter_contract_version,
+        "planned_steps": steps,
+        "planned_step_digest": source.planned_step_digest,
+        "fixture_step_results": fixtures,
+        "fixture_result_digest": source.fixture_result_digest,
+        "reference_rehearsal_results": results,
+        "reference_rehearsal_result_digest": _digest(RESULTS_DOMAIN, results),
+        "local_rehearsal_checks": LOCAL_CHECKS,
+        "local_rehearsal_checks_digest": _digest(LOCAL_CHECKS_DOMAIN, LOCAL_CHECKS),
+        "future_requirements": FUTURE_REQUIREMENTS,
+        "future_requirements_digest": _digest(FUTURE_REQUIREMENTS_DOMAIN, FUTURE_REQUIREMENTS),
+        "reference_rehearsal_status": STATUS,
+        "ready_for_promotion_native_live_adapter_dry_run_request": True,
+        "scope_limitations": SCOPE_LIMITATIONS,
+    }
+    digest = _packet_hash(raw)
+    raw["promotion_reference_rehearsal_hash"] = digest
+    raw["promotion_reference_rehearsal_id"] = f"prar:v1:sha256:{digest}"
+    return verify_canonical_promotion_reference_adapter_in_memory_rehearsal_packet(raw)
+
+
+def verify_canonical_promotion_reference_adapter_in_memory_rehearsal_packet(
+    packet: Any,
+) -> CanonicalPromotionReferenceAdapterInMemoryRehearsalPacket:
+    """Fail closed while independently reconstructing every rehearsal binding."""
+    try:
+        candidate = CanonicalPromotionReferenceAdapterInMemoryRehearsalPacket.model_validate(_json(packet))
+        raw = candidate.model_dump(mode="json")
+        source = _source(candidate.source_adapter_dry_run_fixture_result_packet)
+        intent = _intent(source)
+        _descriptor(source, intent)
+        if (candidate.source_adapter_dry_run_fixture_result_id != source.adapter_dry_run_fixture_result_id
+                or candidate.source_adapter_dry_run_fixture_result_hash != source.adapter_dry_run_fixture_result_hash
+                or any(getattr(candidate, field) != getattr(source, field) for field in LINEAGE_FIELDS)
+                or candidate.execution_intent != intent.to_dict()
+                or candidate.execution_intent_id != intent.execution_intent_id
+                or candidate.execution_intent_hash != hash_execution_intent(intent)
+                or candidate.adapter_contract_descriptor != source.adapter_contract_descriptor
+                or candidate.adapter_contract_id != source.adapter_contract_id
+                or candidate.adapter_contract_hash != source.adapter_contract_hash
+                or candidate.adapter_contract_version != source.adapter_contract_version):
+            raise CanonicalPromotionReferenceAdapterRehearsalError("PRAR_SOURCE_BINDING_MISMATCH")
+        if _aware(candidate.rehearsed_at, "PRAR_REHEARSED_AT_INVALID") < _aware(source.resulted_at, "PRAR_SOURCE_FIXTURE_RESULT_INVALID"):
+            raise CanonicalPromotionReferenceAdapterRehearsalError("PRAR_REHEARSED_BEFORE_RESULT")
+        steps = [_json(item) for item in source.planned_steps]
+        fixtures = [_json(item) for item in source.fixture_step_results]
+        if (list(candidate.planned_steps) != steps
+                or candidate.planned_step_digest != source.planned_step_digest
+                or candidate.planned_step_digest != plan_digest(STEPS_DOMAIN, steps)):
+            raise CanonicalPromotionReferenceAdapterRehearsalError("PRAR_PLANNED_STEPS_MISMATCH")
+        if (list(candidate.fixture_step_results) != fixtures
+                or candidate.fixture_result_digest != source.fixture_result_digest
+                or candidate.fixture_result_digest != fixture_digest(FIXTURE_RESULTS_DOMAIN, fixtures)):
+            raise CanonicalPromotionReferenceAdapterRehearsalError("PRAR_FIXTURE_RESULTS_MISMATCH")
+        expected = _results(source, candidate.reference_rehearsal_fixture)
+        results = [_json(item) for item in candidate.reference_rehearsal_results]
+        if len(results) != 7 or [item["planned_adapter_method"] for item in results] != list(PLANNED_METHODS):
+            raise CanonicalPromotionReferenceAdapterRehearsalError("PRAR_REHEARSAL_RESULTS_INVALID")
+        for result, template, step, fixture in zip(results, expected, steps, fixtures, strict=True):
+            if result != template or result["fixture_step_result_id"] != fixture["step_result_id"] or result["planned_step_id"] != step["step_id"]:
+                raise CanonicalPromotionReferenceAdapterRehearsalError("PRAR_REHEARSAL_RESULTS_INVALID")
+        if candidate.reference_rehearsal_result_digest != _digest(RESULTS_DOMAIN, results):
+            raise CanonicalPromotionReferenceAdapterRehearsalError("PRAR_REHEARSAL_RESULTS_INVALID")
+        if (candidate.local_rehearsal_checks != LOCAL_CHECKS
+                or candidate.local_rehearsal_checks_digest != _digest(LOCAL_CHECKS_DOMAIN, LOCAL_CHECKS)
+                or candidate.future_requirements != FUTURE_REQUIREMENTS
+                or candidate.future_requirements_digest != _digest(FUTURE_REQUIREMENTS_DOMAIN, FUTURE_REQUIREMENTS)
+                or candidate.scope_limitations != SCOPE_LIMITATIONS):
+            raise CanonicalPromotionReferenceAdapterRehearsalError("PRAR_CANONICAL_CHECKS_MISMATCH")
+        digest = _packet_hash(raw)
+        if candidate.promotion_reference_rehearsal_hash != digest or candidate.promotion_reference_rehearsal_id != f"prar:v1:sha256:{digest}":
+            raise CanonicalPromotionReferenceAdapterRehearsalError("PRAR_PACKET_IDENTITY_MISMATCH")
+        return candidate
+    except CanonicalPromotionReferenceAdapterRehearsalError:
+        raise
+    except (TypeError, ValueError, ValidationError, KeyError) as exc:
+        raise CanonicalPromotionReferenceAdapterRehearsalError("PRAR_PACKET_INVALID") from exc

--- a/veritas_os/policy/reference_adapter_rehearsal.py
+++ b/veritas_os/policy/reference_adapter_rehearsal.py
@@ -310,9 +310,16 @@ def _intent(raw: dict[str, Any]) -> ExecutionIntent:
 class InMemoryReferenceRehearsalAdapter:
     """Seven-method local adapter with no execution or I/O capabilities."""
 
-    def __init__(self, intent: ExecutionIntent, fixture: dict[str, Any]) -> None:
+    def __init__(
+        self,
+        intent: ExecutionIntent,
+        fixture: dict[str, Any],
+        *,
+        output_domain: str = OUTPUT_DOMAIN,
+    ) -> None:
         self._intent = intent.to_dict()
         self._fixture = fixture
+        self._output_domain = output_domain
 
     def rehearse(self, method: str, ordinal: int) -> dict[str, Any]:
         """Return a deterministic JSON descriptor for one allowlisted method."""
@@ -322,8 +329,8 @@ class InMemoryReferenceRehearsalAdapter:
             "method": method,
             "ordinal": ordinal,
             "mode": "reference_in_memory_no_effect",
-            "intent_digest": _digest(OUTPUT_DOMAIN, self._intent),
-            "fixture_digest": _digest(OUTPUT_DOMAIN, self._fixture),
+            "intent_digest": _digest(self._output_domain, self._intent),
+            "fixture_digest": _digest(self._output_domain, self._fixture),
             "target_system": self._intent["target_system"],
             "target_resource": self._intent["target_resource"],
         }

--- a/veritas_os/tests/test_canonical_promotion_reference_adapter_rehearsal.py
+++ b/veritas_os/tests/test_canonical_promotion_reference_adapter_rehearsal.py
@@ -12,6 +12,7 @@ from veritas_os.policy.canonical_promotion_reference_adapter_rehearsal import (
     CanonicalPromotionReferenceAdapterRehearsalError,
     PLANNED_METHODS,
     SCOPE_LIMITATIONS,
+    _results,
     _packet_hash,
     build_canonical_promotion_reference_adapter_in_memory_rehearsal_packet,
     verify_canonical_promotion_reference_adapter_in_memory_rehearsal_packet,
@@ -72,6 +73,13 @@ def test_full_promotion_chain_exact_identity_and_no_effect_rehearsal() -> None:
     assert packet.approval_context["required_human_approval"] is True
     assert "human_approval_receipt_ref" not in packet.model_dump(mode="json")
     assert len(packet.reference_rehearsal_results) == 7
+    packet_json = packet.model_dump(mode="json")
+    reconstructed_results = _results(source, FIXTURE)
+    assert packet_json["reference_rehearsal_results"] == reconstructed_results
+    assert all(
+        isinstance(result["rehearsal_scope_limitations"], list)
+        for result in reconstructed_results
+    )
     assert [item.planned_adapter_method for item in packet.reference_rehearsal_results] == list(PLANNED_METHODS)
     for result in packet.reference_rehearsal_results:
         assert result.reference_adapter_instance_created is True

--- a/veritas_os/tests/test_canonical_promotion_reference_adapter_rehearsal.py
+++ b/veritas_os/tests/test_canonical_promotion_reference_adapter_rehearsal.py
@@ -1,0 +1,188 @@
+"""Fail-closed tests for promotion-native reference adapter rehearsal."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import timedelta
+
+import pytest
+
+from veritas_os.policy.bind_artifacts import ExecutionIntent, hash_execution_intent
+from veritas_os.policy.canonical_promotion_reference_adapter_rehearsal import (
+    CanonicalPromotionReferenceAdapterRehearsalError,
+    PLANNED_METHODS,
+    SCOPE_LIMITATIONS,
+    _packet_hash,
+    build_canonical_promotion_reference_adapter_in_memory_rehearsal_packet,
+    verify_canonical_promotion_reference_adapter_in_memory_rehearsal_packet,
+)
+from veritas_os.policy.reference_adapter_rehearsal import (
+    build_reference_adapter_in_memory_rehearsal_packet,
+)
+from veritas_os.tests.test_adapter_dry_run_fixture_result import (
+    RESULTED_AT as LEGACY_RESULTED_AT,
+    _packet as legacy_fixture_packet,
+)
+from veritas_os.tests.test_canonical_promotion_adapter_dry_run_fixture_result import (
+    RESULTED_AT,
+    _packet as promotion_fixture_packet,
+)
+
+REHEARSED_AT = RESULTED_AT + timedelta(seconds=1)
+FIXTURE = {"scenario": "promotion-native-deterministic-reference-v1"}
+
+
+def _packet():
+    return build_canonical_promotion_reference_adapter_in_memory_rehearsal_packet(
+        promotion_fixture_packet(), FIXTURE, REHEARSED_AT
+    )
+
+
+def _rehash(raw: dict) -> None:
+    digest = _packet_hash(raw)
+    raw["promotion_reference_rehearsal_hash"] = digest
+    raw["promotion_reference_rehearsal_id"] = f"prar:v1:sha256:{digest}"
+
+
+def _set(raw: dict, path: str, value: object) -> None:
+    target = raw
+    parts = path.split(".")
+    for part in parts[:-1]:
+        target = target[int(part)] if isinstance(target, list) else target[part]
+    if isinstance(target, list):
+        target[int(parts[-1])] = value
+    else:
+        target[parts[-1]] = value
+
+
+def test_full_promotion_chain_exact_identity_and_no_effect_rehearsal() -> None:
+    source = promotion_fixture_packet()
+    packet = verify_canonical_promotion_reference_adapter_in_memory_rehearsal_packet(
+        _packet()
+    )
+    intent = ExecutionIntent(**packet.execution_intent)
+
+    assert packet.execution_intent == source.execution_intent == intent.to_dict()
+    assert packet.execution_intent_id == source.execution_intent_id
+    assert packet.execution_intent_id == intent.execution_intent_id
+    assert packet.execution_intent_hash == source.execution_intent_hash
+    assert packet.execution_intent_hash == hash_execution_intent(intent)
+    assert packet.adapter_contract_id == source.adapter_contract_id
+    assert packet.adapter_contract_hash == source.adapter_contract_hash
+    assert packet.approval_context["required_human_approval"] is True
+    assert "human_approval_receipt_ref" not in packet.model_dump(mode="json")
+    assert len(packet.reference_rehearsal_results) == 7
+    assert [item.planned_adapter_method for item in packet.reference_rehearsal_results] == list(PLANNED_METHODS)
+    for result in packet.reference_rehearsal_results:
+        assert result.reference_adapter_instance_created is True
+        assert result.reference_adapter_method_called is True
+        assert result.live_adapter_instance_created is False
+        assert result.live_adapter_method_called is False
+        assert result.network_used is False
+        assert result.filesystem_used is False
+        assert result.external_effect_used is False
+        assert result.bind_invoked is False
+        assert result.authority_evidence_proven is False
+        assert result.human_approval_proven is False
+    forbidden = {
+        "source_formation_hash", "source_eligibility_hash", "source_handoff_hash",
+        "trusted_validation_context_hash", "validation_result_hash",
+        "mapping_value_digest", "replay_summary", "apply",
+        "verify_postconditions", "revert",
+    }
+    assert set(packet.model_dump(mode="json")).isdisjoint(forbidden)
+    assert packet.scope_limitations == SCOPE_LIMITATIONS
+
+
+def test_legacy_and_promotion_rehearsals_share_step_semantics() -> None:
+    legacy = build_reference_adapter_in_memory_rehearsal_packet(
+        legacy_fixture_packet(), FIXTURE, LEGACY_RESULTED_AT + timedelta(seconds=1)
+    )
+    promotion = _packet()
+    fields = (
+        "ordinal", "planned_adapter_method", "rehearsal_mode",
+        "reference_adapter_instance_created", "reference_adapter_method_called",
+        "live_adapter_instance_created", "live_adapter_method_called",
+        "network_used", "filesystem_used", "external_effect_used",
+        "matched_expected_output_ref",
+    )
+    assert [tuple(getattr(item, field) for field in fields) for item in promotion.reference_rehearsal_results] == [
+        tuple(getattr(item, field) for field in fields) for item in legacy.reference_rehearsal_results
+    ]
+    summary_fields = ("method", "ordinal", "mode", "target_system", "target_resource")
+    assert [tuple(item.output_summary[key] for key in summary_fields) for item in promotion.reference_rehearsal_results] == [
+        tuple(item.output_summary[key] for key in summary_fields) for item in legacy.reference_rehearsal_results
+    ]
+
+
+@pytest.mark.parametrize(("path", "value"), [
+    ("source_adapter_dry_run_fixture_result_id", "padr:v1:sha256:" + "0" * 64),
+    ("source_adapter_dry_run_fixture_result_hash", "0" * 64),
+    ("source_adapter_dry_run_plan_hash", "0" * 64),
+    ("source_adapter_contract_selection_hash", "0" * 64),
+    ("source_bind_preflight_adjudication_hash", "0" * 64),
+    ("source_pre_bind_validation_hash", "0" * 64),
+    ("source_readiness_hash", "0" * 64),
+    ("source_promotion_hash", "0" * 64),
+    ("execution_intent.actor_identity", "substitute"),
+    ("execution_intent_id", "ei:v1:sha256:" + "0" * 64),
+    ("execution_intent_hash", "0" * 64),
+    ("adapter_contract_descriptor.target_system", "substitute"),
+    ("adapter_contract_id", "adapter-contract:v1:sha256:" + "0" * 64),
+    ("adapter_contract_hash", "0" * 64),
+    ("planned_steps.0.ordinal", 2),
+    ("fixture_step_results.0.ordinal", 2),
+    ("fixture_result_digest", "0" * 64),
+    ("reference_rehearsal_results.0.planned_adapter_method", "snapshot"),
+    ("reference_rehearsal_results.0.output_summary.method", "apply"),
+    ("reference_rehearsal_results.0.output_digest", "0" * 64),
+    ("reference_rehearsal_results.0.live_adapter_instance_created", True),
+    ("reference_rehearsal_results.0.live_adapter_method_called", True),
+    ("reference_rehearsal_results.0.network_used", True),
+    ("reference_rehearsal_results.0.filesystem_used", True),
+    ("reference_rehearsal_results.0.external_effect_used", True),
+    ("reference_rehearsal_results.0.bind_invoked", True),
+    ("reference_rehearsal_results.0.bind_receipt_created", True),
+    ("reference_rehearsal_results.0.human_approval_proven", True),
+    ("reference_rehearsal_results.0.authority_evidence_proven", True),
+    ("approval_context.required_human_approval", False),
+    ("policy_lineage", {}),
+    ("local_rehearsal_checks.no_network", False),
+    ("future_requirements.apply_still_forbidden", False),
+    ("scope_limitations", []),
+])
+def test_tampering_fails_closed(path: str, value: object) -> None:
+    raw = _packet().model_dump(mode="json")
+    _set(raw, path, value)
+    _rehash(raw)
+    with pytest.raises(CanonicalPromotionReferenceAdapterRehearsalError):
+        verify_canonical_promotion_reference_adapter_in_memory_rehearsal_packet(raw)
+
+
+@pytest.mark.parametrize("mutation", ["reorder_fixture", "reorder_rehearsal", "drop_rehearsal", "insert_apply"])
+def test_order_count_and_forbidden_method_fail_closed(mutation: str) -> None:
+    raw = _packet().model_dump(mode="json")
+    key = "fixture_step_results" if mutation == "reorder_fixture" else "reference_rehearsal_results"
+    if mutation.startswith("reorder"):
+        raw[key][0:2] = reversed(raw[key][0:2])
+    elif mutation == "drop_rehearsal":
+        raw[key].pop()
+    else:
+        inserted = deepcopy(raw[key][0])
+        inserted["planned_adapter_method"] = "apply"
+        raw[key].append(inserted)
+    _rehash(raw)
+    with pytest.raises(CanonicalPromotionReferenceAdapterRehearsalError):
+        verify_canonical_promotion_reference_adapter_in_memory_rehearsal_packet(raw)
+
+
+def test_time_and_packet_identity_fail_closed() -> None:
+    raw = _packet().model_dump(mode="json")
+    raw["rehearsed_at"] = (RESULTED_AT - timedelta(seconds=1)).isoformat()
+    _rehash(raw)
+    with pytest.raises(CanonicalPromotionReferenceAdapterRehearsalError):
+        verify_canonical_promotion_reference_adapter_in_memory_rehearsal_packet(raw)
+    raw = _packet().model_dump(mode="json")
+    raw["promotion_reference_rehearsal_hash"] = "0" * 64
+    with pytest.raises(CanonicalPromotionReferenceAdapterRehearsalError):
+        verify_canonical_promotion_reference_adapter_in_memory_rehearsal_packet(raw)

--- a/veritas_os/tests/test_canonical_promotion_reference_adapter_rehearsal.py
+++ b/veritas_os/tests/test_canonical_promotion_reference_adapter_rehearsal.py
@@ -117,10 +117,32 @@ def test_legacy_and_promotion_rehearsals_share_step_semantics() -> None:
     assert [tuple(getattr(item, field) for field in fields) for item in promotion.reference_rehearsal_results] == [
         tuple(getattr(item, field) for field in fields) for item in legacy.reference_rehearsal_results
     ]
-    summary_fields = ("method", "ordinal", "mode", "target_system", "target_resource")
-    assert [tuple(item.output_summary[key] for key in summary_fields) for item in promotion.reference_rehearsal_results] == [
-        tuple(item.output_summary[key] for key in summary_fields) for item in legacy.reference_rehearsal_results
+    invariant_summary_fields = ("method", "ordinal", "mode")
+    assert [
+        tuple(item.output_summary[key] for key in invariant_summary_fields)
+        for item in promotion.reference_rehearsal_results
+    ] == [
+        tuple(item.output_summary[key] for key in invariant_summary_fields)
+        for item in legacy.reference_rehearsal_results
     ]
+    for item in promotion.reference_rehearsal_results:
+        assert (
+            item.output_summary["target_system"]
+            == promotion.execution_intent["target_system"]
+        )
+        assert (
+            item.output_summary["target_resource"]
+            == promotion.execution_intent["target_resource"]
+        )
+    for item in legacy.reference_rehearsal_results:
+        assert (
+            item.output_summary["target_system"]
+            == legacy.execution_intent["target_system"]
+        )
+        assert (
+            item.output_summary["target_resource"]
+            == legacy.execution_intent["target_resource"]
+        )
 
 
 @pytest.mark.parametrize(("path", "value"), [


### PR DESCRIPTION
### Motivation

- Add a promotion-native, deterministic, no-effect rehearsal stage that consumes a verified promotion-native dry-run fixture result and produces a content-addressed rehearsal packet without performing Bind, live adapter calls, I/O, or claiming Authority/Human Approval proof.  This enables the next production boundary in the promotion-native Decision-to-Bind path.
- Reuse the existing in-memory reference rehearsal implementation to keep semantics identical between legacy and promotion-native rehearsal while avoiding fabrication of legacy lineage fields.
- This touches a governance-sensitive Bind path and therefore must remain fail-closed and requires human maintainer review before any production usage.

### Description

- Added `veritas_os/policy/canonical_promotion_reference_adapter_rehearsal.py` which defines `CanonicalPromotionReferenceAdapterInMemoryRehearsalPacket` (format version `canonical-promotion-reference-adapter-in-memory-rehearsal/v1`), `build_canonical_promotion_reference_adapter_in_memory_rehearsal_packet(...)`, and `verify_canonical_promotion_reference_adapter_in_memory_rehearsal_packet(...)` that independently verify the embedded promotion-native fixture-result packet, exact `ExecutionIntent` object/ID/hash, adapter descriptor, planned-step/fixture bindings (seven steps), reconstructed deterministic rehearsal outputs, canonical checks, and content-addressed packet identity.
- Reused the existing `InMemoryReferenceRehearsalAdapter` implementation by adding an optional `output_domain` parameter and using it from the new promotion-native module so legacy v1 semantics and hashes are preserved; no legacy packet types or lineage fields were fabricated or removed.
- Added tests `veritas_os/tests/test_canonical_promotion_reference_adapter_rehearsal.py` that exercise full-chain identity assertions, legacy/promotion semantic regression, and fail-closed negative tests for tampering (lineage, intent, descriptor, steps, results, ordering, effect/proof claims, timestamps, and packet identity).

### Testing

- Ran static/lint and compilation checks: `ruff check` and `python -m py_compile` on the new module and modified file; these passed in the local environment.
- Ran focused unit tests with `pytest` on the new and related rehearsal tests where the runtime environment allowed it; the new rehearsal tests and legacy reference rehearsal tests were exercised locally, but the full pytest run was blocked by missing installed dependencies (`pydantic`, network/registry availability) in this checkout, so full matrix (Py3.11/Py3.12, PostgreSQL, CI security gates) could not complete here.
- Summary of automated outcomes: lint/compile checks passed; targeted unit-test invocation for the new module was executed but broader test suite runs were blocked by missing dependency installation and offline/registry errors, so CI must run the full matrix and security gates before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a910b9e8f8483269d3bc6e1c0ebf3b0)