### PR TITLE
ci: harden pnpm audit transport failures

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -527,10 +527,13 @@ jobs:
 
   # ============================================================
   # [Tier 1] Test matrix
+  # The dependency audit remains an independent blocking check. Keep it out of
+  # test-lane `needs` so an upstream registry outage cannot suppress test
+  # evidence while the audit itself still fails closed.
   # ============================================================
   test:
     name: test (py${{ matrix.python-version }}, shard ${{ matrix.shard }}/4)
-    needs: [lint, dependency-audit, governance-smoke, governance-backend-fast]
+    needs: [lint, governance-smoke, governance-backend-fast]
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
@@ -739,7 +742,7 @@ jobs:
   # ============================================================
   test-postgresql:
     name: test-postgresql (py3.12)
-    needs: [lint, dependency-audit, governance-smoke, governance-backend-fast]
+    needs: [lint, governance-smoke, governance-backend-fast]
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -871,7 +874,7 @@ jobs:
 
   test-slow:
     name: test-slow (py3.12)
-    needs: [lint, dependency-audit, governance-smoke, governance-backend-fast]
+    needs: [lint, governance-smoke, governance-backend-fast]
     runs-on: ubuntu-latest
     # test-slow installs the full requirements.txt which includes heavy optional
     # ML wheels (e.g. torch, torchvision). On a cold runner cache these can take
@@ -937,7 +940,7 @@ jobs:
   # ============================================================
   frontend-quality-gate:
     name: frontend-${{ matrix.gate }}
-    needs: [lint, dependency-audit, governance-smoke, governance-backend-fast]
+    needs: [lint, governance-smoke, governance-backend-fast]
     runs-on: ubuntu-latest
     timeout-minutes: 20
 

--- a/scripts/ci/pnpm_audit_gate.py
+++ b/scripts/ci/pnpm_audit_gate.py
@@ -1,16 +1,17 @@
-"""Run ``pnpm audit`` with explicit handling for retired npm audit endpoints.
+"""Run ``pnpm audit`` with bounded handling for npm audit endpoint failures.
 
 This helper keeps production dependency audit blocking for real vulnerability
-or runtime failures, while tolerating the known upstream endpoint retirement
-response (HTTP 410) that currently breaks ``pnpm audit`` regardless of local
-package state.
+or runtime failures. It tolerates only the known upstream endpoint-retirement
+response (HTTP 410), and retries transient registry transport failures before
+failing closed.
 
 Usage:
     python scripts/ci/pnpm_audit_gate.py --prod
 
 Exit codes:
