### PR TITLE
feat(policy): add promotion-native live-adapter dry-run dispatch-readiness artifact

### DIFF
--- a/veritas_os/policy/canonical_promotion_live_adapter_dry_run_dispatch_readiness.py
+++ b/veritas_os/policy/canonical_promotion_live_adapter_dry_run_dispatch_readiness.py
@@ -1,0 +1,566 @@
+"""Evaluate promotion-native dispatch readiness without performing effects.
+
+This pure-data boundary proves only that a verified promotion-native dry-run
+request may proceed to a separate, local endpoint-allowlist evaluation.  It
+cannot resolve endpoints or credentials, instantiate adapters, dispatch, Bind,
+or persist data.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from veritas_os.policy.bind_adapter_contract_selection import (
+    BindAdapterContractSelectionError,
+    verify_bind_adapter_contract_descriptor,
+)
+from veritas_os.policy.bind_artifacts import (
+    ExecutionIntent,
+    canonical_execution_intent_json,
+    hash_execution_intent,
+)
+from veritas_os.policy.canonical_promotion_live_adapter_dry_run_request import (
+    CanonicalPromotionLiveAdapterDryRunRequestError,
+    CanonicalPromotionLiveAdapterDryRunRequestPacket,
+    verify_canonical_promotion_live_adapter_dry_run_request_packet,
+)
+
+FORMAT_VERSION = "canonical-promotion-live-adapter-dry-run-dispatch-readiness/v1"
+DISPATCH_READINESS_MECHANISM = (
+    "evaluate_promotion_live_adapter_dry_run_dispatch_readiness_without_dispatch/v1"
+)
+CHECKS_DOMAIN = "veritas.promotion-live-adapter-dry-run-dispatch-readiness.checks/v1"
+FUTURE_REQUIREMENTS_DOMAIN = (
+    "veritas.promotion-live-adapter-dry-run-dispatch-readiness.future-requirements/v1"
+)
+PACKET_DOMAIN = "veritas.promotion-live-adapter-dry-run-dispatch-readiness.packet/v1"
+
+CHECK_NAMES = (
+    "source_request_independently_verified",
+    "source_request_not_dispatched",
+    "exact_request_descriptor_preserved",
+    "exact_dispatch_preconditions_preserved",
+    "exact_execution_intent_preserved",
+    "exact_adapter_descriptor_preserved",
+    "promotion_native_lineage_preserved",
+    "approval_context_preserved",
+    "policy_lineage_preserved",
+    "no_endpoint_material_or_contact",
+    "no_credential_material_or_access",
+    "no_network",
+    "no_webhook",
+    "no_adapter_instance_or_invocation",
+    "no_bind",
+    "no_trustlog",
+    "endpoint_allowlist_evaluation_still_required",
+    "credential_evaluation_still_required",
+    "operator_pre_dispatch_review_still_required",
+    "final_fresh_source_gate_still_required",
+)
+EFFECT_FIELDS = (
+    "endpoint_resolved",
+    "endpoint_contacted",
+    "dns_used",
+    "credential_resolved",
+    "credential_accessed",
+    "credential_material_embedded",
+    "authorization_header_constructed",
+    "network_used",
+    "webhook_invoked",
+    "live_adapter_instantiated",
+    "live_adapter_method_invoked",
+    "request_dispatched",
+    "bind_invoked",
+    "bind_authorization_issued",
+    "bind_receipt_created",
+    "trustlog_written",
+    "filesystem_used",
+    "database_used",
+    "subprocess_used",
+    "provider_called",
+    "external_effect_used",
+    "operation_committed",
+    "apply_performed",
+    "postcondition_verified",
+    "rollback_or_revert_performed",
+)
+FUTURE_REQUIREMENT_NAMES = (
+    "promotion_native_endpoint_allowlist_evaluation",
+    "credential_resolution_and_scope_evaluation",
+    "operator_pre_dispatch_review",
+    "final_fresh_source_gate",
+    "network_dispatch_boundary",
+    "bind_authorization_boundary",
+    "postcondition_and_rollback_boundary",
+)
+LINEAGE_FIELDS = (
+    "source_live_adapter_dry_run_readiness_id",
+    "source_live_adapter_dry_run_readiness_hash",
+    "source_reference_rehearsal_id",
+    "source_reference_rehearsal_hash",
+    "source_adapter_dry_run_fixture_result_id",
+    "source_adapter_dry_run_fixture_result_hash",
+    "source_adapter_dry_run_plan_id",
+    "source_adapter_dry_run_plan_hash",
+    "source_adapter_contract_selection_id",
+    "source_adapter_contract_selection_hash",
+    "source_bind_preflight_adjudication_id",
+    "source_bind_preflight_adjudication_hash",
+    "source_pre_bind_validation_id",
+    "source_pre_bind_validation_hash",
+    "source_readiness_id",
+    "source_readiness_hash",
+    "source_promotion_id",
+    "source_promotion_hash",
+    "source_decision_identity",
+    "candidate_identity",
+    "selected_action_lineage",
+    "policy_snapshot_lineage",
+    "approval_context",
+    "policy_lineage",
+)
+SCOPE_LIMITATIONS = (
+    "NOT_NETWORK_DISPATCH",
+    "NOT_REAL_BIND",
+    "NOT_EXECUTION_AUTHORIZATION",
+    "NOT_HUMAN_APPROVAL_PROOF",
+    "NOT_AUTHORITY_EVIDENCE",
+    "NOT_ENDPOINT_ALLOWLIST_EVALUATION",
+    "NOT_CREDENTIAL_EVALUATION",
+    "NOT_EXTERNAL_EFFECT",
+)
+
+
+class CanonicalPromotionLiveAdapterDryRunDispatchReadinessError(ValueError):
+    """Stable fail-closed refusal for invalid promotion-native evidence."""
+
+
+class PromotionDispatchReadinessCheck(BaseModel):
+    """One ordered deterministic assertion with explicit no-effect states."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    check_id: str = Field(pattern=r"^pladrdr-check:v1:[1-9][0-9]*:[a-z0-9-]+$")
+    ordinal: int = Field(ge=1, le=len(CHECK_NAMES))
+    name: Literal[*CHECK_NAMES]
+    mode: Literal["deterministic_local_dispatch_readiness_evaluation_only"]
+    passed: Literal[True]
+    evidence_ref: str = Field(min_length=1)
+    endpoint_resolved: Literal[False]
+    endpoint_contacted: Literal[False]
+    dns_used: Literal[False]
+    credential_resolved: Literal[False]
+    credential_accessed: Literal[False]
+    credential_material_embedded: Literal[False]
+    authorization_header_constructed: Literal[False]
+    network_used: Literal[False]
+    webhook_invoked: Literal[False]
+    live_adapter_instantiated: Literal[False]
+    live_adapter_method_invoked: Literal[False]
+    request_dispatched: Literal[False]
+    bind_invoked: Literal[False]
+    bind_authorization_issued: Literal[False]
+    bind_receipt_created: Literal[False]
+    trustlog_written: Literal[False]
+    filesystem_used: Literal[False]
+    database_used: Literal[False]
+    subprocess_used: Literal[False]
+    provider_called: Literal[False]
+    external_effect_used: Literal[False]
+    operation_committed: Literal[False]
+    apply_performed: Literal[False]
+    postcondition_verified: Literal[False]
+    rollback_or_revert_performed: Literal[False]
+
+
+class PromotionFutureDispatchRequirement(BaseModel):
+    """A requirement explicitly unsatisfied until a future boundary."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    ordinal: int = Field(ge=1, le=len(FUTURE_REQUIREMENT_NAMES))
+    name: Literal[*FUTURE_REQUIREMENT_NAMES]
+    separate_future_artifact_required: Literal[True]
+    satisfied_by_this_packet: Literal[False]
+
+
+class CanonicalPromotionLiveAdapterDryRunDispatchReadinessPacket(BaseModel):
+    """Immutable content-addressed promotion-native readiness evidence."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    format_version: Literal[FORMAT_VERSION]
+    promotion_live_adapter_dry_run_dispatch_readiness_id: str = Field(
+        pattern=r"^pladrdr:v1:sha256:[0-9a-f]{64}$"
+    )
+    promotion_live_adapter_dry_run_dispatch_readiness_hash: str = Field(
+        pattern=r"^[0-9a-f]{64}$"
+    )
+    dispatch_readiness_mechanism: Literal[DISPATCH_READINESS_MECHANISM]
+    dispatch_readiness_evaluated_at: str
+    source_live_adapter_dry_run_request_id: str
+    source_live_adapter_dry_run_request_hash: str
+    source_live_adapter_dry_run_request_packet: dict[str, Any]
+    request_descriptor: dict[str, Any]
+    dispatch_preconditions: tuple[dict[str, Any], ...]
+    dispatch_precondition_digest: str
+    execution_intent: dict[str, Any]
+    execution_intent_id: str
+    execution_intent_hash: str
+    adapter_contract_descriptor: dict[str, Any]
+    adapter_contract_id: str
+    adapter_contract_hash: str
+    adapter_contract_version: str
+    source_live_adapter_dry_run_readiness_id: str
+    source_live_adapter_dry_run_readiness_hash: str
+    source_reference_rehearsal_id: str
+    source_reference_rehearsal_hash: str
+    source_adapter_dry_run_fixture_result_id: str
+    source_adapter_dry_run_fixture_result_hash: str
+    source_adapter_dry_run_plan_id: str
+    source_adapter_dry_run_plan_hash: str
+    source_adapter_contract_selection_id: str
+    source_adapter_contract_selection_hash: str
+    source_bind_preflight_adjudication_id: str
+    source_bind_preflight_adjudication_hash: str
+    source_pre_bind_validation_id: str
+    source_pre_bind_validation_hash: str
+    source_readiness_id: str
+    source_readiness_hash: str
+    source_promotion_id: str
+    source_promotion_hash: str
+    source_decision_identity: dict[str, Any]
+    candidate_identity: dict[str, Any]
+    selected_action_lineage: dict[str, Any]
+    policy_snapshot_lineage: dict[str, Any]
+    approval_context: dict[str, Any]
+    policy_lineage: dict[str, Any]
+    dispatch_readiness_status: Literal[
+        "PROMOTION_NATIVE_LIVE_ADAPTER_DRY_RUN_DISPATCH_READINESS_"
+        "EVALUATED_NOT_DISPATCHED"
+    ]
+    request_dispatch_state: Literal["NOT_DISPATCHED"]
+    ready_for_promotion_native_endpoint_allowlist_evaluation: Literal[True]
+    ready_for_network_dispatch: Literal[False]
+    ready_for_real_bind: Literal[False]
+    execution_authorized: Literal[False]
+    human_approval_proven: Literal[False]
+    authority_evidence_proven: Literal[False]
+    dispatch_readiness_checks: tuple[PromotionDispatchReadinessCheck, ...]
+    dispatch_readiness_check_digest: str
+    future_dispatch_requirements: tuple[PromotionFutureDispatchRequirement, ...]
+    future_dispatch_requirement_digest: str
+    scope_limitations: tuple[str, ...]
+
+
+def _json_value(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        value = value.model_dump(mode="python")
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        if value != value or value in (float("inf"), float("-inf")):
+            raise CanonicalPromotionLiveAdapterDryRunDispatchReadinessError(
+                "PLADRDR_PACKET_INVALID"
+            )
+        return value
+    if isinstance(value, datetime):
+        return _aware(value, "PLADRDR_EVALUATED_AT_INVALID").isoformat()
+    if isinstance(value, (list, tuple)):
+        return [_json_value(item) for item in value]
+    if isinstance(value, dict) and all(isinstance(key, str) for key in value):
+        return {key: _json_value(item) for key, item in value.items()}
+    raise CanonicalPromotionLiveAdapterDryRunDispatchReadinessError(
+        "PLADRDR_PACKET_INVALID"
+    )
+
+
+def _aware(value: Any, code: str) -> datetime:
+    try:
+        parsed = value if isinstance(value, datetime) else datetime.fromisoformat(value)
+    except (TypeError, ValueError) as exc:
+        raise CanonicalPromotionLiveAdapterDryRunDispatchReadinessError(code) from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise CanonicalPromotionLiveAdapterDryRunDispatchReadinessError(code)
+    return parsed
+
+
+def _digest(domain: str, value: Any) -> str:
+    encoded = json.dumps(
+        {"domain": domain, "value": _json_value(value)},
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _packet_hash(raw: dict[str, Any]) -> str:
+    omitted = {
+        "promotion_live_adapter_dry_run_dispatch_readiness_id",
+        "promotion_live_adapter_dry_run_dispatch_readiness_hash",
+    }
+    return _digest(
+        PACKET_DOMAIN, {key: value for key, value in raw.items() if key not in omitted}
+    )
+
+
+def _source(value: Any) -> CanonicalPromotionLiveAdapterDryRunRequestPacket:
+    try:
+        return verify_canonical_promotion_live_adapter_dry_run_request_packet(value)
+    except (
+        CanonicalPromotionLiveAdapterDryRunRequestError,
+        TypeError,
+        ValueError,
+    ) as exc:
+        raise CanonicalPromotionLiveAdapterDryRunDispatchReadinessError(
+            "PLADRDR_SOURCE_REQUEST_INVALID"
+        ) from exc
+
+
+def _intent(raw: dict[str, Any]) -> ExecutionIntent:
+    try:
+        intent = ExecutionIntent(**raw)
+        canonical_execution_intent_json(intent)
+    except (TypeError, ValueError) as exc:
+        raise CanonicalPromotionLiveAdapterDryRunDispatchReadinessError(
+            "PLADRDR_EXECUTION_INTENT_INVALID"
+        ) from exc
+    if intent.to_dict() != raw:
+        raise CanonicalPromotionLiveAdapterDryRunDispatchReadinessError(
+            "PLADRDR_EXECUTION_INTENT_INVALID"
+        )
+    return intent
+
+
+def _validate_identity(
+    source: CanonicalPromotionLiveAdapterDryRunRequestPacket,
+) -> None:
+    intent = _intent(source.execution_intent)
+    if intent.execution_intent_id != source.execution_intent_id:
+        raise CanonicalPromotionLiveAdapterDryRunDispatchReadinessError(
+            "PLADRDR_EXECUTION_INTENT_ID_MISMATCH"
+        )
+    if hash_execution_intent(intent) != source.execution_intent_hash:
+        raise CanonicalPromotionLiveAdapterDryRunDispatchReadinessError(
+            "PLADRDR_EXECUTION_INTENT_HASH_MISMATCH"
+        )
+    try:
+        descriptor = verify_bind_adapter_contract_descriptor(
+            source.adapter_contract_descriptor, intent
+        )
+    except BindAdapterContractSelectionError as exc:
+        raise CanonicalPromotionLiveAdapterDryRunDispatchReadinessError(
+            "PLADRDR_ADAPTER_DESCRIPTOR_MISMATCH"
+        ) from exc
+    if (
+        descriptor.model_dump(mode="json") != source.adapter_contract_descriptor
+        or descriptor.adapter_contract_id != source.adapter_contract_id
+        or descriptor.adapter_contract_hash != source.adapter_contract_hash
+        or descriptor.adapter_contract_version != source.adapter_contract_version
+    ):
+        raise CanonicalPromotionLiveAdapterDryRunDispatchReadinessError(
+            "PLADRDR_ADAPTER_DESCRIPTOR_MISMATCH"
+        )
+
+
+def _checks(source_hash: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "check_id": f"pladrdr-check:v1:{ordinal}:{name.replace('_', '-')}",
+            "ordinal": ordinal,
+            "name": name,
+            "mode": "deterministic_local_dispatch_readiness_evaluation_only",
+            "passed": True,
+            "evidence_ref": f"source_request_hash:{source_hash}:{name}",
+            **{field: False for field in EFFECT_FIELDS},
+        }
+        for ordinal, name in enumerate(CHECK_NAMES, 1)
+    ]
+
+
+def _future_requirements() -> list[dict[str, Any]]:
+    return [
+        {
+            "ordinal": ordinal,
+            "name": name,
+            "separate_future_artifact_required": True,
+            "satisfied_by_this_packet": False,
+        }
+        for ordinal, name in enumerate(FUTURE_REQUIREMENT_NAMES, 1)
+    ]
+
+
+def build_canonical_promotion_live_adapter_dry_run_dispatch_readiness_packet(
+    source_live_adapter_dry_run_request_packet: Any,
+    dispatch_readiness_evaluated_at: datetime,
+) -> CanonicalPromotionLiveAdapterDryRunDispatchReadinessPacket:
+    """Build local readiness evidence from the sole authoritative request."""
+    evaluated = _aware(dispatch_readiness_evaluated_at, "PLADRDR_EVALUATED_AT_INVALID")
+    source = _source(_json_value(source_live_adapter_dry_run_request_packet))
+    _validate_identity(source)
+    if evaluated < _aware(source.requested_at, "PLADRDR_SOURCE_REQUEST_INVALID"):
+        raise CanonicalPromotionLiveAdapterDryRunDispatchReadinessError(
+            "PLADRDR_EVALUATED_BEFORE_REQUEST"
+        )
+    source_raw = source.model_dump(mode="json")
+    checks = _checks(source.promotion_live_adapter_dry_run_request_hash)
+    requirements = _future_requirements()
+    raw = {
+        "format_version": FORMAT_VERSION,
+        "dispatch_readiness_mechanism": DISPATCH_READINESS_MECHANISM,
+        "dispatch_readiness_evaluated_at": evaluated.isoformat(),
+        "source_live_adapter_dry_run_request_id": (
+            source.promotion_live_adapter_dry_run_request_id
+        ),
+        "source_live_adapter_dry_run_request_hash": (
+            source.promotion_live_adapter_dry_run_request_hash
+        ),
+        "source_live_adapter_dry_run_request_packet": source_raw,
+        "request_descriptor": source_raw["request_descriptor"],
+        "dispatch_preconditions": source_raw["dispatch_preconditions"],
+        "dispatch_precondition_digest": source.dispatch_precondition_digest,
+        "execution_intent": source_raw["execution_intent"],
+        "execution_intent_id": source.execution_intent_id,
+        "execution_intent_hash": source.execution_intent_hash,
+        "adapter_contract_descriptor": source_raw["adapter_contract_descriptor"],
+        "adapter_contract_id": source.adapter_contract_id,
+        "adapter_contract_hash": source.adapter_contract_hash,
+        "adapter_contract_version": source.adapter_contract_version,
+        **{field: source_raw[field] for field in LINEAGE_FIELDS},
+        "dispatch_readiness_status": (
+            "PROMOTION_NATIVE_LIVE_ADAPTER_DRY_RUN_DISPATCH_READINESS_"
+            "EVALUATED_NOT_DISPATCHED"
+        ),
+        "request_dispatch_state": "NOT_DISPATCHED",
+        "ready_for_promotion_native_endpoint_allowlist_evaluation": True,
+        "ready_for_network_dispatch": False,
+        "ready_for_real_bind": False,
+        "execution_authorized": False,
+        "human_approval_proven": False,
+        "authority_evidence_proven": False,
+        "dispatch_readiness_checks": checks,
+        "dispatch_readiness_check_digest": _digest(CHECKS_DOMAIN, checks),
+        "future_dispatch_requirements": requirements,
+        "future_dispatch_requirement_digest": _digest(
+            FUTURE_REQUIREMENTS_DOMAIN, requirements
+        ),
+        "scope_limitations": SCOPE_LIMITATIONS,
+    }
+    digest = _packet_hash(raw)
+    raw["promotion_live_adapter_dry_run_dispatch_readiness_hash"] = digest
+    raw["promotion_live_adapter_dry_run_dispatch_readiness_id"] = (
+        f"pladrdr:v1:sha256:{digest}"
+    )
+    return verify_canonical_promotion_live_adapter_dry_run_dispatch_readiness_packet(
+        raw
+    )
+
+
+def verify_canonical_promotion_live_adapter_dry_run_dispatch_readiness_packet(
+    packet: Any,
+) -> CanonicalPromotionLiveAdapterDryRunDispatchReadinessPacket:
+    """Independently recompute source identity, claims, digests, hash, and ID."""
+    try:
+        value = (
+            packet.model_dump(mode="json")
+            if isinstance(packet, BaseModel)
+            else _json_value(packet)
+        )
+        candidate = (
+            CanonicalPromotionLiveAdapterDryRunDispatchReadinessPacket.model_validate(
+                value
+            )
+        )
+    except (
+        ValidationError,
+        TypeError,
+        CanonicalPromotionLiveAdapterDryRunDispatchReadinessError,
+    ) as exc:
+        raise CanonicalPromotionLiveAdapterDryRunDispatchReadinessError(
+            "PLADRDR_PACKET_INVALID"
+        ) from exc
+    raw = candidate.model_dump(mode="json")
+    source = _source(candidate.source_live_adapter_dry_run_request_packet)
+    _validate_identity(source)
+    source_raw = source.model_dump(mode="json")
+    if (
+        candidate.source_live_adapter_dry_run_request_id
+        != source.promotion_live_adapter_dry_run_request_id
+        or candidate.source_live_adapter_dry_run_request_hash
+        != source.promotion_live_adapter_dry_run_request_hash
+    ):
+        raise CanonicalPromotionLiveAdapterDryRunDispatchReadinessError(
+            "PLADRDR_SOURCE_SUMMARY_MISMATCH"
+        )
+    if _aware(
+        candidate.dispatch_readiness_evaluated_at, "PLADRDR_EVALUATED_AT_INVALID"
+    ) < _aware(source.requested_at, "PLADRDR_SOURCE_REQUEST_INVALID"):
+        raise CanonicalPromotionLiveAdapterDryRunDispatchReadinessError(
+            "PLADRDR_EVALUATED_BEFORE_REQUEST"
+        )
+    copied = (
+        "request_descriptor",
+        "dispatch_preconditions",
+        "dispatch_precondition_digest",
+        "execution_intent",
+        "execution_intent_id",
+        "execution_intent_hash",
+        "adapter_contract_descriptor",
+        "adapter_contract_id",
+        "adapter_contract_hash",
+        "adapter_contract_version",
+        *LINEAGE_FIELDS,
+    )
+    for field in copied:
+        if _json_value(getattr(candidate, field)) != _json_value(source_raw[field]):
+            raise CanonicalPromotionLiveAdapterDryRunDispatchReadinessError(
+                "PLADRDR_SOURCE_FIELD_MISMATCH"
+            )
+    intent = _intent(candidate.execution_intent)
+    if (
+        intent.execution_intent_id != candidate.execution_intent_id
+        or hash_execution_intent(intent) != candidate.execution_intent_hash
+    ):
+        raise CanonicalPromotionLiveAdapterDryRunDispatchReadinessError(
+            "PLADRDR_EXECUTION_INTENT_MISMATCH"
+        )
+    checks = _checks(source.promotion_live_adapter_dry_run_request_hash)
+    if _json_value(candidate.dispatch_readiness_checks) != checks:
+        raise CanonicalPromotionLiveAdapterDryRunDispatchReadinessError(
+            "PLADRDR_CHECKS_MISMATCH"
+        )
+    if candidate.dispatch_readiness_check_digest != _digest(CHECKS_DOMAIN, checks):
+        raise CanonicalPromotionLiveAdapterDryRunDispatchReadinessError(
+            "PLADRDR_CHECK_DIGEST_MISMATCH"
+        )
+    requirements = _future_requirements()
+    if _json_value(candidate.future_dispatch_requirements) != requirements:
+        raise CanonicalPromotionLiveAdapterDryRunDispatchReadinessError(
+            "PLADRDR_REQUIREMENTS_MISMATCH"
+        )
+    if candidate.future_dispatch_requirement_digest != _digest(
+        FUTURE_REQUIREMENTS_DOMAIN, requirements
+    ):
+        raise CanonicalPromotionLiveAdapterDryRunDispatchReadinessError(
+            "PLADRDR_REQUIREMENT_DIGEST_MISMATCH"
+        )
+    if candidate.scope_limitations != SCOPE_LIMITATIONS:
+        raise CanonicalPromotionLiveAdapterDryRunDispatchReadinessError(
+            "PLADRDR_SCOPE_MISMATCH"
+        )
+    digest = _packet_hash(raw)
+    if candidate.promotion_live_adapter_dry_run_dispatch_readiness_hash != digest:
+        raise CanonicalPromotionLiveAdapterDryRunDispatchReadinessError(
+            "PLADRDR_PACKET_HASH_MISMATCH"
+        )
+    if candidate.promotion_live_adapter_dry_run_dispatch_readiness_id != (
+        f"pladrdr:v1:sha256:{digest}"
+    ):
+        raise CanonicalPromotionLiveAdapterDryRunDispatchReadinessError(
+            "PLADRDR_PACKET_ID_MISMATCH"
+        )
+    return candidate

--- a/veritas_os/tests/test_canonical_promotion_live_adapter_dry_run_dispatch_readiness.py
+++ b/veritas_os/tests/test_canonical_promotion_live_adapter_dry_run_dispatch_readiness.py
@@ -1,0 +1,161 @@
+"""Fail-closed tests for promotion-native dispatch-readiness evidence."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+
+from veritas_os.policy.bind_artifacts import ExecutionIntent, hash_execution_intent
+from veritas_os.policy.canonical_promotion_live_adapter_dry_run_dispatch_readiness import (
+    EFFECT_FIELDS,
+    CanonicalPromotionLiveAdapterDryRunDispatchReadinessError,
+    _packet_hash,
+    build_canonical_promotion_live_adapter_dry_run_dispatch_readiness_packet,
+    verify_canonical_promotion_live_adapter_dry_run_dispatch_readiness_packet,
+)
+from veritas_os.tests.test_canonical_promotion_live_adapter_dry_run_request import (
+    REQUESTED_AT,
+    _packet as request_packet,
+)
+
+EVALUATED_AT = REQUESTED_AT + timedelta(seconds=1)
+
+
+def _packet():
+    return build_canonical_promotion_live_adapter_dry_run_dispatch_readiness_packet(
+        request_packet(), EVALUATED_AT
+    )
+
+
+def _rehash(raw: dict) -> None:
+    digest = _packet_hash(raw)
+    raw["promotion_live_adapter_dry_run_dispatch_readiness_hash"] = digest
+    raw["promotion_live_adapter_dry_run_dispatch_readiness_id"] = (
+        f"pladrdr:v1:sha256:{digest}"
+    )
+
+
+def _set(raw: dict, path: str, value: object) -> None:
+    target = raw
+    parts = path.split(".")
+    for part in parts[:-1]:
+        target = target[int(part)] if isinstance(target, list) else target[part]
+    if isinstance(target, list):
+        target[int(parts[-1])] = value
+    else:
+        target[parts[-1]] = value
+
+
+def test_full_chain_preserves_exact_identity_lineage_and_no_effects() -> None:
+    source = request_packet()
+    packet = verify_canonical_promotion_live_adapter_dry_run_dispatch_readiness_packet(
+        _packet()
+    )
+    intent = ExecutionIntent(**packet.execution_intent)
+
+    assert packet.execution_intent == source.execution_intent == intent.to_dict()
+    assert packet.execution_intent_id == source.execution_intent_id
+    assert packet.execution_intent_id == intent.execution_intent_id
+    assert packet.execution_intent_hash == source.execution_intent_hash
+    assert packet.execution_intent_hash == hash_execution_intent(intent)
+    assert packet.adapter_contract_descriptor == source.adapter_contract_descriptor
+    assert packet.adapter_contract_id == source.adapter_contract_id
+    assert packet.adapter_contract_hash == source.adapter_contract_hash
+    assert packet.adapter_contract_version == source.adapter_contract_version
+    assert packet.approval_context == source.approval_context
+    assert packet.approval_context["required_human_approval"] is True
+    assert packet.policy_lineage == source.policy_lineage
+    assert packet.source_promotion_hash == source.source_promotion_hash
+    assert packet.source_readiness_hash == source.source_readiness_hash
+    assert (
+        packet.source_pre_bind_validation_hash == source.source_pre_bind_validation_hash
+    )
+    assert (
+        packet.source_reference_rehearsal_hash == source.source_reference_rehearsal_hash
+    )
+    assert packet.request_dispatch_state == "NOT_DISPATCHED"
+    assert packet.ready_for_promotion_native_endpoint_allowlist_evaluation is True
+    assert packet.ready_for_network_dispatch is False
+    assert packet.ready_for_real_bind is False
+    assert packet.execution_authorized is False
+    assert packet.human_approval_proven is False
+    assert packet.authority_evidence_proven is False
+    for check in packet.dispatch_readiness_checks:
+        assert all(getattr(check, field) is False for field in EFFECT_FIELDS)
+
+    legacy = {
+        "source_formation_hash",
+        "source_eligibility_hash",
+        "source_handoff_hash",
+        "evidence_lineage",
+        "human_approval_receipt",
+    }
+    assert set(packet.model_dump(mode="json")).isdisjoint(legacy)
+
+
+@pytest.mark.parametrize(
+    ("path", "value"),
+    [
+        ("execution_intent.actor_identity", "substitute"),
+        ("execution_intent_id", "ei:v1:sha256:" + "0" * 64),
+        ("execution_intent_hash", "0" * 64),
+        ("adapter_contract_descriptor.target_system", "substitute"),
+        ("adapter_contract_id", "adapter-contract:v1:sha256:" + "0" * 64),
+        ("adapter_contract_hash", "0" * 64),
+        ("adapter_contract_version", "substitute"),
+        ("source_promotion_hash", "0" * 64),
+        ("source_readiness_hash", "0" * 64),
+        ("source_pre_bind_validation_hash", "0" * 64),
+        ("source_bind_preflight_adjudication_hash", "0" * 64),
+        ("source_adapter_contract_selection_hash", "0" * 64),
+        ("source_adapter_dry_run_plan_hash", "0" * 64),
+        ("source_adapter_dry_run_fixture_result_hash", "0" * 64),
+        ("source_reference_rehearsal_hash", "0" * 64),
+        ("approval_context.required_human_approval", False),
+        ("policy_lineage", {}),
+        ("dispatch_readiness_checks.0.ordinal", 2),
+        ("dispatch_readiness_checks.0.network_used", True),
+        ("dispatch_readiness_check_digest", "0" * 64),
+        ("future_dispatch_requirements.0.satisfied_by_this_packet", True),
+        ("future_dispatch_requirement_digest", "0" * 64),
+        ("ready_for_network_dispatch", True),
+        ("human_approval_proven", True),
+        ("authority_evidence_proven", True),
+    ],
+)
+def test_tampering_fails_closed(path: str, value: object) -> None:
+    raw = _packet().model_dump(mode="json")
+    _set(raw, path, value)
+    _rehash(raw)
+    with pytest.raises(CanonicalPromotionLiveAdapterDryRunDispatchReadinessError):
+        verify_canonical_promotion_live_adapter_dry_run_dispatch_readiness_packet(raw)
+
+
+def test_source_time_hash_id_and_shortcut_claims_fail_closed() -> None:
+    with pytest.raises(CanonicalPromotionLiveAdapterDryRunDispatchReadinessError):
+        build_canonical_promotion_live_adapter_dry_run_dispatch_readiness_packet(
+            request_packet(), REQUESTED_AT - timedelta(seconds=1)
+        )
+
+    raw = _packet().model_dump(mode="json")
+    raw["source_live_adapter_dry_run_request_packet"] = {}
+    _rehash(raw)
+    with pytest.raises(CanonicalPromotionLiveAdapterDryRunDispatchReadinessError):
+        verify_canonical_promotion_live_adapter_dry_run_dispatch_readiness_packet(raw)
+
+    for field, value in (
+        ("promotion_live_adapter_dry_run_dispatch_readiness_hash", "0" * 64),
+        (
+            "promotion_live_adapter_dry_run_dispatch_readiness_id",
+            "pladrdr:v1:sha256:" + "0" * 64,
+        ),
+        ("verified", True),
+        ("dispatch_ready", True),
+    ):
+        raw = _packet().model_dump(mode="json")
+        raw[field] = value
+        with pytest.raises(CanonicalPromotionLiveAdapterDryRunDispatchReadinessError):
+            verify_canonical_promotion_live_adapter_dry_run_dispatch_readiness_packet(
+                raw
+            )


### PR DESCRIPTION
### Motivation

- Introduce a promotion-native, deterministic, content-addressed dispatch-readiness artifact that proves a verified promotion-native live-adapter dry-run request is locally ready to proceed only to the next endpoint-allowlist evaluation boundary. 
- Preserve exact ExecutionIntent identity and adapter descriptor invariants and maintain only genuine promotion-native lineage without inventing legacy readiness/formation/eligibility/handoff fields. 
- Ensure the artifact is pure-data and fail-closed: it must not perform or authorize any network, adapter, Bind, TrustLog, or other external effects. 

### Description

- Added a new production module `veritas_os/policy/canonical_promotion_live_adapter_dry_run_dispatch_readiness.py` that defines the packet format `canonical-promotion-live-adapter-dry-run-dispatch-readiness/v1`, mechanism `evaluate_promotion_live_adapter_dry_run_dispatch_readiness_without_dispatch/v1`, and ID namespace `pladrdr:v1:sha256:<64hex>`. 
- The builder and verifier exclusively accept `CanonicalPromotionLiveAdapterDryRunRequestPacket` as the authoritative source and independently call `verify_canonical_promotion_live_adapter_dry_run_request_packet(...)`, reconstruct the exact serialized `ExecutionIntent`, require exact `execution_intent_id` and `hash_execution_intent(...)` equality, and re-verify the adapter descriptor via `verify_bind_adapter_contract_descriptor(...)`. 
- The packet preserves only real promotion-native lineage fields (readiness, request, rehearsal, fixture, plan, contract selection, pre-bind adjudication, pre-bind validation, promotion, decision/candidate identities, selected action, policy snapshot, approval_context, policy_lineage) and intentionally omits legacy formation/eligibility/handoff lineage. 
- Added deterministic, ordered no-effect checks and explicit future requirements so the packet declares `ready_for_promotion_native_endpoint_allowlist_evaluation = true` while keeping all dispatch/credential/Bind/authority/human-approval fields false. 
- Added tests `veritas_os/tests/test_canonical_promotion_live_adapter_dry_run_dispatch_readiness.py` which exercise full-chain preservation, exact intent/adapter identity, lineage preservation, tamper/fail-closed checks, timestamp ordering, and rejection of shortcut/claimed verification booleans. The legacy readiness module `veritas_os/policy/live_adapter_dry_run_dispatch_readiness.py` was not modified and remains compatible. 

### Testing

- ✅ `ruff check` and `ruff format --check` passed for the new files. 
- ✅ `python -m compileall` succeeded for the new module and test file. 
- ✅ Repository architecture/security scripts passed: `scripts/architecture/check_responsibility_boundaries.py` and `scripts/security/check_subprocess_shell_usage.py`. 
- ✅ `git diff --check` and local formatting/diff checks passed. 
- ⚠️ `pytest` could not be run to completion in this environment because required runtime dependencies (notably `pydantic` in the test runner) were not available and PyPI access was blocked, preventing installation; the test suite therefore could not be executed here though focused unit tests were added. 

Files changed

- Added `veritas_os/policy/canonical_promotion_live_adapter_dry_run_dispatch_readiness.py` (new production module).
- Added `veritas_os/tests/test_canonical_promotion_live_adapter_dry_run_dispatch_readiness.py` (new focused tests).

Notes / remaining boundaries

- This artifact intentionally stops before endpoint allowlist evaluation; endpoint allowlist resolution, credential resolution/scope evaluation, operator pre-dispatch review, and the final fresh source gate remain required future artifacts and are explicitly marked unsatisfied in the packet. 
- Security warning: this packet does not authorize dispatch, Bind, or claim human approval/authority evidence; do not treat it as an execution or authorization artifact.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a92271390f0832689e5d245431984dd)