### PR TITLE
fix: preserve approval-not-required through guarded promotion

### DIFF
--- a/schemas/execution-intent-formation-readiness-v1.schema.json
+++ b/schemas/execution-intent-formation-readiness-v1.schema.json
@@ -246,22 +246,47 @@
           "minLength": 1
         },
         "approval_context": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "human_approval_receipt_ref",
-            "human_approval_receipt_hash"
-          ],
-          "properties": {
-            "human_approval_receipt_ref": {
-              "type": "string",
-              "minLength": 1
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "human_approval_receipt_ref",
+                "human_approval_receipt_hash"
+              ],
+              "properties": {
+                "human_approval_receipt_ref": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "human_approval_receipt_hash": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
             },
-            "human_approval_receipt_hash": {
-              "type": "string",
-              "minLength": 1
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "required_human_approval",
+                "requirement_state",
+                "requirement_policy_ref"
+              ],
+              "properties": {
+                "required_human_approval": {
+                  "const": false
+                },
+                "requirement_state": {
+                  "const": "NOT_REQUIRED_BY_CANONICAL_HANDOFF"
+                },
+                "requirement_policy_ref": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
             }
-          }
+          ]
         },
         "policy_lineage": {
           "type": "object",
@@ -475,12 +500,26 @@
           "minLength": 1
         },
         "human_approval_receipt_ref": {
-          "type": "string",
-          "minLength": 1
+          "anyOf": [
+            {
+              "type": "string",
+              "minLength": 1
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "human_approval_receipt_hash": {
-          "type": "string",
-          "minLength": 1
+          "anyOf": [
+            {
+              "type": "string",
+              "minLength": 1
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "policy_snapshot_id": {
           "type": "string",
@@ -902,10 +941,24 @@
               "type": "string"
             },
             "human_approval_receipt_ref": {
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "human_approval_receipt_hash": {
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "policy_snapshot_id": {
               "type": "string"

--- a/schemas/guarded-promotion-eligibility-packet-v1.schema.json
+++ b/schemas/guarded-promotion-eligibility-packet-v1.schema.json
@@ -288,10 +288,24 @@
           "type": "string"
         },
         "human_approval_receipt_ref": {
-          "type": "string"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "human_approval_receipt_hash": {
-          "type": "string"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "policy_snapshot_id": {
           "type": "string"

--- a/veritas_os/policy/execution_intent_formation_readiness.py
+++ b/veritas_os/policy/execution_intent_formation_readiness.py
@@ -178,8 +178,6 @@ def _require_source_fields(
             "replay_artifact_hash",
             "authority_evidence_ref",
             "authority_evidence_hash",
-            "human_approval_receipt_ref",
-            "human_approval_receipt_hash",
             "policy_snapshot_id",
             "policy_version",
             "policy_semantic_digest",
@@ -194,6 +192,38 @@ def _require_source_fields(
             for field in fields
         ):
             raise ExecutionIntentFormationReadinessError("EIFR_SOURCE_FIELD_MISSING")
+    approval_requirement = eligibility.source_handoff.get(
+        "human_approval_requirement"
+    )
+    if (
+        not isinstance(approval_requirement, dict)
+        or approval_requirement.get("resolved") is not True
+        or type(approval_requirement.get("required")) is not bool
+    ):
+        raise ExecutionIntentFormationReadinessError(
+            "EIFR_APPROVAL_REQUIREMENT_INVALID"
+        )
+    receipt_ref = eligibility.evidence_lineage.get("human_approval_receipt_ref")
+    receipt_hash = eligibility.evidence_lineage.get("human_approval_receipt_hash")
+    if approval_requirement["required"]:
+        if any(
+            not isinstance(value, str) or not value.strip()
+            for value in (receipt_ref, receipt_hash)
+        ):
+            raise ExecutionIntentFormationReadinessError(
+                "EIFR_APPROVAL_RECEIPT_REQUIRED"
+            )
+    else:
+        if receipt_ref is not None or receipt_hash is not None:
+            raise ExecutionIntentFormationReadinessError(
+                "EIFR_APPROVAL_RECEIPT_UNEXPECTED"
+            )
+        policy_ref = approval_requirement.get("policy_ref")
+        if not isinstance(policy_ref, str) or not policy_ref.strip():
+            raise ExecutionIntentFormationReadinessError(
+                "EIFR_APPROVAL_NOT_REQUIRED_SOURCE_MISSING"
+            )
+
     _aware_iso(
         eligibility.source_decision_identity["canonical_decision_ts"],
         "EIFR_SOURCE_FIELD_MISSING",
@@ -212,6 +242,28 @@ def _mapping(
     source = eligibility.source_decision_identity
     candidate = eligibility.candidate_identity
     evidence = eligibility.evidence_lineage
+    approval_requirement = eligibility.source_handoff["human_approval_requirement"]
+    approval_required = approval_requirement["required"]
+    evidence_refs = [
+        evidence["trustlog_artifact_ref"],
+        evidence["replay_artifact_ref"],
+        evidence["authority_evidence_ref"],
+    ]
+    if approval_required:
+        evidence_refs.append(evidence["human_approval_receipt_ref"])
+    evidence_refs.append(evidence["expected_state_source_ref"])
+    approval_context = (
+        {
+            "human_approval_receipt_ref": evidence["human_approval_receipt_ref"],
+            "human_approval_receipt_hash": evidence["human_approval_receipt_hash"],
+        }
+        if approval_required
+        else {
+            "required_human_approval": False,
+            "requirement_state": "NOT_REQUIRED_BY_CANONICAL_HANDOFF",
+            "requirement_policy_ref": approval_requirement["policy_ref"],
+        }
+    )
     return {
         "decision_id": source["canonical_decision_id"],
         "request_id": source["request_id"],
@@ -220,21 +272,12 @@ def _mapping(
         "target_system": candidate["target_system"],
         "target_resource": candidate["target_resource"],
         "intended_action": candidate["action_contract_id"],
-        "evidence_refs": [
-            evidence["trustlog_artifact_ref"],
-            evidence["replay_artifact_ref"],
-            evidence["authority_evidence_ref"],
-            evidence["human_approval_receipt_ref"],
-            evidence["expected_state_source_ref"],
-        ],
+        "evidence_refs": evidence_refs,
         "decision_hash": source["canonical_decision_hash"],
         "decision_ts": source["canonical_decision_ts"],
         "ttl_seconds": None,
         "expected_state_fingerprint": evidence["expected_state_fingerprint"],
-        "approval_context": {
-            "human_approval_receipt_ref": evidence["human_approval_receipt_ref"],
-            "human_approval_receipt_hash": evidence["human_approval_receipt_hash"],
-        },
+        "approval_context": approval_context,
         "policy_lineage": {
             "policy_snapshot_id": evidence["policy_snapshot_id"],
             "policy_version": evidence["policy_version"],

--- a/veritas_os/policy/guarded_promotion_eligibility.py
+++ b/veritas_os/policy/guarded_promotion_eligibility.py
@@ -226,6 +226,7 @@ def _identities(handoff: dict[str, Any]) -> tuple[dict[str, Any], ...]:
     replay = handoff["replay_lineage"]
     authority = handoff["authority_evidence"]
     approval = handoff["human_approval_evidence"]
+    approval_requirement = handoff["human_approval_requirement"]
     policy = handoff["policy_lineage"]
     state = handoff["expected_state"]
     source_identity = {key: source[key] for key in (
@@ -247,14 +248,23 @@ def _identities(handoff: dict[str, Any]) -> tuple[dict[str, Any], ...]:
         "replay_artifact_hash": replay["artifact_hash"],
         "authority_evidence_ref": authority["evidence_ref"],
         "authority_evidence_hash": authority["evidence_hash"],
-        "human_approval_receipt_ref": approval["receipt_ref"],
-        "human_approval_receipt_hash": approval["receipt_hash"],
+        "human_approval_receipt_ref": (
+            approval["receipt_ref"] if approval is not None else None
+        ),
+        "human_approval_receipt_hash": (
+            approval["receipt_hash"] if approval is not None else None
+        ),
         "policy_snapshot_id": policy["snapshot_id"],
         "policy_version": policy["version"],
         "policy_semantic_digest": policy["semantic_digest"],
         "expected_state_fingerprint": state["fingerprint"],
         "expected_state_source_ref": state["source_ref"],
     }
+    if approval_requirement.get("required") is True and approval is None:
+        raise GuardedPromotionEligibilityError("GPE_APPROVAL_REQUIRED_BUT_MISSING")
+    if approval_requirement.get("required") is False and approval is not None:
+        raise GuardedPromotionEligibilityError("GPE_APPROVAL_UNEXPECTED_WHEN_NOT_REQUIRED")
+
     replay_summary = {key: replay.get(key) for key in (
         "original_decision_id", "replay_decision_id", "original_request_id",
         "replay_request_id", "semantic_profile", "semantic_match",

--- a/veritas_os/tests/test_execution_intent_formation_readiness.py
+++ b/veritas_os/tests/test_execution_intent_formation_readiness.py
@@ -43,6 +43,26 @@ def _eligibility():
     )
 
 
+def _eligibility_without_approval():
+    handoff = json.loads(VECTOR.read_text())["input"]
+    handoff["human_approval_requirement"] = {
+        "resolved": True,
+        "required": False,
+        "policy_ref": "fixture-policy",
+    }
+    handoff["human_approval_evidence"] = None
+    for record in handoff["provenance"]:
+        if record["field_path"] == "human_approval_requirement":
+            record["value"] = deepcopy(handoff["human_approval_requirement"])
+            record["provenance_class"] = "VERIFIED_POLICY_ARTIFACT"
+        elif record["field_path"] == "human_approval_evidence":
+            record["value"] = None
+            record["provenance_class"] = "VERIFIED_POLICY_ARTIFACT"
+    return build_guarded_promotion_eligibility_packet(
+        handoff, _complete_context(handoff), NOW, NOW
+    )
+
+
 def _canonical_replay_eligibility(*, semantic_match: bool, fields_changed: list[str]):
     """Build eligibility with explicit, distinct canonical replay identities."""
     handoff = json.loads(VECTOR.read_text())["input"]
@@ -87,6 +107,48 @@ def _resign_eligibility(raw: dict) -> dict:
     raw["eligibility_hash"] = eligibility_digest(ELIGIBILITY_PACKET_DOMAIN, preimage)
     raw["eligibility_id"] = f"gpe:v1:sha256:{raw['eligibility_hash']}"
     return raw
+
+
+def test_approval_not_required_maps_authoritative_context_without_receipt() -> None:
+    eligibility = _eligibility_without_approval()
+    packet = build_execution_intent_formation_readiness_packet(eligibility, NOW)
+    mapping = packet.source_to_execution_intent_mapping
+
+    assert eligibility.evidence_lineage["human_approval_receipt_ref"] is None
+    assert eligibility.evidence_lineage["human_approval_receipt_hash"] is None
+    assert mapping["approval_context"] == {
+        "required_human_approval": False,
+        "requirement_state": "NOT_REQUIRED_BY_CANONICAL_HANDOFF",
+        "requirement_policy_ref": "fixture-policy",
+    }
+    assert None not in mapping["evidence_refs"]
+    assert mapping["evidence_refs"] == [
+        eligibility.evidence_lineage["trustlog_artifact_ref"],
+        eligibility.evidence_lineage["replay_artifact_ref"],
+        eligibility.evidence_lineage["authority_evidence_ref"],
+        eligibility.evidence_lineage["expected_state_source_ref"],
+    ]
+    assert verify_execution_intent_formation_readiness_packet(packet) == packet
+
+    schema = json.loads(
+        Path("schemas/execution-intent-formation-readiness-v1.schema.json").read_text()
+    )
+    Draft202012Validator(schema, format_checker=FormatChecker()).validate(
+        packet.model_dump(mode="json")
+    )
+
+
+def test_approval_not_required_rejects_injected_receipt() -> None:
+    raw = _eligibility_without_approval().model_dump(mode="json")
+    raw["evidence_lineage"]["human_approval_receipt_ref"] = "fake-receipt"
+    raw["evidence_lineage"]["human_approval_receipt_hash"] = "fake-hash"
+    with pytest.raises(
+        ExecutionIntentFormationReadinessError,
+        match="EIFR_ELIGIBILITY_INVALID",
+    ):
+        build_execution_intent_formation_readiness_packet(
+            _resign_eligibility(raw), NOW
+        )
 
 
 def test_build_verify_mapping_and_content_addressing() -> None:

--- a/veritas_os/tests/test_guarded_promotion_eligibility.py
+++ b/veritas_os/tests/test_guarded_promotion_eligibility.py
@@ -32,6 +32,24 @@ def _ready():
     return handoff, _complete_context(handoff)
 
 
+def _ready_without_approval():
+    handoff = json.loads(VECTOR.read_text())["input"]
+    handoff["human_approval_requirement"] = {
+        "resolved": True,
+        "required": False,
+        "policy_ref": "fixture-policy",
+    }
+    handoff["human_approval_evidence"] = None
+    for record in handoff["provenance"]:
+        if record["field_path"] == "human_approval_requirement":
+            record["value"] = deepcopy(handoff["human_approval_requirement"])
+            record["provenance_class"] = "VERIFIED_POLICY_ARTIFACT"
+        elif record["field_path"] == "human_approval_evidence":
+            record["value"] = None
+            record["provenance_class"] = "VERIFIED_POLICY_ARTIFACT"
+    return handoff, _complete_context(handoff)
+
+
 def _packet():
     handoff, context = _ready()
     return build_guarded_promotion_eligibility_packet(handoff, context, NOW, NOW)
@@ -46,6 +64,27 @@ def _resign(raw: dict, *, context_changed: bool = False) -> dict:
     raw["eligibility_hash"] = _packet_hash(raw)
     raw["eligibility_id"] = f"gpe:v1:sha256:{raw['eligibility_hash']}"
     return raw
+
+
+def test_ready_without_approval_preserves_absent_receipt_without_fabrication() -> None:
+    handoff, context = _ready_without_approval()
+    packet = build_guarded_promotion_eligibility_packet(
+        handoff, context, NOW, NOW
+    )
+
+    assert packet.validation_status == "READY_FOR_GUARDED_PROMOTION"
+    assert packet.evidence_lineage["human_approval_receipt_ref"] is None
+    assert packet.evidence_lineage["human_approval_receipt_hash"] is None
+    assert packet.source_handoff["human_approval_requirement"]["required"] is False
+    assert packet.source_handoff["human_approval_evidence"] is None
+    assert verify_guarded_promotion_eligibility_packet(packet) == packet
+
+    schema = json.loads(
+        Path("schemas/guarded-promotion-eligibility-packet-v1.schema.json").read_text()
+    )
+    Draft202012Validator(schema, format_checker=FormatChecker()).validate(
+        packet.model_dump(mode="json")
+    )
 
 
 def test_ready_packet_is_deterministic_verified_and_has_no_authority() -> None:


### PR DESCRIPTION
### Motivation

The native v0.3 benchmark exposed an earlier compatibility gap than the Human Approval linkage layer.

`CanonicalDecisionHandoff v1` can validly return `READY_FOR_GUARDED_PROMOTION` when:

- the Human Approval requirement is resolved,
- `required=false`,
- `human_approval_evidence=null`.

But `guarded_promotion_eligibility._identities()` unconditionally dereferenced `approval["receipt_ref"]`, so an approval-not-required READY handoff crashed before the new contract-bound requirement-resolution path could run.

### Change

This PR preserves the existing approval-required path byte-for-byte while adding an explicit no-approval path:

- Guarded Promotion records `human_approval_receipt_ref/hash = null` when no Human Approval evidence exists.
- It still fails closed if approval is required but missing.
- It rejects an unexpected Human Approval artifact when the handoff says approval is not required.
- ExecutionIntent Formation Readiness conditionally requires receipt metadata only when approval is required.
- For authoritative no-approval, it requires a verified requirement with a non-empty policy reference and maps:
  - `required_human_approval=false`
  - `requirement_state=NOT_REQUIRED_BY_CANONICAL_HANDOFF`
  - `requirement_policy_ref=<verified policy ref>`
- No fake/sentinel Human Approval receipt is inserted into `evidence_refs`.
- Schemas are widened only for the legitimate null-receipt branch.

### Compatibility

The approval-required path retains the existing receipt-based mapping and output semantics. This change only adds behavior for the state already accepted as READY by CanonicalDecisionHandoff but previously crashed in Guarded Promotion.

The later ActionClassContract-bound `HumanApprovalRequirementResolution` remains an independent recheck before Bind governance; this PR does not make the handoff policy declaration sufficient for Bind authorization.

### Tests

Adds regression coverage for:

- READY + approval not required + no approval artifact,
- no fabricated receipt reference/hash,
- authoritative no-approval `approval_context`,
- no null/fake receipt inserted into `evidence_refs`,
- injected receipt on a not-required handoff fails closed,
- JSON Schema acceptance of the new legitimate branch.

### Claim boundary

This remains pre-execution metadata processing only. It does not create Human Approval, execution authority, Bind authorization, BindReceipt, credential access, network dispatch, or external effect.

### Follow-up on latest main (2026-09-07)

- Merged main `e702ab9c859a294163dbde49bac7c18d25ef6498` into the PR branch without rewriting existing history.
- Reproduced CI's readiness schema failure: no-approval evidence has four references, while the schema required five unconditionally. Apply a conditional minimum (four for the explicit no-approval branch; five for the receipt branch).
- Added regression checks for both schema minima and rejection of a rehashed approval downgrade against the unchanged verified readiness source.
- The two Memory test failures were already fixed on main; they pass after integration.
- Related local validation: **293 passed, 1 skipped** in 106.28s. The existing skip applies the REQUIRED-only downgrade test to a NOT_REQUIRED fixture. Required-contract attacks, same-id/version substitutions, missing trusted inputs, and source substitutions were exercised through the existing downstream verifier tests.
- Ruff and diff checks passed. Published tree matches tested local tree: `f4195ec46037442140dc299b08ba83a8469f00e5`.
- Updated head: `d433d86ac25980a53a1613852f069acef3ba6377`. Full CI must be checked on this head; earlier-head results do not apply.
- Scope remains Guarded Promotion / ExecutionIntent Formation Readiness. This is not proof of schema compatibility for the complete downstream no-approval E2E path. Downstream embedded schema propagation remains separate from the independently tested trusted-contract verifier binding.
- No automatic merge; human maintainer review required.
