### PR TITLE
feat(governance): add promotion-native final Bind authorization readiness review

### DIFF
--- a/veritas_os/policy/canonical_promotion_live_adapter_dry_run_final_bind_authorization_readiness.py
+++ b/veritas_os/policy/canonical_promotion_live_adapter_dry_run_final_bind_authorization_readiness.py
@@ -1,0 +1,592 @@
+"""Record promotion-native final Bind authorization readiness evidence.
+
+The boundary is deterministic and local.  It independently verifies the
+Human Approval reference-linkage source and preserves its promotion-native
+bindings, but creates no proof, authority, authorization, dispatch, or effect.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from veritas_os.policy.bind_adapter_contract_selection import (
+    BindAdapterContractSelectionError,
+    verify_bind_adapter_contract_descriptor,
+)
+from veritas_os.policy.bind_artifacts import ExecutionIntent, hash_execution_intent
+from veritas_os.policy.canonical_promotion_live_adapter_dry_run_human_approval_linkage import (
+    CanonicalPromotionLiveAdapterDryRunHumanApprovalLinkageError,
+    CanonicalPromotionLiveAdapterDryRunHumanApprovalLinkageReviewPacket,
+    verify_canonical_promotion_live_adapter_dry_run_human_approval_linkage_review_packet,
+)
+
+FORMAT_VERSION = (
+    "canonical-promotion-live-adapter-dry-run-final-bind-authorization-"
+    "readiness/v1"
+)
+MECHANISM = (
+    "review_promotion_native_final_bind_authorization_readiness_without_"
+    "authorization_or_external_effect/v1"
+)
+STATUS = "PROMOTION_NATIVE_FINAL_BIND_AUTHORIZATION_READINESS_RECORDED_NOT_AUTHORIZED"
+SOURCE_STATUS = "PROMOTION_NATIVE_HUMAN_APPROVAL_REFERENCE_LINKAGE_REVIEWED_NOT_APPROVED"
+CHECK_MODE = (
+    "deterministic_local_promotion_native_final_bind_authorization_readiness_only"
+)
+OUTCOMES = (
+    "ACCEPTED_FOR_FUTURE_PROMOTION_NATIVE_BIND_AUTHORIZATION_GATE_REVIEW",
+    "REJECTED_FOR_FUTURE_PROMOTION_NATIVE_BIND_AUTHORIZATION_GATE_REVIEW",
+)
+PREFIX = "veritas.promotion-live-adapter-dry-run-final-bind-authorization-readiness"
+DOMAINS = {
+    name: f"{PREFIX}.{name}/v1"
+    for name in ("decision", "result", "context", "checks", "future", "packet")
+}
+ACKNOWLEDGEMENTS = (
+    "acknowledged_not_bind_authorization",
+    "acknowledged_no_bind_invocation",
+    "acknowledged_no_bind_receipt",
+    "acknowledged_no_trustlog_write",
+    "acknowledged_no_dispatch",
+    "acknowledged_no_execution_authority",
+    "acknowledged_no_human_approval_creation",
+    "acknowledged_no_authority_evidence_creation",
+    "acknowledged_no_credential_access",
+    "acknowledged_no_authorization_header",
+    "acknowledged_no_network_call",
+    "acknowledged_semantic_match_not_authority",
+)
+CHECK_NAMES = (
+    "source_human_approval_reference_linkage_verified",
+    "exact_execution_intent_reconstructed",
+    "exact_adapter_descriptor_verified",
+    "endpoint_identity_binding_preserved",
+    "credential_scope_binding_preserved",
+    "operator_review_binding_preserved",
+    "bind_boundary_precondition_preserved",
+    "authority_evidence_reference_linkage_preserved",
+    "human_approval_reference_linkage_preserved",
+    "final_review_decision_valid",
+    "all_acknowledgements_present",
+    "timestamp_ordering_valid",
+    "future_requirements_unsatisfied",
+    "human_approval_proof_absent",
+    "authority_evidence_proof_absent",
+    "execution_authority_absent",
+    "bind_authorization_absent",
+    "dispatch_absent",
+    "network_access_absent",
+    "external_effect_absent",
+)
+FUTURE_REQUIREMENTS = (
+    "promotion_native_bind_authorization_gate_review",
+    "fresh_verified_source_gate",
+    "exact_bind_context_hash_derivation",
+    "final_endpoint_identity_recheck",
+    "final_credential_scope_recheck",
+    "runtime_risk_review",
+    "idempotency_and_replay_review",
+    "signed_gate_bound_human_approval_issuance",
+    "human_approval_receipt_verification",
+    "cryptographic_authority_evidence_verification",
+    "revocation_verification_where_applicable",
+    "real_bind_authorization",
+    "authorization_consumption",
+    "single_use_consumption",
+    "credential_material_resolution",
+    "authorization_header_construction",
+    "network_dispatch",
+    "bind_invocation",
+    "bind_receipt",
+    "trustlog_write",
+    "effect_state_handling",
+    "reconciliation",
+    "outcome_receipt",
+)
+COPY_FIELDS = (
+    "request_descriptor", "execution_intent", "execution_intent_id",
+    "execution_intent_hash", "adapter_contract_descriptor",
+    "adapter_contract_id", "adapter_contract_hash", "adapter_contract_version",
+    "endpoint_candidate", "endpoint_candidate_digest",
+    "endpoint_identity_binding", "endpoint_identity_binding_digest",
+    "credential_reference", "credential_reference_digest",
+    "credential_scope_binding", "credential_scope_binding_digest",
+    "operator_review_binding", "operator_review_binding_digest",
+    "bind_boundary_preconditions", "bind_boundary_precondition_digest",
+    "authority_evidence_reference_bundle",
+    "authority_evidence_reference_bundle_digest",
+    "authority_evidence_binding_matrix",
+    "authority_evidence_binding_matrix_digest",
+    "authority_evidence_linkage_context",
+    "authority_evidence_linkage_context_digest",
+    "human_approval_reference_bundle", "human_approval_reference_bundle_digest",
+    "human_approval_binding_matrix", "human_approval_binding_matrix_digest",
+    "human_approval_linkage_context", "human_approval_linkage_context_digest",
+)
+EFFECT_FIELDS = (
+    "human_approval_created", "human_approval_externally_verified",
+    "human_approval_proven", "authority_evidence_created",
+    "authority_evidence_externally_verified", "authority_evidence_proven",
+    "execution_authority_created", "execution_authorized",
+    "bind_authorization_created", "bind_authorization_issued",
+    "credential_resolved", "credential_material_accessed",
+    "credential_material_embedded", "credential_store_accessed",
+    "authorization_header_constructed", "token_embedded", "secret_embedded",
+    "cookie_embedded", "password_embedded", "private_key_embedded",
+    "endpoint_resolved", "endpoint_contacted", "dns_used", "network_used",
+    "webhook_invoked", "live_adapter_instantiated",
+    "live_adapter_method_invoked", "request_dispatched", "bind_invoked",
+    "bind_receipt_created", "trustlog_written", "filesystem_used",
+    "database_used", "provider_called", "subprocess_used",
+    "external_effect_used", "operation_committed", "apply_performed",
+    "postcondition_verified", "rollback_or_revert_performed",
+    "ready_for_real_bind", "ready_for_network_dispatch",
+)
+
+
+class CanonicalPromotionLiveAdapterDryRunFinalBindAuthorizationReadinessError(
+    ValueError
+):
+    """Stable fail-closed error for invalid final readiness evidence."""
+
+
+class FinalBindAuthorizationReadinessReviewDecision(BaseModel):
+    """Closed reviewer decision which expressly grants no authority."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    final_bind_authorization_readiness_review_decision_id: str = Field(min_length=1)
+    reviewer_id: str = Field(min_length=1)
+    reviewer_role: str = Field(min_length=1)
+    reviewer_attestation: str = Field(min_length=1)
+    reviewed_at: str
+    review_outcome: Literal[*OUTCOMES]
+    review_reason: str = Field(min_length=1)
+    acknowledged_not_bind_authorization: bool
+    acknowledged_no_bind_invocation: bool
+    acknowledged_no_bind_receipt: bool
+    acknowledged_no_trustlog_write: bool
+    acknowledged_no_dispatch: bool
+    acknowledged_no_execution_authority: bool
+    acknowledged_no_human_approval_creation: bool
+    acknowledged_no_authority_evidence_creation: bool
+    acknowledged_no_credential_access: bool
+    acknowledged_no_authorization_header: bool
+    acknowledged_no_network_call: bool
+    acknowledged_semantic_match_not_authority: bool
+
+
+class FinalReadinessResult(BaseModel):
+    """Final local comparison result with no proof or authorization semantics."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    review_outcome: Literal[*OUTCOMES]
+    ready_for_promotion_native_bind_authorization_gate_review: bool
+    rejection_reasons: tuple[str, ...]
+    comparison_mode: Literal[CHECK_MODE]
+    human_approval_proven: Literal[False]
+    human_approval_externally_verified: Literal[False]
+    authority_evidence_proven: Literal[False]
+    authority_evidence_externally_verified: Literal[False]
+    execution_authorized: Literal[False]
+    bind_authorization_issued: Literal[False]
+
+
+class ReadinessCheck(BaseModel):
+    """An ordered deterministic check that cannot perform an effect."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    ordinal: int = Field(ge=1)
+    name: Literal[*CHECK_NAMES]
+    passed: Literal[True]
+    comparison_mode: Literal[CHECK_MODE]
+
+
+class FutureRequirement(BaseModel):
+    """A lifecycle requirement deliberately unsatisfied by this artifact."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    ordinal: int = Field(ge=1)
+    name: Literal[*FUTURE_REQUIREMENTS]
+    separate_future_artifact_required: Literal[True]
+    satisfied_by_this_packet: Literal[False]
+
+
+class CanonicalPromotionLiveAdapterDryRunFinalBindAuthorizationReadinessPacket(
+    BaseModel
+):
+    """Content-addressed promotion-native final readiness evidence."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    format_version: Literal[FORMAT_VERSION]
+    promotion_live_adapter_dry_run_final_bind_authorization_readiness_id: str
+    promotion_live_adapter_dry_run_final_bind_authorization_readiness_hash: str
+    final_bind_authorization_readiness_mechanism: Literal[MECHANISM]
+    final_bind_authorization_readiness_recorded_at: str
+    source_human_approval_linkage_review_id: str
+    source_human_approval_linkage_review_hash: str
+    source_human_approval_linkage_review_packet: dict[str, Any]
+    request_descriptor: dict[str, Any]
+    execution_intent: dict[str, Any]
+    execution_intent_id: str
+    execution_intent_hash: str
+    adapter_contract_descriptor: dict[str, Any]
+    adapter_contract_id: str
+    adapter_contract_hash: str
+    adapter_contract_version: str
+    endpoint_candidate: dict[str, Any]
+    endpoint_candidate_digest: str
+    endpoint_identity_binding: dict[str, Any]
+    endpoint_identity_binding_digest: str
+    credential_reference: dict[str, Any]
+    credential_reference_digest: str
+    credential_scope_binding: dict[str, Any]
+    credential_scope_binding_digest: str
+    operator_review_binding: dict[str, Any]
+    operator_review_binding_digest: str
+    bind_boundary_preconditions: dict[str, Any]
+    bind_boundary_precondition_digest: str
+    authority_evidence_reference_bundle: dict[str, Any]
+    authority_evidence_reference_bundle_digest: str
+    authority_evidence_binding_matrix: tuple[dict[str, Any], ...]
+    authority_evidence_binding_matrix_digest: str
+    authority_evidence_linkage_context: dict[str, Any]
+    authority_evidence_linkage_context_digest: str
+    human_approval_reference_bundle: dict[str, Any]
+    human_approval_reference_bundle_digest: str
+    human_approval_binding_matrix: tuple[dict[str, Any], ...]
+    human_approval_binding_matrix_digest: str
+    human_approval_linkage_context: dict[str, Any]
+    human_approval_linkage_context_digest: str
+    final_bind_authorization_readiness_review_decision: FinalBindAuthorizationReadinessReviewDecision
+    final_bind_authorization_readiness_review_decision_digest: str
+    final_bind_authorization_readiness_result: FinalReadinessResult
+    final_bind_authorization_readiness_result_digest: str
+    final_readiness_context: dict[str, Any]
+    final_readiness_context_digest: str
+    final_bind_authorization_readiness_checks: tuple[ReadinessCheck, ...]
+    final_bind_authorization_readiness_check_digest: str
+    future_requirements: tuple[FutureRequirement, ...]
+    future_requirement_digest: str
+    final_bind_authorization_readiness_status: Literal[STATUS]
+    request_dispatch_state: Literal["NOT_DISPATCHED"]
+    bind_state: Literal["NOT_BOUND"]
+    authority_state: Literal["NOT_AUTHORIZED"]
+    human_approval_state: Literal["NOT_APPROVED"]
+    ready_for_promotion_native_bind_authorization_gate_review: bool
+    fail_closed: bool
+    human_approval_proven: Literal[False]
+    human_approval_externally_verified: Literal[False]
+    authority_evidence_proven: Literal[False]
+    authority_evidence_externally_verified: Literal[False]
+    execution_authorized: Literal[False]
+    bind_authorization_issued: Literal[False]
+    ready_for_real_bind: Literal[False]
+    ready_for_network_dispatch: Literal[False]
+    human_approval_created: Literal[False]
+    authority_evidence_created: Literal[False]
+    execution_authority_created: Literal[False]
+    bind_authorization_created: Literal[False]
+    credential_resolved: Literal[False]
+    credential_material_accessed: Literal[False]
+    credential_material_embedded: Literal[False]
+    credential_store_accessed: Literal[False]
+    authorization_header_constructed: Literal[False]
+    token_embedded: Literal[False]
+    secret_embedded: Literal[False]
+    cookie_embedded: Literal[False]
+    password_embedded: Literal[False]
+    private_key_embedded: Literal[False]
+    endpoint_resolved: Literal[False]
+    endpoint_contacted: Literal[False]
+    dns_used: Literal[False]
+    network_used: Literal[False]
+    webhook_invoked: Literal[False]
+    live_adapter_instantiated: Literal[False]
+    live_adapter_method_invoked: Literal[False]
+    request_dispatched: Literal[False]
+    bind_invoked: Literal[False]
+    bind_receipt_created: Literal[False]
+    trustlog_written: Literal[False]
+    filesystem_used: Literal[False]
+    database_used: Literal[False]
+    provider_called: Literal[False]
+    subprocess_used: Literal[False]
+    external_effect_used: Literal[False]
+    operation_committed: Literal[False]
+    apply_performed: Literal[False]
+    postcondition_verified: Literal[False]
+    rollback_or_revert_performed: Literal[False]
+
+
+def _fail(code: str) -> None:
+    raise CanonicalPromotionLiveAdapterDryRunFinalBindAuthorizationReadinessError(
+        code
+    )
+
+
+def _timestamp(value: Any) -> str:
+    try:
+        parsed = value if isinstance(value, datetime) else datetime.fromisoformat(value)
+    except (TypeError, ValueError) as exc:
+        raise CanonicalPromotionLiveAdapterDryRunFinalBindAuthorizationReadinessError(
+            "CPLADFBAR_TIMESTAMP_INVALID"
+        ) from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        _fail("CPLADFBAR_TIMESTAMP_INVALID")
+    return parsed.astimezone(timezone.utc).isoformat()
+
+
+def _json(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        value = value.model_dump(mode="json")
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float) and value == value and value not in (
+        float("inf"), float("-inf")
+    ):
+        return value
+    if isinstance(value, datetime):
+        return _timestamp(value)
+    if isinstance(value, (list, tuple)):
+        return [_json(item) for item in value]
+    if isinstance(value, dict) and all(isinstance(key, str) for key in value):
+        return {key: _json(item) for key, item in value.items()}
+    _fail("CPLADFBAR_JSON_INVALID")
+
+
+def _digest(domain: str, value: Any) -> str:
+    encoded = json.dumps(
+        {"domain": domain, "value": _json(value)},
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _packet_hash(raw: dict[str, Any]) -> str:
+    omitted = {
+        "promotion_live_adapter_dry_run_final_bind_authorization_readiness_id",
+        "promotion_live_adapter_dry_run_final_bind_authorization_readiness_hash",
+    }
+    return _digest(
+        DOMAINS["packet"],
+        {key: value for key, value in raw.items() if key not in omitted},
+    )
+
+
+def _source(
+    value: Any,
+) -> CanonicalPromotionLiveAdapterDryRunHumanApprovalLinkageReviewPacket:
+    try:
+        return verify_canonical_promotion_live_adapter_dry_run_human_approval_linkage_review_packet(
+            value
+        )
+    except (
+        CanonicalPromotionLiveAdapterDryRunHumanApprovalLinkageError,
+        TypeError,
+        ValueError,
+    ) as exc:
+        raise CanonicalPromotionLiveAdapterDryRunFinalBindAuthorizationReadinessError(
+            "CPLADFBAR_SOURCE_INVALID"
+        ) from exc
+
+
+def _validate_source(
+    source: CanonicalPromotionLiveAdapterDryRunHumanApprovalLinkageReviewPacket,
+) -> None:
+    required = (
+        source.human_approval_linkage_status == SOURCE_STATUS,
+        source.request_dispatch_state == "NOT_DISPATCHED",
+        source.bind_state == "NOT_BOUND",
+        source.authority_state == "NOT_AUTHORIZED",
+        source.human_approval_state == "NOT_APPROVED",
+        source.ready_for_promotion_native_final_bind_authorization_readiness_review,
+        not source.fail_closed,
+    )
+    if not all(required) or any(getattr(source, field) for field in EFFECT_FIELDS):
+        _fail("CPLADFBAR_SOURCE_STATE_INVALID")
+    try:
+        intent = ExecutionIntent(**source.execution_intent)
+        descriptor = verify_bind_adapter_contract_descriptor(
+            source.adapter_contract_descriptor, intent
+        )
+    except (
+        TypeError,
+        ValidationError,
+        BindAdapterContractSelectionError,
+        ValueError,
+    ) as exc:
+        raise CanonicalPromotionLiveAdapterDryRunFinalBindAuthorizationReadinessError(
+            "CPLADFBAR_SOURCE_BINDING_INVALID"
+        ) from exc
+    if hash_execution_intent(intent) != source.execution_intent_hash:
+        _fail("CPLADFBAR_EXECUTION_INTENT_INVALID")
+    if intent.execution_intent_id != source.execution_intent_id:
+        _fail("CPLADFBAR_EXECUTION_INTENT_INVALID")
+    if descriptor.adapter_contract_id != source.adapter_contract_id:
+        _fail("CPLADFBAR_ADAPTER_INVALID")
+    if descriptor.adapter_contract_hash != source.adapter_contract_hash:
+        _fail("CPLADFBAR_ADAPTER_INVALID")
+
+
+def _decision(value: Any) -> FinalBindAuthorizationReadinessReviewDecision:
+    try:
+        decision = FinalBindAuthorizationReadinessReviewDecision.model_validate(
+            _json(value)
+        )
+        decision = decision.model_copy(
+            update={"reviewed_at": _timestamp(decision.reviewed_at)}
+        )
+    except (ValidationError, TypeError) as exc:
+        raise CanonicalPromotionLiveAdapterDryRunFinalBindAuthorizationReadinessError(
+            "CPLADFBAR_DECISION_INVALID"
+        ) from exc
+    if not all(getattr(decision, field) for field in ACKNOWLEDGEMENTS):
+        _fail("CPLADFBAR_ACKNOWLEDGEMENT_MISSING")
+    return decision
+
+
+def _derived(source: Any, decision: Any) -> tuple[Any, ...]:
+    accepted = decision.review_outcome == OUTCOMES[0]
+    result = {
+        "review_outcome": decision.review_outcome,
+        "ready_for_promotion_native_bind_authorization_gate_review": accepted,
+        "rejection_reasons": [] if accepted else ["FINAL_READINESS_REVIEW_REJECTED"],
+        "comparison_mode": CHECK_MODE,
+        "human_approval_proven": False,
+        "human_approval_externally_verified": False,
+        "authority_evidence_proven": False,
+        "authority_evidence_externally_verified": False,
+        "execution_authorized": False,
+        "bind_authorization_issued": False,
+    }
+    context = {
+        field: _json(getattr(source, field))
+        for field in COPY_FIELDS
+        if field.endswith(("_id", "_hash", "_digest"))
+    }
+    context["review_outcome"] = decision.review_outcome
+    checks = [
+        {
+            "ordinal": ordinal,
+            "name": name,
+            "passed": True,
+            "comparison_mode": CHECK_MODE,
+        }
+        for ordinal, name in enumerate(CHECK_NAMES, 1)
+    ]
+    future = [
+        {
+            "ordinal": ordinal,
+            "name": name,
+            "separate_future_artifact_required": True,
+            "satisfied_by_this_packet": False,
+        }
+        for ordinal, name in enumerate(FUTURE_REQUIREMENTS, 1)
+    ]
+    return result, context, checks, future
+
+
+def _assemble(source: Any, decision: Any, recorded_at: str) -> dict[str, Any]:
+    source_raw = source.model_dump(mode="json")
+    result, context, checks, future = _derived(source, decision)
+    accepted = result[
+        "ready_for_promotion_native_bind_authorization_gate_review"
+    ]
+    raw = {
+        "format_version": FORMAT_VERSION,
+        "final_bind_authorization_readiness_mechanism": MECHANISM,
+        "final_bind_authorization_readiness_recorded_at": recorded_at,
+        "source_human_approval_linkage_review_id": source.promotion_live_adapter_dry_run_human_approval_linkage_review_id,
+        "source_human_approval_linkage_review_hash": source.promotion_live_adapter_dry_run_human_approval_linkage_review_hash,
+        "source_human_approval_linkage_review_packet": source_raw,
+        **{field: source_raw[field] for field in COPY_FIELDS},
+        "final_bind_authorization_readiness_review_decision": decision.model_dump(
+            mode="json"
+        ),
+        "final_bind_authorization_readiness_review_decision_digest": _digest(
+            DOMAINS["decision"], decision
+        ),
+        "final_bind_authorization_readiness_result": result,
+        "final_bind_authorization_readiness_result_digest": _digest(
+            DOMAINS["result"], result
+        ),
+        "final_readiness_context": context,
+        "final_readiness_context_digest": _digest(DOMAINS["context"], context),
+        "final_bind_authorization_readiness_checks": checks,
+        "final_bind_authorization_readiness_check_digest": _digest(
+            DOMAINS["checks"], checks
+        ),
+        "future_requirements": future,
+        "future_requirement_digest": _digest(DOMAINS["future"], future),
+        "final_bind_authorization_readiness_status": STATUS,
+        "request_dispatch_state": "NOT_DISPATCHED",
+        "bind_state": "NOT_BOUND",
+        "authority_state": "NOT_AUTHORIZED",
+        "human_approval_state": "NOT_APPROVED",
+        "ready_for_promotion_native_bind_authorization_gate_review": accepted,
+        "fail_closed": not accepted,
+        **{field: False for field in EFFECT_FIELDS},
+    }
+    digest = _packet_hash(raw)
+    raw[
+        "promotion_live_adapter_dry_run_final_bind_authorization_readiness_hash"
+    ] = digest
+    raw[
+        "promotion_live_adapter_dry_run_final_bind_authorization_readiness_id"
+    ] = f"pladfbar:v1:sha256:{digest}"
+    return raw
+
+
+def build_canonical_promotion_live_adapter_dry_run_final_bind_authorization_readiness_packet(
+    source_human_approval_linkage_review_packet: Any,
+    final_bind_authorization_readiness_review_decision: Any,
+    final_bind_authorization_readiness_recorded_at: datetime,
+) -> CanonicalPromotionLiveAdapterDryRunFinalBindAuthorizationReadinessPacket:
+    """Build self-verifying final readiness evidence without granting authority."""
+    source = _source(_json(source_human_approval_linkage_review_packet))
+    _validate_source(source)
+    decision = _decision(final_bind_authorization_readiness_review_decision)
+    recorded_at = _timestamp(final_bind_authorization_readiness_recorded_at)
+    source_at = _timestamp(source.human_approval_linkage_review_recorded_at)
+    if _timestamp(decision.reviewed_at) < source_at or recorded_at < _timestamp(
+        decision.reviewed_at
+    ):
+        _fail("CPLADFBAR_TIMESTAMP_ORDER_INVALID")
+    return verify_canonical_promotion_live_adapter_dry_run_final_bind_authorization_readiness_packet(
+        _assemble(source, decision, recorded_at)
+    )
+
+
+def verify_canonical_promotion_live_adapter_dry_run_final_bind_authorization_readiness_packet(
+    raw: Any,
+) -> CanonicalPromotionLiveAdapterDryRunFinalBindAuthorizationReadinessPacket:
+    """Independently reconstruct and verify the source, bindings, and hashes."""
+    try:
+        value = raw.model_dump(mode="json") if isinstance(raw, BaseModel) else raw
+        packet = CanonicalPromotionLiveAdapterDryRunFinalBindAuthorizationReadinessPacket.model_validate(
+            _json(value)
+        )
+    except (ValidationError, TypeError) as exc:
+        raise CanonicalPromotionLiveAdapterDryRunFinalBindAuthorizationReadinessError(
+            "CPLADFBAR_PACKET_INVALID"
+        ) from exc
+    source = _source(packet.source_human_approval_linkage_review_packet)
+    _validate_source(source)
+    decision = _decision(packet.final_bind_authorization_readiness_review_decision)
+    source_at = _timestamp(source.human_approval_linkage_review_recorded_at)
+    reviewed_at = _timestamp(decision.reviewed_at)
+    recorded_at = _timestamp(packet.final_bind_authorization_readiness_recorded_at)
+    if reviewed_at < source_at or recorded_at < reviewed_at:
+        _fail("CPLADFBAR_TIMESTAMP_ORDER_INVALID")
+    expected = _assemble(source, decision, recorded_at)
+    if packet.model_dump(mode="json") != expected:
+        _fail("CPLADFBAR_RECONSTRUCTION_MISMATCH")
+    return packet

--- a/veritas_os/policy/canonical_promotion_live_adapter_dry_run_final_bind_authorization_readiness.py
+++ b/veritas_os/policy/canonical_promotion_live_adapter_dry_run_final_bind_authorization_readiness.py
@@ -20,6 +20,7 @@ from veritas_os.policy.bind_adapter_contract_selection import (
 )
 from veritas_os.policy.bind_artifacts import ExecutionIntent, hash_execution_intent
 from veritas_os.policy.canonical_promotion_live_adapter_dry_run_human_approval_linkage import (
+    PRESERVED_FIELDS as UPSTREAM_PRESERVED_FIELDS,
     CanonicalPromotionLiveAdapterDryRunHumanApprovalLinkageError,
     CanonicalPromotionLiveAdapterDryRunHumanApprovalLinkageReviewPacket,
     verify_canonical_promotion_live_adapter_dry_run_human_approval_linkage_review_packet,
@@ -55,11 +56,15 @@ ACKNOWLEDGEMENTS = (
     "acknowledged_no_dispatch",
     "acknowledged_no_execution_authority",
     "acknowledged_no_human_approval_creation",
+    "acknowledged_no_human_approval_verification",
     "acknowledged_no_authority_evidence_creation",
+    "acknowledged_no_authority_evidence_verification",
     "acknowledged_no_credential_access",
     "acknowledged_no_authorization_header",
     "acknowledged_no_network_call",
-    "acknowledged_semantic_match_not_authority",
+    "acknowledged_final_fresh_source_gate_still_required",
+    "acknowledged_gate_bound_human_approval_still_required",
+    "acknowledged_cryptographic_authority_verification_still_required",
 )
 CHECK_NAMES = (
     "source_human_approval_reference_linkage_verified",
@@ -83,7 +88,7 @@ CHECK_NAMES = (
     "network_access_absent",
     "external_effect_absent",
 )
-FUTURE_REQUIREMENTS = (
+FUTURE_BIND_AUTHORIZATION_REQUIREMENTS = (
     "promotion_native_bind_authorization_gate_review",
     "fresh_verified_source_gate",
     "exact_bind_context_hash_derivation",
@@ -96,6 +101,8 @@ FUTURE_REQUIREMENTS = (
     "cryptographic_authority_evidence_verification",
     "revocation_verification_where_applicable",
     "real_bind_authorization",
+)
+FUTURE_BIND_INVOCATION_REQUIREMENTS = (
     "authorization_consumption",
     "single_use_consumption",
     "credential_material_resolution",
@@ -108,26 +115,22 @@ FUTURE_REQUIREMENTS = (
     "reconciliation",
     "outcome_receipt",
 )
-COPY_FIELDS = (
-    "request_descriptor", "execution_intent", "execution_intent_id",
-    "execution_intent_hash", "adapter_contract_descriptor",
-    "adapter_contract_id", "adapter_contract_hash", "adapter_contract_version",
-    "endpoint_candidate", "endpoint_candidate_digest",
-    "endpoint_identity_binding", "endpoint_identity_binding_digest",
-    "credential_reference", "credential_reference_digest",
-    "credential_scope_binding", "credential_scope_binding_digest",
-    "operator_review_binding", "operator_review_binding_digest",
-    "bind_boundary_preconditions", "bind_boundary_precondition_digest",
-    "authority_evidence_reference_bundle",
-    "authority_evidence_reference_bundle_digest",
-    "authority_evidence_binding_matrix",
-    "authority_evidence_binding_matrix_digest",
-    "authority_evidence_linkage_context",
-    "authority_evidence_linkage_context_digest",
-    "human_approval_reference_bundle", "human_approval_reference_bundle_digest",
-    "human_approval_binding_matrix", "human_approval_binding_matrix_digest",
-    "human_approval_linkage_context", "human_approval_linkage_context_digest",
+FUTURE_REQUIREMENTS = (
+    *FUTURE_BIND_AUTHORIZATION_REQUIREMENTS,
+    *FUTURE_BIND_INVOCATION_REQUIREMENTS,
 )
+HUMAN_APPROVAL_LINKAGE_FIELDS = (
+    "human_approval_reference_bundle",
+    "human_approval_reference_digests",
+    "human_approval_reference_bundle_digest",
+    "human_approval_binding_matrix",
+    "human_approval_binding_matrix_digest",
+    "human_approval_linkage_result",
+    "human_approval_linkage_result_digest",
+    "human_approval_linkage_context",
+    "human_approval_linkage_context_digest",
+)
+COPY_FIELDS = (*UPSTREAM_PRESERVED_FIELDS, *HUMAN_APPROVAL_LINKAGE_FIELDS)
 EFFECT_FIELDS = (
     "human_approval_created", "human_approval_externally_verified",
     "human_approval_proven", "authority_evidence_created",
@@ -166,18 +169,22 @@ class FinalBindAuthorizationReadinessReviewDecision(BaseModel):
     reviewed_at: str
     review_outcome: Literal[*OUTCOMES]
     review_reason: str = Field(min_length=1)
-    acknowledged_not_bind_authorization: bool
-    acknowledged_no_bind_invocation: bool
-    acknowledged_no_bind_receipt: bool
-    acknowledged_no_trustlog_write: bool
-    acknowledged_no_dispatch: bool
-    acknowledged_no_execution_authority: bool
-    acknowledged_no_human_approval_creation: bool
-    acknowledged_no_authority_evidence_creation: bool
-    acknowledged_no_credential_access: bool
-    acknowledged_no_authorization_header: bool
-    acknowledged_no_network_call: bool
-    acknowledged_semantic_match_not_authority: bool
+    acknowledged_not_bind_authorization: Literal[True]
+    acknowledged_no_bind_invocation: Literal[True]
+    acknowledged_no_bind_receipt: Literal[True]
+    acknowledged_no_trustlog_write: Literal[True]
+    acknowledged_no_dispatch: Literal[True]
+    acknowledged_no_execution_authority: Literal[True]
+    acknowledged_no_human_approval_creation: Literal[True]
+    acknowledged_no_human_approval_verification: Literal[True]
+    acknowledged_no_authority_evidence_creation: Literal[True]
+    acknowledged_no_authority_evidence_verification: Literal[True]
+    acknowledged_no_credential_access: Literal[True]
+    acknowledged_no_authorization_header: Literal[True]
+    acknowledged_no_network_call: Literal[True]
+    acknowledged_final_fresh_source_gate_still_required: Literal[True]
+    acknowledged_gate_bound_human_approval_still_required: Literal[True]
+    acknowledged_cryptographic_authority_verification_still_required: Literal[True]
 
 
 class FinalReadinessResult(BaseModel):
@@ -185,9 +192,25 @@ class FinalReadinessResult(BaseModel):
 
     model_config = ConfigDict(extra="forbid", frozen=True)
     review_outcome: Literal[*OUTCOMES]
-    ready_for_promotion_native_bind_authorization_gate_review: bool
+    source_human_approval_reference_linkage_passed: Literal[True]
+    source_authority_evidence_reference_linkage_passed: Literal[True]
+    source_bind_pre_dispatch_review_passed: Literal[True]
+    exact_execution_intent_preserved: Literal[True]
+    exact_adapter_preserved: Literal[True]
+    exact_endpoint_binding_preserved: Literal[True]
+    exact_credential_scope_binding_preserved: Literal[True]
+    all_required_local_linkage_artifacts_present: Literal[True]
+    all_required_local_linkage_artifacts_verified: Literal[True]
+    accepted_for_future_promotion_native_bind_authorization_gate_review: bool
     rejection_reasons: tuple[str, ...]
     comparison_mode: Literal[CHECK_MODE]
+    semantic_match_used: Literal[False]
+    creates_bind_authorization: Literal[False]
+    creates_execution_authority: Literal[False]
+    creates_human_approval: Literal[False]
+    externally_verifies_human_approval: Literal[False]
+    creates_authority_evidence: Literal[False]
+    externally_verifies_authority_evidence: Literal[False]
     human_approval_proven: Literal[False]
     human_approval_externally_verified: Literal[False]
     authority_evidence_proven: Literal[False]
@@ -230,6 +253,60 @@ class CanonicalPromotionLiveAdapterDryRunFinalBindAuthorizationReadinessPacket(
     source_human_approval_linkage_review_id: str
     source_human_approval_linkage_review_hash: str
     source_human_approval_linkage_review_packet: dict[str, Any]
+    credential_policy_snapshot: Any
+    credential_policy_snapshot_hash: Any
+    credential_authorization_result: Any
+    credential_authorization_result_digest: Any
+    operator_review_decision: Any
+    operator_review_decision_digest: Any
+    bind_pre_dispatch_review_decision: Any
+    bind_pre_dispatch_review_decision_digest: Any
+    bind_pre_dispatch_review_result: Any
+    bind_pre_dispatch_review_result_digest: Any
+    authority_evidence_reference_digests: Any
+    authority_evidence_linkage_result: Any
+    authority_evidence_linkage_result_digest: Any
+    source_endpoint_allowlist_evaluation_id: Any
+    source_endpoint_allowlist_evaluation_hash: Any
+    source_dispatch_readiness_id: Any
+    source_dispatch_readiness_hash: Any
+    source_live_adapter_dry_run_request_id: Any
+    source_live_adapter_dry_run_request_hash: Any
+    source_live_adapter_dry_run_readiness_id: Any
+    source_live_adapter_dry_run_readiness_hash: Any
+    source_reference_rehearsal_id: Any
+    source_reference_rehearsal_hash: Any
+    source_adapter_dry_run_fixture_result_id: Any
+    source_adapter_dry_run_fixture_result_hash: Any
+    source_adapter_dry_run_plan_id: Any
+    source_adapter_dry_run_plan_hash: Any
+    source_adapter_contract_selection_id: Any
+    source_adapter_contract_selection_hash: Any
+    source_bind_preflight_adjudication_id: Any
+    source_bind_preflight_adjudication_hash: Any
+    source_pre_bind_validation_id: Any
+    source_pre_bind_validation_hash: Any
+    source_readiness_id: Any
+    source_readiness_hash: Any
+    source_promotion_id: Any
+    source_promotion_hash: Any
+    source_decision_identity: Any
+    candidate_identity: Any
+    selected_action_lineage: Any
+    policy_snapshot_lineage: Any
+    approval_context: Any
+    policy_lineage: Any
+    human_approval_reference_digests: Any
+    human_approval_linkage_result: Any
+    human_approval_linkage_result_digest: Any
+    source_authority_evidence_linkage_review_id: Any
+    source_authority_evidence_linkage_review_hash: Any
+    source_bind_pre_dispatch_review_id: Any
+    source_bind_pre_dispatch_review_hash: Any
+    source_operator_review_id: Any
+    source_operator_review_hash: Any
+    source_credential_authorization_id: Any
+    source_credential_authorization_hash: Any
     request_descriptor: dict[str, Any]
     execution_intent: dict[str, Any]
     execution_intent_id: str
@@ -270,13 +347,20 @@ class CanonicalPromotionLiveAdapterDryRunFinalBindAuthorizationReadinessPacket(
     final_readiness_context_digest: str
     final_bind_authorization_readiness_checks: tuple[ReadinessCheck, ...]
     final_bind_authorization_readiness_check_digest: str
-    future_requirements: tuple[FutureRequirement, ...]
-    future_requirement_digest: str
+    future_bind_authorization_requirements: tuple[FutureRequirement, ...]
+    future_bind_authorization_requirement_digest: str
+    future_bind_invocation_requirements: tuple[FutureRequirement, ...]
+    future_bind_invocation_requirement_digest: str
     final_bind_authorization_readiness_status: Literal[STATUS]
     request_dispatch_state: Literal["NOT_DISPATCHED"]
     bind_state: Literal["NOT_BOUND"]
     authority_state: Literal["NOT_AUTHORIZED"]
     human_approval_state: Literal["NOT_APPROVED"]
+    final_readiness_state: Literal[
+        "READY_FOR_FUTURE_PROMOTION_NATIVE_BIND_AUTHORIZATION_GATE",
+        "NOT_READY_FOR_FUTURE_PROMOTION_NATIVE_BIND_AUTHORIZATION_GATE",
+    ]
+    fresh_verified_source_gate_still_required: Literal[True]
     ready_for_promotion_native_bind_authorization_gate_review: bool
     fail_closed: bool
     human_approval_proven: Literal[False]
@@ -408,6 +492,7 @@ def _validate_source(
         source.authority_state == "NOT_AUTHORIZED",
         source.human_approval_state == "NOT_APPROVED",
         source.ready_for_promotion_native_final_bind_authorization_readiness_review,
+        source.approval_context.get("required_human_approval") is True,
         not source.fail_closed,
     )
     if not all(required) or any(getattr(source, field) for field in EFFECT_FIELDS):
@@ -428,11 +513,17 @@ def _validate_source(
         ) from exc
     if hash_execution_intent(intent) != source.execution_intent_hash:
         _fail("CPLADFBAR_EXECUTION_INTENT_INVALID")
+    if intent.to_dict() != source.execution_intent:
+        _fail("CPLADFBAR_EXECUTION_INTENT_INVALID")
     if intent.execution_intent_id != source.execution_intent_id:
         _fail("CPLADFBAR_EXECUTION_INTENT_INVALID")
     if descriptor.adapter_contract_id != source.adapter_contract_id:
         _fail("CPLADFBAR_ADAPTER_INVALID")
     if descriptor.adapter_contract_hash != source.adapter_contract_hash:
+        _fail("CPLADFBAR_ADAPTER_INVALID")
+    if descriptor.model_dump(mode="json") != source.adapter_contract_descriptor:
+        _fail("CPLADFBAR_ADAPTER_INVALID")
+    if descriptor.adapter_contract_version != source.adapter_contract_version:
         _fail("CPLADFBAR_ADAPTER_INVALID")
 
 
@@ -455,11 +546,28 @@ def _decision(value: Any) -> FinalBindAuthorizationReadinessReviewDecision:
 
 def _derived(source: Any, decision: Any) -> tuple[Any, ...]:
     accepted = decision.review_outcome == OUTCOMES[0]
+    decision_digest = _digest(DOMAINS["decision"], decision)
     result = {
         "review_outcome": decision.review_outcome,
-        "ready_for_promotion_native_bind_authorization_gate_review": accepted,
+        "source_human_approval_reference_linkage_passed": True,
+        "source_authority_evidence_reference_linkage_passed": True,
+        "source_bind_pre_dispatch_review_passed": True,
+        "exact_execution_intent_preserved": True,
+        "exact_adapter_preserved": True,
+        "exact_endpoint_binding_preserved": True,
+        "exact_credential_scope_binding_preserved": True,
+        "all_required_local_linkage_artifacts_present": True,
+        "all_required_local_linkage_artifacts_verified": True,
+        "accepted_for_future_promotion_native_bind_authorization_gate_review": accepted,
         "rejection_reasons": [] if accepted else ["FINAL_READINESS_REVIEW_REJECTED"],
         "comparison_mode": CHECK_MODE,
+        "semantic_match_used": False,
+        "creates_bind_authorization": False,
+        "creates_execution_authority": False,
+        "creates_human_approval": False,
+        "externally_verifies_human_approval": False,
+        "creates_authority_evidence": False,
+        "externally_verifies_authority_evidence": False,
         "human_approval_proven": False,
         "human_approval_externally_verified": False,
         "authority_evidence_proven": False,
@@ -468,11 +576,43 @@ def _derived(source: Any, decision: Any) -> tuple[Any, ...]:
         "bind_authorization_issued": False,
     }
     context = {
-        field: _json(getattr(source, field))
-        for field in COPY_FIELDS
-        if field.endswith(("_id", "_hash", "_digest"))
+        "source_human_approval_linkage_review_id": source.promotion_live_adapter_dry_run_human_approval_linkage_review_id,
+        "source_human_approval_linkage_review_hash": source.promotion_live_adapter_dry_run_human_approval_linkage_review_hash,
+        "source_human_approval_linkage_context_digest": source.human_approval_linkage_context_digest,
+        "source_authority_linkage_review_id": source.source_authority_evidence_linkage_review_id,
+        "source_authority_linkage_review_hash": source.source_authority_evidence_linkage_review_hash,
+        "source_authority_linkage_context_digest": source.authority_evidence_linkage_context_digest,
+        "source_bind_pre_dispatch_review_id": source.source_bind_pre_dispatch_review_id,
+        "source_bind_pre_dispatch_review_hash": source.source_bind_pre_dispatch_review_hash,
+        "source_operator_review_id": source.source_operator_review_id,
+        "source_operator_review_hash": source.source_operator_review_hash,
+        "source_credential_authorization_id": source.source_credential_authorization_id,
+        "source_credential_authorization_hash": source.source_credential_authorization_hash,
+        "source_endpoint_allowlist_evaluation_id": source.source_endpoint_allowlist_evaluation_id,
+        "source_endpoint_allowlist_evaluation_hash": source.source_endpoint_allowlist_evaluation_hash,
+        "execution_intent_id": source.execution_intent_id,
+        "execution_intent_hash": source.execution_intent_hash,
+        "adapter_contract_id": source.adapter_contract_id,
+        "adapter_contract_hash": source.adapter_contract_hash,
+        "endpoint_candidate_id": source.endpoint_candidate["endpoint_candidate_id"],
+        "endpoint_candidate_digest": source.endpoint_candidate_digest,
+        "endpoint_identity_binding_digest": source.endpoint_identity_binding_digest,
+        "credential_reference_id": source.credential_reference["credential_reference_id"],
+        "credential_reference_digest": source.credential_reference_digest,
+        "credential_scope_binding_digest": source.credential_scope_binding_digest,
+        "operator_review_binding_digest": source.operator_review_binding_digest,
+        "bind_boundary_precondition_digest": source.bind_boundary_precondition_digest,
+        "authority_evidence_reference_bundle_digest": source.authority_evidence_reference_bundle_digest,
+        "authority_evidence_binding_matrix_digest": source.authority_evidence_binding_matrix_digest,
+        "authority_evidence_linkage_context_digest": source.authority_evidence_linkage_context_digest,
+        "human_approval_reference_bundle_digest": source.human_approval_reference_bundle_digest,
+        "human_approval_binding_matrix_digest": source.human_approval_binding_matrix_digest,
+        "human_approval_linkage_context_digest": source.human_approval_linkage_context_digest,
+        "final_readiness_decision_digest": decision_digest,
+        "policy_snapshot_lineage": _json(source.policy_snapshot_lineage),
+        "policy_lineage": _json(source.policy_lineage),
+        "approval_context": _json(source.approval_context),
     }
-    context["review_outcome"] = decision.review_outcome
     checks = [
         {
             "ordinal": ordinal,
@@ -482,23 +622,32 @@ def _derived(source: Any, decision: Any) -> tuple[Any, ...]:
         }
         for ordinal, name in enumerate(CHECK_NAMES, 1)
     ]
-    future = [
+    authorization = [
         {
             "ordinal": ordinal,
             "name": name,
             "separate_future_artifact_required": True,
             "satisfied_by_this_packet": False,
         }
-        for ordinal, name in enumerate(FUTURE_REQUIREMENTS, 1)
+        for ordinal, name in enumerate(FUTURE_BIND_AUTHORIZATION_REQUIREMENTS, 1)
     ]
-    return result, context, checks, future
+    invocation = [
+        {
+            "ordinal": ordinal,
+            "name": name,
+            "separate_future_artifact_required": True,
+            "satisfied_by_this_packet": False,
+        }
+        for ordinal, name in enumerate(FUTURE_BIND_INVOCATION_REQUIREMENTS, 1)
+    ]
+    return result, context, checks, authorization, invocation
 
 
 def _assemble(source: Any, decision: Any, recorded_at: str) -> dict[str, Any]:
     source_raw = source.model_dump(mode="json")
-    result, context, checks, future = _derived(source, decision)
+    result, context, checks, authorization, invocation = _derived(source, decision)
     accepted = result[
-        "ready_for_promotion_native_bind_authorization_gate_review"
+        "accepted_for_future_promotion_native_bind_authorization_gate_review"
     ]
     raw = {
         "format_version": FORMAT_VERSION,
@@ -507,6 +656,14 @@ def _assemble(source: Any, decision: Any, recorded_at: str) -> dict[str, Any]:
         "source_human_approval_linkage_review_id": source.promotion_live_adapter_dry_run_human_approval_linkage_review_id,
         "source_human_approval_linkage_review_hash": source.promotion_live_adapter_dry_run_human_approval_linkage_review_hash,
         "source_human_approval_linkage_review_packet": source_raw,
+        "source_authority_evidence_linkage_review_id": source.source_authority_evidence_linkage_review_id,
+        "source_authority_evidence_linkage_review_hash": source.source_authority_evidence_linkage_review_hash,
+        "source_bind_pre_dispatch_review_id": source.source_bind_pre_dispatch_review_id,
+        "source_bind_pre_dispatch_review_hash": source.source_bind_pre_dispatch_review_hash,
+        "source_operator_review_id": source.source_operator_review_id,
+        "source_operator_review_hash": source.source_operator_review_hash,
+        "source_credential_authorization_id": source.source_credential_authorization_id,
+        "source_credential_authorization_hash": source.source_credential_authorization_hash,
         **{field: source_raw[field] for field in COPY_FIELDS},
         "final_bind_authorization_readiness_review_decision": decision.model_dump(
             mode="json"
@@ -524,13 +681,25 @@ def _assemble(source: Any, decision: Any, recorded_at: str) -> dict[str, Any]:
         "final_bind_authorization_readiness_check_digest": _digest(
             DOMAINS["checks"], checks
         ),
-        "future_requirements": future,
-        "future_requirement_digest": _digest(DOMAINS["future"], future),
+        "future_bind_authorization_requirements": authorization,
+        "future_bind_authorization_requirement_digest": _digest(
+            f'{DOMAINS["future"]}.authorization', authorization
+        ),
+        "future_bind_invocation_requirements": invocation,
+        "future_bind_invocation_requirement_digest": _digest(
+            f'{DOMAINS["future"]}.invocation', invocation
+        ),
         "final_bind_authorization_readiness_status": STATUS,
         "request_dispatch_state": "NOT_DISPATCHED",
         "bind_state": "NOT_BOUND",
         "authority_state": "NOT_AUTHORIZED",
         "human_approval_state": "NOT_APPROVED",
+        "final_readiness_state": (
+            "READY_FOR_FUTURE_PROMOTION_NATIVE_BIND_AUTHORIZATION_GATE"
+            if accepted
+            else "NOT_READY_FOR_FUTURE_PROMOTION_NATIVE_BIND_AUTHORIZATION_GATE"
+        ),
+        "fresh_verified_source_gate_still_required": True,
         "ready_for_promotion_native_bind_authorization_gate_review": accepted,
         "fail_closed": not accepted,
         **{field: False for field in EFFECT_FIELDS},

--- a/veritas_os/tests/test_canonical_promotion_live_adapter_dry_run_final_bind_authorization_readiness.py
+++ b/veritas_os/tests/test_canonical_promotion_live_adapter_dry_run_final_bind_authorization_readiness.py
@@ -13,6 +13,7 @@ from veritas_os.policy.canonical_promotion_live_adapter_dry_run_final_bind_autho
     ACKNOWLEDGEMENTS,
     EFFECT_FIELDS,
     FUTURE_REQUIREMENTS,
+    COPY_FIELDS,
     OUTCOMES,
     CanonicalPromotionLiveAdapterDryRunFinalBindAuthorizationReadinessError,
     build_canonical_promotion_live_adapter_dry_run_final_bind_authorization_readiness_packet,
@@ -68,6 +69,11 @@ def test_accepted_independently_verifies_without_authority_or_effects() -> None:
     )
     assert packet.ready_for_promotion_native_bind_authorization_gate_review
     assert packet.fail_closed is False
+    assert (
+        packet.final_readiness_state
+        == "READY_FOR_FUTURE_PROMOTION_NATIVE_BIND_AUTHORIZATION_GATE"
+    )
+    assert packet.fresh_verified_source_gate_still_required
     assert packet.request_dispatch_state == "NOT_DISPATCHED"
     assert packet.bind_state == "NOT_BOUND"
     assert packet.authority_state == "NOT_AUTHORIZED"
@@ -85,6 +91,11 @@ def test_rejected_independently_verifies_and_fails_closed() -> None:
     )
     assert not packet.ready_for_promotion_native_bind_authorization_gate_review
     assert packet.fail_closed
+    assert (
+        packet.final_readiness_state
+        == "NOT_READY_FOR_FUTURE_PROMOTION_NATIVE_BIND_AUTHORIZATION_GATE"
+    )
+    assert packet.fresh_verified_source_gate_still_required
 
 
 def test_exact_promotion_native_chain_is_preserved() -> None:
@@ -129,6 +140,71 @@ def test_json_round_trip_preserves_derived_structures_and_hashes() -> None:
     )
 
 
+def test_same_outcome_different_review_binds_context_and_packet() -> None:
+    source = source_packet()
+    first = build_canonical_promotion_live_adapter_dry_run_final_bind_authorization_readiness_packet(
+        source, _decision(), RECORDED_AT
+    )
+    second = build_canonical_promotion_live_adapter_dry_run_final_bind_authorization_readiness_packet(
+        source,
+        _decision(
+            reviewer_id="operator:bob",
+            reviewer_attestation="I independently reviewed readiness only.",
+            review_reason="independent promotion-native review",
+        ),
+        RECORDED_AT,
+    )
+    assert (
+        first.final_bind_authorization_readiness_review_decision_digest
+        != second.final_bind_authorization_readiness_review_decision_digest
+    )
+    assert (
+        first.final_readiness_context_digest
+        != second.final_readiness_context_digest
+    )
+    assert (
+        first.promotion_live_adapter_dry_run_final_bind_authorization_readiness_hash
+        != second.promotion_live_adapter_dry_run_final_bind_authorization_readiness_hash
+    )
+
+
+def test_context_binds_full_promotion_native_source_and_decision() -> None:
+    source = source_packet()
+    packet = build_canonical_promotion_live_adapter_dry_run_final_bind_authorization_readiness_packet(
+        source, _decision(), RECORDED_AT
+    )
+    context = packet.final_readiness_context
+    expected = {
+        "source_human_approval_linkage_review_id": source.promotion_live_adapter_dry_run_human_approval_linkage_review_id,
+        "source_human_approval_linkage_review_hash": source.promotion_live_adapter_dry_run_human_approval_linkage_review_hash,
+        "source_human_approval_linkage_context_digest": source.human_approval_linkage_context_digest,
+        "source_authority_linkage_review_id": source.source_authority_evidence_linkage_review_id,
+        "source_authority_linkage_review_hash": source.source_authority_evidence_linkage_review_hash,
+        "source_authority_linkage_context_digest": source.authority_evidence_linkage_context_digest,
+        "source_bind_pre_dispatch_review_id": source.source_bind_pre_dispatch_review_id,
+        "source_bind_pre_dispatch_review_hash": source.source_bind_pre_dispatch_review_hash,
+        "source_operator_review_id": source.source_operator_review_id,
+        "source_operator_review_hash": source.source_operator_review_hash,
+        "source_credential_authorization_id": source.source_credential_authorization_id,
+        "source_credential_authorization_hash": source.source_credential_authorization_hash,
+        "source_endpoint_allowlist_evaluation_id": source.source_endpoint_allowlist_evaluation_id,
+        "source_endpoint_allowlist_evaluation_hash": source.source_endpoint_allowlist_evaluation_hash,
+        "policy_snapshot_lineage": source.policy_snapshot_lineage,
+        "policy_lineage": source.policy_lineage,
+        "approval_context": source.approval_context,
+        "final_readiness_decision_digest": packet.final_bind_authorization_readiness_review_decision_digest,
+    }
+    assert all(context[name] == value for name, value in expected.items())
+
+
+def test_complete_upstream_preservation_surface_is_exact() -> None:
+    source = source_packet()
+    packet = build_canonical_promotion_live_adapter_dry_run_final_bind_authorization_readiness_packet(
+        source, _decision(), RECORDED_AT
+    )
+    assert all(getattr(packet, field) == getattr(source, field) for field in COPY_FIELDS)
+
+
 @pytest.mark.parametrize(
     ("path", "value"),
     [
@@ -144,11 +220,20 @@ def test_json_round_trip_preserves_derived_structures_and_hashes() -> None:
         (("final_bind_authorization_readiness_result_digest",), "tampered"),
         (("final_readiness_context_digest",), "tampered"),
         (("final_bind_authorization_readiness_check_digest",), "tampered"),
-        (("future_requirement_digest",), "tampered"),
+        (("future_bind_authorization_requirement_digest",), "tampered"),
+        (("future_bind_invocation_requirement_digest",), "tampered"),
         (("network_used",), True),
         (("request_dispatched",), True),
         (("bind_invoked",), True),
         (("external_effect_used",), True),
+        (("policy_snapshot_lineage",), {"tampered": True}),
+        (("policy_lineage",), {"tampered": True}),
+        (("approval_context",), {"required_human_approval": True}),
+        (("source_human_approval_linkage_review_id",), "tampered"),
+        (("source_authority_evidence_linkage_review_id",), "tampered"),
+        (("adapter_contract_version",), "tampered"),
+        (("adapter_contract_descriptor", "adapter_contract_version"), "tampered"),
+        (("execution_intent", "decision_id"), "plausible-but-wrong"),
     ],
 )
 def test_verifier_rejects_chain_digest_and_effect_tamper(path, value) -> None:
@@ -210,12 +295,27 @@ def test_naive_and_invalid_timestamp_ordering_are_rejected() -> None:
 
 def test_all_future_requirements_remain_unsatisfied() -> None:
     packet = _packet()
-    assert tuple(item.name for item in packet.future_requirements) == FUTURE_REQUIREMENTS
+    requirements = (
+        *packet.future_bind_authorization_requirements,
+        *packet.future_bind_invocation_requirements,
+    )
+    assert tuple(item.name for item in requirements) == FUTURE_REQUIREMENTS
     assert all(
         item.separate_future_artifact_required
         and not item.satisfied_by_this_packet
-        for item in packet.future_requirements
+        for item in requirements
     )
+
+
+def test_required_human_approval_false_fails_closed() -> None:
+    raw = source_packet().model_dump(mode="json")
+    raw["approval_context"]["required_human_approval"] = False
+    with pytest.raises(
+        CanonicalPromotionLiveAdapterDryRunFinalBindAuthorizationReadinessError
+    ):
+        build_canonical_promotion_live_adapter_dry_run_final_bind_authorization_readiness_packet(
+            raw, _decision(), RECORDED_AT
+        )
 
 
 def test_production_module_has_no_test_or_capability_imports() -> None:

--- a/veritas_os/tests/test_canonical_promotion_live_adapter_dry_run_final_bind_authorization_readiness.py
+++ b/veritas_os/tests/test_canonical_promotion_live_adapter_dry_run_final_bind_authorization_readiness.py
@@ -1,0 +1,234 @@
+"""Fail-closed tests for promotion-native final Bind readiness evidence."""
+
+from __future__ import annotations
+
+import ast
+from copy import deepcopy
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+
+from veritas_os.policy.canonical_promotion_live_adapter_dry_run_final_bind_authorization_readiness import (
+    ACKNOWLEDGEMENTS,
+    EFFECT_FIELDS,
+    FUTURE_REQUIREMENTS,
+    OUTCOMES,
+    CanonicalPromotionLiveAdapterDryRunFinalBindAuthorizationReadinessError,
+    build_canonical_promotion_live_adapter_dry_run_final_bind_authorization_readiness_packet,
+    verify_canonical_promotion_live_adapter_dry_run_final_bind_authorization_readiness_packet,
+)
+from veritas_os.tests.test_canonical_promotion_live_adapter_dry_run_human_approval_linkage import (
+    RECORDED_AT as SOURCE_RECORDED_AT,
+    _packet as source_packet,
+)
+
+RECORDED_AT = SOURCE_RECORDED_AT + timedelta(seconds=1)
+MODULE = Path(
+    "veritas_os/policy/"
+    "canonical_promotion_live_adapter_dry_run_final_bind_authorization_readiness.py"
+)
+
+
+def _decision(*, accepted: bool = True, **changes) -> dict:
+    value = {
+        "final_bind_authorization_readiness_review_decision_id": "review:final:1",
+        "reviewer_id": "operator:alice",
+        "reviewer_role": "bind-readiness-reviewer",
+        "reviewer_attestation": "I reviewed readiness evidence only.",
+        "reviewed_at": RECORDED_AT.isoformat(),
+        "review_outcome": OUTCOMES[0] if accepted else OUTCOMES[1],
+        "review_reason": "promotion-native chain reviewed",
+        **{field: True for field in ACKNOWLEDGEMENTS},
+    }
+    value.update(changes)
+    return value
+
+
+def _packet(*, accepted: bool = True):
+    return build_canonical_promotion_live_adapter_dry_run_final_bind_authorization_readiness_packet(
+        source_packet(), _decision(accepted=accepted), RECORDED_AT
+    )
+
+
+def _set(raw: dict, path: tuple, value) -> None:
+    target = raw
+    for key in path[:-1]:
+        target = target[key]
+    target[path[-1]] = value
+
+
+def test_accepted_independently_verifies_without_authority_or_effects() -> None:
+    packet = _packet()
+    assert (
+        verify_canonical_promotion_live_adapter_dry_run_final_bind_authorization_readiness_packet(
+            packet
+        )
+        == packet
+    )
+    assert packet.ready_for_promotion_native_bind_authorization_gate_review
+    assert packet.fail_closed is False
+    assert packet.request_dispatch_state == "NOT_DISPATCHED"
+    assert packet.bind_state == "NOT_BOUND"
+    assert packet.authority_state == "NOT_AUTHORIZED"
+    assert packet.human_approval_state == "NOT_APPROVED"
+    assert not any(getattr(packet, field) for field in EFFECT_FIELDS)
+
+
+def test_rejected_independently_verifies_and_fails_closed() -> None:
+    packet = _packet(accepted=False)
+    assert (
+        verify_canonical_promotion_live_adapter_dry_run_final_bind_authorization_readiness_packet(
+            packet
+        )
+        == packet
+    )
+    assert not packet.ready_for_promotion_native_bind_authorization_gate_review
+    assert packet.fail_closed
+
+
+def test_exact_promotion_native_chain_is_preserved() -> None:
+    source = source_packet()
+    packet = build_canonical_promotion_live_adapter_dry_run_final_bind_authorization_readiness_packet(
+        source, _decision(), RECORDED_AT
+    )
+    fields = (
+        "execution_intent",
+        "execution_intent_id",
+        "execution_intent_hash",
+        "adapter_contract_id",
+        "adapter_contract_hash",
+        "endpoint_candidate_digest",
+        "endpoint_identity_binding_digest",
+        "credential_reference_digest",
+        "credential_scope_binding_digest",
+        "operator_review_binding_digest",
+        "bind_boundary_precondition_digest",
+        "authority_evidence_reference_bundle_digest",
+        "authority_evidence_binding_matrix_digest",
+        "authority_evidence_linkage_context_digest",
+        "human_approval_reference_bundle_digest",
+        "human_approval_binding_matrix_digest",
+        "human_approval_linkage_context_digest",
+    )
+    assert all(getattr(packet, field) == getattr(source, field) for field in fields)
+
+
+def test_json_round_trip_preserves_derived_structures_and_hashes() -> None:
+    packet = _packet()
+    raw = packet.model_dump(mode="json")
+    parsed = type(packet).model_validate(raw)
+    verified = verify_canonical_promotion_live_adapter_dry_run_final_bind_authorization_readiness_packet(
+        parsed
+    )
+    assert verified == packet
+    assert verified.final_readiness_context == packet.final_readiness_context
+    assert (
+        verified.promotion_live_adapter_dry_run_final_bind_authorization_readiness_hash
+        == packet.promotion_live_adapter_dry_run_final_bind_authorization_readiness_hash
+    )
+
+
+@pytest.mark.parametrize(
+    ("path", "value"),
+    [
+        (("execution_intent_hash",), "tampered"),
+        (("adapter_contract_hash",), "tampered"),
+        (("endpoint_identity_binding_digest",), "tampered"),
+        (("credential_scope_binding_digest",), "tampered"),
+        (("operator_review_binding_digest",), "tampered"),
+        (("bind_boundary_precondition_digest",), "tampered"),
+        (("authority_evidence_linkage_context_digest",), "tampered"),
+        (("human_approval_linkage_context_digest",), "tampered"),
+        (("final_bind_authorization_readiness_review_decision_digest",), "tampered"),
+        (("final_bind_authorization_readiness_result_digest",), "tampered"),
+        (("final_readiness_context_digest",), "tampered"),
+        (("final_bind_authorization_readiness_check_digest",), "tampered"),
+        (("future_requirement_digest",), "tampered"),
+        (("network_used",), True),
+        (("request_dispatched",), True),
+        (("bind_invoked",), True),
+        (("external_effect_used",), True),
+    ],
+)
+def test_verifier_rejects_chain_digest_and_effect_tamper(path, value) -> None:
+    raw = _packet().model_dump(mode="json")
+    _set(raw, path, value)
+    with pytest.raises(
+        CanonicalPromotionLiveAdapterDryRunFinalBindAuthorizationReadinessError
+    ):
+        verify_canonical_promotion_live_adapter_dry_run_final_bind_authorization_readiness_packet(
+            raw
+        )
+
+
+@pytest.mark.parametrize("field", ("reviewer_id", "reviewer_role", "reviewer_attestation"))
+def test_empty_reviewer_metadata_is_rejected(field: str) -> None:
+    with pytest.raises(
+        CanonicalPromotionLiveAdapterDryRunFinalBindAuthorizationReadinessError
+    ):
+        build_canonical_promotion_live_adapter_dry_run_final_bind_authorization_readiness_packet(
+            source_packet(), _decision(**{field: ""}), RECORDED_AT
+        )
+
+
+@pytest.mark.parametrize("field", ACKNOWLEDGEMENTS)
+def test_false_acknowledgement_is_rejected(field: str) -> None:
+    with pytest.raises(
+        CanonicalPromotionLiveAdapterDryRunFinalBindAuthorizationReadinessError
+    ):
+        build_canonical_promotion_live_adapter_dry_run_final_bind_authorization_readiness_packet(
+            source_packet(), _decision(**{field: False}), RECORDED_AT
+        )
+
+
+def test_unknown_authorization_shortcut_is_rejected() -> None:
+    raw = _packet().model_dump(mode="json")
+    raw["safe_to_bind"] = True
+    with pytest.raises(
+        CanonicalPromotionLiveAdapterDryRunFinalBindAuthorizationReadinessError
+    ):
+        verify_canonical_promotion_live_adapter_dry_run_final_bind_authorization_readiness_packet(
+            raw
+        )
+
+
+def test_naive_and_invalid_timestamp_ordering_are_rejected() -> None:
+    with pytest.raises(
+        CanonicalPromotionLiveAdapterDryRunFinalBindAuthorizationReadinessError
+    ):
+        build_canonical_promotion_live_adapter_dry_run_final_bind_authorization_readiness_packet(
+            source_packet(), _decision(reviewed_at="2026-01-01T00:00:00"), RECORDED_AT
+        )
+    with pytest.raises(
+        CanonicalPromotionLiveAdapterDryRunFinalBindAuthorizationReadinessError
+    ):
+        build_canonical_promotion_live_adapter_dry_run_final_bind_authorization_readiness_packet(
+            source_packet(), _decision(), RECORDED_AT - timedelta(seconds=2)
+        )
+
+
+def test_all_future_requirements_remain_unsatisfied() -> None:
+    packet = _packet()
+    assert tuple(item.name for item in packet.future_requirements) == FUTURE_REQUIREMENTS
+    assert all(
+        item.separate_future_artifact_required
+        and not item.satisfied_by_this_packet
+        for item in packet.future_requirements
+    )
+
+
+def test_production_module_has_no_test_or_capability_imports() -> None:
+    tree = ast.parse(MODULE.read_text(encoding="utf-8"))
+    imports = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imports.append(node.module)
+    assert not any(name.startswith(("veritas_os.tests", "tests")) for name in imports)
+    assert not any(
+        name.split(".")[0]
+        in {"socket", "subprocess", "requests", "httpx", "urllib", "pathlib"}
+        for name in imports
+    )


### PR DESCRIPTION
### Motivation
- Restore the previously‑designed promotion‑native Final Bind Authorization Readiness boundary so a deterministic local artifact can independently verify promotion‑native Human Approval linkage without creating authority or external effects.
- Ensure the artifact preserves the exact promotion‑native chain (ExecutionIntent, adapter, endpoint, credential, authority evidence and human approval bindings) and fails closed on any tamper or mismatch.
- Add a focused round‑trip regression (build → `model_dump(mode="json")` → parse → independent verify) and tests to prevent past JSON/serialization drift issues.

### Description
- Add production module `veritas_os/policy/canonical_promotion_live_adapter_dry_run_final_bind_authorization_readiness.py` that implements builder `build_canonical_promotion_live_adapter_dry_run_final_bind_authorization_readiness_packet(...)` and verifier `verify_canonical_promotion_live_adapter_dry_run_final_bind_authorization_readiness_packet(...)`, deterministic digests, timestamp ordering checks, ordered checks, future requirements, and explicit non‑effect flags.
- Add focused tests `veritas_os/tests/test_canonical_promotion_live_adapter_dry_run_final_bind_authorization_readiness.py` covering ACCEPTED/REJECTED routing, chain preservation, digest/tamper rejection, acknowledgement and reviewer metadata validation, timestamp ordering, unknown‑shortcut rejection, and round‑trip regression.
- Integrate with the existing canonical promotion Human Approval linkage verifier (`verify_canonical_promotion_live_adapter_dry_run_human_approval_linkage_review_packet`) as the authoritative source and preserved exact fields; ensure no production imports of test helpers or capability/effect code are introduced; small adjustments made to use the `ExecutionIntent` dataclass and to call `verify_bind_adapter_contract_descriptor(..., intent)` for exact adapter verification.
- Preserve CI configuration (120‑minute full Python test timeout) and do not add any network, credential, dispatch, TrustLog, signing, or external‑effect functionality.

### Testing
- Ran `ruff` lint on the new module and test file: passed.
- Verified Python compilation with `python -m py_compile` on the new module and test file: passed.
- Executed the new unit tests locally (`pytest` for the focused test file) with minimal dependency stubs where required; tests passed locally (note: some global governance dependencies were stubbed to allow isolated verification of the new artifact). 
- Ran repository checks: `scripts/architecture/check_responsibility_boundaries.py` and `scripts/security/check_subprocess_shell_usage.py`: passed.
- Performed staged diff/whitespace checks (`git diff --cached --check`) and verified `.github/workflows/main.yml` was not modified: passed.
- CI matrix (Python 3.11/3.12, PostgreSQL, CodeQL, full security/runtime gates) was not executed locally and remains required in CI.

If reviewers want, I can split further (e.g. move helper constants to a shared location) but kept this PR focused to restore the single promotion‑native final readiness artifact and its tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a95201cf82883269361fc9940e0cbbe)