### PR TITLE
feat(policy): add promotion runtime risk review

### DIFF
--- a/veritas_os/policy/canonical_promotion_live_adapter_dry_run_runtime_risk_review.py
+++ b/veritas_os/policy/canonical_promotion_live_adapter_dry_run_runtime_risk_review.py
@@ -1,0 +1,754 @@
+"""Review short-lived promotion runtime-risk evidence without invoking Bind.
+
+This boundary consumes the verified promotion authorization projection created
+from the final credential-scope recheck.  It binds one caller-supplied runtime
+risk signal and observed state fingerprint to the exact intent, adapter,
+endpoint, credential scope, and Bind context.  Missing, stale, mismatched, or
+negative evidence fails closed.
+
+The module performs no adapter call or I/O and grants no authority.  A passing
+packet may proceed only to the remaining Real Bind Authorization requirements;
+``execute_bind_adjudication`` must still obtain a fresh snapshot and call
+``adapter.assess_runtime_risk`` immediately before any apply attempt.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timedelta, timezone
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, create_model
+
+from veritas_os.policy.canonical_promotion_live_adapter_dry_run_final_credential_scope_recheck import (
+    AUTHORIZATION_REQUIREMENTS,
+    EFFECT_FIELDS,
+    INVOCATION_REQUIREMENTS,
+    CanonicalPromotionLiveAdapterDryRunFinalCredentialScopeRecheckError,
+    verify_canonical_promotion_live_adapter_dry_run_final_credential_scope_recheck_packet,
+)
+from veritas_os.policy.canonical_promotion_real_bind_authorization_contract import (
+    BIND_TIME_RISK_OWNER,
+    CONTRACT_VERSION as SOURCE_CONTRACT_VERSION,
+    NEXT_AUTHORIZATION_REQUIREMENT,
+    CanonicalPromotionRealBindAuthorizationContractError,
+    RequirementRoute,
+    VerifiedPromotionAuthorizationSource,
+    project_verified_promotion_authorization_source,
+)
+
+FORMAT_VERSION = "canonical-promotion-live-adapter-dry-run-runtime-risk-review/v1"
+REVIEW_MECHANISM = "review_context_bound_pre_authorization_runtime_risk_without_bind/v1"
+MAX_REVIEW_VALIDITY_SECONDS = 300
+HASH_PATTERN = r"^[0-9a-f]{64}$"
+ID_PATTERN = r"^pladrrr:v1:sha256:[0-9a-f]{64}$"
+PREFIX = "veritas.promotion-live-adapter-dry-run-runtime-risk-review"
+DOMAINS = {
+    name: f"{PREFIX}.{name}/v1"
+    for name in (
+        "source-projection",
+        "decision",
+        "result",
+        "requirement-proof",
+        "checks",
+        "packet",
+    )
+}
+
+PASS_OUTCOME = "PASS_FOR_REMAINING_AUTHORIZATION"
+BLOCK_OUTCOME = "BLOCKED_BY_RUNTIME_RISK"
+INDETERMINATE_OUTCOME = "INDETERMINATE_FAIL_CLOSED"
+OUTCOMES = (PASS_OUTCOME, BLOCK_OUTCOME, INDETERMINATE_OUTCOME)
+PASS_STATUS = "PROMOTION_NATIVE_RUNTIME_RISK_REVIEW_PASSED_NOT_AUTHORIZED"
+BLOCK_STATUS = "PROMOTION_NATIVE_RUNTIME_RISK_REVIEW_BLOCKED_NOT_AUTHORIZED"
+STATUSES = (PASS_STATUS, BLOCK_STATUS)
+PASS_STATE = "REVIEWED_FOR_REMAINING_REAL_BIND_AUTHORIZATION_REQUIREMENTS"
+BLOCK_STATE = "RUNTIME_RISK_REVIEW_FAILED_CLOSED"
+STATES = (PASS_STATE, BLOCK_STATE)
+
+CHECK_NAMES = (
+    "verified_authorization_projection_reconstructed",
+    "exact_source_identity_bound",
+    "exact_execution_intent_bound",
+    "exact_adapter_contract_bound",
+    "exact_bind_context_bound",
+    "exact_endpoint_identity_bound",
+    "exact_credential_scope_bound",
+    "runtime_risk_decision_closed_schema_valid",
+    "runtime_risk_evidence_refs_present",
+    "review_window_short_lived_and_ordered",
+    "runtime_risk_outcome_derived_fail_closed",
+    "remaining_requirements_preserved",
+    "bind_time_runtime_risk_recheck_preserved",
+    "no_bind_authorization_created",
+    "no_execution_authority_created",
+    "no_bind_or_dispatch_invocation",
+    "no_credential_material_access",
+    "no_external_effect",
+)
+
+ADDITIONAL_NO_EFFECT_FIELDS = (
+    "human_approval_created",
+    "human_approval_externally_verified",
+    "human_approval_proven",
+    "authority_evidence_created",
+    "authority_evidence_externally_verified",
+    "authority_evidence_proven",
+    "execution_authority_created",
+    "execution_authorized",
+    "bind_authorization_created",
+    "credential_material_accessed",
+    "credential_store_accessed",
+    "cookie_embedded",
+    "password_embedded",
+    "private_key_embedded",
+)
+NO_EFFECT_FIELDS = tuple(dict.fromkeys((*EFFECT_FIELDS, *ADDITIONAL_NO_EFFECT_FIELDS)))
+
+
+class CanonicalPromotionLiveAdapterDryRunRuntimeRiskReviewError(ValueError):
+    """Stable fail-closed error for invalid runtime-risk review evidence."""
+
+
+class RuntimeRiskReviewDecision(BaseModel):
+    """Closed, short-lived risk decision bound to one exact future Bind."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    runtime_risk_review_decision_id: str = Field(min_length=1)
+    reviewer_id: str = Field(min_length=1)
+    reviewer_role: str = Field(min_length=1)
+    reviewer_attestation: str = Field(min_length=1)
+    reviewed_at: str
+    valid_until: str
+    source_final_credential_scope_recheck_id: str = Field(min_length=1)
+    source_final_credential_scope_recheck_hash: str = Field(pattern=HASH_PATTERN)
+    execution_intent_id: str = Field(min_length=1)
+    execution_intent_hash: str = Field(pattern=HASH_PATTERN)
+    adapter_contract_id: str = Field(min_length=1)
+    adapter_contract_hash: str = Field(pattern=HASH_PATTERN)
+    bind_context_hash: str = Field(pattern=HASH_PATTERN)
+    final_endpoint_identity_binding_digest: str = Field(pattern=HASH_PATTERN)
+    final_credential_scope_binding_digest: str = Field(pattern=HASH_PATTERN)
+    expected_state_fingerprint: str | None
+    observed_state_fingerprint: str | None
+    runtime_risk_signal: bool | None
+    runtime_risk_evidence_refs: tuple[str, ...] = Field(min_length=1)
+    risk_reason: str = Field(min_length=1)
+    assessment_input_mode: Literal[
+        "caller_supplied_pre_authorization_runtime_risk_evidence"
+    ]
+    acknowledged_exact_bind_context_only: Literal[True]
+    acknowledged_runtime_risk_review_is_not_authority: Literal[True]
+    acknowledged_no_bind_authorization: Literal[True]
+    acknowledged_no_bind_invocation: Literal[True]
+    acknowledged_no_request_dispatch: Literal[True]
+    acknowledged_no_credential_material_access: Literal[True]
+    acknowledged_missing_stale_or_mismatched_evidence_blocks: Literal[True]
+    acknowledged_bind_time_runtime_risk_recheck_still_required: Literal[True]
+
+
+class RuntimeRiskReviewResult(BaseModel):
+    """Deterministic, fail-closed interpretation of supplied risk evidence."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    outcome: Literal[*OUTCOMES]
+    runtime_risk_acceptable: bool
+    reason_codes: tuple[str, ...] = Field(min_length=1)
+    runtime_risk_signal_present: bool
+    runtime_risk_signal_passed: bool
+    expected_state_fingerprint_present: bool
+    observed_state_fingerprint_present: bool
+    state_fingerprint_matches: bool
+    intent_ttl_present: bool
+    intent_fresh_for_review_window: bool
+    intent_expires_at: str | None
+    source_projection_verified: Literal[True]
+    exact_context_binding_verified: Literal[True]
+    review_window_verified: Literal[True]
+    evidence_refs_present: Literal[True]
+    caller_supplied_evidence_only: Literal[True]
+    external_evidence_authenticity_claimed: Literal[False]
+    creates_execution_authority: Literal[False]
+    creates_bind_authorization: Literal[False]
+    invokes_bind: Literal[False]
+    dispatches_request: Literal[False]
+    bind_time_runtime_risk_recheck_required: Literal[True]
+
+
+class RuntimeRiskRequirementProof(BaseModel):
+    """Evidence that runtime-risk review passed or failed closed."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    ordinal: Literal[1]
+    requirement: Literal[NEXT_AUTHORIZATION_REQUIREMENT]
+    source_route_owner: str = Field(min_length=1)
+    review_decision_id: str = Field(min_length=1)
+    review_decision_digest: str = Field(pattern=HASH_PATTERN)
+    review_result_digest: str = Field(pattern=HASH_PATTERN)
+    outcome: Literal[*OUTCOMES]
+    satisfied_by_this_packet: bool
+    bind_time_recheck_required: Literal[True]
+    bind_time_recheck_owner: Literal[BIND_TIME_RISK_OWNER]
+
+
+class RuntimeRiskReviewCheck(BaseModel):
+    """One ordered deterministic invariant verified by the review boundary."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    ordinal: int = Field(ge=1, le=len(CHECK_NAMES))
+    name: Literal[*CHECK_NAMES]
+    passed: Literal[True]
+    evidence_ref: str = Field(min_length=1)
+
+
+class _PacketBase(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    format_version: Literal[FORMAT_VERSION]
+    promotion_live_adapter_dry_run_runtime_risk_review_id: str = Field(
+        pattern=ID_PATTERN
+    )
+    promotion_live_adapter_dry_run_runtime_risk_review_hash: str = Field(
+        pattern=HASH_PATTERN
+    )
+    runtime_risk_review_mechanism: Literal[REVIEW_MECHANISM]
+    runtime_risk_review_recorded_at: str
+    source_contract_version: Literal[SOURCE_CONTRACT_VERSION]
+    source_final_credential_scope_recheck_id: str = Field(min_length=1)
+    source_final_credential_scope_recheck_hash: str = Field(pattern=HASH_PATTERN)
+    source_credential_scope_rechecked_at: str
+    source_authorization_projection: VerifiedPromotionAuthorizationSource
+    source_authorization_projection_digest: str = Field(pattern=HASH_PATTERN)
+    execution_intent_id: str = Field(min_length=1)
+    execution_intent_hash: str = Field(pattern=HASH_PATTERN)
+    adapter_contract_id: str = Field(min_length=1)
+    adapter_contract_hash: str = Field(pattern=HASH_PATTERN)
+    bind_context_hash: str = Field(pattern=HASH_PATTERN)
+    final_endpoint_identity_binding_digest: str = Field(pattern=HASH_PATTERN)
+    final_credential_scope_binding_digest: str = Field(pattern=HASH_PATTERN)
+    runtime_risk_review_decision: RuntimeRiskReviewDecision
+    runtime_risk_review_decision_digest: str = Field(pattern=HASH_PATTERN)
+    runtime_risk_review_result: RuntimeRiskReviewResult
+    runtime_risk_review_result_digest: str = Field(pattern=HASH_PATTERN)
+    runtime_risk_requirement_proof: RuntimeRiskRequirementProof
+    runtime_risk_requirement_proof_digest: str = Field(pattern=HASH_PATTERN)
+    runtime_risk_review_checks: tuple[RuntimeRiskReviewCheck, ...]
+    runtime_risk_review_check_digest: str = Field(pattern=HASH_PATTERN)
+    remaining_authorization_routes: tuple[RequirementRoute, ...]
+    remaining_invocation_routes: tuple[RequirementRoute, ...]
+    next_authorization_requirement: Literal[*AUTHORIZATION_REQUIREMENTS]
+    runtime_risk_review_status: Literal[*STATUSES]
+    runtime_risk_review_state: Literal[*STATES]
+    runtime_risk_review_completed: Literal[True]
+    runtime_risk_requirement_satisfied: bool
+    ready_for_remaining_real_bind_authorization_requirements: bool
+    bind_time_runtime_risk_recheck_required: Literal[True]
+    bind_time_runtime_risk_owner: Literal[BIND_TIME_RISK_OWNER]
+    request_dispatch_state: Literal["NOT_DISPATCHED"]
+    bind_state: Literal["NOT_BOUND"]
+    authority_state: Literal["NOT_AUTHORIZED"]
+    human_approval_state: Literal["NOT_APPROVED"]
+    bind_authorization_state: Literal["NOT_AUTHORIZED"]
+    ready_for_real_bind: Literal[False]
+    ready_for_network_dispatch: Literal[False]
+    fail_closed: bool
+
+
+CanonicalPromotionLiveAdapterDryRunRuntimeRiskReviewPacket = create_model(
+    "CanonicalPromotionLiveAdapterDryRunRuntimeRiskReviewPacket",
+    __base__=_PacketBase,
+    **{name: (Literal[False], ...) for name in NO_EFFECT_FIELDS},
+)
+
+
+def _fail(code: str) -> None:
+    raise CanonicalPromotionLiveAdapterDryRunRuntimeRiskReviewError(code)
+
+
+def _json(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        value = value.model_dump(mode="json")
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if (
+        isinstance(value, float)
+        and value == value
+        and value
+        not in (
+            float("inf"),
+            float("-inf"),
+        )
+    ):
+        return value
+    if isinstance(value, datetime):
+        if value.tzinfo is None or value.utcoffset() is None:
+            _fail("CPLADRRR_TIMESTAMP_INVALID")
+        return value.isoformat()
+    if isinstance(value, (list, tuple)):
+        return [_json(item) for item in value]
+    if isinstance(value, dict) and all(isinstance(key, str) for key in value):
+        return {key: _json(item) for key, item in value.items()}
+    _fail("CPLADRRR_VALUE_INVALID")
+
+
+def _aware(value: Any, code: str) -> datetime:
+    try:
+        parsed = value if isinstance(value, datetime) else datetime.fromisoformat(value)
+    except (TypeError, ValueError) as exc:
+        raise CanonicalPromotionLiveAdapterDryRunRuntimeRiskReviewError(code) from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        _fail(code)
+    return parsed.astimezone(timezone.utc)
+
+
+def _digest(domain: str, value: Any) -> str:
+    encoded = json.dumps(
+        {"domain": domain, "value": _json(value)},
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _packet_hash(raw: dict[str, Any]) -> str:
+    return _digest(
+        DOMAINS["packet"],
+        {
+            key: value
+            for key, value in raw.items()
+            if key
+            not in {
+                "promotion_live_adapter_dry_run_runtime_risk_review_id",
+                "promotion_live_adapter_dry_run_runtime_risk_review_hash",
+            }
+        },
+    )
+
+
+def _source(value: Any) -> tuple[Any, VerifiedPromotionAuthorizationSource]:
+    try:
+        source = verify_canonical_promotion_live_adapter_dry_run_final_credential_scope_recheck_packet(
+            _json(value)
+        )
+        projection = project_verified_promotion_authorization_source(source)
+    except (
+        CanonicalPromotionLiveAdapterDryRunFinalCredentialScopeRecheckError,
+        CanonicalPromotionRealBindAuthorizationContractError,
+        TypeError,
+        ValueError,
+    ) as exc:
+        raise CanonicalPromotionLiveAdapterDryRunRuntimeRiskReviewError(
+            "CPLADRRR_SOURCE_INVALID"
+        ) from exc
+    return source, projection
+
+
+def _decision(value: Any) -> RuntimeRiskReviewDecision:
+    raw = _json(value)
+    if not isinstance(raw, dict):
+        _fail("CPLADRRR_DECISION_INVALID")
+    signal = raw.get("runtime_risk_signal")
+    if signal is not None and not isinstance(signal, bool):
+        _fail("CPLADRRR_RUNTIME_RISK_SIGNAL_INVALID")
+    refs = raw.get("runtime_risk_evidence_refs")
+    if (
+        not isinstance(refs, (list, tuple))
+        or not refs
+        or any(not isinstance(ref, str) or not ref.strip() for ref in refs)
+        or len(set(refs)) != len(refs)
+    ):
+        _fail("CPLADRRR_EVIDENCE_REFS_INVALID")
+    try:
+        return RuntimeRiskReviewDecision.model_validate(raw)
+    except ValidationError as exc:
+        raise CanonicalPromotionLiveAdapterDryRunRuntimeRiskReviewError(
+            "CPLADRRR_DECISION_INVALID"
+        ) from exc
+
+
+def _validate_decision_binding(
+    projection: VerifiedPromotionAuthorizationSource,
+    decision: RuntimeRiskReviewDecision,
+) -> None:
+    authorization_requirements = tuple(
+        route.requirement for route in projection.authorization_routes
+    )
+    invocation_requirements = tuple(
+        route.requirement for route in projection.invocation_routes
+    )
+    if (
+        authorization_requirements != AUTHORIZATION_REQUIREMENTS
+        or invocation_requirements != INVOCATION_REQUIREMENTS
+        or authorization_requirements[0] != NEXT_AUTHORIZATION_REQUIREMENT
+    ):
+        _fail("CPLADRRR_SOURCE_ROUTE_MISMATCH")
+    expected = {
+        "source_final_credential_scope_recheck_id": (
+            projection.source_final_credential_scope_recheck_id
+        ),
+        "source_final_credential_scope_recheck_hash": (
+            projection.source_final_credential_scope_recheck_hash
+        ),
+        "execution_intent_id": projection.execution_intent_id,
+        "execution_intent_hash": projection.execution_intent_hash,
+        "adapter_contract_id": projection.adapter_contract_id,
+        "adapter_contract_hash": projection.adapter_contract_hash,
+        "bind_context_hash": projection.bind_context_hash,
+        "final_endpoint_identity_binding_digest": (
+            projection.final_endpoint_identity_binding_digest
+        ),
+        "final_credential_scope_binding_digest": (
+            projection.final_credential_scope_binding_digest
+        ),
+        "expected_state_fingerprint": projection.execution_intent.get(
+            "expected_state_fingerprint"
+        ),
+    }
+    if any(getattr(decision, field) != value for field, value in expected.items()):
+        _fail("CPLADRRR_DECISION_BINDING_MISMATCH")
+
+
+def _validate_times(
+    source_rechecked_at: Any,
+    decision: RuntimeRiskReviewDecision,
+    recorded_at: Any,
+) -> tuple[datetime, datetime, datetime]:
+    source_at = _aware(source_rechecked_at, "CPLADRRR_SOURCE_TIME_INVALID")
+    reviewed_at = _aware(decision.reviewed_at, "CPLADRRR_REVIEWED_AT_INVALID")
+    valid_until = _aware(decision.valid_until, "CPLADRRR_VALID_UNTIL_INVALID")
+    recorded = _aware(recorded_at, "CPLADRRR_RECORDED_AT_INVALID")
+    validity = (valid_until - reviewed_at).total_seconds()
+    if (
+        reviewed_at < source_at
+        or recorded < reviewed_at
+        or recorded >= valid_until
+        or validity <= 0
+        or validity > MAX_REVIEW_VALIDITY_SECONDS
+    ):
+        _fail("CPLADRRR_REVIEW_WINDOW_INVALID")
+    return reviewed_at, valid_until, recorded
+
+
+def _result(
+    projection: VerifiedPromotionAuthorizationSource,
+    decision: RuntimeRiskReviewDecision,
+    reviewed_at: datetime,
+    valid_until: datetime,
+) -> dict[str, Any]:
+    expected = decision.expected_state_fingerprint
+    observed = decision.observed_state_fingerprint
+    expected_present = isinstance(expected, str) and bool(expected.strip())
+    observed_present = isinstance(observed, str) and bool(observed.strip())
+    fingerprint_matches = expected_present and observed_present and expected == observed
+
+    ttl = projection.execution_intent.get("ttl_seconds")
+    ttl_present = isinstance(ttl, int) and not isinstance(ttl, bool) and ttl > 0
+    intent_expires_at = None
+    intent_fresh = False
+    if ttl_present:
+        decision_at = _aware(
+            projection.execution_intent.get("decision_ts"),
+            "CPLADRRR_INTENT_DECISION_TIME_INVALID",
+        )
+        expiry = decision_at + timedelta(seconds=ttl)
+        intent_expires_at = expiry.isoformat()
+        intent_fresh = reviewed_at <= expiry and valid_until <= expiry
+
+    block_reasons = []
+    missing_reasons = []
+    if decision.runtime_risk_signal is False:
+        block_reasons.append("CPLADRRR_RUNTIME_RISK_UNACCEPTABLE")
+    elif decision.runtime_risk_signal is None:
+        missing_reasons.append("CPLADRRR_RUNTIME_RISK_SIGNAL_MISSING")
+    if not expected_present:
+        missing_reasons.append("CPLADRRR_EXPECTED_STATE_FINGERPRINT_MISSING")
+    if not observed_present:
+        missing_reasons.append("CPLADRRR_OBSERVED_STATE_FINGERPRINT_MISSING")
+    if expected_present and observed_present and not fingerprint_matches:
+        block_reasons.append("CPLADRRR_STATE_DRIFT_DETECTED")
+    if not ttl_present:
+        missing_reasons.append("CPLADRRR_INTENT_TTL_MISSING")
+    elif not intent_fresh:
+        block_reasons.append("CPLADRRR_INTENT_NOT_FRESH_FOR_REVIEW_WINDOW")
+
+    if block_reasons:
+        outcome = BLOCK_OUTCOME
+        reasons = block_reasons + missing_reasons
+    elif missing_reasons:
+        outcome = INDETERMINATE_OUTCOME
+        reasons = missing_reasons
+    else:
+        outcome = PASS_OUTCOME
+        reasons = ["CPLADRRR_RUNTIME_RISK_ACCEPTABLE"]
+
+    return {
+        "outcome": outcome,
+        "runtime_risk_acceptable": outcome == PASS_OUTCOME,
+        "reason_codes": reasons,
+        "runtime_risk_signal_present": decision.runtime_risk_signal is not None,
+        "runtime_risk_signal_passed": decision.runtime_risk_signal is True,
+        "expected_state_fingerprint_present": expected_present,
+        "observed_state_fingerprint_present": observed_present,
+        "state_fingerprint_matches": fingerprint_matches,
+        "intent_ttl_present": ttl_present,
+        "intent_fresh_for_review_window": intent_fresh,
+        "intent_expires_at": intent_expires_at,
+        "source_projection_verified": True,
+        "exact_context_binding_verified": True,
+        "review_window_verified": True,
+        "evidence_refs_present": True,
+        "caller_supplied_evidence_only": True,
+        "external_evidence_authenticity_claimed": False,
+        "creates_execution_authority": False,
+        "creates_bind_authorization": False,
+        "invokes_bind": False,
+        "dispatches_request": False,
+        "bind_time_runtime_risk_recheck_required": True,
+    }
+
+
+def _derived(
+    projection: VerifiedPromotionAuthorizationSource,
+    decision: RuntimeRiskReviewDecision,
+    reviewed_at: datetime,
+    valid_until: datetime,
+) -> tuple[Any, ...]:
+    decision_raw = decision.model_dump(mode="json")
+    decision_raw["reviewed_at"] = reviewed_at.isoformat()
+    decision_raw["valid_until"] = valid_until.isoformat()
+    decision_digest = _digest(DOMAINS["decision"], decision_raw)
+    result = _result(projection, decision, reviewed_at, valid_until)
+    result_digest = _digest(DOMAINS["result"], result)
+    passed = result["outcome"] == PASS_OUTCOME
+    source_runtime_route = projection.authorization_routes[0]
+    proof = {
+        "ordinal": 1,
+        "requirement": NEXT_AUTHORIZATION_REQUIREMENT,
+        "source_route_owner": source_runtime_route.implementation_owner,
+        "review_decision_id": decision.runtime_risk_review_decision_id,
+        "review_decision_digest": decision_digest,
+        "review_result_digest": result_digest,
+        "outcome": result["outcome"],
+        "satisfied_by_this_packet": passed,
+        "bind_time_recheck_required": True,
+        "bind_time_recheck_owner": BIND_TIME_RISK_OWNER,
+    }
+    proof_digest = _digest(DOMAINS["requirement-proof"], proof)
+    checks = [
+        {
+            "ordinal": ordinal,
+            "name": name,
+            "passed": True,
+            "evidence_ref": (
+                f"source:{projection.source_final_credential_scope_recheck_hash}:"
+                f"decision:{decision_digest}:{name}"
+            ),
+        }
+        for ordinal, name in enumerate(CHECK_NAMES, 1)
+    ]
+    authorization_routes = (
+        projection.authorization_routes[1:]
+        if passed
+        else projection.authorization_routes
+    )
+    return (
+        decision_raw,
+        decision_digest,
+        result,
+        result_digest,
+        proof,
+        proof_digest,
+        checks,
+        authorization_routes,
+        passed,
+    )
+
+
+def _assemble(
+    source: Any,
+    projection: VerifiedPromotionAuthorizationSource,
+    decision: RuntimeRiskReviewDecision,
+    recorded_at: str,
+) -> dict[str, Any]:
+    reviewed_at, valid_until, recorded = _validate_times(
+        source.credential_scope_rechecked_at,
+        decision,
+        recorded_at,
+    )
+    _validate_decision_binding(projection, decision)
+    (
+        decision_raw,
+        decision_digest,
+        result,
+        result_digest,
+        proof,
+        proof_digest,
+        checks,
+        authorization_routes,
+        passed,
+    ) = _derived(projection, decision, reviewed_at, valid_until)
+    projection_raw = projection.model_dump(mode="json")
+    raw = {
+        "format_version": FORMAT_VERSION,
+        "runtime_risk_review_mechanism": REVIEW_MECHANISM,
+        "runtime_risk_review_recorded_at": recorded.isoformat(),
+        "source_contract_version": SOURCE_CONTRACT_VERSION,
+        "source_final_credential_scope_recheck_id": (
+            projection.source_final_credential_scope_recheck_id
+        ),
+        "source_final_credential_scope_recheck_hash": (
+            projection.source_final_credential_scope_recheck_hash
+        ),
+        "source_credential_scope_rechecked_at": source.credential_scope_rechecked_at,
+        "source_authorization_projection": projection_raw,
+        "source_authorization_projection_digest": _digest(
+            DOMAINS["source-projection"], projection_raw
+        ),
+        "execution_intent_id": projection.execution_intent_id,
+        "execution_intent_hash": projection.execution_intent_hash,
+        "adapter_contract_id": projection.adapter_contract_id,
+        "adapter_contract_hash": projection.adapter_contract_hash,
+        "bind_context_hash": projection.bind_context_hash,
+        "final_endpoint_identity_binding_digest": (
+            projection.final_endpoint_identity_binding_digest
+        ),
+        "final_credential_scope_binding_digest": (
+            projection.final_credential_scope_binding_digest
+        ),
+        "runtime_risk_review_decision": decision_raw,
+        "runtime_risk_review_decision_digest": decision_digest,
+        "runtime_risk_review_result": result,
+        "runtime_risk_review_result_digest": result_digest,
+        "runtime_risk_requirement_proof": proof,
+        "runtime_risk_requirement_proof_digest": proof_digest,
+        "runtime_risk_review_checks": checks,
+        "runtime_risk_review_check_digest": _digest(DOMAINS["checks"], checks),
+        "remaining_authorization_routes": [
+            route.model_dump(mode="json") for route in authorization_routes
+        ],
+        "remaining_invocation_routes": [
+            route.model_dump(mode="json") for route in projection.invocation_routes
+        ],
+        "next_authorization_requirement": authorization_routes[0].requirement,
+        "runtime_risk_review_status": PASS_STATUS if passed else BLOCK_STATUS,
+        "runtime_risk_review_state": PASS_STATE if passed else BLOCK_STATE,
+        "runtime_risk_review_completed": True,
+        "runtime_risk_requirement_satisfied": passed,
+        "ready_for_remaining_real_bind_authorization_requirements": passed,
+        "bind_time_runtime_risk_recheck_required": True,
+        "bind_time_runtime_risk_owner": BIND_TIME_RISK_OWNER,
+        "request_dispatch_state": "NOT_DISPATCHED",
+        "bind_state": "NOT_BOUND",
+        "authority_state": "NOT_AUTHORIZED",
+        "human_approval_state": "NOT_APPROVED",
+        "bind_authorization_state": "NOT_AUTHORIZED",
+        "ready_for_real_bind": False,
+        "ready_for_network_dispatch": False,
+        "fail_closed": not passed,
+        **{field: False for field in NO_EFFECT_FIELDS},
+    }
+    digest = _packet_hash(raw)
+    raw["promotion_live_adapter_dry_run_runtime_risk_review_hash"] = digest
+    raw["promotion_live_adapter_dry_run_runtime_risk_review_id"] = (
+        f"pladrrr:v1:sha256:{digest}"
+    )
+    return raw
+
+
+def build_canonical_promotion_live_adapter_dry_run_runtime_risk_review_packet(
+    source_final_credential_scope_recheck_packet: Any,
+    runtime_risk_review_decision: Any,
+    runtime_risk_review_recorded_at: datetime,
+) -> CanonicalPromotionLiveAdapterDryRunRuntimeRiskReviewPacket:
+    """Build and self-verify a non-authorizing runtime-risk review packet."""
+
+    source, projection = _source(source_final_credential_scope_recheck_packet)
+    decision = _decision(runtime_risk_review_decision)
+    raw = _assemble(
+        source,
+        projection,
+        decision,
+        _aware(
+            runtime_risk_review_recorded_at,
+            "CPLADRRR_RECORDED_AT_INVALID",
+        ).isoformat(),
+    )
+    return verify_canonical_promotion_live_adapter_dry_run_runtime_risk_review_packet(
+        raw,
+        source_final_credential_scope_recheck_packet,
+    )
+
+
+def verify_canonical_promotion_live_adapter_dry_run_runtime_risk_review_packet(
+    packet: Any,
+    source_final_credential_scope_recheck_packet: Any,
+) -> CanonicalPromotionLiveAdapterDryRunRuntimeRiskReviewPacket:
+    """Verify the compact packet against its independently supplied full source."""
+
+    source, projection = _source(source_final_credential_scope_recheck_packet)
+    try:
+        value = _json(packet)
+        candidate = (
+            CanonicalPromotionLiveAdapterDryRunRuntimeRiskReviewPacket.model_validate(
+                value
+            )
+        )
+    except (
+        ValidationError,
+        CanonicalPromotionLiveAdapterDryRunRuntimeRiskReviewError,
+        TypeError,
+    ) as exc:
+        raise CanonicalPromotionLiveAdapterDryRunRuntimeRiskReviewError(
+            "CPLADRRR_PACKET_INVALID"
+        ) from exc
+
+    decision = _decision(candidate.runtime_risk_review_decision)
+    expected = _assemble(
+        source,
+        projection,
+        decision,
+        candidate.runtime_risk_review_recorded_at,
+    )
+    expected["promotion_live_adapter_dry_run_runtime_risk_review_id"] = (
+        candidate.promotion_live_adapter_dry_run_runtime_risk_review_id
+    )
+    expected["promotion_live_adapter_dry_run_runtime_risk_review_hash"] = (
+        candidate.promotion_live_adapter_dry_run_runtime_risk_review_hash
+    )
+    raw = candidate.model_dump(mode="json")
+    if any(raw[field] != expected[field] for field in raw):
+        _fail("CPLADRRR_PACKET_RECONSTRUCTION_MISMATCH")
+    digest = _packet_hash(raw)
+    if candidate.promotion_live_adapter_dry_run_runtime_risk_review_hash != digest:
+        _fail("CPLADRRR_PACKET_HASH_MISMATCH")
+    if candidate.promotion_live_adapter_dry_run_runtime_risk_review_id != (
+        f"pladrrr:v1:sha256:{digest}"
+    ):
+        _fail("CPLADRRR_PACKET_ID_MISMATCH")
+    return candidate
+
+
+__all__ = [
+    "BLOCK_OUTCOME",
+    "BLOCK_STATE",
+    "BLOCK_STATUS",
+    "CHECK_NAMES",
+    "DOMAINS",
+    "FORMAT_VERSION",
+    "INDETERMINATE_OUTCOME",
+    "MAX_REVIEW_VALIDITY_SECONDS",
+    "NO_EFFECT_FIELDS",
+    "PASS_OUTCOME",
+    "PASS_STATE",
+    "PASS_STATUS",
+    "CanonicalPromotionLiveAdapterDryRunRuntimeRiskReviewError",
+    "CanonicalPromotionLiveAdapterDryRunRuntimeRiskReviewPacket",
+    "RuntimeRiskRequirementProof",
+    "RuntimeRiskReviewCheck",
+    "RuntimeRiskReviewDecision",
+    "RuntimeRiskReviewResult",
+    "build_canonical_promotion_live_adapter_dry_run_runtime_risk_review_packet",
+    "verify_canonical_promotion_live_adapter_dry_run_runtime_risk_review_packet",
+]

--- a/veritas_os/tests/test_canonical_promotion_live_adapter_dry_run_runtime_risk_review.py
+++ b/veritas_os/tests/test_canonical_promotion_live_adapter_dry_run_runtime_risk_review.py
@@ -1,0 +1,467 @@
+"""Fail-closed tests for promotion-native pre-authorization risk review."""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+from datetime import datetime, timedelta
+
+import pytest
+from pydantic import ValidationError
+
+import veritas_os.policy.canonical_promotion_live_adapter_dry_run_runtime_risk_review as risk_module
+from veritas_os.policy.bind_core.core import execute_bind_adjudication
+from veritas_os.policy.canonical_promotion_live_adapter_dry_run_final_credential_scope_recheck import (
+    AUTHORIZATION_REQUIREMENTS,
+    INVOCATION_REQUIREMENTS,
+)
+from veritas_os.policy.canonical_promotion_live_adapter_dry_run_runtime_risk_review import (
+    BLOCK_OUTCOME,
+    BLOCK_STATE,
+    BLOCK_STATUS,
+    INDETERMINATE_OUTCOME,
+    MAX_REVIEW_VALIDITY_SECONDS,
+    NO_EFFECT_FIELDS,
+    PASS_OUTCOME,
+    PASS_STATE,
+    PASS_STATUS,
+    CanonicalPromotionLiveAdapterDryRunRuntimeRiskReviewError,
+    CanonicalPromotionLiveAdapterDryRunRuntimeRiskReviewPacket,
+    build_canonical_promotion_live_adapter_dry_run_runtime_risk_review_packet,
+    verify_canonical_promotion_live_adapter_dry_run_runtime_risk_review_packet,
+)
+from veritas_os.policy.canonical_promotion_real_bind_authorization_contract import (
+    BIND_TIME_RISK_OWNER,
+    NEXT_AUTHORIZATION_REQUIREMENT,
+    project_verified_promotion_authorization_source,
+)
+from veritas_os.tests.test_canonical_promotion_live_adapter_dry_run_final_credential_scope_recheck import (
+    RECHECKED_AT as SOURCE_AT,
+    _packet as credential_scope_packet,
+)
+from veritas_os.tests.test_canonical_promotion_live_adapter_dry_run_final_endpoint_identity_recheck import (
+    _packet as endpoint_identity_packet,
+    source_packet as bind_context_packet,
+)
+
+REVIEWED_AT = SOURCE_AT + timedelta(seconds=1)
+VALID_UNTIL = REVIEWED_AT + timedelta(seconds=30)
+RECORDED_AT = REVIEWED_AT + timedelta(seconds=1)
+pytestmark = pytest.mark.slow
+
+
+@pytest.fixture(scope="module")
+def source_packet():
+    """Build the recursively verified final credential-scope packet once."""
+
+    endpoint = endpoint_identity_packet(source=bind_context_packet())
+    return credential_scope_packet(source=endpoint)
+
+
+@pytest.fixture(scope="module")
+def projection(source_packet):
+    """Project the exact source bindings used by risk decisions."""
+
+    return project_verified_promotion_authorization_source(source_packet)
+
+
+def _decision(projection, **changes):
+    expected = projection.execution_intent["expected_state_fingerprint"]
+    value = {
+        "runtime_risk_review_decision_id": "risk-review-decision:one",
+        "reviewer_id": "reviewer:risk:one",
+        "reviewer_role": "runtime-risk-reviewer",
+        "reviewer_attestation": "reviewed exact pre-authorization runtime evidence",
+        "reviewed_at": REVIEWED_AT.isoformat(),
+        "valid_until": VALID_UNTIL.isoformat(),
+        "source_final_credential_scope_recheck_id": (
+            projection.source_final_credential_scope_recheck_id
+        ),
+        "source_final_credential_scope_recheck_hash": (
+            projection.source_final_credential_scope_recheck_hash
+        ),
+        "execution_intent_id": projection.execution_intent_id,
+        "execution_intent_hash": projection.execution_intent_hash,
+        "adapter_contract_id": projection.adapter_contract_id,
+        "adapter_contract_hash": projection.adapter_contract_hash,
+        "bind_context_hash": projection.bind_context_hash,
+        "final_endpoint_identity_binding_digest": (
+            projection.final_endpoint_identity_binding_digest
+        ),
+        "final_credential_scope_binding_digest": (
+            projection.final_credential_scope_binding_digest
+        ),
+        "expected_state_fingerprint": expected,
+        "observed_state_fingerprint": expected,
+        "runtime_risk_signal": True,
+        "runtime_risk_evidence_refs": ["risk-evidence:one"],
+        "risk_reason": "runtime risk is acceptable for continued authorization review",
+        "assessment_input_mode": (
+            "caller_supplied_pre_authorization_runtime_risk_evidence"
+        ),
+        "acknowledged_exact_bind_context_only": True,
+        "acknowledged_runtime_risk_review_is_not_authority": True,
+        "acknowledged_no_bind_authorization": True,
+        "acknowledged_no_bind_invocation": True,
+        "acknowledged_no_request_dispatch": True,
+        "acknowledged_no_credential_material_access": True,
+        "acknowledged_missing_stale_or_mismatched_evidence_blocks": True,
+        "acknowledged_bind_time_runtime_risk_recheck_still_required": True,
+    }
+    value.update(changes)
+    return value
+
+
+def _packet(source_packet, projection, **decision_changes):
+    decision = _decision(projection, **decision_changes)
+    reviewed = datetime.fromisoformat(decision["reviewed_at"])
+    recorded = reviewed + timedelta(seconds=1)
+    return build_canonical_promotion_live_adapter_dry_run_runtime_risk_review_packet(
+        source_packet,
+        decision,
+        recorded,
+    )
+
+
+@pytest.fixture(scope="module")
+def valid_packet(source_packet, projection):
+    """Build one passing compact risk-review packet."""
+
+    return _packet(source_packet, projection)
+
+
+def _rehash(raw: dict) -> None:
+    digest = risk_module._packet_hash(raw)
+    raw["promotion_live_adapter_dry_run_runtime_risk_review_hash"] = digest
+    raw["promotion_live_adapter_dry_run_runtime_risk_review_id"] = (
+        f"pladrrr:v1:sha256:{digest}"
+    )
+
+
+def test_passing_review_round_trips_against_independent_source(
+    source_packet,
+    projection,
+    valid_packet,
+):
+    verified = (
+        verify_canonical_promotion_live_adapter_dry_run_runtime_risk_review_packet(
+            json.loads(valid_packet.model_dump_json()),
+            source_packet,
+        )
+    )
+
+    assert verified == valid_packet
+    assert verified.source_authorization_projection == projection
+    assert verified.runtime_risk_review_result.outcome == PASS_OUTCOME
+    assert verified.runtime_risk_review_result.runtime_risk_acceptable is True
+    assert verified.runtime_risk_review_status == PASS_STATUS
+    assert verified.runtime_risk_review_state == PASS_STATE
+    assert verified.fail_closed is False
+
+
+def test_review_consumes_only_runtime_risk_requirement(valid_packet):
+    remaining = tuple(
+        route.requirement for route in valid_packet.remaining_authorization_routes
+    )
+    invocation = tuple(
+        route.requirement for route in valid_packet.remaining_invocation_routes
+    )
+
+    assert remaining == AUTHORIZATION_REQUIREMENTS[1:]
+    assert invocation == INVOCATION_REQUIREMENTS
+    assert valid_packet.next_authorization_requirement == (
+        "idempotency_and_replay_review"
+    )
+    assert valid_packet.runtime_risk_requirement_proof.requirement == (
+        NEXT_AUTHORIZATION_REQUIREMENT
+    )
+    assert valid_packet.runtime_risk_requirement_proof.satisfied_by_this_packet
+    assert valid_packet.runtime_risk_requirement_satisfied
+    assert valid_packet.ready_for_remaining_real_bind_authorization_requirements
+
+
+def test_passing_review_preserves_bind_time_independent_recheck(valid_packet):
+    assert valid_packet.bind_time_runtime_risk_recheck_required is True
+    assert valid_packet.bind_time_runtime_risk_owner == BIND_TIME_RISK_OWNER
+    assert valid_packet.runtime_risk_requirement_proof.bind_time_recheck_required
+    assert "adapter.assess_runtime_risk" in inspect.getsource(execute_bind_adjudication)
+
+
+def test_review_is_compact_but_requires_full_source_for_verification(valid_packet):
+    assert (
+        "source_final_credential_scope_recheck_packet"
+        not in CanonicalPromotionLiveAdapterDryRunRuntimeRiskReviewPacket.model_fields
+    )
+    assert valid_packet.source_final_credential_scope_recheck_hash
+    assert valid_packet.source_authorization_projection.execution_intent_id
+
+
+def test_caller_evidence_is_not_misrepresented_as_authenticated(valid_packet):
+    result = valid_packet.runtime_risk_review_result
+
+    assert result.caller_supplied_evidence_only is True
+    assert result.external_evidence_authenticity_claimed is False
+    assert result.creates_execution_authority is False
+    assert result.creates_bind_authorization is False
+    assert result.invokes_bind is False
+    assert result.dispatches_request is False
+
+
+def test_negative_runtime_risk_signal_blocks_and_keeps_requirement(
+    source_packet,
+    projection,
+):
+    packet = _packet(
+        source_packet,
+        projection,
+        runtime_risk_signal=False,
+        risk_reason="adapter runtime risk is unacceptable",
+    )
+
+    assert packet.runtime_risk_review_result.outcome == BLOCK_OUTCOME
+    assert packet.runtime_risk_review_result.reason_codes[0] == (
+        "CPLADRRR_RUNTIME_RISK_UNACCEPTABLE"
+    )
+    assert packet.runtime_risk_review_status == BLOCK_STATUS
+    assert packet.runtime_risk_review_state == BLOCK_STATE
+    assert packet.fail_closed is True
+    assert packet.runtime_risk_requirement_satisfied is False
+    assert packet.next_authorization_requirement == NEXT_AUTHORIZATION_REQUIREMENT
+    assert (
+        tuple(route.requirement for route in packet.remaining_authorization_routes)
+        == AUTHORIZATION_REQUIREMENTS
+    )
+
+
+@pytest.mark.parametrize(
+    ("changes", "reason"),
+    [
+        (
+            {"runtime_risk_signal": None},
+            "CPLADRRR_RUNTIME_RISK_SIGNAL_MISSING",
+        ),
+        (
+            {"observed_state_fingerprint": None},
+            "CPLADRRR_OBSERVED_STATE_FINGERPRINT_MISSING",
+        ),
+    ],
+)
+def test_missing_runtime_evidence_is_indeterminate_fail_closed(
+    source_packet,
+    projection,
+    changes,
+    reason,
+):
+    packet = _packet(source_packet, projection, **changes)
+
+    assert packet.runtime_risk_review_result.outcome == INDETERMINATE_OUTCOME
+    assert reason in packet.runtime_risk_review_result.reason_codes
+    assert packet.fail_closed is True
+    assert packet.ready_for_remaining_real_bind_authorization_requirements is False
+
+
+def test_observed_state_drift_blocks(source_packet, projection):
+    packet = _packet(
+        source_packet,
+        projection,
+        observed_state_fingerprint="state:drifted",
+    )
+
+    assert packet.runtime_risk_review_result.outcome == BLOCK_OUTCOME
+    assert "CPLADRRR_STATE_DRIFT_DETECTED" in (
+        packet.runtime_risk_review_result.reason_codes
+    )
+    assert packet.runtime_risk_review_result.state_fingerprint_matches is False
+    assert packet.fail_closed is True
+
+
+def test_expired_intent_blocks_even_with_positive_risk_signal(
+    source_packet,
+    projection,
+):
+    decision_at = datetime.fromisoformat(
+        projection.execution_intent["decision_ts"].replace("Z", "+00:00")
+    )
+    reviewed_at = decision_at + timedelta(
+        seconds=projection.execution_intent["ttl_seconds"] + 1
+    )
+    packet = _packet(
+        source_packet,
+        projection,
+        reviewed_at=reviewed_at.isoformat(),
+        valid_until=(reviewed_at + timedelta(seconds=10)).isoformat(),
+    )
+
+    assert packet.runtime_risk_review_result.outcome == BLOCK_OUTCOME
+    assert "CPLADRRR_INTENT_NOT_FRESH_FOR_REVIEW_WINDOW" in (
+        packet.runtime_risk_review_result.reason_codes
+    )
+    assert packet.fail_closed is True
+
+
+def test_review_window_longer_than_five_minutes_is_rejected(
+    source_packet,
+    projection,
+):
+    with pytest.raises(
+        CanonicalPromotionLiveAdapterDryRunRuntimeRiskReviewError,
+        match="CPLADRRR_REVIEW_WINDOW_INVALID",
+    ):
+        _packet(
+            source_packet,
+            projection,
+            valid_until=(
+                REVIEWED_AT + timedelta(seconds=MAX_REVIEW_VALIDITY_SECONDS + 1)
+            ).isoformat(),
+        )
+
+
+@pytest.mark.parametrize(
+    "field",
+    (
+        "source_final_credential_scope_recheck_id",
+        "source_final_credential_scope_recheck_hash",
+        "execution_intent_id",
+        "execution_intent_hash",
+        "adapter_contract_id",
+        "adapter_contract_hash",
+        "bind_context_hash",
+        "final_endpoint_identity_binding_digest",
+        "final_credential_scope_binding_digest",
+        "expected_state_fingerprint",
+    ),
+)
+def test_any_exact_context_substitution_fails_closed(
+    source_packet,
+    projection,
+    field,
+):
+    value = "0" * 64 if field.endswith(("hash", "digest")) else "substitute"
+    with pytest.raises(
+        CanonicalPromotionLiveAdapterDryRunRuntimeRiskReviewError,
+        match="CPLADRRR_DECISION_BINDING_MISMATCH",
+    ):
+        _packet(source_packet, projection, **{field: value})
+
+
+@pytest.mark.parametrize(
+    ("changes", "code"),
+    [
+        ({"runtime_risk_signal": "true"}, "CPLADRRR_RUNTIME_RISK_SIGNAL_INVALID"),
+        ({"runtime_risk_evidence_refs": []}, "CPLADRRR_EVIDENCE_REFS_INVALID"),
+        (
+            {"runtime_risk_evidence_refs": ["risk:one", "risk:one"]},
+            "CPLADRRR_EVIDENCE_REFS_INVALID",
+        ),
+    ],
+)
+def test_open_or_ambiguous_decision_inputs_are_rejected(
+    source_packet,
+    projection,
+    changes,
+    code,
+):
+    with pytest.raises(
+        CanonicalPromotionLiveAdapterDryRunRuntimeRiskReviewError,
+        match=code,
+    ):
+        _packet(source_packet, projection, **changes)
+
+
+def test_tampered_full_source_fails_independent_verification(
+    source_packet,
+    valid_packet,
+):
+    raw_source = source_packet.model_dump(mode="json")
+    raw_source["execution_intent_hash"] = "0" * 64
+
+    with pytest.raises(
+        CanonicalPromotionLiveAdapterDryRunRuntimeRiskReviewError,
+        match="CPLADRRR_SOURCE_INVALID",
+    ):
+        verify_canonical_promotion_live_adapter_dry_run_runtime_risk_review_packet(
+            valid_packet,
+            raw_source,
+        )
+
+
+@pytest.mark.parametrize(
+    ("path", "value"),
+    [
+        (("runtime_risk_review_result", "outcome"), BLOCK_OUTCOME),
+        (("runtime_risk_requirement_proof", "satisfied_by_this_packet"), False),
+        (("remaining_authorization_routes", 0, "requirement"), "runtime_risk_review"),
+        (("source_authorization_projection", "bind_context_hash"), "0" * 64),
+        (("bind_time_runtime_risk_recheck_required",), False),
+        (("execution_authorized",), True),
+        (("network_used",), True),
+    ],
+)
+def test_packet_tamper_fails_even_after_rehash(
+    source_packet,
+    valid_packet,
+    path,
+    value,
+):
+    raw = valid_packet.model_dump(mode="json")
+    target = raw
+    for key in path[:-1]:
+        target = target[key]
+    target[path[-1]] = value
+    _rehash(raw)
+
+    with pytest.raises(CanonicalPromotionLiveAdapterDryRunRuntimeRiskReviewError):
+        verify_canonical_promotion_live_adapter_dry_run_runtime_risk_review_packet(
+            raw,
+            source_packet,
+        )
+
+
+def test_packet_schema_is_closed_frozen_and_non_effecting(valid_packet):
+    raw = valid_packet.model_dump(mode="json")
+    raw["unexpected"] = True
+    with pytest.raises(ValidationError):
+        CanonicalPromotionLiveAdapterDryRunRuntimeRiskReviewPacket.model_validate(raw)
+    with pytest.raises(ValidationError):
+        valid_packet.fail_closed = True
+    assert not any(getattr(valid_packet, field) for field in NO_EFFECT_FIELDS)
+    assert valid_packet.ready_for_real_bind is False
+    assert valid_packet.ready_for_network_dispatch is False
+
+
+def test_module_has_no_adapter_or_io_effect_capabilities():
+    tree = ast.parse(inspect.getsource(risk_module))
+    imported = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    }
+    imported.update(
+        node.module or "" for node in ast.walk(tree) if isinstance(node, ast.ImportFrom)
+    )
+    called_names = {
+        node.func.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    called_attributes = {
+        node.func.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+    }
+
+    assert not any(name.startswith("veritas_os.tests") for name in imported)
+    assert not any(
+        name.split(".")[0] in {"httpx", "requests", "socket", "subprocess", "urllib"}
+        for name in imported
+    )
+    assert not called_names & {"open", "urlopen", "Popen"}
+    assert not called_attributes & {
+        "snapshot",
+        "fingerprint_state",
+        "assess_runtime_risk",
+        "apply",
+        "execute_bind_adjudication",
+    }

--- a/veritas_os/tests/test_canonical_promotion_real_bind_authorization_contract.py
+++ b/veritas_os/tests/test_canonical_promotion_real_bind_authorization_contract.py
@@ -129,7 +129,7 @@ def test_only_runtime_risk_requires_new_pre_authorization_implementation(
     )
 
 
-def test_all_declared_reuse_owners_are_existing_importable_modules(projection):
+def test_all_declared_owners_are_existing_importable_modules(projection):
     owners = {
         route.implementation_owner
         for route in (
@@ -141,7 +141,7 @@ def test_all_declared_reuse_owners_are_existing_importable_modules(projection):
 
     assert owners
     assert all(importlib.util.find_spec(owner) is not None for owner in owners)
-    assert importlib.util.find_spec(RUNTIME_RISK_ARTIFACT_OWNER) is None
+    assert importlib.util.find_spec(RUNTIME_RISK_ARTIFACT_OWNER) is not None
 
 
 def test_runtime_risk_contract_preserves_just_in_time_bind_recheck(projection):


### PR DESCRIPTION
# Summary

Add an inert, independently verifiable Runtime Risk Review artifact for the canonical promotion authorization sequence after Final Credential Scope Recheck.

## Scope

- Add the runtime risk review builder and verifier, bound to the full final credential scope source, intent, adapter, bind context, endpoint, and credential projection.
- Fail closed on missing risk evidence; block negative risk signals, fingerprint drift, and insufficient intent TTL. Cap the review window at 300 seconds.
- Add focused tests and update the authorization contract test to require an importable runtime risk review owner.
- Passing this review consumes only the runtime risk review stage; idempotency and replay review remains next.

## Type of change

- [x] Runtime
- [x] Tests
- [x] Governance / security-sensitive

## Why this change matters

Adds a bounded preauthorization evidence stage without granting execution authority or weakening the just-in-time Bind boundary.

## Market / developer / user value

- Market value: strengthens reviewable governance evidence; does not establish production readiness.
- Developer value: explicit fail-closed contract and regression coverage.
- User/operator value: inspectable reasons for blocked or indeterminate risk review.

## Tests run

- [x] Other: targeted regression across runtime risk review, authorization contract, and final credential scope suites: **100 passed**.
- [x] Other: new review + authorization contract suites: **50 passed**; production-module coverage **94.81%** (one NumPy reload warning).
- [x] Other: Ruff lint for veritas_os and format checks for changed files passed.
- [x] Other: Bandit reported no medium/high findings (3 low findings).
- [x] Other: deployment-defaults, runtime-pickle, unsafe-dynamic-execution, public-key-exposure, and bare-except security checks passed.
- [ ] `make test`
- [ ] `make test-cov`
- [ ] `make quality-checks`

`make quality-checks` was attempted but did not complete: the replay gate requires the missing `audit/replay_reports` directory. Earlier checks passed. These are local results from the implementation step, not a claim that PR CI has passed.

## AI assistance used

- [x] Codex

## Review status

- [ ] CI passed
- [ ] Independent review completed
- [ ] Human maintainer reviewed

## Risk checklist

- [x] Touches bind/admissibility logic
- [x] Touches governance policy behavior
- [x] Touches secrets or credentials (credential-scope projections only; no credential access)
- [ ] Changes public claims
- [ ] Involves private user/customer data

## Human approval required?

- [x] Yes

Reason: governance-sensitive authorization evidence changes require human maintainer review.

## Notes for reviewer

- This artifact performs no live adapter calls, network requests, credential acquisition, or Bind execution.
- Caller-supplied risk evidence is not authenticated by this layer.
- Verification requires the full source separately and reconstructs the projection and artifact/hash.
- Bind-time `adapter.assess_runtime_risk` remains mandatory; this review is not its replacement.
- Published through the connected GitHub API. Remote commit `b973f2583f073b631f2cf5e745501e324f2003b4` has the same Git tree as the tested local commit `f8ddbe168c3b98e8b0fae657afec066a7b43a6f7`: `90dc3d09643b6f6f3f84351997be44f046de235b`.
