### PR TITLE
feat(policy): add final credential scope recheck

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -425,7 +425,13 @@ jobs:
           set -euxo pipefail
           python -m pip install --upgrade pip
           python -m pip install -r veritas_os/requirements.txt
-          python -m pip install --upgrade "fastapi>=0.121,<0.123" "pydantic>=2.10,<2.12"
+          # Starlette 0.49.1 still imports anyio.abc.BlockingPortal. AnyIO 4.15
+          # deprecates that alias, so keep this preview on the last warning-clean
+          # AnyIO 4.x range until Starlette removes the upstream reference.
+          python -m pip install --upgrade \
+            "fastapi>=0.121,<0.123" \
+            "pydantic>=2.10,<2.12" \
+            "anyio<4.15"
 
       - name: Print resolved dependency versions
         run: |
@@ -434,10 +440,12 @@ jobs:
           import fastapi
           import pydantic
           import starlette
+          from importlib.metadata import version
 
           print(f"fastapi {fastapi.__version__}")
           print(f"pydantic {pydantic.__version__}")
           print(f"starlette {starlette.__version__}")
+          print(f"anyio {version('anyio')}")
           PY
           python -m pip check
 
@@ -480,6 +488,7 @@ jobs:
             echo "### Dry-run ranges"
             echo "- fastapi: \`>=0.121,<0.123\`"
             echo "- pydantic: \`>=2.10,<2.12\`"
+            echo "- anyio: \`<4.15\` (temporary Starlette 0.49.1 compatibility ceiling)"
             echo ""
             echo "### Resolved versions"
             echo "\`\`\`text"

