### PR TITLE
feat(policy): add promotion idempotency replay review

### DIFF
--- a/docs/en/development/promotion-idempotency-replay-review.md
+++ b/docs/en/development/promotion-idempotency-replay-review.md
@@ -1,0 +1,26 @@
+# Promotion idempotency and replay review
+
+After a passing Runtime Risk Review, call
+`review_promotion_idempotency_and_replay` in
+`veritas_os.policy.live_adapter_bind_authorization_requirements` with the risk
+packet, its full final credential-scope source, and an aware `reviewed_at`.
+The function independently verifies the source and requires the review time
+to be within the remaining risk window (expiry is exclusive).
+
+The returned immutable model serializes with `model_dump(mode="json")`.
+Verify it with `verify_promotion_idempotency_replay_review`, supplying both
+independent sources and a trusted current `now`. Verification reconstructs
+every field and checks expiry again. A digest is integrity evidence, not a
+signature or evidence that an authorization is unused.
+
+This stage reviews the required replay policy and existing implementation
+owners. It does not query a store or reserve a key. The final authorization
+key still requires the signed authorization decision and validity interval;
+it remains owned by `live_adapter_bind_authorization_checks`. Atomic single-use
+consumption remains mandatory before credential resolution and dispatch.
+Runtime Bind risk checks remain mandatory. A passing artifact advances only
+to signed gate-bound human approval issuance; it grants no execution authority.
+
+This is a callable composition boundary, not automatic runtime integration.
+Tests in `test_promotion_idempotency_replay_review.py` include serialization,
+tampering, blocked/missing risk signals, and temporal boundary checks.

--- a/docs/ja/development/promotion-idempotency-replay-review.md
+++ b/docs/ja/development/promotion-idempotency-replay-review.md
@@ -1,0 +1,22 @@
+# Promotionの冪等性・再利用防止レビュー
+
+Runtime Risk Review通過後、
+`veritas_os.policy.live_adapter_bind_authorization_requirements` の
+`review_promotion_idempotency_and_replay` にリスク評価packet、その完全な
+最終credential-scopeソース、タイムゾーン付き`reviewed_at`を渡します。
+ソースを独立検証し、リスク評価の記録時刻以降かつ失効時刻より前であることを確認します。
+
+戻り値は`model_dump(mode="json")`でシリアライズできます。
+`verify_promotion_idempotency_replay_review`に両ソースと信頼できる現在時刻`now`を
+渡すと、全フィールドを再構築し、有効期限も再確認します。
+ハッシュは署名や未使用の証明ではありません。
+
+本段階は再利用防止の要件と既存の実装担当を確認します。ストア照会やキー予約は行いません。
+最終キーの発行には署名済み承認判断と有効期間が必要で、既存の
+`live_adapter_bind_authorization_checks`が担当します。
+資格情報取得・送信前の原子的な一回限りの消費と、Bind時のリスク再確認は引き続き必須です。
+通過後は署名付きgate-bound人間承認の発行へ進めますが、実行権限は付与しません。
+
+呼び出し可能な合成用境界であり、ランタイムへの自動統合ではありません。
+`test_promotion_idempotency_replay_review.py`でシリアライズ、改ざん、
+リスク拒否・欠落、有効期限境界を検証します。

