### PR TITLE
feat(governance): add promotion-native Bind authorization gate review

### DIFF
--- a/veritas_os/policy/canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review.py
+++ b/veritas_os/policy/canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review.py
@@ -26,6 +26,10 @@ from veritas_os.policy.canonical_promotion_live_adapter_dry_run_final_bind_autho
     CanonicalPromotionLiveAdapterDryRunFinalBindAuthorizationReadinessPacket,
     verify_canonical_promotion_live_adapter_dry_run_final_bind_authorization_readiness_packet,
 )
+from veritas_os.policy.canonical_promotion_live_adapter_dry_run_human_approval_linkage import (
+    CanonicalPromotionLiveAdapterDryRunHumanApprovalLinkageError,
+    verify_canonical_promotion_live_adapter_dry_run_human_approval_linkage_review_packet,
+)
 
 FORMAT_VERSION = "canonical-promotion-live-adapter-dry-run-bind-authorization-gate-review/v1"
 MECHANISM = (
@@ -497,38 +501,38 @@ def _validate_source_requirements(
 def _verified_linkage_identity(
     source: CanonicalPromotionLiveAdapterDryRunFinalBindAuthorizationReadinessPacket,
 ) -> dict[str, str]:
-    """Derive linkage identities only from the already verified embedded source."""
+    """Verify the embedded Human Approval linkage and derive exact lineage IDs."""
 
-    embedded = source.source_human_approval_linkage_review_packet
-    final_context = source.final_readiness_context
     try:
-        identity = {
-            "source_human_approval_linkage_review_id": embedded[
-                "promotion_live_adapter_dry_run_human_approval_linkage_review_id"
-            ],
-            "source_human_approval_linkage_review_hash": embedded[
-                "promotion_live_adapter_dry_run_human_approval_linkage_review_hash"
-            ],
-            "source_human_approval_linkage_context_digest": embedded[
-                "human_approval_linkage_context_digest"
-            ],
-            "source_authority_evidence_linkage_review_id": embedded[
-                "source_authority_evidence_linkage_review_id"
-            ],
-            "source_authority_evidence_linkage_review_hash": embedded[
-                "source_authority_evidence_linkage_review_hash"
-            ],
-            "source_authority_evidence_linkage_context_digest": embedded[
-                "source_authority_evidence_linkage_context_digest"
-            ],
-        }
-    except (KeyError, TypeError) as exc:
+        embedded = verify_canonical_promotion_live_adapter_dry_run_human_approval_linkage_review_packet(
+            source.source_human_approval_linkage_review_packet
+        )
+    except (
+        CanonicalPromotionLiveAdapterDryRunHumanApprovalLinkageError,
+        TypeError,
+        ValueError,
+    ) as exc:
         raise CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError(
-            "CPLADBAGR_SOURCE_LINKAGE_IDENTITY_INVALID"
+            "CPLADBAGR_SOURCE_HUMAN_LINKAGE_PACKET_INVALID"
         ) from exc
 
-    required_strings = tuple(identity.values())
-    if not all(isinstance(value, str) and value for value in required_strings):
+    identity = {
+        "source_human_approval_linkage_review_id": embedded.promotion_live_adapter_dry_run_human_approval_linkage_review_id,
+        "source_human_approval_linkage_review_hash": embedded.promotion_live_adapter_dry_run_human_approval_linkage_review_hash,
+        "source_human_approval_linkage_context_digest": embedded.human_approval_linkage_context_digest,
+        "source_authority_evidence_linkage_review_id": embedded.source_authority_evidence_linkage_review_id,
+        "source_authority_evidence_linkage_review_hash": embedded.source_authority_evidence_linkage_review_hash,
+        "source_authority_evidence_linkage_context_digest": embedded.source_authority_evidence_linkage_context_digest,
+        "source_bind_pre_dispatch_review_id": embedded.source_bind_pre_dispatch_review_id,
+        "source_bind_pre_dispatch_review_hash": embedded.source_bind_pre_dispatch_review_hash,
+        "source_operator_review_id": embedded.source_operator_review_id,
+        "source_operator_review_hash": embedded.source_operator_review_hash,
+        "source_credential_authorization_id": embedded.source_credential_authorization_id,
+        "source_credential_authorization_hash": embedded.source_credential_authorization_hash,
+        "source_endpoint_allowlist_evaluation_id": embedded.source_endpoint_allowlist_evaluation_id,
+        "source_endpoint_allowlist_evaluation_hash": embedded.source_endpoint_allowlist_evaluation_hash,
+    }
+    if not all(isinstance(value, str) and value for value in identity.values()):
         _fail("CPLADBAGR_SOURCE_LINKAGE_IDENTITY_INVALID")
 
     if (
@@ -538,9 +542,16 @@ def _verified_linkage_identity(
         != source.source_human_approval_linkage_review_hash
         or identity["source_human_approval_linkage_context_digest"]
         != source.human_approval_linkage_context_digest
+        or identity["source_authority_evidence_linkage_context_digest"]
+        != source.authority_evidence_linkage_context_digest
+        or identity["source_endpoint_allowlist_evaluation_id"]
+        != source.source_endpoint_allowlist_evaluation_id
+        or identity["source_endpoint_allowlist_evaluation_hash"]
+        != source.source_endpoint_allowlist_evaluation_hash
     ):
-        _fail("CPLADBAGR_SOURCE_HUMAN_LINKAGE_IDENTITY_MISMATCH")
+        _fail("CPLADBAGR_SOURCE_LINKAGE_IDENTITY_MISMATCH")
 
+    final_context = source.final_readiness_context
     for key, value in identity.items():
         if final_context.get(key) != value:
             _fail("CPLADBAGR_FINAL_READINESS_LINKAGE_CONTEXT_MISMATCH")
@@ -668,14 +679,6 @@ def _derived(source: Any, decision: Any) -> tuple[Any, ...]:
         "source_final_readiness_authorization_requirements_digest": source.future_bind_authorization_requirement_digest,
         "source_final_readiness_invocation_requirements_digest": source.future_bind_invocation_requirement_digest,
         **linkage_identity,
-        "source_bind_pre_dispatch_review_id": source.source_bind_pre_dispatch_review_id,
-        "source_bind_pre_dispatch_review_hash": source.source_bind_pre_dispatch_review_hash,
-        "source_operator_review_id": source.source_operator_review_id,
-        "source_operator_review_hash": source.source_operator_review_hash,
-        "source_credential_authorization_id": source.source_credential_authorization_id,
-        "source_credential_authorization_hash": source.source_credential_authorization_hash,
-        "source_endpoint_allowlist_evaluation_id": source.source_endpoint_allowlist_evaluation_id,
-        "source_endpoint_allowlist_evaluation_hash": source.source_endpoint_allowlist_evaluation_hash,
         "execution_intent_id": source.execution_intent_id,
         "execution_intent_hash": source.execution_intent_hash,
         "adapter_contract_id": source.adapter_contract_id,

--- a/veritas_os/policy/canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review.py
+++ b/veritas_os/policy/canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review.py
@@ -494,6 +494,59 @@ def _validate_source_requirements(
         _fail("CPLADBAGR_SOURCE_REQUIREMENT_STATE_INVALID")
 
 
+def _verified_linkage_identity(
+    source: CanonicalPromotionLiveAdapterDryRunFinalBindAuthorizationReadinessPacket,
+) -> dict[str, str]:
+    """Derive linkage identities only from the already verified embedded source."""
+
+    embedded = source.source_human_approval_linkage_review_packet
+    final_context = source.final_readiness_context
+    try:
+        identity = {
+            "source_human_approval_linkage_review_id": embedded[
+                "promotion_live_adapter_dry_run_human_approval_linkage_review_id"
+            ],
+            "source_human_approval_linkage_review_hash": embedded[
+                "promotion_live_adapter_dry_run_human_approval_linkage_review_hash"
+            ],
+            "source_human_approval_linkage_context_digest": embedded[
+                "human_approval_linkage_context_digest"
+            ],
+            "source_authority_evidence_linkage_review_id": embedded[
+                "source_authority_evidence_linkage_review_id"
+            ],
+            "source_authority_evidence_linkage_review_hash": embedded[
+                "source_authority_evidence_linkage_review_hash"
+            ],
+            "source_authority_evidence_linkage_context_digest": embedded[
+                "source_authority_evidence_linkage_context_digest"
+            ],
+        }
+    except (KeyError, TypeError) as exc:
+        raise CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError(
+            "CPLADBAGR_SOURCE_LINKAGE_IDENTITY_INVALID"
+        ) from exc
+
+    required_strings = tuple(identity.values())
+    if not all(isinstance(value, str) and value for value in required_strings):
+        _fail("CPLADBAGR_SOURCE_LINKAGE_IDENTITY_INVALID")
+
+    if (
+        identity["source_human_approval_linkage_review_id"]
+        != source.source_human_approval_linkage_review_id
+        or identity["source_human_approval_linkage_review_hash"]
+        != source.source_human_approval_linkage_review_hash
+        or identity["source_human_approval_linkage_context_digest"]
+        != source.human_approval_linkage_context_digest
+    ):
+        _fail("CPLADBAGR_SOURCE_HUMAN_LINKAGE_IDENTITY_MISMATCH")
+
+    for key, value in identity.items():
+        if final_context.get(key) != value:
+            _fail("CPLADBAGR_FINAL_READINESS_LINKAGE_CONTEXT_MISMATCH")
+    return identity
+
+
 def _validate_source(
     source: CanonicalPromotionLiveAdapterDryRunFinalBindAuthorizationReadinessPacket,
 ) -> None:
@@ -515,6 +568,7 @@ def _validate_source(
     if not all(required) or any(getattr(source, field) for field in EFFECT_FIELDS):
         _fail("CPLADBAGR_SOURCE_STATE_INVALID")
     _validate_source_requirements(source)
+    _verified_linkage_identity(source)
 
     try:
         intent = ExecutionIntent(**source.execution_intent)
@@ -577,6 +631,7 @@ def _future_requirements(names: tuple[str, ...]) -> list[dict[str, Any]]:
 def _derived(source: Any, decision: Any) -> tuple[Any, ...]:
     accepted = decision.review_outcome == OUTCOMES[0]
     decision_digest = _digest(DOMAINS["decision"], decision)
+    linkage_identity = _verified_linkage_identity(source)
     result = {
         "source_human_approval_reference_linkage_passed": True,
         "source_authority_evidence_reference_linkage_passed": True,
@@ -612,12 +667,7 @@ def _derived(source: Any, decision: Any) -> tuple[Any, ...]:
         "source_final_readiness_check_digest": source.final_bind_authorization_readiness_check_digest,
         "source_final_readiness_authorization_requirements_digest": source.future_bind_authorization_requirement_digest,
         "source_final_readiness_invocation_requirements_digest": source.future_bind_invocation_requirement_digest,
-        "source_human_approval_linkage_review_id": source.source_human_approval_linkage_review_id,
-        "source_human_approval_linkage_review_hash": source.source_human_approval_linkage_review_hash,
-        "source_human_approval_linkage_context_digest": source.human_approval_linkage_context_digest,
-        "source_authority_evidence_linkage_review_id": source.source_authority_evidence_linkage_review_id,
-        "source_authority_evidence_linkage_review_hash": source.source_authority_evidence_linkage_review_hash,
-        "source_authority_evidence_linkage_context_digest": source.source_authority_evidence_linkage_context_digest,
+        **linkage_identity,
         "source_bind_pre_dispatch_review_id": source.source_bind_pre_dispatch_review_id,
         "source_bind_pre_dispatch_review_hash": source.source_bind_pre_dispatch_review_hash,
         "source_operator_review_id": source.source_operator_review_id,

--- a/veritas_os/policy/canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review.py
+++ b/veritas_os/policy/canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review.py
@@ -1,8 +1,9 @@
 """Review the promotion-native Bind authorization gate without granting authority.
 
-The boundary is deterministic and local.  It independently verifies the
-Human Approval reference-linkage source and preserves its promotion-native
-bindings, but creates no proof, authority, authorization, dispatch, or effect.
+The boundary is deterministic and local. It independently verifies the
+promotion-native Final Bind Authorization Readiness source and preserves its
+bindings, but creates no proof, authority, authorization, bind context,
+dispatch, or external effect.
 """
 
 from __future__ import annotations
@@ -27,12 +28,13 @@ from veritas_os.policy.canonical_promotion_live_adapter_dry_run_final_bind_autho
 )
 
 FORMAT_VERSION = "canonical-promotion-live-adapter-dry-run-bind-authorization-gate-review/v1"
-MECHANISM = "review_promotion_native_bind_authorization_gate_without_authorization_creation_or_external_effect/v1"
+MECHANISM = (
+    "review_promotion_native_bind_authorization_gate_without_"
+    "authorization_creation_or_external_effect/v1"
+)
 STATUS = "PROMOTION_NATIVE_BIND_AUTHORIZATION_GATE_REVIEWED_NOT_AUTHORIZED"
 SOURCE_STATUS = "PROMOTION_NATIVE_FINAL_BIND_AUTHORIZATION_READINESS_RECORDED_NOT_AUTHORIZED"
-CHECK_MODE = (
-    "deterministic_local_promotion_native_bind_authorization_gate_review_only"
-)
+CHECK_MODE = "deterministic_local_promotion_native_bind_authorization_gate_review_only"
 OUTCOMES = (
     "PASSED_FOR_FUTURE_PROMOTION_NATIVE_FRESH_VERIFIED_SOURCE_GATE",
     "FAILED_FOR_FUTURE_PROMOTION_NATIVE_FRESH_VERIFIED_SOURCE_GATE",
@@ -41,10 +43,16 @@ PREFIX = "veritas.promotion-live-adapter-dry-run-bind-authorization-gate-review"
 DOMAINS = {
     name: f"{PREFIX}.{name}/v1"
     for name in (
-        "decision", "result", "context", "checks", "authorization",
-        "invocation", "packet",
+        "decision",
+        "result",
+        "context",
+        "checks",
+        "authorization",
+        "invocation",
+        "packet",
     )
 }
+
 ACKNOWLEDGEMENTS = (
     "acknowledged_not_real_bind_authorization",
     "acknowledged_no_bind_invocation",
@@ -113,61 +121,91 @@ INVOCATION_REQUIREMENTS = (
     "reconciliation",
     "outcome_receipt",
 )
+SOURCE_AUTHORIZATION_REQUIREMENTS = (
+    "promotion_native_bind_authorization_gate_review",
+    *AUTHORIZATION_REQUIREMENTS,
+)
+
+# Final Readiness evidence preserved under its original names. The source
+# future-requirement fields are deliberately excluded because the Gate owns
+# fields with those names for the remaining lifecycle requirements.
 FINAL_READINESS_EVIDENCE_FIELDS = (
     "final_bind_authorization_readiness_review_decision",
     "final_bind_authorization_readiness_review_decision_digest",
     "final_bind_authorization_readiness_result",
     "final_bind_authorization_readiness_result_digest",
-    "final_readiness_context", "final_readiness_context_digest",
+    "final_readiness_context",
+    "final_readiness_context_digest",
     "final_bind_authorization_readiness_checks",
     "final_bind_authorization_readiness_check_digest",
-    "future_bind_authorization_requirements",
-    "future_bind_authorization_requirement_digest",
-    "future_bind_invocation_requirements",
-    "future_bind_invocation_requirement_digest",
     "source_human_approval_linkage_review_id",
     "source_human_approval_linkage_review_hash",
 )
 PRESERVED_FIELDS = tuple(
-    dict.fromkeys(
-        (
-            *UPSTREAM_PRESERVED_FIELDS,
-            *FINAL_READINESS_EVIDENCE_FIELDS,
-        )
-    )
+    dict.fromkeys((*UPSTREAM_PRESERVED_FIELDS, *FINAL_READINESS_EVIDENCE_FIELDS))
 )
 COPY_FIELDS = PRESERVED_FIELDS
+SOURCE_REQUIREMENT_FIELD_MAP = {
+    "source_final_bind_authorization_requirements": "future_bind_authorization_requirements",
+    "source_final_bind_authorization_requirement_digest": "future_bind_authorization_requirement_digest",
+    "source_final_bind_invocation_requirements": "future_bind_invocation_requirements",
+    "source_final_bind_invocation_requirement_digest": "future_bind_invocation_requirement_digest",
+}
 EFFECT_FIELDS = (
-    "human_approval_created", "human_approval_externally_verified",
-    "human_approval_proven", "authority_evidence_created",
-    "authority_evidence_externally_verified", "authority_evidence_proven",
-    "execution_authority_created", "execution_authorized",
-    "bind_authorization_created", "bind_authorization_issued",
-    "credential_resolved", "credential_material_accessed",
-    "credential_material_embedded", "credential_store_accessed",
-    "authorization_header_constructed", "token_embedded", "secret_embedded",
-    "cookie_embedded", "password_embedded", "private_key_embedded",
-    "endpoint_resolved", "endpoint_contacted", "dns_used", "network_used",
-    "webhook_invoked", "live_adapter_instantiated",
-    "live_adapter_method_invoked", "request_dispatched", "bind_invoked",
-    "bind_receipt_created", "trustlog_written", "filesystem_used",
-    "database_used", "provider_called", "subprocess_used",
-    "external_effect_used", "operation_committed", "apply_performed",
-    "postcondition_verified", "rollback_or_revert_performed",
-    "ready_for_real_bind", "ready_for_network_dispatch",
+    "human_approval_created",
+    "human_approval_externally_verified",
+    "human_approval_proven",
+    "authority_evidence_created",
+    "authority_evidence_externally_verified",
+    "authority_evidence_proven",
+    "execution_authority_created",
+    "execution_authorized",
+    "bind_authorization_created",
+    "bind_authorization_issued",
+    "credential_resolved",
+    "credential_material_accessed",
+    "credential_material_embedded",
+    "credential_store_accessed",
+    "authorization_header_constructed",
+    "token_embedded",
+    "secret_embedded",
+    "cookie_embedded",
+    "password_embedded",
+    "private_key_embedded",
+    "endpoint_resolved",
+    "endpoint_contacted",
+    "dns_used",
+    "network_used",
+    "webhook_invoked",
+    "live_adapter_instantiated",
+    "live_adapter_method_invoked",
+    "request_dispatched",
+    "bind_invoked",
+    "bind_receipt_created",
+    "trustlog_written",
+    "filesystem_used",
+    "database_used",
+    "provider_called",
+    "subprocess_used",
+    "external_effect_used",
+    "operation_committed",
+    "apply_performed",
+    "postcondition_verified",
+    "rollback_or_revert_performed",
+    "ready_for_real_bind",
+    "ready_for_network_dispatch",
 )
 
 
-class CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError(
-    ValueError
-):
-    """Stable fail-closed error for invalid final readiness evidence."""
+class CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError(ValueError):
+    """Stable fail-closed error for invalid promotion-native Gate evidence."""
 
 
 class BindAuthorizationGateReviewDecision(BaseModel):
     """Closed reviewer decision which expressly grants no authority."""
 
     model_config = ConfigDict(extra="forbid", frozen=True)
+
     bind_authorization_gate_review_decision_id: str = Field(min_length=1)
     reviewer_id: str = Field(min_length=1)
     reviewer_role: str = Field(min_length=1)
@@ -196,9 +234,10 @@ class BindAuthorizationGateReviewDecision(BaseModel):
 
 
 class BindAuthorizationGateReviewResult(BaseModel):
-    """Final local comparison result with no proof or authorization semantics."""
+    """Deterministic local Gate result with explicit non-authority semantics."""
 
     model_config = ConfigDict(extra="forbid", frozen=True)
+
     source_human_approval_reference_linkage_passed: Literal[True]
     source_authority_evidence_reference_linkage_passed: Literal[True]
     source_bind_pre_dispatch_review_passed: Literal[True]
@@ -220,6 +259,7 @@ class BindAuthorizationGateReviewResult(BaseModel):
     externally_verifies_human_approval: Literal[False]
     creates_authority_evidence: Literal[False]
     externally_verifies_authority_evidence: Literal[False]
+    derives_bind_context_hash: Literal[False]
 
 
 class GateReviewCheck(BaseModel):
@@ -243,9 +283,10 @@ class FutureRequirement(BaseModel):
 
 
 class _BindAuthorizationGateReviewPacketBase(BaseModel):
-    """Content-addressed promotion-native final readiness evidence."""
+    """Content-addressed promotion-native Bind Gate Review evidence."""
 
     model_config = ConfigDict(extra="forbid", frozen=True)
+
     format_version: Literal[FORMAT_VERSION]
     promotion_live_adapter_dry_run_bind_authorization_gate_review_id: str
     promotion_live_adapter_dry_run_bind_authorization_gate_review_hash: str
@@ -330,20 +371,26 @@ _PRESERVED_PACKET_FIELDS = {
     )
     for field_name in PRESERVED_FIELDS
 }
-
-CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewPacket = (
-    create_model(
-        "CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewPacket",
-        __base__=_BindAuthorizationGateReviewPacketBase,
-        **_PRESERVED_PACKET_FIELDS,
+_SOURCE_REQUIREMENT_PACKET_FIELDS = {
+    target_name: (
+        CanonicalPromotionLiveAdapterDryRunFinalBindAuthorizationReadinessPacket
+        .model_fields[source_name]
+        .annotation,
+        ...,
     )
+    for target_name, source_name in SOURCE_REQUIREMENT_FIELD_MAP.items()
+}
+
+CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewPacket = create_model(
+    "CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewPacket",
+    __base__=_BindAuthorizationGateReviewPacketBase,
+    **_PRESERVED_PACKET_FIELDS,
+    **_SOURCE_REQUIREMENT_PACKET_FIELDS,
 )
 
 
 def _fail(code: str) -> None:
-    raise CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError(
-        code
-    )
+    raise CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError(code)
 
 
 def _timestamp(value: Any) -> str:
@@ -364,7 +411,8 @@ def _json(value: Any) -> Any:
     if value is None or isinstance(value, (str, bool, int)):
         return value
     if isinstance(value, float) and value == value and value not in (
-        float("inf"), float("-inf")
+        float("inf"),
+        float("-inf"),
     ):
         return value
     if isinstance(value, datetime):
@@ -415,6 +463,37 @@ def _source(
         ) from exc
 
 
+def _requirement_names(items: Any) -> tuple[str, ...]:
+    try:
+        return tuple(item.name for item in items)
+    except (AttributeError, TypeError) as exc:
+        raise CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError(
+            "CPLADBAGR_SOURCE_REQUIREMENTS_INVALID"
+        ) from exc
+
+
+def _validate_source_requirements(
+    source: CanonicalPromotionLiveAdapterDryRunFinalBindAuthorizationReadinessPacket,
+) -> None:
+    if _requirement_names(source.future_bind_authorization_requirements) != (
+        SOURCE_AUTHORIZATION_REQUIREMENTS
+    ):
+        _fail("CPLADBAGR_SOURCE_AUTHORIZATION_REQUIREMENTS_MISMATCH")
+    if _requirement_names(source.future_bind_invocation_requirements) != (
+        INVOCATION_REQUIREMENTS
+    ):
+        _fail("CPLADBAGR_SOURCE_INVOCATION_REQUIREMENTS_MISMATCH")
+    source_requirements = (
+        *source.future_bind_authorization_requirements,
+        *source.future_bind_invocation_requirements,
+    )
+    if any(
+        not item.separate_future_artifact_required or item.satisfied_by_this_packet
+        for item in source_requirements
+    ):
+        _fail("CPLADBAGR_SOURCE_REQUIREMENT_STATE_INVALID")
+
+
 def _validate_source(
     source: CanonicalPromotionLiveAdapterDryRunFinalBindAuthorizationReadinessPacket,
 ) -> None:
@@ -430,14 +509,18 @@ def _validate_source(
         source.fresh_verified_source_gate_still_required,
         source.final_bind_authorization_readiness_result
         .accepted_for_future_promotion_native_bind_authorization_gate_review,
+        source.approval_context.get("required_human_approval") is True,
         not source.fail_closed,
     )
     if not all(required) or any(getattr(source, field) for field in EFFECT_FIELDS):
         _fail("CPLADBAGR_SOURCE_STATE_INVALID")
+    _validate_source_requirements(source)
+
     try:
         intent = ExecutionIntent(**source.execution_intent)
         descriptor = verify_bind_adapter_contract_descriptor(
-            source.adapter_contract_descriptor, intent
+            source.adapter_contract_descriptor,
+            intent,
         )
     except (
         TypeError,
@@ -448,27 +531,25 @@ def _validate_source(
         raise CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError(
             "CPLADBAGR_SOURCE_BINDING_INVALID"
         ) from exc
-    if intent.to_dict() != source.execution_intent:
+
+    if (
+        intent.to_dict() != source.execution_intent
+        or hash_execution_intent(intent) != source.execution_intent_hash
+        or intent.execution_intent_id != source.execution_intent_id
+    ):
         _fail("CPLADBAGR_EXECUTION_INTENT_INVALID")
-    if hash_execution_intent(intent) != source.execution_intent_hash:
-        _fail("CPLADBAGR_EXECUTION_INTENT_INVALID")
-    if intent.execution_intent_id != source.execution_intent_id:
-        _fail("CPLADBAGR_EXECUTION_INTENT_INVALID")
-    if descriptor.adapter_contract_id != source.adapter_contract_id:
-        _fail("CPLADBAGR_ADAPTER_INVALID")
-    if descriptor.adapter_contract_hash != source.adapter_contract_hash:
-        _fail("CPLADBAGR_ADAPTER_INVALID")
-    if descriptor.adapter_contract_version != source.adapter_contract_version:
-        _fail("CPLADBAGR_ADAPTER_INVALID")
-    if descriptor.model_dump(mode="json") != source.adapter_contract_descriptor:
+    if (
+        descriptor.adapter_contract_id != source.adapter_contract_id
+        or descriptor.adapter_contract_hash != source.adapter_contract_hash
+        or descriptor.adapter_contract_version != source.adapter_contract_version
+        or descriptor.model_dump(mode="json") != source.adapter_contract_descriptor
+    ):
         _fail("CPLADBAGR_ADAPTER_INVALID")
 
 
 def _decision(value: Any) -> BindAuthorizationGateReviewDecision:
     try:
-        decision = BindAuthorizationGateReviewDecision.model_validate(
-            _json(value)
-        )
+        decision = BindAuthorizationGateReviewDecision.model_validate(_json(value))
         decision = decision.model_copy(
             update={"reviewed_at": _timestamp(decision.reviewed_at)}
         )
@@ -479,6 +560,18 @@ def _decision(value: Any) -> BindAuthorizationGateReviewDecision:
     if not all(getattr(decision, field) for field in ACKNOWLEDGEMENTS):
         _fail("CPLADBAGR_ACKNOWLEDGEMENT_MISSING")
     return decision
+
+
+def _future_requirements(names: tuple[str, ...]) -> list[dict[str, Any]]:
+    return [
+        {
+            "ordinal": ordinal,
+            "name": name,
+            "separate_future_artifact_required": True,
+            "satisfied_by_this_packet": False,
+        }
+        for ordinal, name in enumerate(names, 1)
+    ]
 
 
 def _derived(source: Any, decision: Any) -> tuple[Any, ...]:
@@ -497,7 +590,9 @@ def _derived(source: Any, decision: Any) -> tuple[Any, ...]:
         "source_final_readiness_passed": True,
         "gate_review_passed": accepted,
         "accepted_for_future_promotion_native_fresh_verified_source_gate": accepted,
-        "rejection_reasons": [] if accepted else ["BIND_AUTHORIZATION_GATE_REVIEW_FAILED"],
+        "rejection_reasons": []
+        if accepted
+        else ["BIND_AUTHORIZATION_GATE_REVIEW_FAILED"],
         "comparison_mode": CHECK_MODE,
         "semantic_match_used": False,
         "creates_bind_authorization": False,
@@ -506,6 +601,7 @@ def _derived(source: Any, decision: Any) -> tuple[Any, ...]:
         "externally_verifies_human_approval": False,
         "creates_authority_evidence": False,
         "externally_verifies_authority_evidence": False,
+        "derives_bind_context_hash": False,
     }
     context = {
         "source_final_bind_authorization_readiness_id": source.promotion_live_adapter_dry_run_final_bind_authorization_readiness_id,
@@ -516,6 +612,8 @@ def _derived(source: Any, decision: Any) -> tuple[Any, ...]:
         "source_final_readiness_check_digest": source.final_bind_authorization_readiness_check_digest,
         "source_final_readiness_authorization_requirements_digest": source.future_bind_authorization_requirement_digest,
         "source_final_readiness_invocation_requirements_digest": source.future_bind_invocation_requirement_digest,
+        "source_human_approval_linkage_review_id": source.source_human_approval_linkage_review_id,
+        "source_human_approval_linkage_review_hash": source.source_human_approval_linkage_review_hash,
         "source_human_approval_linkage_context_digest": source.human_approval_linkage_context_digest,
         "source_authority_evidence_linkage_review_id": source.source_authority_evidence_linkage_review_id,
         "source_authority_evidence_linkage_review_hash": source.source_authority_evidence_linkage_review_hash,
@@ -560,25 +658,14 @@ def _derived(source: Any, decision: Any) -> tuple[Any, ...]:
         }
         for ordinal, name in enumerate(CHECK_NAMES, 1)
     ]
-    authorization = [
-        {
-            "ordinal": ordinal,
-            "name": name,
-            "separate_future_artifact_required": True,
-            "satisfied_by_this_packet": False,
-        }
-        for ordinal, name in enumerate(AUTHORIZATION_REQUIREMENTS, 1)
-    ]
-    invocation = [
-        {
-            "ordinal": ordinal,
-            "name": name,
-            "separate_future_artifact_required": True,
-            "satisfied_by_this_packet": False,
-        }
-        for ordinal, name in enumerate(INVOCATION_REQUIREMENTS, 1)
-    ]
-    return decision_digest, result, context, checks, authorization, invocation
+    return (
+        decision_digest,
+        result,
+        context,
+        checks,
+        _future_requirements(AUTHORIZATION_REQUIREMENTS),
+        _future_requirements(INVOCATION_REQUIREMENTS),
+    )
 
 
 def _assemble(source: Any, decision: Any, recorded_at: str) -> dict[str, Any]:
@@ -597,16 +684,20 @@ def _assemble(source: Any, decision: Any, recorded_at: str) -> dict[str, Any]:
         "source_final_bind_authorization_readiness_hash": source.promotion_live_adapter_dry_run_final_bind_authorization_readiness_hash,
         "source_final_bind_authorization_readiness_packet": source_raw,
         **{field: source_raw[field] for field in COPY_FIELDS},
-        "bind_authorization_gate_review_decision": decision.model_dump(
-            mode="json"
-        ),
+        **{
+            target_name: source_raw[source_name]
+            for target_name, source_name in SOURCE_REQUIREMENT_FIELD_MAP.items()
+        },
+        "bind_authorization_gate_review_decision": decision.model_dump(mode="json"),
         "bind_authorization_gate_review_decision_digest": decision_digest,
         "bind_authorization_gate_review_result": result,
         "bind_authorization_gate_review_result_digest": _digest(
             DOMAINS["result"], result
         ),
         "bind_authorization_gate_review_context": context,
-        "bind_authorization_gate_review_context_digest": _digest(DOMAINS["context"], context),
+        "bind_authorization_gate_review_context_digest": _digest(
+            DOMAINS["context"], context
+        ),
         "bind_authorization_gate_review_checks": checks,
         "bind_authorization_gate_review_check_digest": _digest(
             DOMAINS["checks"], checks
@@ -633,12 +724,10 @@ def _assemble(source: Any, decision: Any, recorded_at: str) -> dict[str, Any]:
         **{field: False for field in EFFECT_FIELDS},
     }
     digest = _packet_hash(raw)
-    raw[
-        "promotion_live_adapter_dry_run_bind_authorization_gate_review_hash"
-    ] = digest
-    raw[
-        "promotion_live_adapter_dry_run_bind_authorization_gate_review_id"
-    ] = f"pladbagr:v1:sha256:{digest}"
+    raw["promotion_live_adapter_dry_run_bind_authorization_gate_review_hash"] = digest
+    raw["promotion_live_adapter_dry_run_bind_authorization_gate_review_id"] = (
+        f"pladbagr:v1:sha256:{digest}"
+    )
     return raw
 
 
@@ -647,15 +736,15 @@ def build_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_revie
     bind_authorization_gate_review_decision: Any,
     bind_authorization_gate_review_recorded_at: datetime,
 ) -> CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewPacket:
-    """Build self-verifying final readiness evidence without granting authority."""
+    """Build self-verifying Gate Review evidence without granting authority."""
+
     source = _source(_json(source_final_bind_authorization_readiness_packet))
     _validate_source(source)
     decision = _decision(bind_authorization_gate_review_decision)
     recorded_at = _timestamp(bind_authorization_gate_review_recorded_at)
     source_at = _timestamp(source.final_bind_authorization_readiness_recorded_at)
-    if _timestamp(decision.reviewed_at) < source_at or recorded_at < _timestamp(
-        decision.reviewed_at
-    ):
+    reviewed_at = _timestamp(decision.reviewed_at)
+    if reviewed_at < source_at or recorded_at < reviewed_at:
         _fail("CPLADBAGR_TIMESTAMP_ORDER_INVALID")
     return verify_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review_packet(
         _assemble(source, decision, recorded_at)
@@ -666,6 +755,7 @@ def verify_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_revi
     raw: Any,
 ) -> CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewPacket:
     """Independently reconstruct and verify the source, bindings, and hashes."""
+
     try:
         value = raw.model_dump(mode="json") if isinstance(raw, BaseModel) else raw
         packet = CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewPacket.model_validate(
@@ -675,6 +765,7 @@ def verify_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_revi
         raise CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError(
             "CPLADBAGR_PACKET_INVALID"
         ) from exc
+
     source = _source(packet.source_final_bind_authorization_readiness_packet)
     _validate_source(source)
     decision = _decision(packet.bind_authorization_gate_review_decision)
@@ -683,6 +774,7 @@ def verify_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_revi
     recorded_at = _timestamp(packet.bind_authorization_gate_review_recorded_at)
     if reviewed_at < source_at or recorded_at < reviewed_at:
         _fail("CPLADBAGR_TIMESTAMP_ORDER_INVALID")
+
     expected = _assemble(source, decision, recorded_at)
     if packet.model_dump(mode="json") != expected:
         _fail("CPLADBAGR_RECONSTRUCTION_MISMATCH")

--- a/veritas_os/policy/canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review.py
+++ b/veritas_os/policy/canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review.py
@@ -1,0 +1,689 @@
+"""Review the promotion-native Bind authorization gate without granting authority.
+
+The boundary is deterministic and local.  It independently verifies the
+Human Approval reference-linkage source and preserves its promotion-native
+bindings, but creates no proof, authority, authorization, dispatch, or effect.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, create_model
+
+from veritas_os.policy.bind_adapter_contract_selection import (
+    BindAdapterContractSelectionError,
+    verify_bind_adapter_contract_descriptor,
+)
+from veritas_os.policy.bind_artifacts import ExecutionIntent, hash_execution_intent
+from veritas_os.policy.canonical_promotion_live_adapter_dry_run_final_bind_authorization_readiness import (
+    PRESERVED_FIELDS as UPSTREAM_PRESERVED_FIELDS,
+    CanonicalPromotionLiveAdapterDryRunFinalBindAuthorizationReadinessError,
+    CanonicalPromotionLiveAdapterDryRunFinalBindAuthorizationReadinessPacket,
+    verify_canonical_promotion_live_adapter_dry_run_final_bind_authorization_readiness_packet,
+)
+
+FORMAT_VERSION = "canonical-promotion-live-adapter-dry-run-bind-authorization-gate-review/v1"
+MECHANISM = "review_promotion_native_bind_authorization_gate_without_authorization_creation_or_external_effect/v1"
+STATUS = "PROMOTION_NATIVE_BIND_AUTHORIZATION_GATE_REVIEWED_NOT_AUTHORIZED"
+SOURCE_STATUS = "PROMOTION_NATIVE_FINAL_BIND_AUTHORIZATION_READINESS_RECORDED_NOT_AUTHORIZED"
+CHECK_MODE = (
+    "deterministic_local_promotion_native_bind_authorization_gate_review_only"
+)
+OUTCOMES = (
+    "PASSED_FOR_FUTURE_PROMOTION_NATIVE_FRESH_VERIFIED_SOURCE_GATE",
+    "FAILED_FOR_FUTURE_PROMOTION_NATIVE_FRESH_VERIFIED_SOURCE_GATE",
+)
+PREFIX = "veritas.promotion-live-adapter-dry-run-bind-authorization-gate-review"
+DOMAINS = {
+    name: f"{PREFIX}.{name}/v1"
+    for name in (
+        "decision", "result", "context", "checks", "authorization",
+        "invocation", "packet",
+    )
+}
+ACKNOWLEDGEMENTS = (
+    "acknowledged_not_real_bind_authorization",
+    "acknowledged_no_bind_invocation",
+    "acknowledged_no_bind_receipt",
+    "acknowledged_no_trustlog_write",
+    "acknowledged_no_dispatch",
+    "acknowledged_no_execution_authority",
+    "acknowledged_no_human_approval_creation",
+    "acknowledged_no_human_approval_verification",
+    "acknowledged_no_authority_evidence_creation",
+    "acknowledged_no_authority_evidence_verification",
+    "acknowledged_no_credential_access",
+    "acknowledged_no_authorization_header",
+    "acknowledged_no_network_call",
+    "acknowledged_fresh_verified_source_gate_still_required",
+    "acknowledged_bind_context_hash_not_derived",
+    "acknowledged_gate_bound_human_approval_still_required",
+    "acknowledged_cryptographic_authority_verification_still_required",
+    "acknowledged_real_bind_authorization_still_required",
+)
+CHECK_NAMES = (
+    "source_human_approval_reference_linkage_verified",
+    "exact_execution_intent_reconstructed",
+    "exact_adapter_descriptor_verified",
+    "endpoint_identity_binding_preserved",
+    "credential_scope_binding_preserved",
+    "operator_review_binding_preserved",
+    "bind_boundary_precondition_preserved",
+    "authority_evidence_reference_linkage_preserved",
+    "human_approval_reference_linkage_preserved",
+    "final_review_decision_valid",
+    "all_acknowledgements_present",
+    "timestamp_ordering_valid",
+    "future_requirements_unsatisfied",
+    "human_approval_proof_absent",
+    "authority_evidence_proof_absent",
+    "execution_authority_absent",
+    "bind_authorization_absent",
+    "dispatch_absent",
+    "network_access_absent",
+    "external_effect_absent",
+)
+AUTHORIZATION_REQUIREMENTS = (
+    "fresh_verified_source_gate",
+    "exact_bind_context_hash_derivation",
+    "final_endpoint_identity_recheck",
+    "final_credential_scope_recheck",
+    "runtime_risk_review",
+    "idempotency_and_replay_review",
+    "signed_gate_bound_human_approval_issuance",
+    "human_approval_receipt_verification",
+    "cryptographic_authority_evidence_verification",
+    "revocation_verification_where_applicable",
+    "real_bind_authorization",
+)
+INVOCATION_REQUIREMENTS = (
+    "authorization_consumption",
+    "single_use_consumption",
+    "credential_material_resolution",
+    "authorization_header_construction",
+    "network_dispatch",
+    "bind_invocation",
+    "bind_receipt",
+    "trustlog_write",
+    "effect_state_handling",
+    "reconciliation",
+    "outcome_receipt",
+)
+FINAL_READINESS_EVIDENCE_FIELDS = (
+    "final_bind_authorization_readiness_review_decision",
+    "final_bind_authorization_readiness_review_decision_digest",
+    "final_bind_authorization_readiness_result",
+    "final_bind_authorization_readiness_result_digest",
+    "final_readiness_context", "final_readiness_context_digest",
+    "final_bind_authorization_readiness_checks",
+    "final_bind_authorization_readiness_check_digest",
+    "future_bind_authorization_requirements",
+    "future_bind_authorization_requirement_digest",
+    "future_bind_invocation_requirements",
+    "future_bind_invocation_requirement_digest",
+    "source_human_approval_linkage_review_id",
+    "source_human_approval_linkage_review_hash",
+)
+PRESERVED_FIELDS = tuple(
+    dict.fromkeys(
+        (
+            *UPSTREAM_PRESERVED_FIELDS,
+            *FINAL_READINESS_EVIDENCE_FIELDS,
+        )
+    )
+)
+COPY_FIELDS = PRESERVED_FIELDS
+EFFECT_FIELDS = (
+    "human_approval_created", "human_approval_externally_verified",
+    "human_approval_proven", "authority_evidence_created",
+    "authority_evidence_externally_verified", "authority_evidence_proven",
+    "execution_authority_created", "execution_authorized",
+    "bind_authorization_created", "bind_authorization_issued",
+    "credential_resolved", "credential_material_accessed",
+    "credential_material_embedded", "credential_store_accessed",
+    "authorization_header_constructed", "token_embedded", "secret_embedded",
+    "cookie_embedded", "password_embedded", "private_key_embedded",
+    "endpoint_resolved", "endpoint_contacted", "dns_used", "network_used",
+    "webhook_invoked", "live_adapter_instantiated",
+    "live_adapter_method_invoked", "request_dispatched", "bind_invoked",
+    "bind_receipt_created", "trustlog_written", "filesystem_used",
+    "database_used", "provider_called", "subprocess_used",
+    "external_effect_used", "operation_committed", "apply_performed",
+    "postcondition_verified", "rollback_or_revert_performed",
+    "ready_for_real_bind", "ready_for_network_dispatch",
+)
+
+
+class CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError(
+    ValueError
+):
+    """Stable fail-closed error for invalid final readiness evidence."""
+
+
+class BindAuthorizationGateReviewDecision(BaseModel):
+    """Closed reviewer decision which expressly grants no authority."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    bind_authorization_gate_review_decision_id: str = Field(min_length=1)
+    reviewer_id: str = Field(min_length=1)
+    reviewer_role: str = Field(min_length=1)
+    reviewer_attestation: str = Field(min_length=1)
+    reviewed_at: str
+    review_outcome: Literal[*OUTCOMES]
+    review_reason: str = Field(min_length=1)
+    acknowledged_not_real_bind_authorization: Literal[True]
+    acknowledged_no_bind_invocation: Literal[True]
+    acknowledged_no_bind_receipt: Literal[True]
+    acknowledged_no_trustlog_write: Literal[True]
+    acknowledged_no_dispatch: Literal[True]
+    acknowledged_no_execution_authority: Literal[True]
+    acknowledged_no_human_approval_creation: Literal[True]
+    acknowledged_no_human_approval_verification: Literal[True]
+    acknowledged_no_authority_evidence_creation: Literal[True]
+    acknowledged_no_authority_evidence_verification: Literal[True]
+    acknowledged_no_credential_access: Literal[True]
+    acknowledged_no_authorization_header: Literal[True]
+    acknowledged_no_network_call: Literal[True]
+    acknowledged_fresh_verified_source_gate_still_required: Literal[True]
+    acknowledged_bind_context_hash_not_derived: Literal[True]
+    acknowledged_gate_bound_human_approval_still_required: Literal[True]
+    acknowledged_cryptographic_authority_verification_still_required: Literal[True]
+    acknowledged_real_bind_authorization_still_required: Literal[True]
+
+
+class BindAuthorizationGateReviewResult(BaseModel):
+    """Final local comparison result with no proof or authorization semantics."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    source_human_approval_reference_linkage_passed: Literal[True]
+    source_authority_evidence_reference_linkage_passed: Literal[True]
+    source_bind_pre_dispatch_review_passed: Literal[True]
+    exact_execution_intent_preserved: Literal[True]
+    exact_adapter_preserved: Literal[True]
+    exact_endpoint_binding_preserved: Literal[True]
+    exact_credential_scope_binding_preserved: Literal[True]
+    all_required_local_linkage_artifacts_present: Literal[True]
+    all_required_local_linkage_artifacts_verified: Literal[True]
+    source_final_readiness_passed: Literal[True]
+    gate_review_passed: bool
+    accepted_for_future_promotion_native_fresh_verified_source_gate: bool
+    rejection_reasons: tuple[str, ...]
+    comparison_mode: Literal[CHECK_MODE]
+    semantic_match_used: Literal[False]
+    creates_bind_authorization: Literal[False]
+    creates_execution_authority: Literal[False]
+    creates_human_approval: Literal[False]
+    externally_verifies_human_approval: Literal[False]
+    creates_authority_evidence: Literal[False]
+    externally_verifies_authority_evidence: Literal[False]
+
+
+class GateReviewCheck(BaseModel):
+    """An ordered deterministic check that cannot perform an effect."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    ordinal: int = Field(ge=1)
+    name: Literal[*CHECK_NAMES]
+    passed: Literal[True]
+    comparison_mode: Literal[CHECK_MODE]
+
+
+class FutureRequirement(BaseModel):
+    """A lifecycle requirement deliberately unsatisfied by this artifact."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    ordinal: int = Field(ge=1)
+    name: Literal[*AUTHORIZATION_REQUIREMENTS, *INVOCATION_REQUIREMENTS]
+    separate_future_artifact_required: Literal[True]
+    satisfied_by_this_packet: Literal[False]
+
+
+class _BindAuthorizationGateReviewPacketBase(BaseModel):
+    """Content-addressed promotion-native final readiness evidence."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    format_version: Literal[FORMAT_VERSION]
+    promotion_live_adapter_dry_run_bind_authorization_gate_review_id: str
+    promotion_live_adapter_dry_run_bind_authorization_gate_review_hash: str
+    bind_authorization_gate_review_mechanism: Literal[MECHANISM]
+    bind_authorization_gate_review_recorded_at: str
+    source_final_bind_authorization_readiness_id: str
+    source_final_bind_authorization_readiness_hash: str
+    source_final_bind_authorization_readiness_packet: dict[str, Any]
+    bind_authorization_gate_review_decision: BindAuthorizationGateReviewDecision
+    bind_authorization_gate_review_decision_digest: str
+    bind_authorization_gate_review_result: BindAuthorizationGateReviewResult
+    bind_authorization_gate_review_result_digest: str
+    bind_authorization_gate_review_context: dict[str, Any]
+    bind_authorization_gate_review_context_digest: str
+    bind_authorization_gate_review_checks: tuple[GateReviewCheck, ...]
+    bind_authorization_gate_review_check_digest: str
+    future_bind_authorization_requirements: tuple[FutureRequirement, ...]
+    future_bind_authorization_requirement_digest: str
+    future_bind_invocation_requirements: tuple[FutureRequirement, ...]
+    future_bind_invocation_requirement_digest: str
+    bind_authorization_gate_review_status: Literal[STATUS]
+    request_dispatch_state: Literal["NOT_DISPATCHED"]
+    bind_state: Literal["NOT_BOUND"]
+    authority_state: Literal["NOT_AUTHORIZED"]
+    human_approval_state: Literal["NOT_APPROVED"]
+    gate_review_state: Literal[*OUTCOMES]
+    ready_for_promotion_native_fresh_verified_source_gate: bool
+    bind_authorization_state: Literal["NOT_AUTHORIZED"]
+    bind_context_hash_derived: Literal[False]
+    fresh_verified_source_gate_still_required: Literal[True]
+    fail_closed: bool
+    human_approval_proven: Literal[False]
+    human_approval_externally_verified: Literal[False]
+    authority_evidence_proven: Literal[False]
+    authority_evidence_externally_verified: Literal[False]
+    execution_authorized: Literal[False]
+    bind_authorization_issued: Literal[False]
+    ready_for_real_bind: Literal[False]
+    ready_for_network_dispatch: Literal[False]
+    human_approval_created: Literal[False]
+    authority_evidence_created: Literal[False]
+    execution_authority_created: Literal[False]
+    bind_authorization_created: Literal[False]
+    credential_resolved: Literal[False]
+    credential_material_accessed: Literal[False]
+    credential_material_embedded: Literal[False]
+    credential_store_accessed: Literal[False]
+    authorization_header_constructed: Literal[False]
+    token_embedded: Literal[False]
+    secret_embedded: Literal[False]
+    cookie_embedded: Literal[False]
+    password_embedded: Literal[False]
+    private_key_embedded: Literal[False]
+    endpoint_resolved: Literal[False]
+    endpoint_contacted: Literal[False]
+    dns_used: Literal[False]
+    network_used: Literal[False]
+    webhook_invoked: Literal[False]
+    live_adapter_instantiated: Literal[False]
+    live_adapter_method_invoked: Literal[False]
+    request_dispatched: Literal[False]
+    bind_invoked: Literal[False]
+    bind_receipt_created: Literal[False]
+    trustlog_written: Literal[False]
+    filesystem_used: Literal[False]
+    database_used: Literal[False]
+    provider_called: Literal[False]
+    subprocess_used: Literal[False]
+    external_effect_used: Literal[False]
+    operation_committed: Literal[False]
+    apply_performed: Literal[False]
+    postcondition_verified: Literal[False]
+    rollback_or_revert_performed: Literal[False]
+
+
+_PRESERVED_PACKET_FIELDS = {
+    field_name: (
+        CanonicalPromotionLiveAdapterDryRunFinalBindAuthorizationReadinessPacket
+        .model_fields[field_name]
+        .annotation,
+        ...,
+    )
+    for field_name in PRESERVED_FIELDS
+}
+
+CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewPacket = (
+    create_model(
+        "CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewPacket",
+        __base__=_BindAuthorizationGateReviewPacketBase,
+        **_PRESERVED_PACKET_FIELDS,
+    )
+)
+
+
+def _fail(code: str) -> None:
+    raise CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError(
+        code
+    )
+
+
+def _timestamp(value: Any) -> str:
+    try:
+        parsed = value if isinstance(value, datetime) else datetime.fromisoformat(value)
+    except (TypeError, ValueError) as exc:
+        raise CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError(
+            "CPLADBAGR_TIMESTAMP_INVALID"
+        ) from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        _fail("CPLADBAGR_TIMESTAMP_INVALID")
+    return parsed.astimezone(timezone.utc).isoformat()
+
+
+def _json(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        value = value.model_dump(mode="json")
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float) and value == value and value not in (
+        float("inf"), float("-inf")
+    ):
+        return value
+    if isinstance(value, datetime):
+        return _timestamp(value)
+    if isinstance(value, (list, tuple)):
+        return [_json(item) for item in value]
+    if isinstance(value, dict) and all(isinstance(key, str) for key in value):
+        return {key: _json(item) for key, item in value.items()}
+    _fail("CPLADBAGR_JSON_INVALID")
+
+
+def _digest(domain: str, value: Any) -> str:
+    encoded = json.dumps(
+        {"domain": domain, "value": _json(value)},
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _packet_hash(raw: dict[str, Any]) -> str:
+    omitted = {
+        "promotion_live_adapter_dry_run_bind_authorization_gate_review_id",
+        "promotion_live_adapter_dry_run_bind_authorization_gate_review_hash",
+    }
+    return _digest(
+        DOMAINS["packet"],
+        {key: value for key, value in raw.items() if key not in omitted},
+    )
+
+
+def _source(
+    value: Any,
+) -> CanonicalPromotionLiveAdapterDryRunFinalBindAuthorizationReadinessPacket:
+    try:
+        return verify_canonical_promotion_live_adapter_dry_run_final_bind_authorization_readiness_packet(
+            value
+        )
+    except (
+        CanonicalPromotionLiveAdapterDryRunFinalBindAuthorizationReadinessError,
+        TypeError,
+        ValueError,
+    ) as exc:
+        raise CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError(
+            "CPLADBAGR_SOURCE_INVALID"
+        ) from exc
+
+
+def _validate_source(
+    source: CanonicalPromotionLiveAdapterDryRunFinalBindAuthorizationReadinessPacket,
+) -> None:
+    required = (
+        source.final_bind_authorization_readiness_status == SOURCE_STATUS,
+        source.request_dispatch_state == "NOT_DISPATCHED",
+        source.bind_state == "NOT_BOUND",
+        source.authority_state == "NOT_AUTHORIZED",
+        source.human_approval_state == "NOT_APPROVED",
+        source.final_readiness_state
+        == "READY_FOR_FUTURE_PROMOTION_NATIVE_BIND_AUTHORIZATION_GATE",
+        source.ready_for_promotion_native_bind_authorization_gate_review,
+        source.fresh_verified_source_gate_still_required,
+        source.final_bind_authorization_readiness_result
+        .accepted_for_future_promotion_native_bind_authorization_gate_review,
+        not source.fail_closed,
+    )
+    if not all(required) or any(getattr(source, field) for field in EFFECT_FIELDS):
+        _fail("CPLADBAGR_SOURCE_STATE_INVALID")
+    try:
+        intent = ExecutionIntent(**source.execution_intent)
+        descriptor = verify_bind_adapter_contract_descriptor(
+            source.adapter_contract_descriptor, intent
+        )
+    except (
+        TypeError,
+        ValidationError,
+        BindAdapterContractSelectionError,
+        ValueError,
+    ) as exc:
+        raise CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError(
+            "CPLADBAGR_SOURCE_BINDING_INVALID"
+        ) from exc
+    if intent.to_dict() != source.execution_intent:
+        _fail("CPLADBAGR_EXECUTION_INTENT_INVALID")
+    if hash_execution_intent(intent) != source.execution_intent_hash:
+        _fail("CPLADBAGR_EXECUTION_INTENT_INVALID")
+    if intent.execution_intent_id != source.execution_intent_id:
+        _fail("CPLADBAGR_EXECUTION_INTENT_INVALID")
+    if descriptor.adapter_contract_id != source.adapter_contract_id:
+        _fail("CPLADBAGR_ADAPTER_INVALID")
+    if descriptor.adapter_contract_hash != source.adapter_contract_hash:
+        _fail("CPLADBAGR_ADAPTER_INVALID")
+    if descriptor.adapter_contract_version != source.adapter_contract_version:
+        _fail("CPLADBAGR_ADAPTER_INVALID")
+    if descriptor.model_dump(mode="json") != source.adapter_contract_descriptor:
+        _fail("CPLADBAGR_ADAPTER_INVALID")
+
+
+def _decision(value: Any) -> BindAuthorizationGateReviewDecision:
+    try:
+        decision = BindAuthorizationGateReviewDecision.model_validate(
+            _json(value)
+        )
+        decision = decision.model_copy(
+            update={"reviewed_at": _timestamp(decision.reviewed_at)}
+        )
+    except (ValidationError, TypeError) as exc:
+        raise CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError(
+            "CPLADBAGR_DECISION_INVALID"
+        ) from exc
+    if not all(getattr(decision, field) for field in ACKNOWLEDGEMENTS):
+        _fail("CPLADBAGR_ACKNOWLEDGEMENT_MISSING")
+    return decision
+
+
+def _derived(source: Any, decision: Any) -> tuple[Any, ...]:
+    accepted = decision.review_outcome == OUTCOMES[0]
+    decision_digest = _digest(DOMAINS["decision"], decision)
+    result = {
+        "source_human_approval_reference_linkage_passed": True,
+        "source_authority_evidence_reference_linkage_passed": True,
+        "source_bind_pre_dispatch_review_passed": True,
+        "exact_execution_intent_preserved": True,
+        "exact_adapter_preserved": True,
+        "exact_endpoint_binding_preserved": True,
+        "exact_credential_scope_binding_preserved": True,
+        "all_required_local_linkage_artifacts_present": True,
+        "all_required_local_linkage_artifacts_verified": True,
+        "source_final_readiness_passed": True,
+        "gate_review_passed": accepted,
+        "accepted_for_future_promotion_native_fresh_verified_source_gate": accepted,
+        "rejection_reasons": [] if accepted else ["BIND_AUTHORIZATION_GATE_REVIEW_FAILED"],
+        "comparison_mode": CHECK_MODE,
+        "semantic_match_used": False,
+        "creates_bind_authorization": False,
+        "creates_execution_authority": False,
+        "creates_human_approval": False,
+        "externally_verifies_human_approval": False,
+        "creates_authority_evidence": False,
+        "externally_verifies_authority_evidence": False,
+    }
+    context = {
+        "source_final_bind_authorization_readiness_id": source.promotion_live_adapter_dry_run_final_bind_authorization_readiness_id,
+        "source_final_bind_authorization_readiness_hash": source.promotion_live_adapter_dry_run_final_bind_authorization_readiness_hash,
+        "source_final_readiness_context_digest": source.final_readiness_context_digest,
+        "source_final_readiness_decision_digest": source.final_bind_authorization_readiness_review_decision_digest,
+        "source_final_readiness_result_digest": source.final_bind_authorization_readiness_result_digest,
+        "source_final_readiness_check_digest": source.final_bind_authorization_readiness_check_digest,
+        "source_final_readiness_authorization_requirements_digest": source.future_bind_authorization_requirement_digest,
+        "source_final_readiness_invocation_requirements_digest": source.future_bind_invocation_requirement_digest,
+        "source_human_approval_linkage_context_digest": source.human_approval_linkage_context_digest,
+        "source_authority_evidence_linkage_review_id": source.source_authority_evidence_linkage_review_id,
+        "source_authority_evidence_linkage_review_hash": source.source_authority_evidence_linkage_review_hash,
+        "source_authority_evidence_linkage_context_digest": source.source_authority_evidence_linkage_context_digest,
+        "source_bind_pre_dispatch_review_id": source.source_bind_pre_dispatch_review_id,
+        "source_bind_pre_dispatch_review_hash": source.source_bind_pre_dispatch_review_hash,
+        "source_operator_review_id": source.source_operator_review_id,
+        "source_operator_review_hash": source.source_operator_review_hash,
+        "source_credential_authorization_id": source.source_credential_authorization_id,
+        "source_credential_authorization_hash": source.source_credential_authorization_hash,
+        "source_endpoint_allowlist_evaluation_id": source.source_endpoint_allowlist_evaluation_id,
+        "source_endpoint_allowlist_evaluation_hash": source.source_endpoint_allowlist_evaluation_hash,
+        "execution_intent_id": source.execution_intent_id,
+        "execution_intent_hash": source.execution_intent_hash,
+        "adapter_contract_id": source.adapter_contract_id,
+        "adapter_contract_hash": source.adapter_contract_hash,
+        "endpoint_candidate_id": source.endpoint_candidate["endpoint_candidate_id"],
+        "endpoint_candidate_digest": source.endpoint_candidate_digest,
+        "endpoint_identity_binding_digest": source.endpoint_identity_binding_digest,
+        "credential_reference_id": source.credential_reference["credential_reference_id"],
+        "credential_reference_digest": source.credential_reference_digest,
+        "credential_scope_binding_digest": source.credential_scope_binding_digest,
+        "operator_review_binding_digest": source.operator_review_binding_digest,
+        "bind_boundary_precondition_digest": source.bind_boundary_precondition_digest,
+        "authority_evidence_reference_bundle_digest": source.authority_evidence_reference_bundle_digest,
+        "authority_evidence_binding_matrix_digest": source.authority_evidence_binding_matrix_digest,
+        "authority_evidence_linkage_context_digest": source.authority_evidence_linkage_context_digest,
+        "human_approval_reference_bundle_digest": source.human_approval_reference_bundle_digest,
+        "human_approval_binding_matrix_digest": source.human_approval_binding_matrix_digest,
+        "human_approval_linkage_context_digest": source.human_approval_linkage_context_digest,
+        "bind_authorization_gate_review_decision_digest": decision_digest,
+        "policy_snapshot_lineage": _json(source.policy_snapshot_lineage),
+        "policy_lineage": _json(source.policy_lineage),
+        "approval_context": _json(source.approval_context),
+    }
+    checks = [
+        {
+            "ordinal": ordinal,
+            "name": name,
+            "passed": True,
+            "comparison_mode": CHECK_MODE,
+        }
+        for ordinal, name in enumerate(CHECK_NAMES, 1)
+    ]
+    authorization = [
+        {
+            "ordinal": ordinal,
+            "name": name,
+            "separate_future_artifact_required": True,
+            "satisfied_by_this_packet": False,
+        }
+        for ordinal, name in enumerate(AUTHORIZATION_REQUIREMENTS, 1)
+    ]
+    invocation = [
+        {
+            "ordinal": ordinal,
+            "name": name,
+            "separate_future_artifact_required": True,
+            "satisfied_by_this_packet": False,
+        }
+        for ordinal, name in enumerate(INVOCATION_REQUIREMENTS, 1)
+    ]
+    return decision_digest, result, context, checks, authorization, invocation
+
+
+def _assemble(source: Any, decision: Any, recorded_at: str) -> dict[str, Any]:
+    source_raw = source.model_dump(mode="json")
+    decision_digest, result, context, checks, authorization, invocation = _derived(
+        source, decision
+    )
+    accepted = result[
+        "accepted_for_future_promotion_native_fresh_verified_source_gate"
+    ]
+    raw = {
+        "format_version": FORMAT_VERSION,
+        "bind_authorization_gate_review_mechanism": MECHANISM,
+        "bind_authorization_gate_review_recorded_at": recorded_at,
+        "source_final_bind_authorization_readiness_id": source.promotion_live_adapter_dry_run_final_bind_authorization_readiness_id,
+        "source_final_bind_authorization_readiness_hash": source.promotion_live_adapter_dry_run_final_bind_authorization_readiness_hash,
+        "source_final_bind_authorization_readiness_packet": source_raw,
+        **{field: source_raw[field] for field in COPY_FIELDS},
+        "bind_authorization_gate_review_decision": decision.model_dump(
+            mode="json"
+        ),
+        "bind_authorization_gate_review_decision_digest": decision_digest,
+        "bind_authorization_gate_review_result": result,
+        "bind_authorization_gate_review_result_digest": _digest(
+            DOMAINS["result"], result
+        ),
+        "bind_authorization_gate_review_context": context,
+        "bind_authorization_gate_review_context_digest": _digest(DOMAINS["context"], context),
+        "bind_authorization_gate_review_checks": checks,
+        "bind_authorization_gate_review_check_digest": _digest(
+            DOMAINS["checks"], checks
+        ),
+        "future_bind_authorization_requirements": authorization,
+        "future_bind_authorization_requirement_digest": _digest(
+            DOMAINS["authorization"], authorization
+        ),
+        "future_bind_invocation_requirements": invocation,
+        "future_bind_invocation_requirement_digest": _digest(
+            DOMAINS["invocation"], invocation
+        ),
+        "bind_authorization_gate_review_status": STATUS,
+        "request_dispatch_state": "NOT_DISPATCHED",
+        "bind_state": "NOT_BOUND",
+        "authority_state": "NOT_AUTHORIZED",
+        "human_approval_state": "NOT_APPROVED",
+        "gate_review_state": OUTCOMES[0] if accepted else OUTCOMES[1],
+        "ready_for_promotion_native_fresh_verified_source_gate": accepted,
+        "bind_authorization_state": "NOT_AUTHORIZED",
+        "bind_context_hash_derived": False,
+        "fresh_verified_source_gate_still_required": True,
+        "fail_closed": not accepted,
+        **{field: False for field in EFFECT_FIELDS},
+    }
+    digest = _packet_hash(raw)
+    raw[
+        "promotion_live_adapter_dry_run_bind_authorization_gate_review_hash"
+    ] = digest
+    raw[
+        "promotion_live_adapter_dry_run_bind_authorization_gate_review_id"
+    ] = f"pladbagr:v1:sha256:{digest}"
+    return raw
+
+
+def build_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review_packet(
+    source_final_bind_authorization_readiness_packet: Any,
+    bind_authorization_gate_review_decision: Any,
+    bind_authorization_gate_review_recorded_at: datetime,
+) -> CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewPacket:
+    """Build self-verifying final readiness evidence without granting authority."""
+    source = _source(_json(source_final_bind_authorization_readiness_packet))
+    _validate_source(source)
+    decision = _decision(bind_authorization_gate_review_decision)
+    recorded_at = _timestamp(bind_authorization_gate_review_recorded_at)
+    source_at = _timestamp(source.final_bind_authorization_readiness_recorded_at)
+    if _timestamp(decision.reviewed_at) < source_at or recorded_at < _timestamp(
+        decision.reviewed_at
+    ):
+        _fail("CPLADBAGR_TIMESTAMP_ORDER_INVALID")
+    return verify_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review_packet(
+        _assemble(source, decision, recorded_at)
+    )
+
+
+def verify_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review_packet(
+    raw: Any,
+) -> CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewPacket:
+    """Independently reconstruct and verify the source, bindings, and hashes."""
+    try:
+        value = raw.model_dump(mode="json") if isinstance(raw, BaseModel) else raw
+        packet = CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewPacket.model_validate(
+            _json(value)
+        )
+    except (ValidationError, TypeError) as exc:
+        raise CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError(
+            "CPLADBAGR_PACKET_INVALID"
+        ) from exc
+    source = _source(packet.source_final_bind_authorization_readiness_packet)
+    _validate_source(source)
+    decision = _decision(packet.bind_authorization_gate_review_decision)
+    source_at = _timestamp(source.final_bind_authorization_readiness_recorded_at)
+    reviewed_at = _timestamp(decision.reviewed_at)
+    recorded_at = _timestamp(packet.bind_authorization_gate_review_recorded_at)
+    if reviewed_at < source_at or recorded_at < reviewed_at:
+        _fail("CPLADBAGR_TIMESTAMP_ORDER_INVALID")
+    expected = _assemble(source, decision, recorded_at)
+    if packet.model_dump(mode="json") != expected:
+        _fail("CPLADBAGR_RECONSTRUCTION_MISMATCH")
+    return packet

--- a/veritas_os/tests/test_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review.py
+++ b/veritas_os/tests/test_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review.py
@@ -1,0 +1,139 @@
+"""Fail-closed tests for the promotion-native Bind gate review boundary."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+
+from veritas_os.policy.canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review import (
+    ACKNOWLEDGEMENTS,
+    AUTHORIZATION_REQUIREMENTS,
+    EFFECT_FIELDS,
+    INVOCATION_REQUIREMENTS,
+    OUTCOMES,
+    CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError,
+    build_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review_packet,
+    verify_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review_packet,
+)
+from veritas_os.tests.test_canonical_promotion_live_adapter_dry_run_final_bind_authorization_readiness import (
+    RECORDED_AT as SOURCE_AT,
+    _packet as source_packet,
+)
+
+RECORDED_AT = SOURCE_AT + timedelta(seconds=1)
+
+
+def _decision(*, passed: bool = True, **changes):
+    value = {
+        "bind_authorization_gate_review_decision_id": "gate-review:1",
+        "reviewer_id": "operator:alice",
+        "reviewer_role": "bind-gate-reviewer",
+        "reviewer_attestation": "I reviewed only the local prerequisite gate.",
+        "reviewed_at": RECORDED_AT.isoformat(),
+        "review_outcome": OUTCOMES[0] if passed else OUTCOMES[1],
+        "review_reason": "verified final readiness packet",
+        **{name: True for name in ACKNOWLEDGEMENTS},
+    }
+    value.update(changes)
+    return value
+
+
+def _packet(*, passed=True, decision=None):
+    return build_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review_packet(
+        source_packet(), decision or _decision(passed=passed), RECORDED_AT
+    )
+
+
+def test_pass_and_fail_route_without_authority_or_effects():
+    passed = _packet()
+    failed = _packet(passed=False)
+    assert verify_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review_packet(passed) == passed
+    assert verify_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review_packet(failed) == failed
+    assert passed.ready_for_promotion_native_fresh_verified_source_gate
+    assert not passed.fail_closed
+    assert not failed.ready_for_promotion_native_fresh_verified_source_gate
+    assert failed.fail_closed
+    assert passed.gate_review_state == OUTCOMES[0]
+    assert failed.gate_review_state == OUTCOMES[1]
+    assert not any(getattr(passed, name) for name in EFFECT_FIELDS)
+    assert passed.bind_context_hash_derived is False
+
+
+def test_exact_typed_preservation_and_json_round_trip():
+    source = source_packet()
+    packet = _packet()
+    for name in source.model_fields:
+        if name in packet.model_fields and name not in {
+            "future_bind_authorization_requirements",
+            "future_bind_authorization_requirement_digest",
+        }:
+            assert getattr(packet, name) == getattr(source, name)
+    raw = packet.model_dump(mode="json")
+    assert verify_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review_packet(raw) == packet
+    assert packet.source_final_bind_authorization_readiness_packet == source.model_dump(mode="json")
+
+
+def test_decision_is_bound_to_context_and_packet_hash():
+    first = _packet()
+    second = _packet(decision=_decision(reviewer_id="operator:bob", review_reason="independent review"))
+    assert first.bind_authorization_gate_review_decision_digest != second.bind_authorization_gate_review_decision_digest
+    assert first.bind_authorization_gate_review_context_digest != second.bind_authorization_gate_review_context_digest
+    assert first.promotion_live_adapter_dry_run_bind_authorization_gate_review_hash != second.promotion_live_adapter_dry_run_bind_authorization_gate_review_hash
+
+
+def test_remaining_requirements_are_exact_and_unsatisfied():
+    packet = _packet()
+    assert tuple(item.name for item in packet.future_bind_authorization_requirements) == AUTHORIZATION_REQUIREMENTS
+    assert tuple(item.name for item in packet.future_bind_invocation_requirements) == INVOCATION_REQUIREMENTS
+    assert all(not item.satisfied_by_this_packet for item in (*packet.future_bind_authorization_requirements, *packet.future_bind_invocation_requirements))
+
+
+@pytest.mark.parametrize("field", ACKNOWLEDGEMENTS)
+def test_false_acknowledgement_fails(field):
+    with pytest.raises(CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError):
+        _packet(decision=_decision(**{field: False}))
+
+
+@pytest.mark.parametrize("field", ["reviewer_id", "reviewer_role", "reviewer_attestation"])
+def test_empty_reviewer_metadata_fails(field):
+    with pytest.raises(CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError):
+        _packet(decision=_decision(**{field: ""}))
+
+
+@pytest.mark.parametrize("field", [
+    "execution_intent_hash", "adapter_contract_hash", "endpoint_identity_binding_digest",
+    "credential_scope_binding_digest", "operator_review_binding_digest",
+    "bind_boundary_precondition_digest", "authority_evidence_linkage_context_digest",
+    "human_approval_linkage_context_digest", "final_readiness_context_digest",
+])
+def test_source_tamper_fails(field):
+    raw = source_packet().model_dump(mode="json")
+    raw[field] = "0" * 64
+    with pytest.raises(CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError):
+        build_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review_packet(raw, _decision(), RECORDED_AT)
+
+
+@pytest.mark.parametrize("field,value", [
+    ("bind_authorization_gate_review_decision_digest", "0" * 64),
+    ("bind_authorization_gate_review_result_digest", "0" * 64),
+    ("bind_authorization_gate_review_context_digest", "0" * 64),
+    ("network_used", True), ("credential_material_accessed", True),
+    ("request_dispatched", True), ("bind_invoked", True),
+    ("external_effect_used", True), ("execution_authorized", True),
+    ("bind_authorization_issued", True), ("bind_context_hash_derived", True),
+])
+def test_output_tamper_fails(field, value):
+    raw = _packet().model_dump(mode="json")
+    raw[field] = value
+    with pytest.raises(CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError):
+        verify_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review_packet(raw)
+
+
+def test_unknown_shortcut_and_timestamp_fail_closed():
+    raw = _packet().model_dump(mode="json")
+    raw["safe_to_bind"] = True
+    with pytest.raises(CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError):
+        verify_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review_packet(raw)
+    with pytest.raises(CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError):
+        _packet(decision=_decision(reviewed_at="2026-01-01T00:00:00"))

--- a/veritas_os/tests/test_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review.py
+++ b/veritas_os/tests/test_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review.py
@@ -2,16 +2,21 @@
 
 from __future__ import annotations
 
+import ast
+import inspect
 from datetime import timedelta
 
 import pytest
 
+import veritas_os.policy.canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review as gate_module
 from veritas_os.policy.canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review import (
     ACKNOWLEDGEMENTS,
     AUTHORIZATION_REQUIREMENTS,
+    COPY_FIELDS,
     EFFECT_FIELDS,
     INVOCATION_REQUIREMENTS,
     OUTCOMES,
+    SOURCE_AUTHORIZATION_REQUIREMENTS,
     CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError,
     build_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review_packet,
     verify_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review_packet,
@@ -39,54 +44,165 @@ def _decision(*, passed: bool = True, **changes):
     return value
 
 
-def _packet(*, passed=True, decision=None):
+def _packet(*, passed: bool = True, decision=None, recorded_at=RECORDED_AT):
     return build_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review_packet(
-        source_packet(), decision or _decision(passed=passed), RECORDED_AT
+        source_packet(), decision or _decision(passed=passed), recorded_at
+    )
+
+
+def _source_raw():
+    return source_packet().model_dump(mode="json")
+
+
+def _build_from_source_raw(raw):
+    return build_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review_packet(
+        raw, _decision(), RECORDED_AT
     )
 
 
 def test_pass_and_fail_route_without_authority_or_effects():
     passed = _packet()
     failed = _packet(passed=False)
-    assert verify_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review_packet(passed) == passed
-    assert verify_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review_packet(failed) == failed
+    assert (
+        verify_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review_packet(
+            passed
+        )
+        == passed
+    )
+    assert (
+        verify_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review_packet(
+            failed
+        )
+        == failed
+    )
     assert passed.ready_for_promotion_native_fresh_verified_source_gate
     assert not passed.fail_closed
     assert not failed.ready_for_promotion_native_fresh_verified_source_gate
     assert failed.fail_closed
     assert passed.gate_review_state == OUTCOMES[0]
     assert failed.gate_review_state == OUTCOMES[1]
-    assert not any(getattr(passed, name) for name in EFFECT_FIELDS)
+    assert passed.fresh_verified_source_gate_still_required is True
+    assert failed.fresh_verified_source_gate_still_required is True
+    assert passed.bind_authorization_state == "NOT_AUTHORIZED"
     assert passed.bind_context_hash_derived is False
+    assert passed.bind_authorization_gate_review_result.derives_bind_context_hash is False
+    assert not any(getattr(passed, name) for name in EFFECT_FIELDS)
 
 
-def test_exact_typed_preservation_and_json_round_trip():
+def test_complete_typed_preservation_and_json_round_trip():
     source = source_packet()
     packet = _packet()
-    for name in source.model_fields:
-        if name in packet.model_fields and name not in {
-            "future_bind_authorization_requirements",
-            "future_bind_authorization_requirement_digest",
-        }:
-            assert getattr(packet, name) == getattr(source, name)
-    raw = packet.model_dump(mode="json")
-    assert verify_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review_packet(raw) == packet
-    assert packet.source_final_bind_authorization_readiness_packet == source.model_dump(mode="json")
+    source_json = source.model_dump(mode="json")
+    packet_json = packet.model_dump(mode="json")
+
+    for name in COPY_FIELDS:
+        assert name in source.model_fields, name
+        assert name in packet.model_fields, name
+        assert getattr(packet, name) == getattr(source, name), name
+        assert packet_json[name] == source_json[name], name
+
+    assert (
+        packet.source_final_bind_authorization_requirements
+        == source.future_bind_authorization_requirements
+    )
+    assert (
+        packet.source_final_bind_authorization_requirement_digest
+        == source.future_bind_authorization_requirement_digest
+    )
+    assert (
+        packet.source_final_bind_invocation_requirements
+        == source.future_bind_invocation_requirements
+    )
+    assert (
+        packet.source_final_bind_invocation_requirement_digest
+        == source.future_bind_invocation_requirement_digest
+    )
+    assert packet.source_final_bind_authorization_readiness_packet == source_json
+
+    verified = verify_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review_packet(
+        packet_json
+    )
+    assert verified == packet
+    assert verified.bind_authorization_gate_review_context == packet.bind_authorization_gate_review_context
+    assert (
+        verified.promotion_live_adapter_dry_run_bind_authorization_gate_review_hash
+        == packet.promotion_live_adapter_dry_run_bind_authorization_gate_review_hash
+    )
+
+
+def test_source_to_gate_requirement_transition_is_exact():
+    source = source_packet()
+    packet = _packet()
+
+    source_auth = tuple(item.name for item in source.future_bind_authorization_requirements)
+    source_invocation = tuple(item.name for item in source.future_bind_invocation_requirements)
+    gate_auth = tuple(item.name for item in packet.future_bind_authorization_requirements)
+    gate_invocation = tuple(item.name for item in packet.future_bind_invocation_requirements)
+
+    assert source_auth == SOURCE_AUTHORIZATION_REQUIREMENTS
+    assert source_invocation == INVOCATION_REQUIREMENTS
+    assert gate_auth == AUTHORIZATION_REQUIREMENTS
+    assert gate_auth == source_auth[1:]
+    assert gate_invocation == source_invocation
+    assert all(
+        item.separate_future_artifact_required and not item.satisfied_by_this_packet
+        for item in (
+            *packet.future_bind_authorization_requirements,
+            *packet.future_bind_invocation_requirements,
+        )
+    )
+
+
+def test_human_and_authority_linkage_identity_are_directly_bound_in_context():
+    source = source_packet()
+    context = _packet().bind_authorization_gate_review_context
+    assert (
+        context["source_human_approval_linkage_review_id"]
+        == source.source_human_approval_linkage_review_id
+    )
+    assert (
+        context["source_human_approval_linkage_review_hash"]
+        == source.source_human_approval_linkage_review_hash
+    )
+    assert (
+        context["source_human_approval_linkage_context_digest"]
+        == source.human_approval_linkage_context_digest
+    )
+    assert (
+        context["source_authority_evidence_linkage_review_id"]
+        == source.source_authority_evidence_linkage_review_id
+    )
+    assert (
+        context["source_authority_evidence_linkage_review_hash"]
+        == source.source_authority_evidence_linkage_review_hash
+    )
+    assert (
+        context["source_authority_evidence_linkage_context_digest"]
+        == source.source_authority_evidence_linkage_context_digest
+    )
 
 
 def test_decision_is_bound_to_context_and_packet_hash():
     first = _packet()
-    second = _packet(decision=_decision(reviewer_id="operator:bob", review_reason="independent review"))
-    assert first.bind_authorization_gate_review_decision_digest != second.bind_authorization_gate_review_decision_digest
-    assert first.bind_authorization_gate_review_context_digest != second.bind_authorization_gate_review_context_digest
-    assert first.promotion_live_adapter_dry_run_bind_authorization_gate_review_hash != second.promotion_live_adapter_dry_run_bind_authorization_gate_review_hash
-
-
-def test_remaining_requirements_are_exact_and_unsatisfied():
-    packet = _packet()
-    assert tuple(item.name for item in packet.future_bind_authorization_requirements) == AUTHORIZATION_REQUIREMENTS
-    assert tuple(item.name for item in packet.future_bind_invocation_requirements) == INVOCATION_REQUIREMENTS
-    assert all(not item.satisfied_by_this_packet for item in (*packet.future_bind_authorization_requirements, *packet.future_bind_invocation_requirements))
+    second = _packet(
+        decision=_decision(
+            reviewer_id="operator:bob",
+            reviewer_attestation="Independent local prerequisite review.",
+            review_reason="independent review",
+        )
+    )
+    assert (
+        first.bind_authorization_gate_review_decision_digest
+        != second.bind_authorization_gate_review_decision_digest
+    )
+    assert (
+        first.bind_authorization_gate_review_context_digest
+        != second.bind_authorization_gate_review_context_digest
+    )
+    assert (
+        first.promotion_live_adapter_dry_run_bind_authorization_gate_review_hash
+        != second.promotion_live_adapter_dry_run_bind_authorization_gate_review_hash
+    )
 
 
 @pytest.mark.parametrize("field", ACKNOWLEDGEMENTS)
@@ -101,39 +217,200 @@ def test_empty_reviewer_metadata_fails(field):
         _packet(decision=_decision(**{field: ""}))
 
 
-@pytest.mark.parametrize("field", [
-    "execution_intent_hash", "adapter_contract_hash", "endpoint_identity_binding_digest",
-    "credential_scope_binding_digest", "operator_review_binding_digest",
-    "bind_boundary_precondition_digest", "authority_evidence_linkage_context_digest",
-    "human_approval_linkage_context_digest", "final_readiness_context_digest",
-])
-def test_source_tamper_fails(field):
-    raw = source_packet().model_dump(mode="json")
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("fail_closed", True),
+        ("ready_for_promotion_native_bind_authorization_gate_review", False),
+        ("fresh_verified_source_gate_still_required", False),
+    ],
+)
+def test_source_readiness_state_tamper_fails(field, value):
+    raw = _source_raw()
+    raw[field] = value
+    with pytest.raises(CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError):
+        _build_from_source_raw(raw)
+
+
+def test_rejected_source_final_readiness_cannot_enter_gate():
+    raw = _source_raw()
+    raw["final_readiness_state"] = (
+        "NOT_READY_FOR_FUTURE_PROMOTION_NATIVE_BIND_AUTHORIZATION_GATE"
+    )
+    raw["ready_for_promotion_native_bind_authorization_gate_review"] = False
+    raw["fail_closed"] = True
+    with pytest.raises(CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError):
+        _build_from_source_raw(raw)
+
+
+def test_source_authorization_requirement_lifecycle_drift_fails():
+    source = source_packet()
+    first = source.future_bind_authorization_requirements[0].model_copy(
+        update={"name": "fresh_verified_source_gate"}
+    )
+    modified = source.model_copy(
+        update={
+            "future_bind_authorization_requirements": (
+                first,
+                *source.future_bind_authorization_requirements[1:],
+            )
+        }
+    )
+    with pytest.raises(CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError):
+        gate_module._validate_source(modified)
+
+
+def test_source_invocation_requirement_lifecycle_drift_fails():
+    source = source_packet()
+    first = source.future_bind_invocation_requirements[0].model_copy(
+        update={"name": "network_dispatch"}
+    )
+    modified = source.model_copy(
+        update={
+            "future_bind_invocation_requirements": (
+                first,
+                *source.future_bind_invocation_requirements[1:],
+            )
+        }
+    )
+    with pytest.raises(CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError):
+        gate_module._validate_source(modified)
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "execution_intent_hash",
+        "adapter_contract_hash",
+        "endpoint_identity_binding_digest",
+        "credential_scope_binding_digest",
+        "operator_review_binding_digest",
+        "bind_boundary_precondition_digest",
+        "authority_evidence_linkage_context_digest",
+        "human_approval_linkage_context_digest",
+        "final_bind_authorization_readiness_review_decision_digest",
+        "final_bind_authorization_readiness_result_digest",
+        "final_bind_authorization_readiness_check_digest",
+        "final_readiness_context_digest",
+        "source_human_approval_linkage_review_id",
+        "source_human_approval_linkage_review_hash",
+        "source_authority_evidence_linkage_review_id",
+        "source_authority_evidence_linkage_review_hash",
+    ],
+)
+def test_source_scalar_tamper_fails(field):
+    raw = _source_raw()
     raw[field] = "0" * 64
     with pytest.raises(CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError):
-        build_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review_packet(raw, _decision(), RECORDED_AT)
+        _build_from_source_raw(raw)
 
 
-@pytest.mark.parametrize("field,value", [
-    ("bind_authorization_gate_review_decision_digest", "0" * 64),
-    ("bind_authorization_gate_review_result_digest", "0" * 64),
-    ("bind_authorization_gate_review_context_digest", "0" * 64),
-    ("network_used", True), ("credential_material_accessed", True),
-    ("request_dispatched", True), ("bind_invoked", True),
-    ("external_effect_used", True), ("execution_authorized", True),
-    ("bind_authorization_issued", True), ("bind_context_hash_derived", True),
-])
-def test_output_tamper_fails(field, value):
+@pytest.mark.parametrize("field", ["policy_snapshot_lineage", "policy_lineage", "approval_context"])
+def test_source_lineage_or_approval_context_tamper_fails(field):
+    raw = _source_raw()
+    raw[field] = {"tampered": True}
+    with pytest.raises(CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError):
+        _build_from_source_raw(raw)
+
+
+def test_nested_execution_intent_tamper_fails():
+    raw = _source_raw()
+    raw["execution_intent"] = dict(raw["execution_intent"])
+    raw["execution_intent"]["request_id"] = "request:tampered"
+    with pytest.raises(CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError):
+        _build_from_source_raw(raw)
+
+
+@pytest.mark.parametrize("field", ["adapter_contract_descriptor", "adapter_contract_version"])
+def test_adapter_descriptor_or_version_tamper_fails(field):
+    raw = _source_raw()
+    if field == "adapter_contract_descriptor":
+        raw[field] = dict(raw[field])
+        raw[field]["adapter_contract_version"] = "tampered"
+    else:
+        raw[field] = "tampered"
+    with pytest.raises(CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError):
+        _build_from_source_raw(raw)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("bind_authorization_gate_review_decision_digest", "0" * 64),
+        ("bind_authorization_gate_review_result_digest", "0" * 64),
+        ("bind_authorization_gate_review_context_digest", "0" * 64),
+        ("bind_authorization_gate_review_check_digest", "0" * 64),
+        ("network_used", True),
+        ("credential_material_accessed", True),
+        ("request_dispatched", True),
+        ("bind_invoked", True),
+        ("external_effect_used", True),
+        ("execution_authorized", True),
+        ("bind_authorization_issued", True),
+        ("bind_context_hash_derived", True),
+    ],
+)
+def test_output_scalar_tamper_fails(field, value):
     raw = _packet().model_dump(mode="json")
     raw[field] = value
     with pytest.raises(CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError):
-        verify_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review_packet(raw)
+        verify_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review_packet(
+            raw
+        )
+
+
+def test_gate_result_cannot_claim_bind_context_derivation():
+    raw = _packet().model_dump(mode="json")
+    raw["bind_authorization_gate_review_result"]["derives_bind_context_hash"] = True
+    with pytest.raises(CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError):
+        verify_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review_packet(
+            raw
+        )
+
+
+def test_future_authorization_requirement_tamper_fails():
+    raw = _packet().model_dump(mode="json")
+    raw["future_bind_authorization_requirements"][0]["name"] = (
+        "final_endpoint_identity_recheck"
+    )
+    with pytest.raises(CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError):
+        verify_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review_packet(
+            raw
+        )
+
+
+def test_future_invocation_requirement_tamper_fails():
+    raw = _packet().model_dump(mode="json")
+    raw["future_bind_invocation_requirements"][0]["name"] = "network_dispatch"
+    with pytest.raises(CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError):
+        verify_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review_packet(
+            raw
+        )
 
 
 def test_unknown_shortcut_and_timestamp_fail_closed():
     raw = _packet().model_dump(mode="json")
     raw["safe_to_bind"] = True
     with pytest.raises(CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError):
-        verify_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review_packet(raw)
+        verify_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review_packet(
+            raw
+        )
     with pytest.raises(CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError):
         _packet(decision=_decision(reviewed_at="2026-01-01T00:00:00"))
+    with pytest.raises(CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError):
+        _packet(recorded_at=SOURCE_AT)
+
+
+def test_production_module_has_no_test_or_effect_imports():
+    tree = ast.parse(inspect.getsource(gate_module))
+    imports = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imports.add(node.module)
+
+    assert not any(name.startswith("veritas_os.tests") for name in imports)
+    assert not any(name == "tests" or name.startswith("tests.") for name in imports)
+    forbidden = {"socket", "requests", "httpx", "urllib", "subprocess"}
+    assert forbidden.isdisjoint(imports)

--- a/veritas_os/tests/test_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review.py
+++ b/veritas_os/tests/test_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review.py
@@ -123,7 +123,10 @@ def test_complete_typed_preservation_and_json_round_trip():
         packet_json
     )
     assert verified == packet
-    assert verified.bind_authorization_gate_review_context == packet.bind_authorization_gate_review_context
+    assert (
+        verified.bind_authorization_gate_review_context
+        == packet.bind_authorization_gate_review_context
+    )
     assert (
         verified.promotion_live_adapter_dry_run_bind_authorization_gate_review_hash
         == packet.promotion_live_adapter_dry_run_bind_authorization_gate_review_hash
@@ -155,30 +158,44 @@ def test_source_to_gate_requirement_transition_is_exact():
 
 def test_human_and_authority_linkage_identity_are_directly_bound_in_context():
     source = source_packet()
+    embedded = source.source_human_approval_linkage_review_packet
     context = _packet().bind_authorization_gate_review_context
+
     assert (
         context["source_human_approval_linkage_review_id"]
         == source.source_human_approval_linkage_review_id
+        == embedded["promotion_live_adapter_dry_run_human_approval_linkage_review_id"]
     )
     assert (
         context["source_human_approval_linkage_review_hash"]
         == source.source_human_approval_linkage_review_hash
+        == embedded["promotion_live_adapter_dry_run_human_approval_linkage_review_hash"]
     )
     assert (
         context["source_human_approval_linkage_context_digest"]
         == source.human_approval_linkage_context_digest
+        == embedded["human_approval_linkage_context_digest"]
     )
     assert (
         context["source_authority_evidence_linkage_review_id"]
-        == source.source_authority_evidence_linkage_review_id
+        == embedded["source_authority_evidence_linkage_review_id"]
+        == source.final_readiness_context[
+            "source_authority_evidence_linkage_review_id"
+        ]
     )
     assert (
         context["source_authority_evidence_linkage_review_hash"]
-        == source.source_authority_evidence_linkage_review_hash
+        == embedded["source_authority_evidence_linkage_review_hash"]
+        == source.final_readiness_context[
+            "source_authority_evidence_linkage_review_hash"
+        ]
     )
     assert (
         context["source_authority_evidence_linkage_context_digest"]
-        == source.source_authority_evidence_linkage_context_digest
+        == embedded["source_authority_evidence_linkage_context_digest"]
+        == source.final_readiness_context[
+            "source_authority_evidence_linkage_context_digest"
+        ]
     )
 
 
@@ -294,13 +311,39 @@ def test_source_invocation_requirement_lifecycle_drift_fails():
         "final_readiness_context_digest",
         "source_human_approval_linkage_review_id",
         "source_human_approval_linkage_review_hash",
-        "source_authority_evidence_linkage_review_id",
-        "source_authority_evidence_linkage_review_hash",
     ],
 )
 def test_source_scalar_tamper_fails(field):
     raw = _source_raw()
     raw[field] = "0" * 64
+    with pytest.raises(CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError):
+        _build_from_source_raw(raw)
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "source_authority_evidence_linkage_review_id",
+        "source_authority_evidence_linkage_review_hash",
+        "source_authority_evidence_linkage_context_digest",
+    ],
+)
+def test_nested_authority_linkage_identity_tamper_fails(field):
+    raw = _source_raw()
+    raw["source_human_approval_linkage_review_packet"] = dict(
+        raw["source_human_approval_linkage_review_packet"]
+    )
+    raw["source_human_approval_linkage_review_packet"][field] = "0" * 64
+    with pytest.raises(CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError):
+        _build_from_source_raw(raw)
+
+
+def test_final_readiness_authority_identity_context_tamper_fails():
+    raw = _source_raw()
+    raw["final_readiness_context"] = dict(raw["final_readiness_context"])
+    raw["final_readiness_context"]["source_authority_evidence_linkage_review_id"] = (
+        "authority-linkage:tampered"
+    )
     with pytest.raises(CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError):
         _build_from_source_raw(raw)
 

--- a/veritas_os/tests/test_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review.py
+++ b/veritas_os/tests/test_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review.py
@@ -156,47 +156,91 @@ def test_source_to_gate_requirement_transition_is_exact():
     )
 
 
-def test_human_and_authority_linkage_identity_are_directly_bound_in_context():
+def test_human_and_nested_lineage_identity_are_directly_bound_in_context():
     source = source_packet()
     embedded = source.source_human_approval_linkage_review_packet
     context = _packet().bind_authorization_gate_review_context
 
+    expected = {
+        "source_human_approval_linkage_review_id": embedded[
+            "promotion_live_adapter_dry_run_human_approval_linkage_review_id"
+        ],
+        "source_human_approval_linkage_review_hash": embedded[
+            "promotion_live_adapter_dry_run_human_approval_linkage_review_hash"
+        ],
+        "source_human_approval_linkage_context_digest": embedded[
+            "human_approval_linkage_context_digest"
+        ],
+        "source_authority_evidence_linkage_review_id": embedded[
+            "source_authority_evidence_linkage_review_id"
+        ],
+        "source_authority_evidence_linkage_review_hash": embedded[
+            "source_authority_evidence_linkage_review_hash"
+        ],
+        "source_authority_evidence_linkage_context_digest": embedded[
+            "source_authority_evidence_linkage_context_digest"
+        ],
+        "source_bind_pre_dispatch_review_id": embedded[
+            "source_bind_pre_dispatch_review_id"
+        ],
+        "source_bind_pre_dispatch_review_hash": embedded[
+            "source_bind_pre_dispatch_review_hash"
+        ],
+        "source_operator_review_id": embedded["source_operator_review_id"],
+        "source_operator_review_hash": embedded["source_operator_review_hash"],
+        "source_credential_authorization_id": embedded[
+            "source_credential_authorization_id"
+        ],
+        "source_credential_authorization_hash": embedded[
+            "source_credential_authorization_hash"
+        ],
+        "source_endpoint_allowlist_evaluation_id": embedded[
+            "source_endpoint_allowlist_evaluation_id"
+        ],
+        "source_endpoint_allowlist_evaluation_hash": embedded[
+            "source_endpoint_allowlist_evaluation_hash"
+        ],
+    }
+    for key, value in expected.items():
+        assert context[key] == value, key
+        assert source.final_readiness_context[key] == value, key
+
     assert (
         context["source_human_approval_linkage_review_id"]
         == source.source_human_approval_linkage_review_id
-        == embedded["promotion_live_adapter_dry_run_human_approval_linkage_review_id"]
     )
     assert (
         context["source_human_approval_linkage_review_hash"]
         == source.source_human_approval_linkage_review_hash
-        == embedded["promotion_live_adapter_dry_run_human_approval_linkage_review_hash"]
     )
     assert (
-        context["source_human_approval_linkage_context_digest"]
-        == source.human_approval_linkage_context_digest
-        == embedded["human_approval_linkage_context_digest"]
+        context["source_endpoint_allowlist_evaluation_id"]
+        == source.source_endpoint_allowlist_evaluation_id
     )
     assert (
-        context["source_authority_evidence_linkage_review_id"]
-        == embedded["source_authority_evidence_linkage_review_id"]
-        == source.final_readiness_context[
-            "source_authority_evidence_linkage_review_id"
-        ]
+        context["source_endpoint_allowlist_evaluation_hash"]
+        == source.source_endpoint_allowlist_evaluation_hash
     )
-    assert (
-        context["source_authority_evidence_linkage_review_hash"]
-        == embedded["source_authority_evidence_linkage_review_hash"]
-        == source.final_readiness_context[
-            "source_authority_evidence_linkage_review_hash"
-        ]
+
+
+def test_non_promoted_lineage_is_derived_from_verified_embedded_packet():
+    source = source_packet()
+    embedded = source.source_human_approval_linkage_review_packet
+    context = _packet().bind_authorization_gate_review_context
+
+    non_promoted = (
+        "source_authority_evidence_linkage_review_id",
+        "source_authority_evidence_linkage_review_hash",
+        "source_bind_pre_dispatch_review_id",
+        "source_bind_pre_dispatch_review_hash",
+        "source_operator_review_id",
+        "source_operator_review_hash",
+        "source_credential_authorization_id",
+        "source_credential_authorization_hash",
     )
-    assert (
-        context["source_authority_evidence_linkage_context_digest"]
-        == embedded["source_authority_evidence_linkage_context_digest"]
-        == source.final_readiness_context[
-            "source_authority_evidence_linkage_context_digest"
-        ]
-    )
+    for field in non_promoted:
+        assert field not in source.model_fields, field
+        assert context[field] == embedded[field], field
 
 
 def test_decision_is_bound_to_context_and_packet_hash():
@@ -326,9 +370,17 @@ def test_source_scalar_tamper_fails(field):
         "source_authority_evidence_linkage_review_id",
         "source_authority_evidence_linkage_review_hash",
         "source_authority_evidence_linkage_context_digest",
+        "source_bind_pre_dispatch_review_id",
+        "source_bind_pre_dispatch_review_hash",
+        "source_operator_review_id",
+        "source_operator_review_hash",
+        "source_credential_authorization_id",
+        "source_credential_authorization_hash",
+        "source_endpoint_allowlist_evaluation_id",
+        "source_endpoint_allowlist_evaluation_hash",
     ],
 )
-def test_nested_authority_linkage_identity_tamper_fails(field):
+def test_nested_lineage_identity_tamper_fails(field):
     raw = _source_raw()
     raw["source_human_approval_linkage_review_packet"] = dict(
         raw["source_human_approval_linkage_review_packet"]
@@ -336,6 +388,45 @@ def test_nested_authority_linkage_identity_tamper_fails(field):
     raw["source_human_approval_linkage_review_packet"][field] = "0" * 64
     with pytest.raises(CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError):
         _build_from_source_raw(raw)
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "source_authority_evidence_linkage_review_id",
+        "source_bind_pre_dispatch_review_id",
+        "source_operator_review_id",
+        "source_credential_authorization_id",
+        "source_endpoint_allowlist_evaluation_id",
+    ],
+)
+def test_gate_helper_rejects_final_readiness_context_lineage_mismatch(field):
+    source = source_packet()
+    context = dict(source.final_readiness_context)
+    context[field] = "lineage:tampered"
+    modified = source.model_copy(update={"final_readiness_context": context})
+    with pytest.raises(CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError):
+        gate_module._verified_linkage_identity(modified)
+
+
+def test_gate_helper_rejects_human_linkage_top_level_identity_mismatch():
+    source = source_packet()
+    modified = source.model_copy(
+        update={"source_human_approval_linkage_review_id": "pladhal:tampered"}
+    )
+    with pytest.raises(CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError):
+        gate_module._verified_linkage_identity(modified)
+
+
+def test_gate_helper_rejects_unverified_nested_human_linkage_packet():
+    source = source_packet()
+    embedded = dict(source.source_human_approval_linkage_review_packet)
+    embedded["source_operator_review_id"] = "operator-review:tampered"
+    modified = source.model_copy(
+        update={"source_human_approval_linkage_review_packet": embedded}
+    )
+    with pytest.raises(CanonicalPromotionLiveAdapterDryRunBindAuthorizationGateReviewError):
+        gate_module._verified_linkage_identity(modified)
 
 
 def test_final_readiness_authority_identity_context_tamper_fails():


### PR DESCRIPTION
### Motivation

- Implement a promotion-native deterministic local prerequisite that reviews an accepted Final Bind Authorization Readiness packet without creating any authority, proofs, or external effects.
- Preserve and reverify the exact promotion-native chain (ExecutionIntent, adapter descriptor, endpoint/credential/operator bindings, Final Readiness evidence) so the next lifecycle boundary (Fresh Verified Source Gate) can be evaluated with typed, content-addressed artifacts.
- Enforce fail-closed, no-effect invariants and strict typed reviewer acknowledgements so the artifact cannot be used to create execution authority, bind context, dispatch, network calls, or credential access.

### Description

- Added a new production module `veritas_os/policy/canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review.py` implementing a content-addressed Gate Review packet with builder `build_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review_packet(...)` and verifier `verify_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review_packet(...)`.
- The Gate Review imports and independently verifies the authoritative promotion-native Final Bind Authorization Readiness packet and preserves the complete upstream typed field surface (imports `PRESERVED_FIELDS` from the Final Readiness module and includes the Final Readiness evidence digests and packet binding fields).
- Defines a frozen Pydantic review decision and a structured Gate Review result/context that explicitly records no-authority/no-effect acknowledgements, computes domain-separated canonical digests for decision/result/context/packet, and uses `pladbagr:v1:sha256:<64hex>` identity format.
- Implements deterministic PASS/FAIL routing: PASSED routes only to `ready_for_promotion_native_fresh_verified_source_gate` and FAILED sets `fail_closed=True`; both preserve `NOT_DISPATCHED`, `NOT_BOUND`, `NOT_AUTHORIZED`, no `bind_context_hash` derived, and keep all future authorization/invocation requirements unsatisfied except the current gate requirement.

### Testing

- Ran static/quick automated checks: `python -m py_compile veritas_os/policy/canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review.py veritas_os/tests/test_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review.py` which completed successfully in this environment.
- Ran style/lint verification: `ruff check veritas_os/policy/canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review.py veritas_os/tests/test_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review.py` which passed.
- Added focused pytest coverage under `veritas_os/tests/test_canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review.py` to verify PASSED/FAILED routing, exact typed preservation, context/decision binding, fail-closed behavior, tamper detection, timestamp ordering, and that no effect/capability flags can be set; however, running the full pytest matrix in this environment was blocked by missing runtime dependencies and interpreter configuration so full automated execution must be validated by CI (Py3.11/Py3.12/PostgreSQL matrix and repository security checks).
- Commit: `8cc8fdbd4ac80593cf263b20852cfc026c8a3c9a`; starting main SHA asserted was `5fa4ca1613bde0af771507ae5de1a44879f6ba55`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a96064c67ac8326ad343c0d8cd973c0)