--- a/veritas_os/policy/canonical_promotion_live_adapter_dry_run_final_credential_scope_recheck.py
+++ b/veritas_os/policy/canonical_promotion_live_adapter_dry_run_final_credential_scope_recheck.py
@@ -1,0 +1,684 @@
+"""Recheck exact credential metadata and scope without credential access.
+
+This deterministic, content-addressed boundary consumes only the final
+credential scope recheck lifecycle requirement.  It compares caller-supplied
+complete credential metadata and the operation-required scope with the
+credential reference, scope binding, and exact Bind context already committed
+by the verified source packet.  Scope containment is never inferred: every
+scope character must match.  The boundary never resolves credential material,
+accesses a credential store, grants authority, dispatches, writes TrustLog, or
+performs Bind.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, create_model
+
+from veritas_os.policy.canonical_promotion_live_adapter_dry_run_credential_authorization import (
+    PROHIBITED_KEYS,
+    REFERENCE_DOMAIN,
+    SCOPE_BINDING_DOMAIN,
+    CredentialReference,
+)
+from veritas_os.policy.canonical_promotion_live_adapter_dry_run_final_endpoint_identity_recheck import (
+    AUTHORIZATION_REQUIREMENTS as SOURCE_AUTHORIZATION_REQUIREMENTS,
+    EFFECT_FIELDS,
+    INVOCATION_REQUIREMENTS,
+    PRESERVED_FIELDS as UPSTREAM_PRESERVED_FIELDS,
+    STATE as SOURCE_STATE,
+    STATUS as SOURCE_STATUS,
+    CanonicalPromotionLiveAdapterDryRunFinalEndpointIdentityRecheckError,
+    CanonicalPromotionLiveAdapterDryRunFinalEndpointIdentityRecheckPacket,
+    verify_canonical_promotion_live_adapter_dry_run_final_endpoint_identity_recheck_packet,
+)
+from veritas_os.policy.canonical_promotion_live_adapter_dry_run_bind_context_hash_derivation import (
+    DOMAINS as BIND_CONTEXT_DOMAINS,
+)
+
+FORMAT_VERSION = (
+    "canonical-promotion-live-adapter-dry-run-final-credential-scope-recheck/v1"
+)
+MECHANISM = "exact_local_bind_context_bound_credential_scope_recheck_only/v1"
+STATUS = "PROMOTION_NATIVE_FINAL_CREDENTIAL_SCOPE_RECHECKED_NOT_AUTHORIZED"
+STATE = "RECHECKED_FOR_FUTURE_RUNTIME_RISK_REVIEW"
+CHECK_MODE = "deterministic_local_exact_credential_metadata_scope_recheck_only"
+SCOPE_MATCH_MODE = "exact_character_match_only_no_containment_inference"
+PREFIX = "veritas.promotion-live-adapter-dry-run-final-credential-scope-recheck"
+HASH_PATTERN = r"^[0-9a-f]{64}$"
+DOMAINS = {
+    name: f"{PREFIX}.{name}/v1"
+    for name in (
+        "binding",
+        "result",
+        "context",
+        "checks",
+        "authorization",
+        "invocation",
+        "packet",
+    )
+}
+AUTHORIZATION_REQUIREMENTS = SOURCE_AUTHORIZATION_REQUIREMENTS[1:]
+CHECK_NAMES = (
+    "source_final_endpoint_identity_recheck_verified",
+    "source_endpoint_identity_recheck_bound",
+    "source_exact_bind_context_hash_recomputed",
+    "caller_credential_reference_closed_schema_valid",
+    "caller_credential_reference_exact_match",
+    "caller_credential_reference_digest_verified",
+    "source_credential_scope_binding_digest_verified",
+    "credential_scope_binding_bound_to_bind_context",
+    "required_credential_scope_non_empty",
+    "required_credential_scope_exact_character_match",
+    "credential_scope_containment_not_inferred",
+    "credential_reference_swap_absent",
+    "future_authorization_requirements_preserved",
+    "future_invocation_requirements_preserved",
+    "credential_resolution_absent",
+    "credential_store_access_absent",
+    "credential_material_access_absent",
+    "execution_authority_absent",
+    "bind_authorization_absent",
+    "network_access_absent",
+    "trustlog_write_absent",
+    "external_effect_absent",
+)
+ENDPOINT_RECHECK_EVIDENCE_FIELDS = (
+    "endpoint_identity_rechecked_at",
+    "rechecked_endpoint_candidate",
+    "rechecked_endpoint_candidate_digest",
+    "final_endpoint_identity_binding",
+    "final_endpoint_identity_binding_digest",
+    "final_endpoint_identity_recheck_result",
+    "final_endpoint_identity_recheck_result_digest",
+    "final_endpoint_identity_recheck_context",
+    "final_endpoint_identity_recheck_context_digest",
+    "final_endpoint_identity_recheck_checks",
+    "final_endpoint_identity_recheck_check_digest",
+    "final_endpoint_identity_recheck_status",
+    "final_endpoint_identity_recheck_state",
+)
+PRESERVED_FIELDS = tuple(
+    dict.fromkeys((*UPSTREAM_PRESERVED_FIELDS, *ENDPOINT_RECHECK_EVIDENCE_FIELDS))
+)
+
+
+class CanonicalPromotionLiveAdapterDryRunFinalCredentialScopeRecheckError(ValueError):
+    """Stable fail-closed error for invalid final credential recheck evidence."""
+
+
+class FinalCredentialScopeRecheckResult(BaseModel):
+    """Truthful exact credential metadata comparison with no runtime claims."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    source_final_endpoint_identity_recheck_verified: Literal[True]
+    source_endpoint_identity_recheck_bound: Literal[True]
+    source_exact_bind_context_hash_recomputed: Literal[True]
+    caller_credential_reference_closed_schema_valid: Literal[True]
+    caller_credential_reference_exact_match: Literal[True]
+    caller_credential_reference_digest_verified: Literal[True]
+    source_credential_scope_binding_digest_verified: Literal[True]
+    credential_scope_binding_bound_to_bind_context: Literal[True]
+    required_credential_scope_non_empty: Literal[True]
+    required_credential_scope_exact_character_match: Literal[True]
+    credential_scope_containment_not_inferred: Literal[True]
+    credential_reference_swap_absent: Literal[True]
+    future_authorization_requirements_preserved: Literal[True]
+    future_invocation_requirements_preserved: Literal[True]
+    credential_resolution_absent: Literal[True]
+    credential_store_access_absent: Literal[True]
+    credential_material_access_absent: Literal[True]
+    execution_authority_absent: Literal[True]
+    bind_authorization_absent: Literal[True]
+    network_access_absent: Literal[True]
+    trustlog_write_absent: Literal[True]
+    external_effect_absent: Literal[True]
+    bind_context_hash: str = Field(pattern=HASH_PATTERN)
+    credential_reference_digest: str = Field(pattern=HASH_PATTERN)
+    credential_scope_binding_digest: str = Field(pattern=HASH_PATTERN)
+    final_credential_scope_binding_digest: str = Field(pattern=HASH_PATTERN)
+    required_credential_scope: str = Field(min_length=1)
+    bound_credential_scope: str = Field(min_length=1)
+    recheck_mode: Literal[CHECK_MODE]
+    scope_match_mode: Literal[SCOPE_MATCH_MODE]
+    credential_reference_rechecked: Literal[True]
+    credential_scope_rechecked: Literal[True]
+    scope_containment_inferred: Literal[False]
+    trusted_clock_verified: Literal[False]
+    external_policy_freshness_verified: Literal[False]
+    credential_resolved: Literal[False]
+    credential_store_accessed: Literal[False]
+    credential_material_accessed: Literal[False]
+    revocation_verified: Literal[False]
+
+
+class FinalCredentialScopeRecheckCheck(BaseModel):
+    """An ordered local comparison check which performs no external effect."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    ordinal: int = Field(ge=1)
+    name: Literal[*CHECK_NAMES]
+    passed: Literal[True]
+    comparison_mode: Literal[CHECK_MODE]
+
+
+class FutureRequirement(BaseModel):
+    """A remaining lifecycle requirement not satisfied by this packet."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    ordinal: int = Field(ge=1)
+    name: Literal[*AUTHORIZATION_REQUIREMENTS, *INVOCATION_REQUIREMENTS]
+    separate_future_artifact_required: Literal[True]
+    satisfied_by_this_packet: Literal[False]
+
+
+class _PacketBase(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    format_version: Literal[FORMAT_VERSION]
+    promotion_live_adapter_dry_run_final_credential_scope_recheck_id: str = Field(
+        min_length=1
+    )
+    promotion_live_adapter_dry_run_final_credential_scope_recheck_hash: str = Field(
+        pattern=HASH_PATTERN
+    )
+    final_credential_scope_recheck_mechanism: Literal[MECHANISM]
+    credential_scope_rechecked_at: str
+    source_final_endpoint_identity_recheck_id: str = Field(min_length=1)
+    source_final_endpoint_identity_recheck_hash: str = Field(pattern=HASH_PATTERN)
+    source_final_endpoint_identity_recheck_packet: dict[str, Any]
+    rechecked_credential_reference: CredentialReference
+    rechecked_credential_reference_digest: str = Field(pattern=HASH_PATTERN)
+    required_credential_scope: str = Field(min_length=1)
+    final_credential_scope_binding: dict[str, Any]
+    final_credential_scope_binding_digest: str = Field(pattern=HASH_PATTERN)
+    final_credential_scope_recheck_result: FinalCredentialScopeRecheckResult
+    final_credential_scope_recheck_result_digest: str = Field(pattern=HASH_PATTERN)
+    final_credential_scope_recheck_context: dict[str, Any]
+    final_credential_scope_recheck_context_digest: str = Field(pattern=HASH_PATTERN)
+    final_credential_scope_recheck_checks: tuple[FinalCredentialScopeRecheckCheck, ...]
+    final_credential_scope_recheck_check_digest: str = Field(pattern=HASH_PATTERN)
+    future_bind_authorization_requirements: tuple[FutureRequirement, ...]
+    future_bind_authorization_requirement_digest: str = Field(pattern=HASH_PATTERN)
+    future_bind_invocation_requirements: tuple[FutureRequirement, ...]
+    future_bind_invocation_requirement_digest: str = Field(pattern=HASH_PATTERN)
+    final_credential_scope_recheck_status: Literal[STATUS]
+    final_credential_scope_recheck_state: Literal[STATE]
+    ready_for_promotion_native_runtime_risk_review: Literal[True]
+    fresh_verified_source_gate_still_required: Literal[False]
+    bind_context_hash_derivation_still_required: Literal[False]
+    bind_context_hash_derived: Literal[True]
+    final_endpoint_identity_recheck_still_required: Literal[False]
+    final_endpoint_identity_rechecked: Literal[True]
+    final_credential_scope_recheck_still_required: Literal[False]
+    final_credential_scope_rechecked: Literal[True]
+    runtime_risk_review_still_required: Literal[True]
+    request_dispatch_state: Literal["NOT_DISPATCHED"]
+    bind_state: Literal["NOT_BOUND"]
+    authority_state: Literal["NOT_AUTHORIZED"]
+    human_approval_state: Literal["NOT_APPROVED"]
+    bind_authorization_state: Literal["NOT_AUTHORIZED"]
+    fail_closed: Literal[False]
+    human_approval_created: Literal[False]
+    human_approval_externally_verified: Literal[False]
+    human_approval_proven: Literal[False]
+    authority_evidence_created: Literal[False]
+    authority_evidence_externally_verified: Literal[False]
+    authority_evidence_proven: Literal[False]
+    execution_authority_created: Literal[False]
+    execution_authorized: Literal[False]
+    bind_authorization_created: Literal[False]
+    bind_authorization_issued: Literal[False]
+    credential_resolved: Literal[False]
+    credential_material_accessed: Literal[False]
+    credential_material_embedded: Literal[False]
+    credential_store_accessed: Literal[False]
+    authorization_header_constructed: Literal[False]
+    token_embedded: Literal[False]
+    secret_embedded: Literal[False]
+    cookie_embedded: Literal[False]
+    password_embedded: Literal[False]
+    private_key_embedded: Literal[False]
+    endpoint_resolved: Literal[False]
+    endpoint_contacted: Literal[False]
+    dns_used: Literal[False]
+    network_used: Literal[False]
+    webhook_invoked: Literal[False]
+    live_adapter_instantiated: Literal[False]
+    live_adapter_method_invoked: Literal[False]
+    request_dispatched: Literal[False]
+    bind_invoked: Literal[False]
+    bind_receipt_created: Literal[False]
+    trustlog_written: Literal[False]
+    filesystem_used: Literal[False]
+    database_used: Literal[False]
+    provider_called: Literal[False]
+    subprocess_used: Literal[False]
+    external_effect_used: Literal[False]
+    operation_committed: Literal[False]
+    apply_performed: Literal[False]
+    postcondition_verified: Literal[False]
+    rollback_or_revert_performed: Literal[False]
+    ready_for_real_bind: Literal[False]
+    ready_for_network_dispatch: Literal[False]
+
+
+CanonicalPromotionLiveAdapterDryRunFinalCredentialScopeRecheckPacket = create_model(
+    "CanonicalPromotionLiveAdapterDryRunFinalCredentialScopeRecheckPacket",
+    __base__=_PacketBase,
+    **{
+        name: (
+            CanonicalPromotionLiveAdapterDryRunFinalEndpointIdentityRecheckPacket.model_fields[
+                name
+            ].annotation,
+            ...,
+        )
+        for name in PRESERVED_FIELDS
+    },
+)
+
+
+def _fail(code: str) -> None:
+    raise CanonicalPromotionLiveAdapterDryRunFinalCredentialScopeRecheckError(code)
+
+
+def _timestamp(value: Any) -> str:
+    try:
+        parsed = value if isinstance(value, datetime) else datetime.fromisoformat(value)
+    except (TypeError, ValueError) as exc:
+        raise CanonicalPromotionLiveAdapterDryRunFinalCredentialScopeRecheckError(
+            "CPLADFCSR_TIMESTAMP_INVALID"
+        ) from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        _fail("CPLADFCSR_TIMESTAMP_INVALID")
+    return parsed.astimezone(timezone.utc).isoformat()
+
+
+def _json(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        value = value.model_dump(mode="json")
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        if value != value or value in (float("inf"), float("-inf")):
+            _fail("CPLADFCSR_JSON_INVALID")
+        return value
+    if isinstance(value, datetime):
+        return _timestamp(value)
+    if isinstance(value, (list, tuple)):
+        return [_json(item) for item in value]
+    if isinstance(value, dict) and all(isinstance(key, str) for key in value):
+        return {key: _json(item) for key, item in value.items()}
+    _fail("CPLADFCSR_JSON_INVALID")
+
+
+def _digest(domain: str, value: Any) -> str:
+    encoded = json.dumps(
+        {"domain": domain, "value": _json(value)},
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _source(
+    value: Any,
+) -> CanonicalPromotionLiveAdapterDryRunFinalEndpointIdentityRecheckPacket:
+    try:
+        return verify_canonical_promotion_live_adapter_dry_run_final_endpoint_identity_recheck_packet(
+            value
+        )
+    except (
+        CanonicalPromotionLiveAdapterDryRunFinalEndpointIdentityRecheckError,
+        TypeError,
+        ValueError,
+    ) as exc:
+        raise CanonicalPromotionLiveAdapterDryRunFinalCredentialScopeRecheckError(
+            "CPLADFCSR_SOURCE_INVALID"
+        ) from exc
+
+
+def _reference(value: Any) -> CredentialReference:
+    raw = _json(value)
+    if isinstance(raw, dict) and any(
+        key.lower().replace("-", "_") in PROHIBITED_KEYS for key in raw
+    ):
+        _fail("CPLADFCSR_SENSITIVE_INPUT")
+    try:
+        return CredentialReference.model_validate(raw)
+    except ValidationError as exc:
+        raise CanonicalPromotionLiveAdapterDryRunFinalCredentialScopeRecheckError(
+            "CPLADFCSR_CREDENTIAL_REFERENCE_INVALID"
+        ) from exc
+
+
+def _scope(value: Any) -> str:
+    if not isinstance(value, str) or not value:
+        _fail("CPLADFCSR_REQUIRED_SCOPE_INVALID")
+    return value
+
+
+def _requirements(names: tuple[str, ...]) -> list[dict[str, Any]]:
+    return [
+        {
+            "ordinal": ordinal,
+            "name": name,
+            "separate_future_artifact_required": True,
+            "satisfied_by_this_packet": False,
+        }
+        for ordinal, name in enumerate(names, 1)
+    ]
+
+
+def _validate_source(source: Any) -> None:
+    result = source.final_endpoint_identity_recheck_result
+    required = (
+        source.final_endpoint_identity_recheck_status == SOURCE_STATUS,
+        source.final_endpoint_identity_recheck_state == SOURCE_STATE,
+        source.ready_for_promotion_native_final_credential_scope_recheck,
+        not source.fail_closed,
+        not source.fresh_verified_source_gate_still_required,
+        not source.bind_context_hash_derivation_still_required,
+        source.bind_context_hash_derived,
+        not source.final_endpoint_identity_recheck_still_required,
+        source.final_endpoint_identity_rechecked,
+        source.final_credential_scope_recheck_still_required,
+        source.bind_authorization_state == "NOT_AUTHORIZED",
+        source.request_dispatch_state == "NOT_DISPATCHED",
+        source.bind_state == "NOT_BOUND",
+        source.authority_state == "NOT_AUTHORIZED",
+        source.human_approval_state == "NOT_APPROVED",
+        result.bind_context_hash == source.bind_context_hash,
+        result.endpoint_rechecked,
+        not result.credential_scope_rechecked,
+        not result.revocation_verified,
+        not result.external_policy_freshness_verified,
+    )
+    if not all(required) or any(getattr(source, name) for name in EFFECT_FIELDS):
+        _fail("CPLADFCSR_SOURCE_STATE_INVALID")
+    authorization = tuple(
+        item.name for item in source.future_bind_authorization_requirements
+    )
+    invocation = tuple(item.name for item in source.future_bind_invocation_requirements)
+    if authorization != SOURCE_AUTHORIZATION_REQUIREMENTS:
+        _fail("CPLADFCSR_SOURCE_AUTHORIZATION_REQUIREMENTS_INVALID")
+    if invocation != INVOCATION_REQUIREMENTS:
+        _fail("CPLADFCSR_SOURCE_INVOCATION_REQUIREMENTS_INVALID")
+    context = source.exact_bind_context.model_dump(mode="json")
+    if source.bind_context_hash != _digest(
+        BIND_CONTEXT_DOMAINS["bind-context"], context
+    ):
+        _fail("CPLADFCSR_BIND_CONTEXT_HASH_INVALID")
+
+
+def _validate_reference_and_scope(
+    source: Any,
+    reference: CredentialReference,
+    required_scope: str,
+) -> None:
+    reference_raw = reference.model_dump(mode="json")
+    source_reference = _reference(source.credential_reference)
+    source_reference_raw = source_reference.model_dump(mode="json")
+    if reference_raw != source_reference_raw:
+        _fail("CPLADFCSR_CREDENTIAL_REFERENCE_MISMATCH")
+    reference_digest = _digest(REFERENCE_DOMAIN, reference_raw)
+    context = source.exact_bind_context
+    binding = _json(source.credential_scope_binding)
+    binding_digest = _digest(SCOPE_BINDING_DOMAIN, binding)
+    required = (
+        reference_digest == source.credential_reference_digest,
+        reference_digest == context.credential_reference_digest,
+        binding_digest == source.credential_scope_binding_digest,
+        binding_digest == context.credential_scope_binding_digest,
+        binding.get("credential_reference_id") == reference.credential_reference_id,
+        binding.get("credential_reference_digest") == reference_digest,
+        binding.get("credential_kind") == reference.credential_kind,
+        binding.get("credential_provider_type") == reference.credential_provider_type,
+        binding.get("credential_scope") == reference.credential_scope,
+        binding.get("credential_environment") == reference.credential_environment,
+        binding.get("credential_purpose") == reference.credential_purpose,
+        binding.get("target_system") == reference.target_system,
+        binding.get("target_resource_scope") == reference.target_resource_scope,
+        binding.get("execution_intent_id") == context.execution_intent_id,
+        binding.get("execution_intent_hash") == context.execution_intent_hash,
+        binding.get("adapter_contract_id") == context.adapter_contract_id,
+        binding.get("adapter_contract_hash") == context.adapter_contract_hash,
+        binding.get("endpoint_candidate_digest") == context.endpoint_candidate_digest,
+        binding.get("endpoint_identity_binding_digest")
+        == context.endpoint_identity_binding_digest,
+        binding.get("credential_policy_snapshot_hash")
+        == context.credential_policy_snapshot_hash,
+        binding.get("credential_authorization_result_digest")
+        == context.credential_authorization_result_digest,
+    )
+    if not all(required):
+        _fail("CPLADFCSR_CREDENTIAL_BINDING_MISMATCH")
+    if required_scope != reference.credential_scope:
+        _fail("CPLADFCSR_REQUIRED_SCOPE_MISMATCH")
+
+
+def _binding(
+    source: Any,
+    reference: CredentialReference,
+    required_scope: str,
+) -> dict[str, Any]:
+    return {
+        "source_final_endpoint_identity_recheck_id": (
+            source.promotion_live_adapter_dry_run_final_endpoint_identity_recheck_id
+        ),
+        "source_final_endpoint_identity_recheck_hash": (
+            source.promotion_live_adapter_dry_run_final_endpoint_identity_recheck_hash
+        ),
+        "source_bind_context_hash_derivation_id": (
+            source.source_bind_context_hash_derivation_id
+        ),
+        "source_bind_context_hash_derivation_hash": (
+            source.source_bind_context_hash_derivation_hash
+        ),
+        "bind_context_hash": source.bind_context_hash,
+        "execution_intent_id": source.exact_bind_context.execution_intent_id,
+        "execution_intent_hash": source.exact_bind_context.execution_intent_hash,
+        "adapter_contract_id": source.exact_bind_context.adapter_contract_id,
+        "adapter_contract_hash": source.exact_bind_context.adapter_contract_hash,
+        "final_endpoint_identity_binding_digest": (
+            source.final_endpoint_identity_binding_digest
+        ),
+        "credential_reference_id": reference.credential_reference_id,
+        "credential_reference_digest": source.credential_reference_digest,
+        "credential_scope_binding_digest": source.credential_scope_binding_digest,
+        "required_credential_scope": required_scope,
+        "bound_credential_scope": reference.credential_scope,
+        "scope_match_mode": SCOPE_MATCH_MODE,
+        "scope_containment_inferred": False,
+    }
+
+
+def _assemble(
+    source: Any,
+    reference: CredentialReference,
+    required_scope: str,
+    rechecked_at: str,
+) -> dict[str, Any]:
+    source_raw = source.model_dump(mode="json")
+    reference_raw = reference.model_dump(mode="json")
+    reference_digest = _digest(REFERENCE_DOMAIN, reference_raw)
+    binding = _binding(source, reference, required_scope)
+    binding_digest = _digest(DOMAINS["binding"], binding)
+    result = {name: True for name in CHECK_NAMES}
+    result.update(
+        {
+            "bind_context_hash": source.bind_context_hash,
+            "credential_reference_digest": reference_digest,
+            "credential_scope_binding_digest": (source.credential_scope_binding_digest),
+            "final_credential_scope_binding_digest": binding_digest,
+            "required_credential_scope": required_scope,
+            "bound_credential_scope": reference.credential_scope,
+            "recheck_mode": CHECK_MODE,
+            "scope_match_mode": SCOPE_MATCH_MODE,
+            "credential_reference_rechecked": True,
+            "credential_scope_rechecked": True,
+            "scope_containment_inferred": False,
+            "trusted_clock_verified": False,
+            "external_policy_freshness_verified": False,
+            "credential_resolved": False,
+            "credential_store_accessed": False,
+            "credential_material_accessed": False,
+            "revocation_verified": False,
+        }
+    )
+    result_digest = _digest(DOMAINS["result"], result)
+    context = {
+        "source_final_endpoint_identity_recheck_id": (
+            source.promotion_live_adapter_dry_run_final_endpoint_identity_recheck_id
+        ),
+        "source_final_endpoint_identity_recheck_hash": (
+            source.promotion_live_adapter_dry_run_final_endpoint_identity_recheck_hash
+        ),
+        "source_bind_context_hash_derivation_hash": (
+            source.source_bind_context_hash_derivation_hash
+        ),
+        "bind_context_hash": source.bind_context_hash,
+        "credential_reference_digest": reference_digest,
+        "credential_scope_binding_digest": source.credential_scope_binding_digest,
+        "required_credential_scope": required_scope,
+        "credential_scope_rechecked_at": rechecked_at,
+        "final_credential_scope_binding_digest": binding_digest,
+        "final_credential_scope_recheck_result_digest": result_digest,
+    }
+    checks = [
+        {
+            "ordinal": ordinal,
+            "name": name,
+            "passed": True,
+            "comparison_mode": CHECK_MODE,
+        }
+        for ordinal, name in enumerate(CHECK_NAMES, 1)
+    ]
+    authorization = _requirements(AUTHORIZATION_REQUIREMENTS)
+    invocation = _requirements(INVOCATION_REQUIREMENTS)
+    raw = {
+        "format_version": FORMAT_VERSION,
+        "final_credential_scope_recheck_mechanism": MECHANISM,
+        "credential_scope_rechecked_at": rechecked_at,
+        "source_final_endpoint_identity_recheck_id": (
+            source.promotion_live_adapter_dry_run_final_endpoint_identity_recheck_id
+        ),
+        "source_final_endpoint_identity_recheck_hash": (
+            source.promotion_live_adapter_dry_run_final_endpoint_identity_recheck_hash
+        ),
+        "source_final_endpoint_identity_recheck_packet": source_raw,
+        **{name: source_raw[name] for name in PRESERVED_FIELDS},
+        "rechecked_credential_reference": reference_raw,
+        "rechecked_credential_reference_digest": reference_digest,
+        "required_credential_scope": required_scope,
+        "final_credential_scope_binding": binding,
+        "final_credential_scope_binding_digest": binding_digest,
+        "final_credential_scope_recheck_result": result,
+        "final_credential_scope_recheck_result_digest": result_digest,
+        "final_credential_scope_recheck_context": context,
+        "final_credential_scope_recheck_context_digest": _digest(
+            DOMAINS["context"], context
+        ),
+        "final_credential_scope_recheck_checks": checks,
+        "final_credential_scope_recheck_check_digest": _digest(
+            DOMAINS["checks"], checks
+        ),
+        "future_bind_authorization_requirements": authorization,
+        "future_bind_authorization_requirement_digest": _digest(
+            DOMAINS["authorization"], authorization
+        ),
+        "future_bind_invocation_requirements": invocation,
+        "future_bind_invocation_requirement_digest": _digest(
+            DOMAINS["invocation"], invocation
+        ),
+        "final_credential_scope_recheck_status": STATUS,
+        "final_credential_scope_recheck_state": STATE,
+        "ready_for_promotion_native_runtime_risk_review": True,
+        "fresh_verified_source_gate_still_required": False,
+        "bind_context_hash_derivation_still_required": False,
+        "bind_context_hash_derived": True,
+        "final_endpoint_identity_recheck_still_required": False,
+        "final_endpoint_identity_rechecked": True,
+        "final_credential_scope_recheck_still_required": False,
+        "final_credential_scope_rechecked": True,
+        "runtime_risk_review_still_required": True,
+        "request_dispatch_state": "NOT_DISPATCHED",
+        "bind_state": "NOT_BOUND",
+        "authority_state": "NOT_AUTHORIZED",
+        "human_approval_state": "NOT_APPROVED",
+        "bind_authorization_state": "NOT_AUTHORIZED",
+        "fail_closed": False,
+        **{name: False for name in EFFECT_FIELDS},
+    }
+    omitted = {
+        "promotion_live_adapter_dry_run_final_credential_scope_recheck_id",
+        "promotion_live_adapter_dry_run_final_credential_scope_recheck_hash",
+    }
+    digest = _digest(
+        DOMAINS["packet"],
+        {key: value for key, value in raw.items() if key not in omitted},
+    )
+    raw["promotion_live_adapter_dry_run_final_credential_scope_recheck_hash"] = digest
+    raw["promotion_live_adapter_dry_run_final_credential_scope_recheck_id"] = (
+        f"pladfcsr:v1:sha256:{digest}"
+    )
+    return raw
+
+
+def build_canonical_promotion_live_adapter_dry_run_final_credential_scope_recheck_packet(
+    source_final_endpoint_identity_recheck_packet: Any,
+    credential_reference: Any,
+    required_credential_scope: str,
+    credential_scope_rechecked_at: datetime,
+) -> CanonicalPromotionLiveAdapterDryRunFinalCredentialScopeRecheckPacket:
+    """Build exact local final credential scope evidence without authority."""
+
+    source = _source(_json(source_final_endpoint_identity_recheck_packet))
+    _validate_source(source)
+    reference = _reference(credential_reference)
+    required_scope = _scope(required_credential_scope)
+    _validate_reference_and_scope(source, reference, required_scope)
+    rechecked_at = _timestamp(credential_scope_rechecked_at)
+    if rechecked_at < _timestamp(
+        source.endpoint_identity_rechecked_at
+    ) or rechecked_at < _timestamp(reference.declared_at):
+        _fail("CPLADFCSR_TIMESTAMP_ORDER_INVALID")
+    return verify_canonical_promotion_live_adapter_dry_run_final_credential_scope_recheck_packet(
+        _assemble(source, reference, required_scope, rechecked_at)
+    )
+
+
+def verify_canonical_promotion_live_adapter_dry_run_final_credential_scope_recheck_packet(
+    raw: Any,
+) -> CanonicalPromotionLiveAdapterDryRunFinalCredentialScopeRecheckPacket:
+    """Re-verify the source and reconstruct every credential comparison field."""
+
+    try:
+        value = raw.model_dump(mode="json") if isinstance(raw, BaseModel) else raw
+        packet = CanonicalPromotionLiveAdapterDryRunFinalCredentialScopeRecheckPacket.model_validate(
+            _json(value)
+        )
+    except (ValidationError, TypeError) as exc:
+        raise CanonicalPromotionLiveAdapterDryRunFinalCredentialScopeRecheckError(
+            "CPLADFCSR_PACKET_INVALID"
+        ) from exc
+    source = _source(packet.source_final_endpoint_identity_recheck_packet)
+    _validate_source(source)
+    reference = _reference(packet.rechecked_credential_reference)
+    required_scope = _scope(packet.required_credential_scope)
+    _validate_reference_and_scope(source, reference, required_scope)
+    rechecked_at = _timestamp(packet.credential_scope_rechecked_at)
+    if rechecked_at < _timestamp(
+        source.endpoint_identity_rechecked_at
+    ) or rechecked_at < _timestamp(reference.declared_at):
+        _fail("CPLADFCSR_TIMESTAMP_ORDER_INVALID")
+    if packet.model_dump(mode="json") != _assemble(
+        source, reference, required_scope, rechecked_at
+    ):
+        _fail("CPLADFCSR_RECONSTRUCTION_MISMATCH")
+    return packet

--- a/veritas_os/tests/test_canonical_promotion_live_adapter_dry_run_final_credential_scope_recheck.py
+++ b/veritas_os/tests/test_canonical_promotion_live_adapter_dry_run_final_credential_scope_recheck.py
@@ -1,0 +1,486 @@
+"""Fail-closed tests for promotion-native final credential scope recheck."""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+from datetime import datetime, timedelta
+
+import pytest
+
+import veritas_os.policy.canonical_promotion_live_adapter_dry_run_final_credential_scope_recheck as scope_module
+from veritas_os.policy.canonical_promotion_live_adapter_dry_run_final_credential_scope_recheck import (
+    AUTHORIZATION_REQUIREMENTS,
+    CHECK_MODE,
+    DOMAINS,
+    EFFECT_FIELDS,
+    INVOCATION_REQUIREMENTS,
+    PRESERVED_FIELDS,
+    SCOPE_MATCH_MODE,
+    CanonicalPromotionLiveAdapterDryRunFinalCredentialScopeRecheckError,
+    build_canonical_promotion_live_adapter_dry_run_final_credential_scope_recheck_packet,
+    verify_canonical_promotion_live_adapter_dry_run_final_credential_scope_recheck_packet,
+)
+from veritas_os.tests.test_canonical_promotion_live_adapter_dry_run_final_endpoint_identity_recheck import (
+    RECHECKED_AT as SOURCE_AT,
+    _packet as endpoint_packet,
+    source_packet as bind_context_packet,
+)
+
+RECHECKED_AT = SOURCE_AT + timedelta(seconds=1)
+pytestmark = pytest.mark.slow
+
+
+def _reference(source, **changes):
+    value = dict(source.credential_reference)
+    value.update(changes)
+    return value
+
+
+def _packet(
+    *,
+    source,
+    reference=None,
+    required_scope=None,
+    rechecked_at=RECHECKED_AT,
+):
+    reference = reference if reference is not None else _reference(source)
+    required_scope = (
+        required_scope if required_scope is not None else reference["credential_scope"]
+    )
+    return build_canonical_promotion_live_adapter_dry_run_final_credential_scope_recheck_packet(
+        source,
+        reference,
+        required_scope,
+        rechecked_at,
+    )
+
+
+def _tamper_source(source, path: tuple[str, ...], value):
+    raw = source.model_dump(mode="json")
+    target = raw
+    for key in path[:-1]:
+        target = target[key]
+    target[path[-1]] = value
+    return raw
+
+
+@pytest.fixture(scope="module")
+def source():
+    """Build the deeply verified endpoint packet only in the slow lane."""
+
+    return endpoint_packet(source=bind_context_packet())
+
+
+@pytest.fixture(scope="module")
+def valid_packet(source):
+    """Build one verified packet for reconstruction-focused tests."""
+
+    return _packet(source=source)
+
+
+def test_valid_source_round_trips_and_preserves_exact_typed_fields(
+    source, valid_packet
+):
+    packet = valid_packet
+    verified = verify_canonical_promotion_live_adapter_dry_run_final_credential_scope_recheck_packet(
+        json.loads(packet.model_dump_json())
+    )
+
+    assert verified == packet
+    for name in PRESERVED_FIELDS:
+        assert getattr(packet, name) == getattr(source, name), name
+        assert (
+            type(packet).model_fields[name].annotation
+            == type(source).model_fields[name].annotation
+        )
+    assert packet.source_final_endpoint_identity_recheck_packet == source.model_dump(
+        mode="json"
+    )
+
+
+def test_requirement_transition_consumes_only_final_credential_scope_recheck(
+    source, valid_packet
+):
+    packet = valid_packet
+    source_authorization = tuple(
+        item.name for item in source.future_bind_authorization_requirements
+    )
+    output_authorization = tuple(
+        item.name for item in packet.future_bind_authorization_requirements
+    )
+    invocation = tuple(item.name for item in packet.future_bind_invocation_requirements)
+
+    assert source_authorization[0] == "final_credential_scope_recheck"
+    assert output_authorization == source_authorization[1:]
+    assert output_authorization == AUTHORIZATION_REQUIREMENTS
+    assert output_authorization[0] == "runtime_risk_review"
+    assert invocation == INVOCATION_REQUIREMENTS
+    assert all(
+        item.separate_future_artifact_required and not item.satisfied_by_this_packet
+        for item in (
+            *packet.future_bind_authorization_requirements,
+            *packet.future_bind_invocation_requirements,
+        )
+    )
+
+
+def test_output_routes_only_to_runtime_risk_review_without_authority_or_effect(
+    valid_packet,
+):
+    packet = valid_packet
+
+    assert packet.ready_for_promotion_native_runtime_risk_review
+    assert packet.fresh_verified_source_gate_still_required is False
+    assert packet.bind_context_hash_derivation_still_required is False
+    assert packet.bind_context_hash_derived is True
+    assert packet.final_endpoint_identity_recheck_still_required is False
+    assert packet.final_endpoint_identity_rechecked is True
+    assert packet.final_credential_scope_recheck_still_required is False
+    assert packet.final_credential_scope_rechecked is True
+    assert packet.runtime_risk_review_still_required is True
+    assert packet.bind_authorization_state == "NOT_AUTHORIZED"
+    assert packet.authority_state == "NOT_AUTHORIZED"
+    assert packet.human_approval_state == "NOT_APPROVED"
+    assert not any(getattr(packet, field) for field in EFFECT_FIELDS)
+
+
+def test_result_truthfully_limits_recheck_to_exact_local_metadata(valid_packet):
+    result = valid_packet.final_credential_scope_recheck_result
+
+    assert result.credential_reference_rechecked is True
+    assert result.credential_scope_rechecked is True
+    assert result.scope_match_mode == SCOPE_MATCH_MODE
+    assert result.scope_containment_inferred is False
+    assert result.trusted_clock_verified is False
+    assert result.external_policy_freshness_verified is False
+    assert result.credential_resolved is False
+    assert result.credential_store_accessed is False
+    assert result.credential_material_accessed is False
+    assert result.revocation_verified is False
+
+
+def test_recheck_binds_complete_reference_and_scope_to_exact_bind_context(
+    source, valid_packet
+):
+    packet = valid_packet
+    binding = packet.final_credential_scope_binding
+
+    assert (
+        packet.rechecked_credential_reference.model_dump(mode="json")
+        == source.credential_reference
+    )
+    assert (
+        packet.rechecked_credential_reference_digest
+        == source.credential_reference_digest
+        == source.exact_bind_context.credential_reference_digest
+    )
+    assert (
+        binding["credential_scope_binding_digest"]
+        == source.credential_scope_binding_digest
+        == source.exact_bind_context.credential_scope_binding_digest
+    )
+    assert binding["bind_context_hash"] == source.bind_context_hash
+    assert binding["required_credential_scope"] == "invoice:write"
+    assert binding["bound_credential_scope"] == "invoice:write"
+    assert binding["scope_match_mode"] == SCOPE_MATCH_MODE
+    assert binding["scope_containment_inferred"] is False
+    assert packet.final_credential_scope_binding_digest == scope_module._digest(
+        DOMAINS["binding"], binding
+    )
+
+
+def test_recheck_packet_records_auditable_input_lineage_and_unsatisfied_work(
+    source, valid_packet
+):
+    context = valid_packet.final_credential_scope_recheck_context
+
+    assert context["source_final_endpoint_identity_recheck_hash"] == (
+        source.promotion_live_adapter_dry_run_final_endpoint_identity_recheck_hash
+    )
+    assert context["source_bind_context_hash_derivation_hash"] == (
+        source.source_bind_context_hash_derivation_hash
+    )
+    assert context["bind_context_hash"] == source.bind_context_hash
+    assert context["credential_reference_digest"] == source.credential_reference_digest
+    assert context["required_credential_scope"] == "invoice:write"
+    assert valid_packet.trustlog_written is False
+    assert valid_packet.future_bind_authorization_requirements[0].name == (
+        "runtime_risk_review"
+    )
+
+
+def test_recheck_timestamp_changes_packet_not_frozen_bind_or_credential_identity(
+    source, valid_packet
+):
+    first = valid_packet
+    later = scope_module._assemble(
+        source,
+        scope_module._reference(_reference(source)),
+        "invoice:write",
+        scope_module._timestamp(RECHECKED_AT + timedelta(seconds=1)),
+    )
+
+    assert first.bind_context_hash == later["bind_context_hash"]
+    assert (
+        first.rechecked_credential_reference_digest
+        == later["rechecked_credential_reference_digest"]
+    )
+    assert (
+        first.final_credential_scope_binding_digest
+        == later["final_credential_scope_binding_digest"]
+    )
+    assert (
+        first.final_credential_scope_recheck_context_digest
+        != later["final_credential_scope_recheck_context_digest"]
+    )
+    assert (
+        first.promotion_live_adapter_dry_run_final_credential_scope_recheck_hash
+        != later["promotion_live_adapter_dry_run_final_credential_scope_recheck_hash"]
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("credential_reference_id", "credential-ref:other:v1"),
+        ("credential_kind", "OTHER_REFERENCE"),
+        ("credential_provider_type", "OTHER_STORE_REFERENCE"),
+        ("credential_scope", "invoice:read"),
+        ("credential_environment", "production"),
+        ("credential_purpose", "other-purpose"),
+        ("adapter_contract_id", "adapter:other:v1"),
+        ("endpoint_candidate_id", "endpoint:other:v1"),
+        ("target_system", "other-system"),
+        ("target_resource_scope", "other-resource"),
+        ("declared_by", "operator:other"),
+        ("declared_at", (RECHECKED_AT + timedelta(seconds=1)).isoformat()),
+    ],
+)
+def test_any_complete_credential_metadata_change_fails_closed(source, field, value):
+    reference = _reference(source, **{field: value})
+    with pytest.raises(
+        CanonicalPromotionLiveAdapterDryRunFinalCredentialScopeRecheckError
+    ):
+        _packet(source=source, reference=reference, required_scope="invoice:write")
+
+
+@pytest.mark.parametrize(
+    "required_scope",
+    [
+        "invoice:read",
+        "invoice:*",
+        "invoice:write ",
+        "Invoice:write",
+        "",
+    ],
+)
+def test_scope_difference_or_inferred_containment_fails_closed(source, required_scope):
+    with pytest.raises(
+        CanonicalPromotionLiveAdapterDryRunFinalCredentialScopeRecheckError
+    ):
+        _packet(source=source, required_scope=required_scope)
+
+
+def test_sensitive_or_open_credential_input_fails_closed(source):
+    reference = _reference(source)
+    reference["token"] = "must-not-be-accepted"
+    with pytest.raises(
+        CanonicalPromotionLiveAdapterDryRunFinalCredentialScopeRecheckError
+    ):
+        _packet(source=source, reference=reference)
+
+
+@pytest.mark.parametrize(
+    ("path", "value"),
+    [
+        (("final_endpoint_identity_recheck_status",), "tampered"),
+        (("ready_for_promotion_native_final_credential_scope_recheck",), False),
+        (("bind_context_hash",), "0" * 64),
+        (("credential_reference_digest",), "0" * 64),
+        (("credential_scope_binding_digest",), "0" * 64),
+        (
+            ("final_endpoint_identity_recheck_result", "credential_scope_rechecked"),
+            True,
+        ),
+    ],
+)
+def test_source_tamper_fails_closed(source, path, value):
+    with pytest.raises(
+        CanonicalPromotionLiveAdapterDryRunFinalCredentialScopeRecheckError
+    ):
+        _packet(
+            source=_tamper_source(source, path, value), reference=_reference(source)
+        )
+
+
+@pytest.mark.parametrize(
+    "field",
+    (
+        "execution_authorized",
+        "bind_authorization_issued",
+        "credential_resolved",
+        "credential_material_accessed",
+        "credential_store_accessed",
+        "network_used",
+        "request_dispatched",
+        "trustlog_written",
+        "external_effect_used",
+        "ready_for_real_bind",
+    ),
+)
+def test_representative_source_effect_or_authority_claim_fails_closed(source, field):
+    tampered = source.model_copy(update={field: True})
+    with pytest.raises(
+        CanonicalPromotionLiveAdapterDryRunFinalCredentialScopeRecheckError
+    ):
+        scope_module._validate_source(tampered)
+
+
+def test_source_requirement_and_invocation_order_drift_fail_closed(source):
+    for field in (
+        "future_bind_authorization_requirements",
+        "future_bind_invocation_requirements",
+    ):
+        requirements = list(getattr(source, field))
+        requirements[0], requirements[1] = requirements[1], requirements[0]
+        tampered = source.model_copy(update={field: tuple(requirements)})
+        with pytest.raises(
+            CanonicalPromotionLiveAdapterDryRunFinalCredentialScopeRecheckError
+        ):
+            scope_module._validate_source(tampered)
+
+
+def test_recheck_timestamp_before_source_fails_closed(source):
+    with pytest.raises(
+        CanonicalPromotionLiveAdapterDryRunFinalCredentialScopeRecheckError
+    ):
+        _packet(source=source, rechecked_at=SOURCE_AT - timedelta(microseconds=1))
+
+
+@pytest.mark.parametrize("value", [datetime(2030, 1, 1), "not-a-timestamp"])
+def test_naive_or_invalid_timestamp_fails_closed(value):
+    with pytest.raises(
+        CanonicalPromotionLiveAdapterDryRunFinalCredentialScopeRecheckError
+    ):
+        scope_module._timestamp(value)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("final_credential_scope_recheck_context_digest", "0" * 64),
+        ("execution_authorized", True),
+    ],
+)
+def test_packet_tamper_fails_reconstruction(valid_packet, field, value):
+    raw = valid_packet.model_dump(mode="json")
+    raw[field] = value
+    with pytest.raises(
+        CanonicalPromotionLiveAdapterDryRunFinalCredentialScopeRecheckError
+    ):
+        verify_canonical_promotion_live_adapter_dry_run_final_credential_scope_recheck_packet(
+            raw
+        )
+
+
+def test_nested_binding_reference_or_result_tamper_fails_reconstruction(
+    valid_packet,
+):
+    raw = valid_packet.model_dump(mode="json")
+    raw["final_credential_scope_binding"]["bind_context_hash"] = "0" * 64
+    with pytest.raises(
+        CanonicalPromotionLiveAdapterDryRunFinalCredentialScopeRecheckError
+    ):
+        verify_canonical_promotion_live_adapter_dry_run_final_credential_scope_recheck_packet(
+            raw
+        )
+
+    raw = valid_packet.model_dump(mode="json")
+    raw["rechecked_credential_reference"]["declared_by"] = "operator:other"
+    with pytest.raises(
+        CanonicalPromotionLiveAdapterDryRunFinalCredentialScopeRecheckError
+    ):
+        verify_canonical_promotion_live_adapter_dry_run_final_credential_scope_recheck_packet(
+            raw
+        )
+
+    raw = valid_packet.model_dump(mode="json")
+    raw["final_credential_scope_recheck_result"]["scope_containment_inferred"] = True
+    with pytest.raises(
+        CanonicalPromotionLiveAdapterDryRunFinalCredentialScopeRecheckError
+    ):
+        verify_canonical_promotion_live_adapter_dry_run_final_credential_scope_recheck_packet(
+            raw
+        )
+
+
+def test_builder_accepts_only_verified_source_reference_scope_and_timestamp():
+    parameters = inspect.signature(
+        build_canonical_promotion_live_adapter_dry_run_final_credential_scope_recheck_packet
+    ).parameters
+    assert tuple(parameters) == (
+        "source_final_endpoint_identity_recheck_packet",
+        "credential_reference",
+        "required_credential_scope",
+        "credential_scope_rechecked_at",
+    )
+
+
+def test_production_imports_and_calls_have_no_effect_capabilities():
+    tree = ast.parse(inspect.getsource(scope_module))
+    imported = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    }
+    imported.update(
+        node.module or "" for node in ast.walk(tree) if isinstance(node, ast.ImportFrom)
+    )
+    called_names = {
+        node.func.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    called_attributes = {
+        (node.func.value.id, node.func.attr)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and isinstance(node.func.value, ast.Name)
+    }
+    forbidden_imports = {"requests", "httpx", "urllib", "socket", "subprocess"}
+    forbidden_direct_calls = {"open", "urlopen", "Popen"}
+    effect_receivers = {
+        "client",
+        "connection",
+        "httpx",
+        "requests",
+        "session",
+        "socket",
+        "subprocess",
+        "urllib",
+    }
+    effect_methods = {
+        "connect",
+        "delete",
+        "get",
+        "patch",
+        "post",
+        "put",
+        "request",
+        "run",
+        "send",
+    }
+
+    assert not any(name.startswith("veritas_os.tests") for name in imported)
+    assert not any(name.split(".")[0] in forbidden_imports for name in imported)
+    assert not called_names & forbidden_direct_calls
+    assert not {
+        (receiver, method)
+        for receiver, method in called_attributes
+        if receiver in effect_receivers and method in effect_methods
+    }
+    assert CHECK_MODE in inspect.getsource(scope_module)

--- a/veritas_os/tests/test_memory_vector.py
+++ b/veritas_os/tests/test_memory_vector.py
@@ -244,8 +244,6 @@ def test_vector_memory_add_and_search_performance():
     assert search_time < 5.0
 
 
-
-
 def test_warn_for_legacy_pickle_artifacts_scans_recursively(tmp_path: Path, caplog):
     """ランタイム配下を再帰走査して危険拡張子を検知する。"""
     import logging
@@ -374,20 +372,25 @@ def test_load_model_is_thread_safe(monkeypatch):
     import threading
     import types
 
+    import veritas_os.core.config as config_module
+
     init_calls = {"count": 0}
-    barrier = threading.Barrier(2, timeout=5)
+    constructor_entered = threading.Event()
+    release_constructor = threading.Event()
 
     class SlowSentenceTransformer:
         def __init__(self, model_name):
             init_calls["count"] += 1
-            try:
-                barrier.wait()
-            except threading.BrokenBarrierError:
-                pass
+            constructor_entered.set()
+            assert release_constructor.wait(timeout=5)
             self.model_name = model_name
 
+    # Other tests reload config_module, so the memory facade can retain an older
+    # capability_cfg object. _load_model intentionally resolves the current
+    # config at call time; patch that authoritative object instead.
+    current_capability_cfg = config_module.capability_cfg
     monkeypatch.setattr(
-        memory.capability_cfg,
+        current_capability_cfg,
         "enable_memory_sentence_transformers",
         False,
     )
@@ -397,18 +400,24 @@ def test_load_model_is_thread_safe(monkeypatch):
     fake_module.SentenceTransformer = SlowSentenceTransformer
     monkeypatch.setitem(sys.modules, "sentence_transformers", fake_module)
     monkeypatch.setattr(
-        memory.capability_cfg,
+        current_capability_cfg,
         "enable_memory_sentence_transformers",
         True,
     )
 
     vm.model = None
 
-    threads = [threading.Thread(target=vm._load_model) for _ in range(2)]
-    for thread in threads:
-        thread.start()
-    for thread in threads:
-        thread.join()
+    first_thread = threading.Thread(target=vm._load_model)
+    second_thread = threading.Thread(target=vm._load_model)
+    first_thread.start()
+    assert constructor_entered.wait(timeout=5)
+    second_thread.start()
+    release_constructor.set()
 
+    threads = [first_thread, second_thread]
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert all(not thread.is_alive() for thread in threads)
     assert init_calls["count"] == 1
     assert isinstance(vm.model, SlowSentenceTransformer)


### PR DESCRIPTION
# Summary

Add a deterministic, content-addressed Final Credential Scope Recheck immediately after the Final Endpoint Identity Recheck introduced by #2173.

The new boundary compares caller-supplied complete credential metadata and the operation-required scope with the credential reference, scope binding, and exact Bind context already committed by the verified source packet. Scope containment is never inferred; any character difference fails closed.

## Scope

- Add canonical_promotion_live_adapter_dry_run_final_credential_scope_recheck.py.
- Re-verify the full #2173 source packet and recompute the exact Bind context hash.
- Verify credential_reference_digest and credential_scope_binding_digest against the frozen Bind context.
- Reject credential substitution, scope mismatch, context mismatch, source drift, and packet tampering.
- Consume only final_credential_scope_recheck and route only to runtime_risk_review.
- Preserve all remaining authorization and invocation requirements as unsatisfied.
- Keep credential resolution, credential-store access, secret access, network use, TrustLog writes, dispatch, Bind, and execution authority absent.

## Type of change

- [x] Runtime
- [x] Tests
- [ ] Docs
- [ ] CI
- [ ] Frontend
- [ ] Website / positioning
- [x] Governance / security-sensitive
- [ ] Other

## Why this change matters

This closes the next explicit lifecycle gap after #2173. A credential reference or requested scope cannot be swapped after the exact Bind context is frozen, while the recheck itself remains a metadata-only, no-effect boundary.

## Market / developer / user value

- Market value: strengthens demonstrable pre-execution credential governance.
- Developer value: provides a deterministic builder/verifier contract with stable fail-closed errors.
- User/operator value: makes late credential or scope drift independently detectable before runtime risk review.

## Tests run

- [ ] Not applicable, docs-only change
- [ ] make test
- [ ] make test-cov
- [ ] make quality-checks
- [ ] frontend tests
- [x] other:
  - 50 dedicated tests passed.
  - 181 predecessor and integration regression tests passed.
  - New module coverage: 97%.
  - Target files pass Ruff lint and format checks.
  - Responsibility-boundary and core-complexity checks passed.
  - HTTP raw-upload, subprocess, pickle-artifact, and memory-directory safety checks passed.

Repository-wide Ruff additionally reports a pre-existing missing-final-newline warning in scripts/run_decision_to_external_bind_poc.py; that unrelated file is not changed by this PR.

## AI assistance used

- [ ] ChatGPT
- [x] Codex
- [ ] Claude Code
- [ ] GitHub Copilot
- [ ] Gemini
- [ ] Grok
- [ ] Meta AI
- [ ] Other
- [ ] No AI assistance

## Review status

- [ ] CI passed
- [ ] Claude Code review completed
- [x] Codex review completed
- [ ] External advisory review completed
- [ ] Human maintainer reviewed

## Risk checklist

- [x] Touches bind/admissibility logic
- [x] Touches governance policy behavior
- [ ] Touches release gates
- [x] Touches secrets or credentials
- [ ] Touches TrustLog persistence or encryption behavior
- [ ] Touches FUJI Gate fail-closed behavior
- [ ] Changes public claims
- [ ] Changes website positioning
- [ ] Involves private user/customer data
- [ ] None of the above

Credential handling is metadata-only. No secret or credential material is accepted, resolved, accessed, embedded, or logged.

## Human approval required?

- [x] Yes
- [ ] No

Reason: this is a credential-governance and Bind-lifecycle boundary. Human review remains the merge boundary.

## Notes for reviewer

- Confirm that exact-character scope matching is intentional; wildcard, hierarchy, normalization, and semantic containment are not inferred.
- Confirm the lifecycle transition is Final Endpoint Identity Recheck -> Final Credential Scope Recheck -> Runtime Risk Review.
- Do not merge until all required CI checks pass.