--- a/veritas_os/policy/live_adapter_bind_authorization_requirements.py
+++ b/veritas_os/policy/live_adapter_bind_authorization_requirements.py
@@ -2,7 +2,17 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from veritas_os.policy.canonical_promotion_live_adapter_dry_run_runtime_risk_review import (
+    verify_canonical_promotion_live_adapter_dry_run_runtime_risk_review_packet,
+)
+from veritas_os.policy.canonical_promotion_real_bind_authorization_contract import (
+    RequirementRoute,
+)
 
 from veritas_os.policy.live_adapter_bind_authorization_contracts import (
     COPIED_FIELDS,
@@ -124,7 +134,9 @@ def _requirement_proofs(
         ),
         (
             governance.human_approval_status,
-            "verified_human_approval" if governance.human_approval_proof else "action_contract",
+            "verified_human_approval"
+            if governance.human_approval_proof
+            else "action_contract",
             human_id,
             human_digest,
             (
@@ -283,3 +295,168 @@ def _copied_source_fields(
     for field in COPIED_FIELDS:
         result[field] = raw[field]
     return result
+
+
+class PromotionIdempotencyReplayReview(BaseModel):
+    """Inert review of replay requirements, never proof of an unused key.
+
+    The final authorization key needs the signed decision and validity window
+    and therefore cannot be issued at this stage. Atomic consumption remains
+    mandatory before credential access. This artifact makes no store query,
+    reservation, duplicate-absence claim, or execution-authority claim.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+    format_version: Literal["promotion-idempotency-replay-review/v1"]
+    review_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    source_runtime_risk_review_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    source_projection_digest: str = Field(pattern=r"^[0-9a-f]{64}$")
+    reviewed_at: str
+    valid_until: str
+    requirement: Literal["idempotency_and_replay_review"]
+    requirement_satisfied: Literal[True]
+    remaining_authorization_routes: tuple[RequirementRoute, ...]
+    remaining_invocation_routes: tuple[RequirementRoute, ...]
+    next_authorization_requirement: Literal["signed_gate_bound_human_approval_issuance"]
+    final_authorization_key_required: Literal[True]
+    final_authorization_key_owner: Literal[
+        "veritas_os.policy.live_adapter_bind_authorization_checks"
+    ]
+    atomic_consumption_owner: Literal[
+        "veritas_os.policy.live_adapter_bind_authorization_consumption"
+    ]
+    atomic_consumption_before_credentials_required: Literal[True]
+    single_use_required: Literal[True]
+    duplicate_dispatch_prohibited: Literal[True]
+    bind_time_runtime_risk_recheck_required: Literal[True]
+    duplicate_absence_verified: Literal[False]
+    authorization_consumed: Literal[False]
+    execution_authorized: Literal[False]
+    bind_invoked: Literal[False]
+    request_dispatched: Literal[False]
+
+
+def _promotion_review_time(value: datetime) -> datetime:
+    if (
+        not isinstance(value, datetime)
+        or value.tzinfo is None
+        or value.utcoffset() is None
+    ):
+        raise LiveAdapterBindAuthorizationError("LABA_PROMOTION_REVIEW_TIME_INVALID")
+    return value.astimezone(timezone.utc)
+
+
+def review_promotion_idempotency_and_replay(
+    runtime_risk_review: Any,
+    source_final_credential_scope_recheck_packet: Any,
+    *,
+    reviewed_at: datetime,
+) -> PromotionIdempotencyReplayReview:
+    """Verify a fresh passing source and preserve existing consumption owners.
+
+    Raises:
+        LiveAdapterBindAuthorizationError: Source is invalid, blocked, expired,
+            or does not route through the existing replay/consumption owners.
+    """
+    current = _promotion_review_time(reviewed_at)
+    try:
+        source = (
+            verify_canonical_promotion_live_adapter_dry_run_runtime_risk_review_packet(
+                runtime_risk_review, source_final_credential_scope_recheck_packet
+            )
+        )
+    except (TypeError, ValueError) as exc:
+        raise LiveAdapterBindAuthorizationError(
+            "LABA_PROMOTION_RISK_SOURCE_INVALID"
+        ) from exc
+    if (
+        source.fail_closed
+        or not source.runtime_risk_requirement_satisfied
+        or not source.ready_for_remaining_real_bind_authorization_requirements
+    ):
+        raise LiveAdapterBindAuthorizationError("LABA_PROMOTION_RISK_NOT_PASSED")
+    recorded = datetime.fromisoformat(source.runtime_risk_review_recorded_at)
+    deadline = datetime.fromisoformat(source.runtime_risk_review_decision.valid_until)
+    if not recorded <= current < deadline:
+        raise LiveAdapterBindAuthorizationError("LABA_PROMOTION_RISK_NOT_FRESH")
+    routes = source.remaining_authorization_routes
+    invocation = {
+        route.requirement: route for route in source.remaining_invocation_routes
+    }
+    owner = "veritas_os.policy.live_adapter_bind_authorization_consumption"
+    if (
+        len(routes) < 2
+        or routes[0].requirement != "idempotency_and_replay_review"
+        or routes[0].implementation_owner != __name__
+        or routes[1].requirement != "signed_gate_bound_human_approval_issuance"
+        or any(
+            name not in invocation or invocation[name].implementation_owner != owner
+            for name in ("authorization_consumption", "single_use_consumption")
+        )
+    ):
+        raise LiveAdapterBindAuthorizationError("LABA_PROMOTION_REPLAY_ROUTE_INVALID")
+    body = {
+        "format_version": "promotion-idempotency-replay-review/v1",
+        "source_runtime_risk_review_hash": source.promotion_live_adapter_dry_run_runtime_risk_review_hash,
+        "source_projection_digest": source.source_authorization_projection_digest,
+        "reviewed_at": current.isoformat(),
+        "valid_until": deadline.astimezone(timezone.utc).isoformat(),
+        "requirement": "idempotency_and_replay_review",
+        "requirement_satisfied": True,
+        "remaining_authorization_routes": routes[1:],
+        "remaining_invocation_routes": source.remaining_invocation_routes,
+        "next_authorization_requirement": routes[1].requirement,
+        "final_authorization_key_required": True,
+        "final_authorization_key_owner": "veritas_os.policy.live_adapter_bind_authorization_checks",
+        "atomic_consumption_owner": owner,
+        "atomic_consumption_before_credentials_required": True,
+        "single_use_required": True,
+        "duplicate_dispatch_prohibited": True,
+        "bind_time_runtime_risk_recheck_required": True,
+        "duplicate_absence_verified": False,
+        "authorization_consumed": False,
+        "execution_authorized": False,
+        "bind_invoked": False,
+        "request_dispatched": False,
+    }
+    candidate = PromotionIdempotencyReplayReview(review_hash="0" * 64, **body)
+    canonical = candidate.model_dump(mode="json", exclude={"review_hash"})
+    return candidate.model_copy(
+        update={
+            "review_hash": _digest("promotion-idempotency-replay-review/v1", canonical)
+        }
+    )
+
+
+def verify_promotion_idempotency_replay_review(
+    review: Any,
+    runtime_risk_review: Any,
+    source_final_credential_scope_recheck_packet: Any,
+    *,
+    now: datetime,
+) -> PromotionIdempotencyReplayReview:
+    """Reconstruct against full independent sources and check freshness now."""
+    current = _promotion_review_time(now)
+    try:
+        raw = (
+            review.model_dump(mode="json") if isinstance(review, BaseModel) else review
+        )
+        if not isinstance(raw, dict):
+            raise ValueError("review must be a mapping")
+        recorded = datetime.fromisoformat(raw["reviewed_at"])
+        expected = review_promotion_idempotency_and_replay(
+            runtime_risk_review,
+            source_final_credential_scope_recheck_packet,
+            reviewed_at=recorded,
+        )
+        if _digest("promotion-replay-verification/v1", raw) != _digest(
+            "promotion-replay-verification/v1", expected.model_dump(mode="json")
+        ):
+            raise ValueError("review reconstruction mismatch")
+        if not recorded <= current < datetime.fromisoformat(expected.valid_until):
+            raise ValueError("review expired or not yet valid")
+    except (KeyError, TypeError, ValueError) as exc:
+        raise LiveAdapterBindAuthorizationError(
+            "LABA_PROMOTION_REPLAY_REVIEW_INVALID"
+        ) from exc
+    return expected

--- a/veritas_os/tests/test_promotion_idempotency_replay_review.py
+++ b/veritas_os/tests/test_promotion_idempotency_replay_review.py
@@ -1,0 +1,144 @@
+"""Promotion replay handoff rejects stale and substituted evidence."""
+
+from datetime import timedelta
+
+import pytest
+import veritas_os.tests.test_canonical_promotion_live_adapter_dry_run_runtime_risk_review as risk_tests
+
+from veritas_os.policy.live_adapter_bind_authorization_requirements import (
+    LiveAdapterBindAuthorizationError,
+    review_promotion_idempotency_and_replay,
+    verify_promotion_idempotency_replay_review,
+)
+from veritas_os.tests.test_canonical_promotion_live_adapter_dry_run_runtime_risk_review import (
+    RECORDED_AT,
+    VALID_UNTIL,
+    _packet,
+)
+
+pytestmark = pytest.mark.slow
+
+
+@pytest.fixture(scope="module")
+def source_packet():
+    return risk_tests.source_packet.__wrapped__()
+
+
+@pytest.fixture(scope="module")
+def projection(source_packet):
+    return risk_tests.projection.__wrapped__(source_packet)
+
+
+@pytest.fixture(scope="module")
+def valid_packet(source_packet, projection):
+    return _packet(source_packet, projection)
+
+
+@pytest.fixture(scope="module")
+def review(valid_packet, source_packet):
+    return review_promotion_idempotency_and_replay(
+        valid_packet, source_packet, reviewed_at=RECORDED_AT
+    )
+
+
+def test_roundtrip_and_remaining_boundaries(review, valid_packet, source_packet):
+    verified = verify_promotion_idempotency_replay_review(
+        review.model_dump(mode="json"), valid_packet, source_packet, now=RECORDED_AT
+    )
+    assert verified == review
+    assert (
+        verified.remaining_authorization_routes
+        == valid_packet.remaining_authorization_routes[1:]
+    )
+    assert (
+        verified.remaining_invocation_routes == valid_packet.remaining_invocation_routes
+    )
+    assert verified.final_authorization_key_required
+    assert verified.atomic_consumption_before_credentials_required
+    assert not verified.duplicate_absence_verified
+    assert not verified.execution_authorized
+    assert not verified.authorization_consumed
+    assert (
+        review_promotion_idempotency_and_replay(
+            valid_packet, source_packet, reviewed_at=RECORDED_AT
+        )
+        == review
+    )
+
+
+@pytest.mark.parametrize(
+    "time",
+    [
+        RECORDED_AT - timedelta(seconds=1),
+        VALID_UNTIL,
+        VALID_UNTIL + timedelta(seconds=1),
+    ],
+)
+def test_builder_rejects_outside_window(valid_packet, source_packet, time):
+    with pytest.raises(LiveAdapterBindAuthorizationError, match="NOT_FRESH"):
+        review_promotion_idempotency_and_replay(
+            valid_packet, source_packet, reviewed_at=time
+        )
+
+
+@pytest.mark.parametrize("time", [RECORDED_AT.replace(tzinfo=None), "invalid", None])
+def test_invalid_clock(valid_packet, source_packet, time):
+    with pytest.raises(LiveAdapterBindAuthorizationError, match="TIME_INVALID"):
+        review_promotion_idempotency_and_replay(
+            valid_packet, source_packet, reviewed_at=time
+        )
+
+
+@pytest.mark.parametrize("signal", [False, None])
+def test_nonpassing_risk(source_packet, projection, signal):
+    risk = _packet(source_packet, projection, runtime_risk_signal=signal)
+    with pytest.raises(LiveAdapterBindAuthorizationError, match="NOT_PASSED"):
+        review_promotion_idempotency_and_replay(
+            risk, source_packet, reviewed_at=RECORDED_AT
+        )
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("review_hash", "a" * 64),
+        ("source_projection_digest", "a" * 64),
+        ("source_runtime_risk_review_hash", "a" * 64),
+        ("execution_authorized", True),
+        ("execution_authorized", 0),
+        ("duplicate_absence_verified", True),
+        ("remaining_authorization_routes", []),
+        ("remaining_invocation_routes", []),
+        ("extra", True),
+        ("reviewed_at", "invalid"),
+    ],
+)
+def test_tampering(review, valid_packet, source_packet, field, value):
+    raw = review.model_dump(mode="json")
+    raw[field] = value
+    with pytest.raises(LiveAdapterBindAuthorizationError, match="REVIEW_INVALID"):
+        verify_promotion_idempotency_replay_review(
+            raw, valid_packet, source_packet, now=RECORDED_AT
+        )
+
+
+def test_verifier_rejects_expired_review(review, valid_packet, source_packet):
+    with pytest.raises(LiveAdapterBindAuthorizationError, match="REVIEW_INVALID"):
+        verify_promotion_idempotency_replay_review(
+            review, valid_packet, source_packet, now=VALID_UNTIL
+        )
+
+
+@pytest.mark.parametrize("raw", [None, {}, []])
+def test_malformed_review(raw, valid_packet, source_packet):
+    with pytest.raises(LiveAdapterBindAuthorizationError, match="REVIEW_INVALID"):
+        verify_promotion_idempotency_replay_review(
+            raw, valid_packet, source_packet, now=RECORDED_AT
+        )
+
+
+def test_independent_source_required(valid_packet):
+    with pytest.raises(LiveAdapterBindAuthorizationError, match="SOURCE_INVALID"):
+        review_promotion_idempotency_and_replay(
+            valid_packet, {}, reviewed_at=RECORDED_AT
+        )


### PR DESCRIPTION
# Summary

The promotion authorization sequence needs a verified handoff from Runtime Risk Review to the existing idempotency and replay requirements. Add that callable composition boundary in the existing requirement owner.

## Scope

- Independently verify the runtime-risk packet and its full final credential-scope source.
- Reject nonpassing risk evidence and review times outside the remaining risk window.
- Reconstruct the serialized review against independent sources and check freshness at a required current time.
- Preserve final authorization-key issuance, atomic single-use consumption before credential access, and Bind-time risk checks.
- Advance only to signed gate-bound human approval issuance.
- Add focused regression tests and English/Japanese usage documentation.

## Type of change

- [x] Runtime
- [x] Tests
- [x] Docs
- [x] Governance / security-sensitive

## Why this change matters

Connects promotion evidence to existing replay-protection owners without duplicating storage or execution mechanisms.

## Market / developer / user value

- Market value: clearer, reviewable preauthorization boundaries; no production-readiness claim.
- Developer value: a callable builder/verifier with explicit remaining requirements.
- User/operator value: stale or substituted evidence cannot pass the review verifier.

## Tests run

- [x] Other: 39 tests passed across promotion replay review, existing authorization, and existing authorization consumption.
- [x] Other: target module coverage 92.92%, exceeding the 90% test-run gate.
- [x] Other: Ruff check for veritas_os and formatting for changed Python files passed.
- [x] Other: responsibility boundaries, core complexity, bilingual docs, runtime pickle, bare except, unsafe dynamic execution, deployment defaults, and git diff checks passed.
- [ ] `make test`
- [ ] `make test-cov`
- [ ] `make quality-checks`

Tests used Python 3.12.13. Five warnings concerned NumPy reloading and jsonschema RefResolver deprecation. Full-suite and aggregate quality gates were not run for this change; PR CI is pending.

## AI assistance used

- [x] Codex

## Review status

- [ ] CI passed
- [ ] Independent review completed
- [ ] Human maintainer reviewed

## Risk checklist

- [x] Touches bind/admissibility logic
- [x] Touches governance policy behavior
- [ ] Touches release gates
- [ ] Touches secrets or credentials
- [ ] Touches TrustLog persistence or encryption behavior
- [ ] Changes public claims
- [ ] Involves private user/customer data

## Human approval required?

- [x] Yes

Reason: governance-sensitive preauthorization evidence requires human maintainer review.

## Notes for reviewer

This is a callable composition boundary, not automatic runtime integration. A passing review confirms the required replay policy and implementation routing; it does not query a store, reserve a key, prove duplicate absence, consume authorization, or grant execution authority.

Final authorization-key issuance still requires the signed decision and validity interval. Atomic consumption remains mandatory before credentials and dispatch. Digests do not authenticate external evidence.

Published through the connected GitHub API. Remote commit `a809aeb817c9d6dcf95ac7e271cae6616b5734ac` matches the tested local commit `5a48afe5447bbb530ac22abbf89841f04f7873b5` at Git tree `29484e2bd7bb01255edbc319bdcf59a42a97a15a`.
