### PR TITLE
feat: wire approval-not-required native Bind route v0.3

### DIFF
--- a/veritas_os/policy/live_adapter_dry_run_bind_authorization_gate_review_v2.py
+++ b/veritas_os/policy/live_adapter_dry_run_bind_authorization_gate_review_v2.py
@@ -1,0 +1,514 @@
+"""Dry-run Bind Authorization Gate review for contract-bound no-approval routes.
+
+This v2 gate consumes only the v2 Final Bind Authorization Readiness packet
+whose Human Approval requirement was resolved to NOT_REQUIRED_BY_ACTION_CONTRACT.
+It records readiness for a separate future real Bind authorization artifact and
+creates no authority, credentials, dispatch, network call, or external effect.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from veritas_os.policy.live_adapter_dry_run_bind_authorization_gate_review import (
+    ACKNOWLEDGEMENTS,
+    AUTHORIZATION_REQUIREMENTS,
+    INVOCATION_REQUIREMENTS,
+    OUTCOMES,
+    BindAuthorizationGateReviewDecision,
+)
+from veritas_os.policy.live_adapter_dry_run_final_bind_authorization_readiness_v2 import (
+    CanonicalLiveAdapterDryRunFinalBindAuthorizationReadinessV2Packet,
+    LiveAdapterDryRunFinalBindAuthorizationReadinessV2Error,
+    verify_live_adapter_dry_run_final_bind_authorization_readiness_v2_packet,
+)
+
+FORMAT_VERSION = "canonical-live-adapter-dry-run-bind-authorization-gate-review/v2"
+MECHANISM = (
+    "review_live_adapter_dry_run_bind_authorization_gate_"
+    "with_contract_bound_no_approval/v2"
+)
+STATUS = "LIVE_ADAPTER_DRY_RUN_BIND_AUTHORIZATION_GATE_V2_REVIEWED_NOT_AUTHORIZED"
+CHECK_MODE = "deterministic_local_bind_authorization_gate_review_v2_only"
+DOMAIN = "veritas.live-adapter-dry-run-bind-authorization-gate-review-v2.packet/v1"
+SCOPE_LIMITATIONS = (
+    "NOT_DISPATCHED",
+    "NOT_BIND_INVOCATION",
+    "NOT_BIND_AUTHORIZATION",
+    "NOT_BIND_RECEIPT",
+    "NOT_EXECUTION_AUTHORITY",
+    "NOT_HUMAN_APPROVAL",
+    "HUMAN_APPROVAL_NOT_REQUIRED_BY_ACTION_CONTRACT",
+    "NOT_CREDENTIAL_ACCESS",
+    "NOT_AUTHORIZATION_HEADER",
+    "NOT_NETWORK_CALL",
+    "NOT_EXTERNAL_EFFECT",
+)
+
+
+class LiveAdapterDryRunBindAuthorizationGateReviewV2Error(ValueError):
+    """Stable fail-closed error for the v2 no-approval gate."""
+
+
+class FutureRequirementV2(BaseModel):
+    """Requirement intentionally left for a separate future real artifact."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    ordinal: int
+    name: str
+    separate_future_artifact_required: Literal[True]
+    satisfied_by_this_packet: Literal[False]
+
+
+class BindAuthorizationGateReviewV2Result(BaseModel):
+    """Deterministic non-authorizing gate result."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    source_final_readiness_passed: Literal[True]
+    source_human_approval_requirement_satisfied: Literal[True]
+    source_human_approval_not_required_by_action_contract: Literal[True]
+    source_authority_evidence_linkage_passed: Literal[True]
+    gate_review_passed: bool
+    accepted_for_future_real_bind_authorization_artifact: bool
+    rejection_reasons: tuple[str, ...]
+    comparison_mode: Literal[CHECK_MODE]
+    creates_real_bind_authorization: Literal[False]
+    creates_execution_authority: Literal[False]
+    creates_human_approval: Literal[False]
+
+
+class CanonicalLiveAdapterDryRunBindAuthorizationGateReviewV2Packet(BaseModel):
+    """Content-addressed no-approval gate review packet."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    format_version: Literal[FORMAT_VERSION]
+    live_adapter_dry_run_bind_authorization_gate_review_v2_id: str = Field(
+        pattern=r"^ladbagr:v2:sha256:[0-9a-f]{64}$"
+    )
+    live_adapter_dry_run_bind_authorization_gate_review_v2_hash: str = Field(
+        pattern=r"^[0-9a-f]{64}$"
+    )
+    bind_authorization_gate_review_mechanism: Literal[MECHANISM]
+    bind_authorization_gate_review_recorded_at: str
+
+    source_final_bind_authorization_readiness_v2_id: str
+    source_final_bind_authorization_readiness_v2_hash: str
+    source_final_bind_authorization_readiness_v2_packet: dict[str, Any]
+    source_human_approval_not_required_linkage_hash: str
+    source_authority_evidence_linkage_review_hash: str
+    human_approval_requirement_resolution_hash: str
+
+    execution_intent_id: str
+    execution_intent_hash: str
+    action_contract_id: str
+    action_contract_version: str
+    action_contract_digest: str = Field(pattern=r"^[0-9a-f]{64}$")
+    requested_scope: tuple[str, ...]
+
+    bind_authorization_gate_review_decision: BindAuthorizationGateReviewDecision
+    bind_authorization_gate_review_decision_digest: str = Field(
+        pattern=r"^[0-9a-f]{64}$"
+    )
+    bind_authorization_gate_review_result: BindAuthorizationGateReviewV2Result
+    bind_authorization_gate_review_result_digest: str = Field(
+        pattern=r"^[0-9a-f]{64}$"
+    )
+    future_real_bind_authorization_artifact_requirements: tuple[
+        FutureRequirementV2, ...
+    ]
+    future_real_bind_authorization_artifact_requirements_digest: str = Field(
+        pattern=r"^[0-9a-f]{64}$"
+    )
+    future_bind_invocation_requirements: tuple[FutureRequirementV2, ...]
+    future_bind_invocation_requirements_digest: str = Field(
+        pattern=r"^[0-9a-f]{64}$"
+    )
+
+    request_dispatch_state: Literal["NOT_DISPATCHED"]
+    bind_state: Literal["NOT_BOUND"]
+    authority_state: Literal["NOT_AUTHORIZED"]
+    human_approval_state: Literal["NOT_REQUIRED"]
+    bind_authorization_state: Literal["NOT_AUTHORIZED"]
+    gate_review_state: Literal[
+        "PASSED_FOR_FUTURE_BIND_AUTHORIZATION_ARTIFACT",
+        "FAILED_FOR_FUTURE_BIND_AUTHORIZATION_ARTIFACT",
+    ]
+
+    human_approval_created: Literal[False]
+    execution_authority_created: Literal[False]
+    bind_authorization_created: Literal[False]
+    bind_invoked: Literal[False]
+    bind_receipt_created: Literal[False]
+    credential_material_accessed: Literal[False]
+    authorization_header_constructed: Literal[False]
+    request_dispatched: Literal[False]
+    network_used: Literal[False]
+    external_effect_occurred: Literal[False]
+    fail_closed: bool
+    bind_authorization_gate_review_status: Literal[STATUS]
+    scope_limitations: tuple[Literal[*SCOPE_LIMITATIONS], ...]
+
+
+def _timestamp(value: Any) -> str:
+    try:
+        parsed = value if isinstance(value, datetime) else datetime.fromisoformat(value)
+    except (TypeError, ValueError) as exc:
+        raise LiveAdapterDryRunBindAuthorizationGateReviewV2Error(
+            "LADBAGRV2_TIMESTAMP_INVALID"
+        ) from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise LiveAdapterDryRunBindAuthorizationGateReviewV2Error(
+            "LADBAGRV2_TIMESTAMP_INVALID"
+        )
+    return parsed.astimezone(timezone.utc).isoformat()
+
+
+def _json(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        value = value.model_dump(mode="python")
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float) and value == value and value not in (
+        float("inf"),
+        float("-inf"),
+    ):
+        return value
+    if isinstance(value, datetime):
+        return _timestamp(value)
+    if isinstance(value, (list, tuple)):
+        return [_json(item) for item in value]
+    if isinstance(value, dict) and all(isinstance(key, str) for key in value):
+        return {key: _json(item) for key, item in value.items()}
+    raise LiveAdapterDryRunBindAuthorizationGateReviewV2Error(
+        "LADBAGRV2_INVALID_JSON_VALUE"
+    )
+
+
+def _digest(domain: str, value: Any) -> str:
+    encoded = json.dumps(
+        {"domain": domain, "value": _json(value)},
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _packet_hash(raw: dict[str, Any]) -> str:
+    omitted = {
+        "live_adapter_dry_run_bind_authorization_gate_review_v2_id",
+        "live_adapter_dry_run_bind_authorization_gate_review_v2_hash",
+    }
+    return _digest(
+        DOMAIN,
+        {key: value for key, value in raw.items() if key not in omitted},
+    )
+
+
+def _source(
+    value: Any,
+) -> CanonicalLiveAdapterDryRunFinalBindAuthorizationReadinessV2Packet:
+    try:
+        return verify_live_adapter_dry_run_final_bind_authorization_readiness_v2_packet(
+            value
+        )
+    except (
+        LiveAdapterDryRunFinalBindAuthorizationReadinessV2Error,
+        TypeError,
+        ValueError,
+    ) as exc:
+        raise LiveAdapterDryRunBindAuthorizationGateReviewV2Error(
+            "LADBAGRV2_SOURCE_INVALID"
+        ) from exc
+
+
+def _validate_source(
+    source: CanonicalLiveAdapterDryRunFinalBindAuthorizationReadinessV2Packet,
+) -> None:
+    result = source.final_bind_authorization_readiness_result
+    if (
+        source.request_dispatch_state != "NOT_DISPATCHED"
+        or source.bind_state != "NOT_BOUND"
+        or source.authority_state != "NOT_AUTHORIZED"
+        or source.human_approval_state != "NOT_REQUIRED"
+        or source.final_readiness_state
+        != "READY_FOR_FUTURE_BIND_AUTHORIZATION_GATE"
+        or source.fail_closed
+        or not result.accepted_for_future_bind_authorization_gate_review
+        or not result.source_human_approval_requirement_satisfied
+        or not result.source_human_approval_not_required_by_action_contract
+        or source.human_approval_created
+        or source.execution_authority_created
+        or source.bind_authorization_created
+        or source.bind_invoked
+        or source.network_used
+        or source.external_effect_occurred
+    ):
+        raise LiveAdapterDryRunBindAuthorizationGateReviewV2Error(
+            "LADBAGRV2_SOURCE_REJECTED"
+        )
+
+
+def _decision(value: Any) -> BindAuthorizationGateReviewDecision:
+    try:
+        decision = BindAuthorizationGateReviewDecision.model_validate(_json(value))
+        normalized = decision.model_copy(
+            update={"reviewed_at": _timestamp(decision.reviewed_at)}
+        )
+    except (ValidationError, TypeError, ValueError) as exc:
+        raise LiveAdapterDryRunBindAuthorizationGateReviewV2Error(
+            "LADBAGRV2_DECISION_INVALID"
+        ) from exc
+    if not all(getattr(normalized, field) for field in ACKNOWLEDGEMENTS):
+        raise LiveAdapterDryRunBindAuthorizationGateReviewV2Error(
+            "LADBAGRV2_ACKNOWLEDGEMENT_MISSING"
+        )
+    return normalized
+
+
+def _requirements(names: tuple[str, ...]) -> list[dict[str, Any]]:
+    return [
+        {
+            "ordinal": ordinal,
+            "name": name,
+            "separate_future_artifact_required": True,
+            "satisfied_by_this_packet": False,
+        }
+        for ordinal, name in enumerate(names, 1)
+    ]
+
+
+def _derived(
+    decision: BindAuthorizationGateReviewDecision,
+) -> tuple[dict[str, Any], list[dict[str, Any]], list[dict[str, Any]]]:
+    accepted = decision.review_outcome == OUTCOMES[0]
+    result = {
+        "source_final_readiness_passed": True,
+        "source_human_approval_requirement_satisfied": True,
+        "source_human_approval_not_required_by_action_contract": True,
+        "source_authority_evidence_linkage_passed": True,
+        "gate_review_passed": accepted,
+        "accepted_for_future_real_bind_authorization_artifact": accepted,
+        "rejection_reasons": (
+            [] if accepted else ["BIND_AUTHORIZATION_GATE_REVIEW_FAILED"]
+        ),
+        "comparison_mode": CHECK_MODE,
+        "creates_real_bind_authorization": False,
+        "creates_execution_authority": False,
+        "creates_human_approval": False,
+    }
+    return (
+        result,
+        _requirements(AUTHORIZATION_REQUIREMENTS),
+        _requirements(INVOCATION_REQUIREMENTS),
+    )
+
+
+def build_live_adapter_dry_run_bind_authorization_gate_review_v2_packet(
+    source_final_bind_authorization_readiness_v2_packet: Any,
+    bind_authorization_gate_review_decision: Any,
+    bind_authorization_gate_review_recorded_at: datetime,
+) -> CanonicalLiveAdapterDryRunBindAuthorizationGateReviewV2Packet:
+    """Build a non-authorizing gate packet for the no-approval route."""
+
+    source = _source(source_final_bind_authorization_readiness_v2_packet)
+    _validate_source(source)
+    decision = _decision(bind_authorization_gate_review_decision)
+    result, authorization, invocation = _derived(decision)
+    accepted = result["accepted_for_future_real_bind_authorization_artifact"]
+
+    decision_digest = _digest("decision/v2", decision)
+    result_digest = _digest("result/v2", result)
+    authorization_digest = _digest("authorization-requirements/v2", authorization)
+    invocation_digest = _digest("invocation-requirements/v2", invocation)
+    source_raw = source.model_dump(mode="json")
+    raw = {
+        "format_version": FORMAT_VERSION,
+        "bind_authorization_gate_review_mechanism": MECHANISM,
+        "bind_authorization_gate_review_recorded_at": _timestamp(
+            bind_authorization_gate_review_recorded_at
+        ),
+        "source_final_bind_authorization_readiness_v2_id": (
+            source.live_adapter_dry_run_final_bind_authorization_readiness_v2_id
+        ),
+        "source_final_bind_authorization_readiness_v2_hash": (
+            source.live_adapter_dry_run_final_bind_authorization_readiness_v2_hash
+        ),
+        "source_final_bind_authorization_readiness_v2_packet": source_raw,
+        "source_human_approval_not_required_linkage_hash": (
+            source.source_human_approval_not_required_linkage_hash
+        ),
+        "source_authority_evidence_linkage_review_hash": (
+            source.source_authority_evidence_linkage_review_hash
+        ),
+        "human_approval_requirement_resolution_hash": (
+            source.human_approval_requirement_resolution_hash
+        ),
+        "execution_intent_id": source.execution_intent_id,
+        "execution_intent_hash": source.execution_intent_hash,
+        "action_contract_id": source.action_contract_id,
+        "action_contract_version": source.action_contract_version,
+        "action_contract_digest": source.action_contract_digest,
+        "requested_scope": source.requested_scope,
+        "bind_authorization_gate_review_decision": decision.model_dump(mode="json"),
+        "bind_authorization_gate_review_decision_digest": decision_digest,
+        "bind_authorization_gate_review_result": result,
+        "bind_authorization_gate_review_result_digest": result_digest,
+        "future_real_bind_authorization_artifact_requirements": authorization,
+        "future_real_bind_authorization_artifact_requirements_digest": (
+            authorization_digest
+        ),
+        "future_bind_invocation_requirements": invocation,
+        "future_bind_invocation_requirements_digest": invocation_digest,
+        "request_dispatch_state": "NOT_DISPATCHED",
+        "bind_state": "NOT_BOUND",
+        "authority_state": "NOT_AUTHORIZED",
+        "human_approval_state": "NOT_REQUIRED",
+        "bind_authorization_state": "NOT_AUTHORIZED",
+        "gate_review_state": (
+            "PASSED_FOR_FUTURE_BIND_AUTHORIZATION_ARTIFACT"
+            if accepted
+            else "FAILED_FOR_FUTURE_BIND_AUTHORIZATION_ARTIFACT"
+        ),
+        "human_approval_created": False,
+        "execution_authority_created": False,
+        "bind_authorization_created": False,
+        "bind_invoked": False,
+        "bind_receipt_created": False,
+        "credential_material_accessed": False,
+        "authorization_header_constructed": False,
+        "request_dispatched": False,
+        "network_used": False,
+        "external_effect_occurred": False,
+        "fail_closed": not accepted,
+        "bind_authorization_gate_review_status": STATUS,
+        "scope_limitations": SCOPE_LIMITATIONS,
+    }
+    digest = _packet_hash(raw)
+    raw["live_adapter_dry_run_bind_authorization_gate_review_v2_hash"] = digest
+    raw["live_adapter_dry_run_bind_authorization_gate_review_v2_id"] = (
+        f"ladbagr:v2:sha256:{digest}"
+    )
+    return verify_live_adapter_dry_run_bind_authorization_gate_review_v2_packet(raw)
+
+
+def verify_live_adapter_dry_run_bind_authorization_gate_review_v2_packet(
+    value: Any,
+) -> CanonicalLiveAdapterDryRunBindAuthorizationGateReviewV2Packet:
+    """Re-verify source, decision, requirements, non-effects, and packet hash."""
+
+    try:
+        packet = (
+            value
+            if isinstance(
+                value,
+                CanonicalLiveAdapterDryRunBindAuthorizationGateReviewV2Packet,
+            )
+            else CanonicalLiveAdapterDryRunBindAuthorizationGateReviewV2Packet.model_validate(
+                _json(value)
+            )
+        )
+    except (
+        ValidationError,
+        TypeError,
+        LiveAdapterDryRunBindAuthorizationGateReviewV2Error,
+    ) as exc:
+        raise LiveAdapterDryRunBindAuthorizationGateReviewV2Error(
+            "LADBAGRV2_PACKET_SCHEMA_INVALID"
+        ) from exc
+
+    source = _source(packet.source_final_bind_authorization_readiness_v2_packet)
+    _validate_source(source)
+    decision = _decision(packet.bind_authorization_gate_review_decision)
+    result, authorization, invocation = _derived(decision)
+    accepted = result["accepted_for_future_real_bind_authorization_artifact"]
+
+    identities = (
+        packet.source_final_bind_authorization_readiness_v2_id
+        == source.live_adapter_dry_run_final_bind_authorization_readiness_v2_id,
+        packet.source_final_bind_authorization_readiness_v2_hash
+        == source.live_adapter_dry_run_final_bind_authorization_readiness_v2_hash,
+        packet.source_human_approval_not_required_linkage_hash
+        == source.source_human_approval_not_required_linkage_hash,
+        packet.source_authority_evidence_linkage_review_hash
+        == source.source_authority_evidence_linkage_review_hash,
+        packet.human_approval_requirement_resolution_hash
+        == source.human_approval_requirement_resolution_hash,
+        packet.execution_intent_id == source.execution_intent_id,
+        packet.execution_intent_hash == source.execution_intent_hash,
+        packet.action_contract_id == source.action_contract_id,
+        packet.action_contract_version == source.action_contract_version,
+        packet.action_contract_digest == source.action_contract_digest,
+        packet.requested_scope == source.requested_scope,
+    )
+    if not all(identities):
+        raise LiveAdapterDryRunBindAuthorizationGateReviewV2Error(
+            "LADBAGRV2_IDENTITY_MISMATCH"
+        )
+
+    expected_gate_state = (
+        "PASSED_FOR_FUTURE_BIND_AUTHORIZATION_ARTIFACT"
+        if accepted
+        else "FAILED_FOR_FUTURE_BIND_AUTHORIZATION_ARTIFACT"
+    )
+    if (
+        packet.bind_authorization_gate_review_decision_digest
+        != _digest("decision/v2", decision)
+        or _json(packet.bind_authorization_gate_review_result) != _json(result)
+        or packet.bind_authorization_gate_review_result_digest
+        != _digest("result/v2", result)
+        or _json(packet.future_real_bind_authorization_artifact_requirements)
+        != _json(authorization)
+        or packet.future_real_bind_authorization_artifact_requirements_digest
+        != _digest("authorization-requirements/v2", authorization)
+        or _json(packet.future_bind_invocation_requirements)
+        != _json(invocation)
+        or packet.future_bind_invocation_requirements_digest
+        != _digest("invocation-requirements/v2", invocation)
+        or packet.gate_review_state != expected_gate_state
+        or packet.fail_closed != (not accepted)
+    ):
+        raise LiveAdapterDryRunBindAuthorizationGateReviewV2Error(
+            "LADBAGRV2_DERIVED_MISMATCH"
+        )
+
+    effects = (
+        packet.human_approval_created,
+        packet.execution_authority_created,
+        packet.bind_authorization_created,
+        packet.bind_invoked,
+        packet.bind_receipt_created,
+        packet.credential_material_accessed,
+        packet.authorization_header_constructed,
+        packet.request_dispatched,
+        packet.network_used,
+        packet.external_effect_occurred,
+    )
+    if any(effects):
+        raise LiveAdapterDryRunBindAuthorizationGateReviewV2Error(
+            "LADBAGRV2_EFFECT_INVALID"
+        )
+    if packet.scope_limitations != SCOPE_LIMITATIONS:
+        raise LiveAdapterDryRunBindAuthorizationGateReviewV2Error(
+            "LADBAGRV2_SCOPE_LIMITATIONS_MISMATCH"
+        )
+
+    actual = packet.model_dump(mode="python")
+    digest = _packet_hash(actual)
+    if (
+        packet.live_adapter_dry_run_bind_authorization_gate_review_v2_hash
+        != digest
+        or packet.live_adapter_dry_run_bind_authorization_gate_review_v2_id
+        != f"ladbagr:v2:sha256:{digest}"
+    ):
+        raise LiveAdapterDryRunBindAuthorizationGateReviewV2Error(
+            "LADBAGRV2_HASH_MISMATCH"
+        )
+    return packet

--- a/veritas_os/policy/live_adapter_dry_run_final_bind_authorization_readiness_v2.py
+++ b/veritas_os/policy/live_adapter_dry_run_final_bind_authorization_readiness_v2.py
@@ -1,0 +1,457 @@
+"""Final dry-run Bind readiness for contract-bound no-approval routes.
+
+This v2 artifact accepts only a verified Human Approval Not Required linkage
+packet. It preserves the existing v1 approval-required path unchanged and does
+not create Human Approval, execution authority, Bind authorization, or effects.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from veritas_os.policy.live_adapter_dry_run_final_bind_authorization_readiness import (
+    ACKNOWLEDGEMENTS,
+    OUTCOMES,
+    FinalBindAuthorizationReadinessReviewDecision,
+)
+from veritas_os.policy.live_adapter_dry_run_human_approval_not_required_linkage import (
+    CanonicalLiveAdapterDryRunHumanApprovalNotRequiredLinkagePacket,
+    LiveAdapterDryRunHumanApprovalNotRequiredLinkageError,
+    verify_live_adapter_dry_run_human_approval_not_required_linkage_packet,
+)
+
+FORMAT_VERSION = "canonical-live-adapter-dry-run-final-bind-authorization-readiness/v2"
+MECHANISM = (
+    "evaluate_live_adapter_dry_run_final_bind_authorization_readiness_"
+    "with_contract_bound_no_approval/v2"
+)
+STATUS = (
+    "LIVE_ADAPTER_DRY_RUN_FINAL_BIND_AUTHORIZATION_READINESS_V2_"
+    "RECORDED_NOT_AUTHORIZED"
+)
+CHECK_MODE = "deterministic_local_final_bind_authorization_readiness_v2_only"
+DOMAIN = "veritas.live-adapter-dry-run-final-bind-authorization-readiness-v2.packet/v1"
+SCOPE_LIMITATIONS = (
+    "NOT_DISPATCHED",
+    "NOT_BIND_INVOCATION",
+    "NOT_BIND_AUTHORIZATION",
+    "NOT_BIND_RECEIPT",
+    "NOT_EXECUTION_AUTHORITY",
+    "NOT_HUMAN_APPROVAL",
+    "HUMAN_APPROVAL_NOT_REQUIRED_BY_ACTION_CONTRACT",
+    "NOT_CREDENTIAL_ACCESS",
+    "NOT_AUTHORIZATION_HEADER",
+    "NOT_NETWORK_CALL",
+    "NOT_EXTERNAL_EFFECT",
+)
+
+
+class LiveAdapterDryRunFinalBindAuthorizationReadinessV2Error(ValueError):
+    """Stable fail-closed error for v2 final readiness."""
+
+
+class FinalReadinessV2Result(BaseModel):
+    """Deterministic readiness result for the no-approval route."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    source_no_approval_linkage_verified: Literal[True]
+    source_human_approval_requirement_satisfied: Literal[True]
+    source_human_approval_not_required_by_action_contract: Literal[True]
+    source_authority_evidence_linkage_passed: Literal[True]
+    final_review_passed: bool
+    accepted_for_future_bind_authorization_gate_review: bool
+    rejection_reasons: tuple[str, ...]
+    comparison_mode: Literal[CHECK_MODE]
+    creates_bind_authorization: Literal[False]
+    creates_execution_authority: Literal[False]
+    creates_human_approval: Literal[False]
+
+
+class CanonicalLiveAdapterDryRunFinalBindAuthorizationReadinessV2Packet(BaseModel):
+    """Content-addressed final readiness packet for no-approval routes."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    format_version: Literal[FORMAT_VERSION]
+    live_adapter_dry_run_final_bind_authorization_readiness_v2_id: str = Field(
+        pattern=r"^ladfbar:v2:sha256:[0-9a-f]{64}$"
+    )
+    live_adapter_dry_run_final_bind_authorization_readiness_v2_hash: str = Field(
+        pattern=r"^[0-9a-f]{64}$"
+    )
+    final_bind_authorization_readiness_mechanism: Literal[MECHANISM]
+    final_bind_authorization_readiness_recorded_at: str
+
+    source_human_approval_not_required_linkage_id: str
+    source_human_approval_not_required_linkage_hash: str
+    source_human_approval_not_required_linkage_packet: dict[str, Any]
+    source_authority_evidence_linkage_review_hash: str
+    human_approval_requirement_resolution_hash: str
+
+    execution_intent_id: str
+    execution_intent_hash: str
+    action_contract_id: str
+    action_contract_version: str
+    action_contract_digest: str = Field(pattern=r"^[0-9a-f]{64}$")
+    requested_scope: tuple[str, ...]
+
+    final_bind_authorization_readiness_review_decision: (
+        FinalBindAuthorizationReadinessReviewDecision
+    )
+    final_bind_authorization_readiness_review_decision_digest: str = Field(
+        pattern=r"^[0-9a-f]{64}$"
+    )
+    final_bind_authorization_readiness_result: FinalReadinessV2Result
+    final_bind_authorization_readiness_result_digest: str = Field(
+        pattern=r"^[0-9a-f]{64}$"
+    )
+
+    request_dispatch_state: Literal["NOT_DISPATCHED"]
+    bind_state: Literal["NOT_BOUND"]
+    authority_state: Literal["NOT_AUTHORIZED"]
+    human_approval_state: Literal["NOT_REQUIRED"]
+    final_readiness_state: Literal[
+        "READY_FOR_FUTURE_BIND_AUTHORIZATION_GATE",
+        "NOT_READY_FOR_FUTURE_BIND_AUTHORIZATION_GATE",
+    ]
+
+    human_approval_created: Literal[False]
+    execution_authority_created: Literal[False]
+    bind_authorization_created: Literal[False]
+    bind_invoked: Literal[False]
+    bind_receipt_created: Literal[False]
+    credential_material_accessed: Literal[False]
+    authorization_header_constructed: Literal[False]
+    network_used: Literal[False]
+    external_effect_occurred: Literal[False]
+    fail_closed: bool
+    final_bind_authorization_readiness_status: Literal[STATUS]
+    scope_limitations: tuple[Literal[*SCOPE_LIMITATIONS], ...]
+
+
+def _timestamp(value: Any) -> str:
+    try:
+        parsed = value if isinstance(value, datetime) else datetime.fromisoformat(value)
+    except (TypeError, ValueError) as exc:
+        raise LiveAdapterDryRunFinalBindAuthorizationReadinessV2Error(
+            "LADFBARV2_TIMESTAMP_INVALID"
+        ) from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise LiveAdapterDryRunFinalBindAuthorizationReadinessV2Error(
+            "LADFBARV2_TIMESTAMP_INVALID"
+        )
+    return parsed.astimezone(timezone.utc).isoformat()
+
+
+def _json(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        value = value.model_dump(mode="python")
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float) and value == value and value not in (
+        float("inf"),
+        float("-inf"),
+    ):
+        return value
+    if isinstance(value, datetime):
+        return _timestamp(value)
+    if isinstance(value, (list, tuple)):
+        return [_json(item) for item in value]
+    if isinstance(value, dict) and all(isinstance(key, str) for key in value):
+        return {key: _json(item) for key, item in value.items()}
+    raise LiveAdapterDryRunFinalBindAuthorizationReadinessV2Error(
+        "LADFBARV2_INVALID_JSON_VALUE"
+    )
+
+
+def _digest(domain: str, value: Any) -> str:
+    encoded = json.dumps(
+        {"domain": domain, "value": _json(value)},
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _packet_hash(raw: dict[str, Any]) -> str:
+    omitted = {
+        "live_adapter_dry_run_final_bind_authorization_readiness_v2_id",
+        "live_adapter_dry_run_final_bind_authorization_readiness_v2_hash",
+    }
+    return _digest(
+        DOMAIN,
+        {key: value for key, value in raw.items() if key not in omitted},
+    )
+
+
+def _source(
+    value: Any,
+) -> CanonicalLiveAdapterDryRunHumanApprovalNotRequiredLinkagePacket:
+    try:
+        return verify_live_adapter_dry_run_human_approval_not_required_linkage_packet(
+            value
+        )
+    except (
+        LiveAdapterDryRunHumanApprovalNotRequiredLinkageError,
+        TypeError,
+        ValueError,
+    ) as exc:
+        raise LiveAdapterDryRunFinalBindAuthorizationReadinessV2Error(
+            "LADFBARV2_SOURCE_INVALID"
+        ) from exc
+
+
+def _validate_source(
+    source: CanonicalLiveAdapterDryRunHumanApprovalNotRequiredLinkagePacket,
+) -> None:
+    result = source.human_approval_not_required_linkage_result
+    if (
+        source.request_dispatch_state != "NOT_DISPATCHED"
+        or source.bind_state != "NOT_BOUND"
+        or source.authority_state != "NOT_AUTHORIZED"
+        or source.human_approval_state != "NOT_REQUIRED"
+        or source.fail_closed
+        or not result.accepted_for_final_bind_authorization_readiness
+        or result.human_approval_required
+        or source.human_approval_reference_count != 0
+        or source.human_approval_created
+        or source.execution_authority_created
+        or source.bind_authorization_created
+        or source.bind_invoked
+        or source.network_used
+        or source.external_effect_occurred
+    ):
+        raise LiveAdapterDryRunFinalBindAuthorizationReadinessV2Error(
+            "LADFBARV2_SOURCE_REJECTED"
+        )
+
+
+def _decision(value: Any) -> FinalBindAuthorizationReadinessReviewDecision:
+    try:
+        decision = FinalBindAuthorizationReadinessReviewDecision.model_validate(
+            _json(value)
+        )
+        normalized = decision.model_copy(
+            update={"reviewed_at": _timestamp(decision.reviewed_at)}
+        )
+    except (ValidationError, TypeError, ValueError) as exc:
+        raise LiveAdapterDryRunFinalBindAuthorizationReadinessV2Error(
+            "LADFBARV2_DECISION_INVALID"
+        ) from exc
+    if not all(getattr(normalized, field) for field in ACKNOWLEDGEMENTS):
+        raise LiveAdapterDryRunFinalBindAuthorizationReadinessV2Error(
+            "LADFBARV2_ACKNOWLEDGEMENT_MISSING"
+        )
+    return normalized
+
+
+def _derived(
+    decision: FinalBindAuthorizationReadinessReviewDecision,
+) -> dict[str, Any]:
+    accepted = decision.review_outcome == OUTCOMES[0]
+    return {
+        "source_no_approval_linkage_verified": True,
+        "source_human_approval_requirement_satisfied": True,
+        "source_human_approval_not_required_by_action_contract": True,
+        "source_authority_evidence_linkage_passed": True,
+        "final_review_passed": accepted,
+        "accepted_for_future_bind_authorization_gate_review": accepted,
+        "rejection_reasons": (
+            [] if accepted else ["FINAL_BIND_AUTHORIZATION_READINESS_REJECTED"]
+        ),
+        "comparison_mode": CHECK_MODE,
+        "creates_bind_authorization": False,
+        "creates_execution_authority": False,
+        "creates_human_approval": False,
+    }
+
+
+def build_live_adapter_dry_run_final_bind_authorization_readiness_v2_packet(
+    source_human_approval_not_required_linkage_packet: Any,
+    final_bind_authorization_readiness_review_decision: Any,
+    final_bind_authorization_readiness_recorded_at: datetime,
+) -> CanonicalLiveAdapterDryRunFinalBindAuthorizationReadinessV2Packet:
+    """Build final readiness without requiring or inventing Human Approval."""
+
+    source = _source(source_human_approval_not_required_linkage_packet)
+    _validate_source(source)
+    decision = _decision(final_bind_authorization_readiness_review_decision)
+    result = _derived(decision)
+    accepted = result["accepted_for_future_bind_authorization_gate_review"]
+
+    source_raw = source.model_dump(mode="json")
+    decision_digest = _digest("decision/v2", decision)
+    result_digest = _digest("result/v2", result)
+    raw = {
+        "format_version": FORMAT_VERSION,
+        "final_bind_authorization_readiness_mechanism": MECHANISM,
+        "final_bind_authorization_readiness_recorded_at": _timestamp(
+            final_bind_authorization_readiness_recorded_at
+        ),
+        "source_human_approval_not_required_linkage_id": (
+            source.live_adapter_dry_run_human_approval_not_required_linkage_id
+        ),
+        "source_human_approval_not_required_linkage_hash": (
+            source.live_adapter_dry_run_human_approval_not_required_linkage_hash
+        ),
+        "source_human_approval_not_required_linkage_packet": source_raw,
+        "source_authority_evidence_linkage_review_hash": (
+            source.source_authority_evidence_linkage_review_hash
+        ),
+        "human_approval_requirement_resolution_hash": (
+            source.human_approval_requirement_resolution_hash
+        ),
+        "execution_intent_id": source.execution_intent_id,
+        "execution_intent_hash": source.execution_intent_hash,
+        "action_contract_id": source.action_contract_id,
+        "action_contract_version": source.action_contract_version,
+        "action_contract_digest": source.action_contract_digest,
+        "requested_scope": source.requested_scope,
+        "final_bind_authorization_readiness_review_decision": decision.model_dump(
+            mode="json"
+        ),
+        "final_bind_authorization_readiness_review_decision_digest": decision_digest,
+        "final_bind_authorization_readiness_result": result,
+        "final_bind_authorization_readiness_result_digest": result_digest,
+        "request_dispatch_state": "NOT_DISPATCHED",
+        "bind_state": "NOT_BOUND",
+        "authority_state": "NOT_AUTHORIZED",
+        "human_approval_state": "NOT_REQUIRED",
+        "final_readiness_state": (
+            "READY_FOR_FUTURE_BIND_AUTHORIZATION_GATE"
+            if accepted
+            else "NOT_READY_FOR_FUTURE_BIND_AUTHORIZATION_GATE"
+        ),
+        "human_approval_created": False,
+        "execution_authority_created": False,
+        "bind_authorization_created": False,
+        "bind_invoked": False,
+        "bind_receipt_created": False,
+        "credential_material_accessed": False,
+        "authorization_header_constructed": False,
+        "network_used": False,
+        "external_effect_occurred": False,
+        "fail_closed": not accepted,
+        "final_bind_authorization_readiness_status": STATUS,
+        "scope_limitations": SCOPE_LIMITATIONS,
+    }
+    digest = _packet_hash(raw)
+    raw["live_adapter_dry_run_final_bind_authorization_readiness_v2_hash"] = digest
+    raw["live_adapter_dry_run_final_bind_authorization_readiness_v2_id"] = (
+        f"ladfbar:v2:sha256:{digest}"
+    )
+    return verify_live_adapter_dry_run_final_bind_authorization_readiness_v2_packet(
+        raw
+    )
+
+
+def verify_live_adapter_dry_run_final_bind_authorization_readiness_v2_packet(
+    value: Any,
+) -> CanonicalLiveAdapterDryRunFinalBindAuthorizationReadinessV2Packet:
+    """Re-verify source, decision, derived result, non-effects, and hash."""
+
+    try:
+        packet = (
+            value
+            if isinstance(
+                value,
+                CanonicalLiveAdapterDryRunFinalBindAuthorizationReadinessV2Packet,
+            )
+            else CanonicalLiveAdapterDryRunFinalBindAuthorizationReadinessV2Packet.model_validate(
+                _json(value)
+            )
+        )
+    except (
+        ValidationError,
+        TypeError,
+        LiveAdapterDryRunFinalBindAuthorizationReadinessV2Error,
+    ) as exc:
+        raise LiveAdapterDryRunFinalBindAuthorizationReadinessV2Error(
+            "LADFBARV2_PACKET_SCHEMA_INVALID"
+        ) from exc
+
+    source = _source(packet.source_human_approval_not_required_linkage_packet)
+    _validate_source(source)
+    decision = _decision(packet.final_bind_authorization_readiness_review_decision)
+    expected_result = _derived(decision)
+    accepted = expected_result["accepted_for_future_bind_authorization_gate_review"]
+
+    identities = (
+        packet.source_human_approval_not_required_linkage_id
+        == source.live_adapter_dry_run_human_approval_not_required_linkage_id,
+        packet.source_human_approval_not_required_linkage_hash
+        == source.live_adapter_dry_run_human_approval_not_required_linkage_hash,
+        packet.source_authority_evidence_linkage_review_hash
+        == source.source_authority_evidence_linkage_review_hash,
+        packet.human_approval_requirement_resolution_hash
+        == source.human_approval_requirement_resolution_hash,
+        packet.execution_intent_id == source.execution_intent_id,
+        packet.execution_intent_hash == source.execution_intent_hash,
+        packet.action_contract_id == source.action_contract_id,
+        packet.action_contract_version == source.action_contract_version,
+        packet.action_contract_digest == source.action_contract_digest,
+        packet.requested_scope == source.requested_scope,
+    )
+    if not all(identities):
+        raise LiveAdapterDryRunFinalBindAuthorizationReadinessV2Error(
+            "LADFBARV2_IDENTITY_MISMATCH"
+        )
+
+    if (
+        packet.final_bind_authorization_readiness_review_decision_digest
+        != _digest("decision/v2", decision)
+        or _json(packet.final_bind_authorization_readiness_result)
+        != _json(expected_result)
+        or packet.final_bind_authorization_readiness_result_digest
+        != _digest("result/v2", expected_result)
+        or packet.final_readiness_state
+        != (
+            "READY_FOR_FUTURE_BIND_AUTHORIZATION_GATE"
+            if accepted
+            else "NOT_READY_FOR_FUTURE_BIND_AUTHORIZATION_GATE"
+        )
+        or packet.fail_closed != (not accepted)
+    ):
+        raise LiveAdapterDryRunFinalBindAuthorizationReadinessV2Error(
+            "LADFBARV2_DERIVED_MISMATCH"
+        )
+
+    effects = (
+        packet.human_approval_created,
+        packet.execution_authority_created,
+        packet.bind_authorization_created,
+        packet.bind_invoked,
+        packet.bind_receipt_created,
+        packet.credential_material_accessed,
+        packet.authorization_header_constructed,
+        packet.network_used,
+        packet.external_effect_occurred,
+    )
+    if any(effects):
+        raise LiveAdapterDryRunFinalBindAuthorizationReadinessV2Error(
+            "LADFBARV2_EFFECT_INVALID"
+        )
+    if packet.scope_limitations != SCOPE_LIMITATIONS:
+        raise LiveAdapterDryRunFinalBindAuthorizationReadinessV2Error(
+            "LADFBARV2_SCOPE_LIMITATIONS_MISMATCH"
+        )
+
+    actual = packet.model_dump(mode="python")
+    digest = _packet_hash(actual)
+    if (
+        packet.live_adapter_dry_run_final_bind_authorization_readiness_v2_hash
+        != digest
+        or packet.live_adapter_dry_run_final_bind_authorization_readiness_v2_id
+        != f"ladfbar:v2:sha256:{digest}"
+    ):
+        raise LiveAdapterDryRunFinalBindAuthorizationReadinessV2Error(
+            "LADFBARV2_HASH_MISMATCH"
+        )
+    return packet

--- a/veritas_os/policy/live_adapter_dry_run_human_approval_not_required_linkage.py
+++ b/veritas_os/policy/live_adapter_dry_run_human_approval_not_required_linkage.py
@@ -1,0 +1,439 @@
+"""Bind contract-derived Human Approval non-requirement to the dry-run chain.
+
+This module is deliberately non-authorizing. It verifies both the upstream
+Authority Evidence linkage packet and a HumanApprovalRequirementResolution
+packet, requires the latter to resolve to NOT_REQUIRED_BY_ACTION_CONTRACT, and
+emits a content-addressed linkage artifact without fabricating Human Approval.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from veritas_os.policy.human_approval_requirement_resolution import (
+    CanonicalHumanApprovalRequirementResolutionPacket,
+    HumanApprovalRequirementResolutionError,
+    verify_human_approval_requirement_resolution_packet,
+)
+from veritas_os.policy.live_adapter_dry_run_authority_evidence_linkage import (
+    CanonicalLiveAdapterDryRunAuthorityEvidenceLinkageReviewPacket,
+    LiveAdapterDryRunAuthorityEvidenceLinkageError,
+    verify_live_adapter_dry_run_authority_evidence_linkage_review_packet,
+)
+
+FORMAT_VERSION = "canonical-live-adapter-dry-run-human-approval-not-required-linkage/v1"
+MECHANISM = "bind_contract_derived_human_approval_non_requirement/v1"
+STATUS = "LIVE_ADAPTER_DRY_RUN_HUMAN_APPROVAL_REQUIREMENT_SATISFIED_NOT_AUTHORIZED"
+DOMAIN = "veritas.live-adapter-dry-run-human-approval-not-required-linkage.packet/v1"
+REQUIREMENT_STATE = "NOT_REQUIRED_BY_ACTION_CONTRACT"
+SCOPE_LIMITATIONS = (
+    "NOT_HUMAN_APPROVAL",
+    "NOT_HUMAN_APPROVAL_CREATION",
+    "NOT_EXECUTION_AUTHORITY",
+    "NOT_BIND_AUTHORIZATION",
+    "NOT_BIND_INVOCATION",
+    "NOT_BIND_RECEIPT",
+    "NOT_CREDENTIAL_ACCESS",
+    "NOT_AUTHORIZATION_HEADER",
+    "NOT_NETWORK_CALL",
+    "NOT_EXTERNAL_EFFECT",
+)
+
+
+class LiveAdapterDryRunHumanApprovalNotRequiredLinkageError(ValueError):
+    """Stable fail-closed error for the no-approval linkage route."""
+
+
+class HumanApprovalNotRequiredLinkageResult(BaseModel):
+    """Deterministic result proving only that approval is not required."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    source_authority_evidence_linkage_verified: Literal[True]
+    requirement_resolution_verified: Literal[True]
+    human_approval_required: Literal[False]
+    human_approval_reference_count: Literal[0]
+    human_approval_references_absent: Literal[True]
+    accepted_for_final_bind_authorization_readiness: Literal[True]
+    creates_human_approval: Literal[False]
+    creates_execution_authority: Literal[False]
+    creates_bind_authorization: Literal[False]
+
+
+class CanonicalLiveAdapterDryRunHumanApprovalNotRequiredLinkagePacket(BaseModel):
+    """Content-addressed proof that Human Approval is contractually not required."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    format_version: Literal[FORMAT_VERSION]
+    live_adapter_dry_run_human_approval_not_required_linkage_id: str = Field(
+        pattern=r"^ladhanr:v1:sha256:[0-9a-f]{64}$"
+    )
+    live_adapter_dry_run_human_approval_not_required_linkage_hash: str = Field(
+        pattern=r"^[0-9a-f]{64}$"
+    )
+    linkage_mechanism: Literal[MECHANISM]
+    linkage_recorded_at: str
+    source_authority_evidence_linkage_review_id: str
+    source_authority_evidence_linkage_review_hash: str
+    source_authority_evidence_linkage_review_packet: dict[str, Any]
+    human_approval_requirement_resolution_id: str
+    human_approval_requirement_resolution_hash: str
+    human_approval_requirement_resolution_packet: dict[str, Any]
+    execution_intent_id: str
+    execution_intent_hash: str
+    action_contract_id: str
+    action_contract_version: str
+    action_contract_digest: str = Field(pattern=r"^[0-9a-f]{64}$")
+    requested_scope: tuple[str, ...]
+    human_approval_requirement_state: Literal[REQUIREMENT_STATE]
+    human_approval_reference_count: Literal[0]
+    human_approval_not_required_linkage_result: HumanApprovalNotRequiredLinkageResult
+    request_dispatch_state: Literal["NOT_DISPATCHED"]
+    bind_state: Literal["NOT_BOUND"]
+    authority_state: Literal["NOT_AUTHORIZED"]
+    human_approval_state: Literal["NOT_REQUIRED"]
+    human_approval_created: Literal[False]
+    execution_authority_created: Literal[False]
+    bind_authorization_created: Literal[False]
+    bind_invoked: Literal[False]
+    bind_receipt_created: Literal[False]
+    credential_material_accessed: Literal[False]
+    authorization_header_constructed: Literal[False]
+    network_used: Literal[False]
+    external_effect_occurred: Literal[False]
+    fail_closed: Literal[False]
+    linkage_status: Literal[STATUS]
+    scope_limitations: tuple[Literal[*SCOPE_LIMITATIONS], ...]
+
+
+def _timestamp(value: Any) -> str:
+    try:
+        parsed = value if isinstance(value, datetime) else datetime.fromisoformat(value)
+    except (TypeError, ValueError) as exc:
+        raise LiveAdapterDryRunHumanApprovalNotRequiredLinkageError(
+            "LADHANR_TIMESTAMP_INVALID"
+        ) from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise LiveAdapterDryRunHumanApprovalNotRequiredLinkageError(
+            "LADHANR_TIMESTAMP_INVALID"
+        )
+    return parsed.astimezone(timezone.utc).isoformat()
+
+
+def _json(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        value = value.model_dump(mode="python")
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float) and value == value and value not in (
+        float("inf"),
+        float("-inf"),
+    ):
+        return value
+    if isinstance(value, datetime):
+        return _timestamp(value)
+    if isinstance(value, (list, tuple)):
+        return [_json(item) for item in value]
+    if isinstance(value, dict) and all(isinstance(key, str) for key in value):
+        return {key: _json(item) for key, item in value.items()}
+    raise LiveAdapterDryRunHumanApprovalNotRequiredLinkageError(
+        "LADHANR_INVALID_JSON_VALUE"
+    )
+
+
+def _digest(value: Any) -> str:
+    encoded = json.dumps(
+        {"domain": DOMAIN, "value": _json(value)},
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _packet_hash(raw: dict[str, Any]) -> str:
+    omitted = {
+        "live_adapter_dry_run_human_approval_not_required_linkage_id",
+        "live_adapter_dry_run_human_approval_not_required_linkage_hash",
+    }
+    return _digest({key: value for key, value in raw.items() if key not in omitted})
+
+
+def _verified_source(
+    value: Any,
+) -> CanonicalLiveAdapterDryRunAuthorityEvidenceLinkageReviewPacket:
+    try:
+        return verify_live_adapter_dry_run_authority_evidence_linkage_review_packet(
+            value
+        )
+    except (
+        LiveAdapterDryRunAuthorityEvidenceLinkageError,
+        TypeError,
+        ValueError,
+    ) as exc:
+        raise LiveAdapterDryRunHumanApprovalNotRequiredLinkageError(
+            "LADHANR_SOURCE_INVALID"
+        ) from exc
+
+
+def _verified_resolution(
+    value: Any,
+) -> CanonicalHumanApprovalRequirementResolutionPacket:
+    try:
+        return verify_human_approval_requirement_resolution_packet(value)
+    except (
+        HumanApprovalRequirementResolutionError,
+        TypeError,
+        ValueError,
+    ) as exc:
+        raise LiveAdapterDryRunHumanApprovalNotRequiredLinkageError(
+            "LADHANR_RESOLUTION_INVALID"
+        ) from exc
+
+
+def _validate_source(
+    source: CanonicalLiveAdapterDryRunAuthorityEvidenceLinkageReviewPacket,
+) -> None:
+    if source.request_dispatch_state != "NOT_DISPATCHED" or source.request_dispatched:
+        raise LiveAdapterDryRunHumanApprovalNotRequiredLinkageError(
+            "LADHANR_SOURCE_DISPATCHED"
+        )
+    if source.bind_state != "NOT_BOUND" or source.bind_invoked:
+        raise LiveAdapterDryRunHumanApprovalNotRequiredLinkageError(
+            "LADHANR_SOURCE_BOUND"
+        )
+    if source.authority_state != "NOT_AUTHORIZED":
+        raise LiveAdapterDryRunHumanApprovalNotRequiredLinkageError(
+            "LADHANR_SOURCE_AUTHORIZED"
+        )
+    result = source.authority_evidence_linkage_result
+    if source.fail_closed or not (
+        result.all_required_references_present
+        and result.all_references_structurally_linked
+        and result.all_binding_claims_matched
+    ):
+        raise LiveAdapterDryRunHumanApprovalNotRequiredLinkageError(
+            "LADHANR_SOURCE_REJECTED"
+        )
+
+
+def _validate_binding(
+    source: CanonicalLiveAdapterDryRunAuthorityEvidenceLinkageReviewPacket,
+    resolution: CanonicalHumanApprovalRequirementResolutionPacket,
+) -> None:
+    if (
+        resolution.required_human_approval
+        or resolution.requirement_state != REQUIREMENT_STATE
+    ):
+        raise LiveAdapterDryRunHumanApprovalNotRequiredLinkageError(
+            "LADHANR_APPROVAL_IS_REQUIRED"
+        )
+    if (
+        resolution.source_authority_evidence_linkage_review_id
+        != source.live_adapter_dry_run_authority_evidence_linkage_review_id
+        or resolution.source_authority_evidence_linkage_review_hash
+        != source.live_adapter_dry_run_authority_evidence_linkage_review_hash
+        or resolution.source_execution_intent_id != source.execution_intent_id
+        or resolution.source_execution_intent_hash != source.execution_intent_hash
+    ):
+        raise LiveAdapterDryRunHumanApprovalNotRequiredLinkageError(
+            "LADHANR_SOURCE_RESOLUTION_MISMATCH"
+        )
+    scope_raw = source.authority_evidence_reference_bundle.get("bundle_scope")
+    if not isinstance(scope_raw, list):
+        raise LiveAdapterDryRunHumanApprovalNotRequiredLinkageError(
+            "LADHANR_SOURCE_SCOPE_INVALID"
+        )
+    requested_scope = tuple(
+        str(item).strip() for item in scope_raw if str(item).strip()
+    )
+    if requested_scope != resolution.requested_scope:
+        raise LiveAdapterDryRunHumanApprovalNotRequiredLinkageError(
+            "LADHANR_SCOPE_RESOLUTION_MISMATCH"
+        )
+
+
+def build_live_adapter_dry_run_human_approval_not_required_linkage_packet(
+    source_authority_evidence_linkage_review_packet: Any,
+    human_approval_requirement_resolution_packet: Any,
+    linkage_recorded_at: datetime,
+) -> CanonicalLiveAdapterDryRunHumanApprovalNotRequiredLinkagePacket:
+    """Build a no-approval linkage packet without creating an approval artifact."""
+
+    source = _verified_source(source_authority_evidence_linkage_review_packet)
+    _validate_source(source)
+    resolution = _verified_resolution(human_approval_requirement_resolution_packet)
+    _validate_binding(source, resolution)
+
+    source_raw = source.model_dump(mode="json")
+    resolution_raw = resolution.model_dump(mode="json")
+    result = {
+        "source_authority_evidence_linkage_verified": True,
+        "requirement_resolution_verified": True,
+        "human_approval_required": False,
+        "human_approval_reference_count": 0,
+        "human_approval_references_absent": True,
+        "accepted_for_final_bind_authorization_readiness": True,
+        "creates_human_approval": False,
+        "creates_execution_authority": False,
+        "creates_bind_authorization": False,
+    }
+    raw = {
+        "format_version": FORMAT_VERSION,
+        "linkage_mechanism": MECHANISM,
+        "linkage_recorded_at": _timestamp(linkage_recorded_at),
+        "source_authority_evidence_linkage_review_id": (
+            source.live_adapter_dry_run_authority_evidence_linkage_review_id
+        ),
+        "source_authority_evidence_linkage_review_hash": (
+            source.live_adapter_dry_run_authority_evidence_linkage_review_hash
+        ),
+        "source_authority_evidence_linkage_review_packet": source_raw,
+        "human_approval_requirement_resolution_id": (
+            resolution.human_approval_requirement_resolution_id
+        ),
+        "human_approval_requirement_resolution_hash": (
+            resolution.human_approval_requirement_resolution_hash
+        ),
+        "human_approval_requirement_resolution_packet": resolution_raw,
+        "execution_intent_id": source.execution_intent_id,
+        "execution_intent_hash": source.execution_intent_hash,
+        "action_contract_id": resolution.action_contract_id,
+        "action_contract_version": resolution.action_contract_version,
+        "action_contract_digest": resolution.action_contract_digest,
+        "requested_scope": resolution.requested_scope,
+        "human_approval_requirement_state": REQUIREMENT_STATE,
+        "human_approval_reference_count": 0,
+        "human_approval_not_required_linkage_result": result,
+        "request_dispatch_state": "NOT_DISPATCHED",
+        "bind_state": "NOT_BOUND",
+        "authority_state": "NOT_AUTHORIZED",
+        "human_approval_state": "NOT_REQUIRED",
+        "human_approval_created": False,
+        "execution_authority_created": False,
+        "bind_authorization_created": False,
+        "bind_invoked": False,
+        "bind_receipt_created": False,
+        "credential_material_accessed": False,
+        "authorization_header_constructed": False,
+        "network_used": False,
+        "external_effect_occurred": False,
+        "fail_closed": False,
+        "linkage_status": STATUS,
+        "scope_limitations": SCOPE_LIMITATIONS,
+    }
+    digest = _packet_hash(raw)
+    raw["live_adapter_dry_run_human_approval_not_required_linkage_hash"] = digest
+    raw["live_adapter_dry_run_human_approval_not_required_linkage_id"] = (
+        f"ladhanr:v1:sha256:{digest}"
+    )
+    return verify_live_adapter_dry_run_human_approval_not_required_linkage_packet(raw)
+
+
+def verify_live_adapter_dry_run_human_approval_not_required_linkage_packet(
+    value: Any,
+) -> CanonicalLiveAdapterDryRunHumanApprovalNotRequiredLinkagePacket:
+    """Re-verify source, resolution, identity binding, non-effects, and hash."""
+
+    try:
+        packet = (
+            value
+            if isinstance(
+                value,
+                CanonicalLiveAdapterDryRunHumanApprovalNotRequiredLinkagePacket,
+            )
+            else CanonicalLiveAdapterDryRunHumanApprovalNotRequiredLinkagePacket.model_validate(
+                _json(value)
+            )
+        )
+    except (
+        ValidationError,
+        TypeError,
+        LiveAdapterDryRunHumanApprovalNotRequiredLinkageError,
+    ) as exc:
+        raise LiveAdapterDryRunHumanApprovalNotRequiredLinkageError(
+            "LADHANR_PACKET_SCHEMA_INVALID"
+        ) from exc
+
+    source = _verified_source(packet.source_authority_evidence_linkage_review_packet)
+    _validate_source(source)
+    resolution = _verified_resolution(
+        packet.human_approval_requirement_resolution_packet
+    )
+    _validate_binding(source, resolution)
+
+    expected_identity = (
+        packet.source_authority_evidence_linkage_review_id
+        == source.live_adapter_dry_run_authority_evidence_linkage_review_id,
+        packet.source_authority_evidence_linkage_review_hash
+        == source.live_adapter_dry_run_authority_evidence_linkage_review_hash,
+        packet.human_approval_requirement_resolution_id
+        == resolution.human_approval_requirement_resolution_id,
+        packet.human_approval_requirement_resolution_hash
+        == resolution.human_approval_requirement_resolution_hash,
+        packet.execution_intent_id == source.execution_intent_id,
+        packet.execution_intent_hash == source.execution_intent_hash,
+        packet.action_contract_id == resolution.action_contract_id,
+        packet.action_contract_version == resolution.action_contract_version,
+        packet.action_contract_digest == resolution.action_contract_digest,
+        packet.requested_scope == resolution.requested_scope,
+    )
+    if not all(expected_identity):
+        raise LiveAdapterDryRunHumanApprovalNotRequiredLinkageError(
+            "LADHANR_IDENTITY_MISMATCH"
+        )
+
+    result = packet.human_approval_not_required_linkage_result
+    if not (
+        result.source_authority_evidence_linkage_verified
+        and result.requirement_resolution_verified
+        and not result.human_approval_required
+        and result.human_approval_reference_count == 0
+        and result.human_approval_references_absent
+        and result.accepted_for_final_bind_authorization_readiness
+        and not result.creates_human_approval
+        and not result.creates_execution_authority
+        and not result.creates_bind_authorization
+    ):
+        raise LiveAdapterDryRunHumanApprovalNotRequiredLinkageError(
+            "LADHANR_RESULT_INVALID"
+        )
+
+    effects = (
+        packet.human_approval_created,
+        packet.execution_authority_created,
+        packet.bind_authorization_created,
+        packet.bind_invoked,
+        packet.bind_receipt_created,
+        packet.credential_material_accessed,
+        packet.authorization_header_constructed,
+        packet.network_used,
+        packet.external_effect_occurred,
+    )
+    if any(effects) or packet.fail_closed:
+        raise LiveAdapterDryRunHumanApprovalNotRequiredLinkageError(
+            "LADHANR_EFFECT_OR_FAIL_CLOSED_INVALID"
+        )
+    if packet.scope_limitations != SCOPE_LIMITATIONS:
+        raise LiveAdapterDryRunHumanApprovalNotRequiredLinkageError(
+            "LADHANR_SCOPE_LIMITATIONS_MISMATCH"
+        )
+
+    actual = packet.model_dump(mode="python")
+    digest = _packet_hash(actual)
+    if (
+        packet.live_adapter_dry_run_human_approval_not_required_linkage_hash
+        != digest
+        or packet.live_adapter_dry_run_human_approval_not_required_linkage_id
+        != f"ladhanr:v1:sha256:{digest}"
+    ):
+        raise LiveAdapterDryRunHumanApprovalNotRequiredLinkageError(
+            "LADHANR_HASH_MISMATCH"
+        )
+    return packet

--- a/veritas_os/tests/test_live_adapter_dry_run_approval_not_required_bind_v0_3.py
+++ b/veritas_os/tests/test_live_adapter_dry_run_approval_not_required_bind_v0_3.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from veritas_os.policy import human_approval_requirement_resolution as resolution
+from veritas_os.policy import live_adapter_dry_run_bind_authorization_gate_review_v2 as gate_v2
+from veritas_os.policy import live_adapter_dry_run_final_bind_authorization_readiness_v2 as final_v2
+from veritas_os.policy import live_adapter_dry_run_human_approval_not_required_linkage as linkage
+from veritas_os.policy.live_adapter_dry_run_bind_authorization_gate_review import (
+    ACKNOWLEDGEMENTS as GATE_ACKNOWLEDGEMENTS,
+    OUTCOMES as GATE_OUTCOMES,
+)
+from veritas_os.policy.live_adapter_dry_run_final_bind_authorization_readiness import (
+    ACKNOWLEDGEMENTS as FINAL_ACKNOWLEDGEMENTS,
+    OUTCOMES as FINAL_OUTCOMES,
+)
+from veritas_os.tests.test_live_adapter_dry_run_human_approval_not_required_linkage import (
+    _AuthorityPacket,
+    _contract,
+    _patch_source_verifier,
+)
+
+T0 = datetime(2026, 9, 5, 5, 10, tzinfo=timezone.utc)
+
+
+def _final_decision(*, accepted: bool = True, **changes):
+    value = {
+        "final_bind_authorization_readiness_review_decision_id": (
+            "final-review:no-approval:v2"
+        ),
+        "reviewer_id": "operator:alice",
+        "reviewer_role": "bind-readiness-reviewer",
+        "reviewer_attestation": "I reviewed local no-approval readiness only.",
+        "reviewed_at": T0.isoformat(),
+        "review_outcome": FINAL_OUTCOMES[0] if accepted else FINAL_OUTCOMES[1],
+        "review_reason": "contract-bound no-approval route reviewed",
+        **{field: True for field in FINAL_ACKNOWLEDGEMENTS},
+    }
+    value.update(changes)
+    return value
+
+
+def _gate_decision(*, passed: bool = True, **changes):
+    value = {
+        "bind_authorization_gate_review_decision_id": "gate-review:no-approval:v2",
+        "reviewer_id": "operator:alice",
+        "reviewer_role": "bind-gate-reviewer",
+        "reviewer_attestation": "I reviewed local no-approval gate evidence only.",
+        "reviewed_at": T0.isoformat(),
+        "review_outcome": GATE_OUTCOMES[0] if passed else GATE_OUTCOMES[1],
+        "review_reason": "deterministic local no-approval gate review",
+        **{field: True for field in GATE_ACKNOWLEDGEMENTS},
+    }
+    value.update(changes)
+    return value
+
+
+def _no_approval_linkage(monkeypatch: pytest.MonkeyPatch):
+    _patch_source_verifier(monkeypatch)
+    source = _AuthorityPacket()
+    requirement = resolution.build_human_approval_requirement_resolution_packet(
+        source,
+        _contract(required=False),
+        T0,
+    )
+    return linkage.build_live_adapter_dry_run_human_approval_not_required_linkage_packet(
+        source,
+        requirement,
+        T0,
+    )
+
+
+def _final(monkeypatch: pytest.MonkeyPatch, *, accepted: bool = True):
+    return final_v2.build_live_adapter_dry_run_final_bind_authorization_readiness_v2_packet(
+        _no_approval_linkage(monkeypatch),
+        _final_decision(accepted=accepted),
+        T0,
+    )
+
+
+def test_contract_bound_no_approval_route_reaches_native_v2_gate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    final = _final(monkeypatch)
+    gate = gate_v2.build_live_adapter_dry_run_bind_authorization_gate_review_v2_packet(
+        final,
+        _gate_decision(),
+        T0,
+    )
+
+    assert final.human_approval_state == "NOT_REQUIRED"
+    assert final.final_readiness_state == "READY_FOR_FUTURE_BIND_AUTHORIZATION_GATE"
+    assert gate.human_approval_state == "NOT_REQUIRED"
+    assert gate.gate_review_state == (
+        "PASSED_FOR_FUTURE_BIND_AUTHORIZATION_ARTIFACT"
+    )
+    assert gate.bind_authorization_gate_review_result.gate_review_passed is True
+    assert (
+        gate.bind_authorization_gate_review_result
+        .source_human_approval_not_required_by_action_contract
+        is True
+    )
+    assert gate.human_approval_created is False
+    assert gate.execution_authority_created is False
+    assert gate.bind_authorization_created is False
+    assert gate.bind_invoked is False
+    assert gate.bind_receipt_created is False
+    assert gate.credential_material_accessed is False
+    assert gate.authorization_header_constructed is False
+    assert gate.request_dispatched is False
+    assert gate.network_used is False
+    assert gate.external_effect_occurred is False
+    assert (
+        gate_v2.verify_live_adapter_dry_run_bind_authorization_gate_review_v2_packet(
+            gate
+        )
+        == gate
+    )
+
+
+def test_rejected_final_readiness_cannot_reach_gate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    final = _final(monkeypatch, accepted=False)
+    assert final.fail_closed is True
+    assert final.final_readiness_state == (
+        "NOT_READY_FOR_FUTURE_BIND_AUTHORIZATION_GATE"
+    )
+
+    with pytest.raises(
+        gate_v2.LiveAdapterDryRunBindAuthorizationGateReviewV2Error,
+        match="LADBAGRV2_SOURCE_REJECTED",
+    ):
+        gate_v2.build_live_adapter_dry_run_bind_authorization_gate_review_v2_packet(
+            final,
+            _gate_decision(),
+            T0,
+        )
+
+
+def test_rejected_gate_is_valid_fail_closed_non_effect_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gate = gate_v2.build_live_adapter_dry_run_bind_authorization_gate_review_v2_packet(
+        _final(monkeypatch),
+        _gate_decision(passed=False),
+        T0,
+    )
+
+    assert gate.fail_closed is True
+    assert gate.gate_review_state == (
+        "FAILED_FOR_FUTURE_BIND_AUTHORIZATION_ARTIFACT"
+    )
+    assert gate.bind_authorization_created is False
+    assert gate.execution_authority_created is False
+    assert gate.external_effect_occurred is False
+
+
+def test_final_packet_hash_tamper_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    final = _final(monkeypatch)
+    raw = final.model_dump(mode="python")
+    raw["final_bind_authorization_readiness_recorded_at"] = (
+        "2026-09-05T05:11:00+00:00"
+    )
+
+    with pytest.raises(
+        final_v2.LiveAdapterDryRunFinalBindAuthorizationReadinessV2Error,
+        match="LADFBARV2_HASH_MISMATCH",
+    ):
+        final_v2.verify_live_adapter_dry_run_final_bind_authorization_readiness_v2_packet(
+            raw
+        )
+
+
+def test_gate_packet_hash_tamper_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gate = gate_v2.build_live_adapter_dry_run_bind_authorization_gate_review_v2_packet(
+        _final(monkeypatch),
+        _gate_decision(),
+        T0,
+    )
+    raw = gate.model_dump(mode="python")
+    raw["bind_authorization_gate_review_recorded_at"] = (
+        "2026-09-05T05:12:00+00:00"
+    )
+
+    with pytest.raises(
+        gate_v2.LiveAdapterDryRunBindAuthorizationGateReviewV2Error,
+        match="LADBAGRV2_HASH_MISMATCH",
+    ):
+        gate_v2.verify_live_adapter_dry_run_bind_authorization_gate_review_v2_packet(
+            raw
+        )

--- a/veritas_os/tests/test_live_adapter_dry_run_human_approval_not_required_linkage.py
+++ b/veritas_os/tests/test_live_adapter_dry_run_human_approval_not_required_linkage.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import BaseModel, ConfigDict
+
+from veritas_os.governance.action_contracts import ActionClassContract
+from veritas_os.policy import human_approval_requirement_resolution as resolution
+from veritas_os.policy import live_adapter_dry_run_human_approval_not_required_linkage as linkage
+
+
+class _AuthorityLinkageResult(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    all_required_references_present: bool = True
+    all_references_structurally_linked: bool = True
+    all_binding_claims_matched: bool = True
+
+
+class _AuthorityPacket(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    live_adapter_dry_run_authority_evidence_linkage_review_id: str = "authority-linkage-1"
+    live_adapter_dry_run_authority_evidence_linkage_review_hash: str = "a" * 64
+    execution_intent: dict = {"intended_action": "payments.transfer"}
+    execution_intent_id: str = "execution-intent-1"
+    execution_intent_hash: str = "b" * 64
+    authority_evidence_reference_bundle: dict = {
+        "bundle_scope": ["payments:transfer"]
+    }
+    authority_evidence_linkage_result: _AuthorityLinkageResult = (
+        _AuthorityLinkageResult()
+    )
+    request_dispatch_state: str = "NOT_DISPATCHED"
+    request_dispatched: bool = False
+    bind_state: str = "NOT_BOUND"
+    bind_invoked: bool = False
+    authority_state: str = "NOT_AUTHORIZED"
+    fail_closed: bool = False
+
+
+def _contract(*, required: bool) -> ActionClassContract:
+    return ActionClassContract(
+        id="payments.transfer",
+        version="1",
+        domain="payments",
+        action_class="payment_transfer",
+        description="approval-not-required linkage test",
+        declared_intent="transfer funds",
+        allowed_scope=["payments:transfer"],
+        prohibited_scope=["payments:admin"],
+        authority_sources=["benchmark-authority"],
+        required_evidence=[],
+        evidence_freshness={},
+        irreversibility={"level": "low"},
+        human_approval_rules={
+            "required": required,
+            "minimum_approvals": 1 if required else 0,
+        },
+        refusal_conditions=[],
+        escalation_conditions=[],
+        default_failure_mode="deny",
+        metadata={"regulated": False},
+    )
+
+
+def _patch_source_verifier(monkeypatch: pytest.MonkeyPatch) -> None:
+    def verify(value):
+        if isinstance(value, _AuthorityPacket):
+            return value
+        return _AuthorityPacket.model_validate(value)
+
+    monkeypatch.setattr(
+        resolution,
+        "verify_live_adapter_dry_run_authority_evidence_linkage_review_packet",
+        verify,
+    )
+    monkeypatch.setattr(
+        linkage,
+        "verify_live_adapter_dry_run_authority_evidence_linkage_review_packet",
+        verify,
+    )
+
+
+def _resolution(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    required: bool = False,
+    source: _AuthorityPacket | None = None,
+):
+    _patch_source_verifier(monkeypatch)
+    return resolution.build_human_approval_requirement_resolution_packet(
+        source or _AuthorityPacket(),
+        _contract(required=required),
+        datetime(2026, 9, 5, 5, 0, tzinfo=timezone.utc),
+    )
+
+
+def test_not_required_resolution_links_without_fabricated_approval(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _AuthorityPacket()
+    requirement = _resolution(monkeypatch, source=source)
+
+    packet = linkage.build_live_adapter_dry_run_human_approval_not_required_linkage_packet(
+        source,
+        requirement,
+        datetime(2026, 9, 5, 5, 1, tzinfo=timezone.utc),
+    )
+
+    assert packet.human_approval_requirement_state == (
+        "NOT_REQUIRED_BY_ACTION_CONTRACT"
+    )
+    assert packet.human_approval_state == "NOT_REQUIRED"
+    assert packet.human_approval_reference_count == 0
+    assert packet.human_approval_created is False
+    assert packet.execution_authority_created is False
+    assert packet.bind_authorization_created is False
+    assert packet.bind_invoked is False
+    assert packet.network_used is False
+    assert packet.external_effect_occurred is False
+    assert (
+        linkage.verify_live_adapter_dry_run_human_approval_not_required_linkage_packet(
+            packet
+        )
+        == packet
+    )
+
+
+def test_required_resolution_cannot_use_no_approval_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _AuthorityPacket()
+    requirement = _resolution(monkeypatch, required=True, source=source)
+
+    with pytest.raises(
+        linkage.LiveAdapterDryRunHumanApprovalNotRequiredLinkageError,
+        match="LADHANR_APPROVAL_IS_REQUIRED",
+    ):
+        linkage.build_live_adapter_dry_run_human_approval_not_required_linkage_packet(
+            source,
+            requirement,
+            datetime(2026, 9, 5, 5, 2, tzinfo=timezone.utc),
+        )
+
+
+def test_resolution_bound_to_other_source_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original = _AuthorityPacket()
+    requirement = _resolution(monkeypatch, source=original)
+    other = original.model_copy(
+        update={
+            "live_adapter_dry_run_authority_evidence_linkage_review_id": (
+                "authority-linkage-2"
+            ),
+            "live_adapter_dry_run_authority_evidence_linkage_review_hash": "c" * 64,
+        }
+    )
+
+    with pytest.raises(
+        linkage.LiveAdapterDryRunHumanApprovalNotRequiredLinkageError,
+        match="LADHANR_SOURCE_RESOLUTION_MISMATCH",
+    ):
+        linkage.build_live_adapter_dry_run_human_approval_not_required_linkage_packet(
+            other,
+            requirement,
+            datetime(2026, 9, 5, 5, 3, tzinfo=timezone.utc),
+        )
+
+
+def test_tampered_linkage_packet_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _AuthorityPacket()
+    requirement = _resolution(monkeypatch, source=source)
+    packet = linkage.build_live_adapter_dry_run_human_approval_not_required_linkage_packet(
+        source,
+        requirement,
+        datetime(2026, 9, 5, 5, 4, tzinfo=timezone.utc),
+    )
+    raw = packet.model_dump(mode="python")
+    raw["linkage_recorded_at"] = "2026-09-05T05:05:00+00:00"
+
+    with pytest.raises(
+        linkage.LiveAdapterDryRunHumanApprovalNotRequiredLinkageError,
+        match="LADHANR_HASH_MISMATCH",
+    ):
+        linkage.verify_live_adapter_dry_run_human_approval_not_required_linkage_packet(
+            raw
+        )


### PR DESCRIPTION
### Motivation

The v0.2 RCC/REVAS → VERITAS benchmark exposed five READY cases where the native dry-run Bind chain stops because the current Human Approval linkage path requires at least one approval reference even when the Action Class Contract does not require Human Approval.

PR #2180 added the canonical `HumanApprovalRequirementResolution v1` artifact. This PR wires the next stage of the v0.3 route without weakening the existing approval-required v1 path.

### Current change

Adds a new non-authorizing artifact:

`CanonicalLiveAdapterDryRunHumanApprovalNotRequiredLinkagePacket`

It:
- independently verifies the upstream Authority Evidence linkage packet,
- independently verifies the contract-bound Human Approval requirement-resolution packet,
- requires `NOT_REQUIRED_BY_ACTION_CONTRACT`,
- rejects use of this route when Human Approval is required,
- binds source Authority Evidence linkage identity, ExecutionIntent identity, Action Class Contract digest, and requested scope,
- records an explicit Human Approval reference count of zero,
- creates no Human Approval, execution authority, Bind authorization, BindReceipt, credential access, network call, or external effect,
- is content-addressed and tamper-verifiable.

### v0.3 wiring target

This branch will next connect this no-approval linkage artifact to versioned Final Bind Readiness and Bind Authorization Gate review artifacts. The existing approval-required v1 chain remains unchanged.

### Claim boundary

`NOT_REQUIRED_BY_ACTION_CONTRACT` is not Human Approval and is not Execution Authority. This PR does not create a real Bind authorization, invoke Bind, dispatch a request, access credential material, or create an external effect.