### PR TITLE
ci: increase full Python test timeout to 180 minutes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -532,7 +532,7 @@ jobs:
     name: test (py${{ matrix.python-version }})
     needs: [lint, dependency-audit, governance-smoke, governance-backend-fast]
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 180
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
### Motivation

PR #2166's full Python 3.12 test job reached the existing 120-minute timeout twice while the Python 3.11 full suite, PostgreSQL, slow tests, governance checks, security gates, and CodeQL passed. This is a CI capacity change only; it does not modify governance or runtime behavior.

### Change

- Increase the full Python matrix job timeout in `.github/workflows/main.yml` from 120 to 180 minutes.
- No other workflow or code changes.

### Scope

This is an interim CI-only fix to allow the current full suite to finish. Longer term, the full test matrix should be sharded/parallelized rather than relying on ever-larger timeouts.

### Verification

The branch is one commit ahead of `main` and the compare shows exactly one file changed with 1 addition / 1 deletion.