-    0  Audit passed, or failed only because of known endpoint retirement.
-    >0 Any other pnpm audit failure (preserves pnpm exit code when possible).
+    0   Audit passed, or failed only because of known endpoint retirement.
+    75  The audit subprocess repeatedly exceeded its bounded timeout.
+    >0  Any other pnpm audit failure (preserves pnpm exit code when possible).
 """
 
 from __future__ import annotations
@@ -18,6 +19,7 @@ from __future__ import annotations
 import argparse
 import subprocess
 import sys
+import time
 from typing import Sequence
 
 _ENDPOINT_RETIREMENT_SIGNATURES = (
@@ -26,6 +28,25 @@ _ENDPOINT_RETIREMENT_SIGNATURES = (
     "responded with 410",
 )
 
+_TRANSIENT_TRANSPORT_SIGNATURES = (
+    "ERR_SOCKET_TIMEOUT",
+    "ETIMEDOUT",
+    "ECONNRESET",
+    "ECONNREFUSED",
+    "EAI_AGAIN",
+    "ENOTFOUND",
+    "socket timeout",
+    "network timeout",
+    "502 Bad Gateway",
+    "503 Service Unavailable",
+    "504 Gateway Timeout",
+)
+
+_MAX_ATTEMPTS = 3
+_ATTEMPT_TIMEOUT_SECONDS = 75
+_RETRY_DELAYS_SECONDS = (5, 15)
+_TEMPORARY_FAILURE_EXIT_CODE = 75
+
 
 def should_tolerate_endpoint_retirement(output: str) -> bool:
     """Return ``True`` when output matches known endpoint-retirement failures."""
@@ -33,45 +54,101 @@ def should_tolerate_endpoint_retirement(output: str) -> bool:
     return any(signature.lower() in lowered for signature in _ENDPOINT_RETIREMENT_SIGNATURES)
 
 
+def is_transient_transport_failure(output: str) -> bool:
+    """Return ``True`` only for known transient npm registry failures."""
+    lowered = output.lower()
+    return any(signature.lower() in lowered for signature in _TRANSIENT_TRANSPORT_SIGNATURES)
+
+
+def _text(value: str | bytes | None) -> str:
+    """Normalize subprocess output captured as text or bytes."""
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode(errors="replace")
+    return value
+
+
+def _emit_output(stdout: str, stderr: str) -> None:
+    """Preserve pnpm output in the workflow log."""
+    if stdout:
+        print(stdout, end="")
+    if stderr:
+        print(stderr, end="", file=sys.stderr)
+
+
 def run_pnpm_audit(args: Sequence[str]) -> int:
     """Execute ``pnpm audit`` and return the intended CI exit code."""
     cmd = ["pnpm", "audit", *args]
-    completed = subprocess.run(
-        cmd,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    for attempt in range(1, _MAX_ATTEMPTS + 1):
+        timed_out = False
+        try:
+            completed = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=_ATTEMPT_TIMEOUT_SECONDS,
+            )
+            stdout = completed.stdout
+            stderr = completed.stderr
+            returncode = completed.returncode
+        except subprocess.TimeoutExpired as exc:
+            timed_out = True
+            stdout = _text(exc.stdout)
+            stderr = _text(exc.stderr)
+            returncode = _TEMPORARY_FAILURE_EXIT_CODE
+            stderr += (
+                f"pnpm audit exceeded {_ATTEMPT_TIMEOUT_SECONDS}s "
+                "subprocess timeout.\n"
+            )
 
-    if completed.stdout:
-        print(completed.stdout, end="")
-    if completed.stderr:
-        print(completed.stderr, end="", file=sys.stderr)
+        _emit_output(stdout, stderr)
 
-    if completed.returncode == 0:
-        return 0
+        if returncode == 0:
+            return 0
 
-    combined_output = f"{completed.stdout}\n{completed.stderr}"
-    if should_tolerate_endpoint_retirement(combined_output):
+        combined_output = f"{stdout}\n{stderr}"
+        if should_tolerate_endpoint_retirement(combined_output):
+            print(
+                "::warning::pnpm audit failed due to npm audit endpoint retirement "
+                "(HTTP 410).",
+                file=sys.stderr,
+            )
+            print(
+                "::warning::Treating this as a temporary upstream outage to "
+                "avoid false-red CI.",
+                file=sys.stderr,
+            )
+            print(
+                "::warning::Security risk: production Node dependency "
+                "vulnerability blocking is degraded until scanner migration is "
+                "completed.",
+                file=sys.stderr,
+            )
+            return 0
+
+        transient = timed_out or is_transient_transport_failure(combined_output)
+        if not transient:
+            return returncode
+
+        if attempt == _MAX_ATTEMPTS:
+            print(
+                "::error::pnpm audit could not reach the npm registry after "
+                f"{_MAX_ATTEMPTS} bounded attempts; failing closed.",
+                file=sys.stderr,
+            )
+            return returncode
+
+        delay = _RETRY_DELAYS_SECONDS[attempt - 1]
         print(
-            "::warning::pnpm audit failed due to npm audit endpoint retirement "
-            "(HTTP 410).",
+            "::warning::Transient npm registry failure during pnpm audit "
+            f"(attempt {attempt}/{_MAX_ATTEMPTS}); retrying in {delay}s.",
             file=sys.stderr,
         )
-        print(
-            "::warning::Treating this as a temporary upstream outage to "
-            "avoid false-red CI.",
-            file=sys.stderr,
-        )
-        print(
-            "::warning::Security risk: production Node dependency "
-            "vulnerability blocking is degraded until scanner migration is "
-            "completed.",
-            file=sys.stderr,
-        )
-        return 0
+        time.sleep(delay)
 
-    return completed.returncode
+    raise AssertionError("unreachable")
 
 
 def parse_args(argv: Sequence[str]) -> argparse.Namespace:

--- a/tests/test_pnpm_audit_gate.py
+++ b/tests/test_pnpm_audit_gate.py
@@ -6,6 +6,8 @@ import subprocess
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 
+import yaml
+
 
 def _load_module():
     module_path = Path(__file__).resolve().parents[1] / "scripts" / "ci" / "pnpm_audit_gate.py"
@@ -41,10 +43,20 @@ def test_should_tolerate_endpoint_retirement_false() -> None:
     assert not pnpm_audit_gate.should_tolerate_endpoint_retirement(output)
 
 
+def test_transient_transport_failure_signatures_are_narrow() -> None:
+    """Known registry transport errors should be retryable, not tolerated."""
+    assert pnpm_audit_gate.is_transient_transport_failure("ERR_SOCKET_TIMEOUT")
+    assert pnpm_audit_gate.is_transient_transport_failure("503 Service Unavailable")
+    assert not pnpm_audit_gate.is_transient_transport_failure(
+        "high severity vulnerabilities found"
+    )
+
+
 def test_run_pnpm_audit_success(monkeypatch) -> None:
     """Successful pnpm audit exits with zero."""
 
-    def _fake_run(*_args, **_kwargs):
+    def _fake_run(*_args, **kwargs):
+        assert kwargs["timeout"] == pnpm_audit_gate._ATTEMPT_TIMEOUT_SECONDS
         return _completed(returncode=0, stdout="ok")
 
     monkeypatch.setattr(pnpm_audit_gate.subprocess, "run", _fake_run)
@@ -65,13 +77,86 @@ def test_run_pnpm_audit_tolerates_known_410(monkeypatch) -> None:
 
 
 def test_run_pnpm_audit_preserves_other_failures(monkeypatch) -> None:
-    """Unexpected pnpm audit failures must remain blocking."""
+    """Vulnerability and unexpected failures remain immediately blocking."""
+
+    calls = 0
 
     def _fake_run(*_args, **_kwargs):
-        return _completed(returncode=42, stderr="network timeout")
+        nonlocal calls
+        calls += 1
+        return _completed(returncode=42, stderr="high severity vulnerabilities found")
 
     monkeypatch.setattr(pnpm_audit_gate.subprocess, "run", _fake_run)
     assert pnpm_audit_gate.run_pnpm_audit(["--audit-level=high", "--prod"]) == 42
+    assert calls == 1
+
+
+def test_run_pnpm_audit_retries_transient_failure_then_succeeds(monkeypatch) -> None:
+    """A transient registry failure should receive a bounded retry."""
+
+    results = iter(
+        [
+            _completed(returncode=1, stderr="ERR_SOCKET_TIMEOUT"),
+            _completed(returncode=0, stdout="No known vulnerabilities found"),
+        ]
+    )
+    sleeps: list[int] = []
+
+    monkeypatch.setattr(pnpm_audit_gate.subprocess, "run", lambda *_a, **_k: next(results))
+    monkeypatch.setattr(pnpm_audit_gate.time, "sleep", sleeps.append)
+
+    assert pnpm_audit_gate.run_pnpm_audit(["--audit-level=high", "--prod"]) == 0
+    assert sleeps == [5]
+
+
+def test_run_pnpm_audit_fails_closed_after_transient_retries(monkeypatch) -> None:
+    """Repeated transport failures must never become a passing audit."""
+
+    calls = 0
+    sleeps: list[int] = []
+
+    def _fake_run(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        return _completed(returncode=37, stderr="request failed: ECONNRESET")
+
+    monkeypatch.setattr(pnpm_audit_gate.subprocess, "run", _fake_run)
+    monkeypatch.setattr(pnpm_audit_gate.time, "sleep", sleeps.append)
+
+    assert pnpm_audit_gate.run_pnpm_audit(["--audit-level=high", "--prod"]) == 37
+    assert calls == 3
+    assert sleeps == [5, 15]
+
+
+def test_run_pnpm_audit_bounds_hung_subprocess(monkeypatch) -> None:
+    """A hung pnpm process should be retried and end as temporary failure."""
+
+    calls = 0
+
+    def _fake_run(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        raise subprocess.TimeoutExpired(cmd="pnpm audit", timeout=75)
+
+    monkeypatch.setattr(pnpm_audit_gate.subprocess, "run", _fake_run)
+    monkeypatch.setattr(pnpm_audit_gate.time, "sleep", lambda _seconds: None)
+
+    assert (
+        pnpm_audit_gate.run_pnpm_audit(["--audit-level=high", "--prod"])
+        == pnpm_audit_gate._TEMPORARY_FAILURE_EXIT_CODE
+    )
+    assert calls == 3
+
+
+def test_main_test_lanes_do_not_wait_for_dependency_audit() -> None:
+    """Registry outages must not suppress independent test evidence."""
+    workflow_path = Path(__file__).resolve().parents[1] / ".github/workflows/main.yml"
+    workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+
+    jobs = workflow["jobs"]
+    assert "continue-on-error" not in jobs["dependency-audit"]
+    for job_name in ("test", "test-postgresql", "test-slow", "frontend-quality-gate"):
+        assert "dependency-audit" not in jobs[job_name]["needs"]
 
 
 def test_parse_args_accepts_pnpm_options_without_separator() -> None:


### PR DESCRIPTION
## Summary

- classify known npm registry transport failures separately from vulnerability findings
- retry transient transport failures at most three times with bounded per-attempt timeouts
- continue to fail closed when transient failures persist or a real audit finding/runtime error occurs
- keep Python, PostgreSQL, slow, and frontend test lanes independent from the external dependency-audit service so test evidence is still produced during a registry outage

## Security boundary

- production `pnpm audit --audit-level=high --prod` remains blocking
- vulnerability findings are not ignored or retried as transport errors
- exhausted transport retries return a non-zero status
- no lint, coverage, test, governance, or release threshold is weakened

## Verification

- audit-gate regression suite: 11 cases
- manual success, HTTP 410, vulnerability, transient recovery, transient exhaustion, and subprocess-timeout checks
- workflow dependency assertions
- Python compilation
- YAML parse
- `git diff --check`

Signed-off-by: Codex <codex@openai.com>