### PR TITLE
fix(policy): independently verify approval requirement sources

### DIFF
--- a/docs/en/development/approval-requirement-source-verification.md
+++ b/docs/en/development/approval-requirement-source-verification.md
@@ -1,0 +1,19 @@
+# Approval requirement source verification
+
+`verify_human_approval_requirement_resolution_packet(packet, source, contract)`
+requires the full Authority Evidence Linkage source and the expected Action
+Class Contract. The one-argument, hash-only interface is no longer supported.
+The verifier revalidates the source and reconstructs every field from it and
+the contract. Rehashing a forged NOT_REQUIRED result cannot bypass this check.
+Both the builder and verifier of requirement satisfaction use this interface.
+
+The caller must obtain the expected contract from trusted policy configuration;
+an attacker-controlled replacement contract is not a trust anchor. A satisfaction
+packet's embedded contract snapshot is integrity evidence, not proof of trusted
+policy selection. Its caller must still bind that snapshot to trusted policy.
+Resolution time is a recorded timestamp, not a live freshness attestation.
+
+Integration tests exercise the real nested metadata-linkage chain without
+mocking its verifier. They do not claim cryptographic authority authentication.
+Authority signature/revocation verification and human approval verification
+remain separate boundaries. No execution or approval authority is created.

--- a/docs/en/development/approval-requirement-source-verification.md
+++ b/docs/en/development/approval-requirement-source-verification.md
@@ -8,9 +8,18 @@ the contract. Rehashing a forged NOT_REQUIRED result cannot bypass this check.
 Both the builder and verifier of requirement satisfaction use this interface.
 
 The caller must obtain the expected contract from trusted policy configuration;
-an attacker-controlled replacement contract is not a trust anchor. A satisfaction
-packet's embedded contract snapshot is integrity evidence, not proof of trusted
-policy selection. Its caller must still bind that snapshot to trusted policy.
+an attacker-controlled replacement contract is not a trust anchor.
+The satisfaction verifier requires keyword-only `expected_source` and
+`expected_contract`, compares the complete embedded source and contract to
+these independently verified inputs, and derives results only from the
+reconstructed resolution. Same-ID/version contract substitutions are rejected.
+Final Bind Readiness and Bind Gate Review builders and verifiers propagate
+these same keywords through every self-verification call. They are optional
+only for the legacy v1 linkage path; a v0.3 satisfaction path fails closed when
+either is absent. No embedded snapshot fallback is permitted. Further callers
+that omit these inputs cannot consume a v0.3 gate; they must explicitly pass
+trusted inputs before enabling that path. Never extract expected inputs from
+the packet under verification.
 Resolution time is a recorded timestamp, not a live freshness attestation.
 
 Integration tests exercise the real nested metadata-linkage chain without

--- a/docs/ja/development/approval-requirement-source-verification.md
+++ b/docs/ja/development/approval-requirement-source-verification.md
@@ -1,0 +1,16 @@
+# 承認要否の元ソース検証
+
+`verify_human_approval_requirement_resolution_packet(packet, source, contract)`
+には、完全なAuthority Evidence Linkageソースと期待するAction Class Contractが必要です。
+引数1個のハッシュ検証のみの呼び出しは廃止します。ソースを再検証し、契約と合わせて全項目を
+再構築します。偽のNOT_REQUIRED結果を再ハッシュしても、この照合は通過しません。
+Requirement Satisfactionのbuilderとverifierも新しい呼び出しを使用します。
+
+期待する契約は信頼できるポリシー設定から取得してください。攻撃者が差し替えた契約を
+信頼の根拠にしてはいけません。Satisfaction packet内の契約snapshotは整合性情報であり、
+信頼済みポリシーとして選択された証明ではありません。利用側で信頼済みポリシーと照合する
+必要があります。解決時刻も記録値であり、現在の鮮度の証明ではありません。
+
+統合テストではソース検証器をモックせず、実際の入れ子のmetadata-linkageチェーンを使います。
+権限証拠の暗号学的認証を実証するものではありません。権限署名・失効検証、人間承認検証は
+別の境界として引き続き必要です。実行権限や承認は生成しません。

--- a/docs/ja/development/approval-requirement-source-verification.md
+++ b/docs/ja/development/approval-requirement-source-verification.md
@@ -7,9 +7,14 @@
 Requirement Satisfactionのbuilderとverifierも新しい呼び出しを使用します。
 
 期待する契約は信頼できるポリシー設定から取得してください。攻撃者が差し替えた契約を
-信頼の根拠にしてはいけません。Satisfaction packet内の契約snapshotは整合性情報であり、
-信頼済みポリシーとして選択された証明ではありません。利用側で信頼済みポリシーと照合する
-必要があります。解決時刻も記録値であり、現在の鮮度の証明ではありません。
+信頼の根拠にしてはいけません。Satisfaction verifierはキーワード引数`expected_source`と
+`expected_contract`を必須とし、埋め込まれた完全なソース・契約と独立入力を照合します。
+再構築されたresolutionだけを後段の導出に使用します。同一ID・versionでの契約差し替えも拒否します。
+Final Bind ReadinessとBind Gate Reviewのbuilder・verifierも、自己検証を含め同じ引数を伝播します。
+省略できるのは既存v1 linkage経路だけです。v0.3 satisfaction経路では片方でも欠ければ拒否し、
+embedded snapshotへのフォールバックはしません。さらに先の呼び出し元が独立入力を渡さない場合も
+v0.3 gateを消費できません。有効化する際は信頼済み入力を明示的に渡す必要があります。
+検証対象packetから期待値を取り出してはいけません。解決時刻は記録値であり現在の鮮度の証明ではありません。
 
 統合テストではソース検証器をモックせず、実際の入れ子のmetadata-linkageチェーンを使います。
 権限証拠の暗号学的認証を実証するものではありません。権限署名・失効検証、人間承認検証は

--- a/veritas_os/policy/human_approval_requirement_resolution.py
+++ b/veritas_os/policy/human_approval_requirement_resolution.py
@@ -58,9 +58,7 @@ class CanonicalHumanApprovalRequirementResolutionPacket(BaseModel):
     human_approval_requirement_resolution_id: str = Field(
         pattern=r"^harr:v1:sha256:[0-9a-f]{64}$"
     )
-    human_approval_requirement_resolution_hash: str = Field(
-        pattern=r"^[0-9a-f]{64}$"
-    )
+    human_approval_requirement_resolution_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
     resolution_mechanism: Literal[MECHANISM]
     resolved_at: str
 
@@ -98,9 +96,7 @@ def requires_human_approval_for_action_contract(
 ) -> bool:
     """Return the canonical contract-derived Human Approval requirement."""
     if not isinstance(contract, ActionClassContract):
-        raise HumanApprovalRequirementResolutionError(
-            "HARR_ACTION_CONTRACT_REQUIRED"
-        )
+        raise HumanApprovalRequirementResolutionError("HARR_ACTION_CONTRACT_REQUIRED")
     rules = contract.human_approval_rules
     minimum_approvals = int(rules.get("minimum_approvals", 0) or 0)
     if bool(rules.get("required", False)):
@@ -112,13 +108,9 @@ def _timestamp(value: Any) -> str:
     try:
         parsed = value if isinstance(value, datetime) else datetime.fromisoformat(value)
     except (TypeError, ValueError) as exc:
-        raise HumanApprovalRequirementResolutionError(
-            "HARR_TIMESTAMP_INVALID"
-        ) from exc
+        raise HumanApprovalRequirementResolutionError("HARR_TIMESTAMP_INVALID") from exc
     if parsed.tzinfo is None or parsed.utcoffset() is None:
-        raise HumanApprovalRequirementResolutionError(
-            "HARR_TIMESTAMP_INVALID"
-        )
+        raise HumanApprovalRequirementResolutionError("HARR_TIMESTAMP_INVALID")
     return parsed.astimezone(timezone.utc).isoformat()
 
 
@@ -127,9 +119,14 @@ def _json(value: Any) -> Any:
         value = value.model_dump(mode="python")
     if value is None or isinstance(value, (str, bool, int)):
         return value
-    if isinstance(value, float) and value == value and value not in (
-        float("inf"),
-        float("-inf"),
+    if (
+        isinstance(value, float)
+        and value == value
+        and value
+        not in (
+            float("inf"),
+            float("-inf"),
+        )
     ):
         return value
     if isinstance(value, datetime):
@@ -163,9 +160,7 @@ def _verified_source(
         TypeError,
         ValueError,
     ) as exc:
-        raise HumanApprovalRequirementResolutionError(
-            "HARR_SOURCE_INVALID"
-        ) from exc
+        raise HumanApprovalRequirementResolutionError("HARR_SOURCE_INVALID") from exc
 
 
 def _validate_contract_binding(
@@ -175,9 +170,7 @@ def _validate_contract_binding(
     intent = source.execution_intent
     intended_action = str(intent.get("intended_action") or "").strip()
     if not intended_action:
-        raise HumanApprovalRequirementResolutionError(
-            "HARR_INTENDED_ACTION_MISSING"
-        )
+        raise HumanApprovalRequirementResolutionError("HARR_INTENDED_ACTION_MISSING")
     if contract.id != intended_action:
         raise HumanApprovalRequirementResolutionError(
             "HARR_ACTION_CONTRACT_SOURCE_MISMATCH"
@@ -213,9 +206,7 @@ def build_human_approval_requirement_resolution_packet(
     """Build a fail-closed, non-authorizing requirement-resolution packet."""
     source = _verified_source(source_authority_evidence_linkage_review_packet)
     if source.fail_closed:
-        raise HumanApprovalRequirementResolutionError(
-            "HARR_SOURCE_FAIL_CLOSED"
-        )
+        raise HumanApprovalRequirementResolutionError("HARR_SOURCE_FAIL_CLOSED")
     result = source.authority_evidence_linkage_result
     if not (
         result.all_required_references_present
@@ -227,9 +218,7 @@ def build_human_approval_requirement_resolution_packet(
         )
 
     if not isinstance(action_contract, ActionClassContract):
-        raise HumanApprovalRequirementResolutionError(
-            "HARR_ACTION_CONTRACT_REQUIRED"
-        )
+        raise HumanApprovalRequirementResolutionError("HARR_ACTION_CONTRACT_REQUIRED")
     requested_scope = _validate_contract_binding(source, action_contract)
     required = requires_human_approval_for_action_contract(action_contract)
     state = "REQUIRED" if required else "NOT_REQUIRED_BY_ACTION_CONTRACT"
@@ -274,9 +263,7 @@ def build_human_approval_requirement_resolution_packet(
     }
     packet_hash = _digest(payload)
     return CanonicalHumanApprovalRequirementResolutionPacket(
-        human_approval_requirement_resolution_id=(
-            f"harr:v1:sha256:{packet_hash}"
-        ),
+        human_approval_requirement_resolution_id=(f"harr:v1:sha256:{packet_hash}"),
         human_approval_requirement_resolution_hash=packet_hash,
         **payload,
     )
@@ -284,13 +271,17 @@ def build_human_approval_requirement_resolution_packet(
 
 def verify_human_approval_requirement_resolution_packet(
     value: Any,
+    source_authority_evidence_linkage_review_packet: Any,
+    action_contract: ActionClassContract,
 ) -> CanonicalHumanApprovalRequirementResolutionPacket:
-    """Verify schema, state consistency, non-effect flags, and packet hash."""
+    """Reconstruct against independent source and trusted policy contract.
+
+    Hash integrity alone does not authenticate authority or policy. Callers
+    must obtain the expected source and contract independently of this packet.
+    """
     try:
-        packet = (
-            value
-            if isinstance(value, CanonicalHumanApprovalRequirementResolutionPacket)
-            else CanonicalHumanApprovalRequirementResolutionPacket.model_validate(value)
+        packet = CanonicalHumanApprovalRequirementResolutionPacket.model_validate(
+            _json(value)
         )
     except ValidationError as exc:
         raise HumanApprovalRequirementResolutionError(
@@ -324,4 +315,13 @@ def verify_human_approval_requirement_resolution_packet(
     expected = _digest(raw)
     if packet_hash != expected or packet_id != f"harr:v1:sha256:{expected}":
         raise HumanApprovalRequirementResolutionError("HARR_HASH_MISMATCH")
-    return packet
+    rebuilt = build_human_approval_requirement_resolution_packet(
+        source_authority_evidence_linkage_review_packet,
+        action_contract,
+        datetime.fromisoformat(_timestamp(packet.resolved_at)),
+    )
+    if _digest(_json(value)) != _digest(rebuilt.model_dump(mode="json")):
+        raise HumanApprovalRequirementResolutionError(
+            "HARR_SOURCE_RECONSTRUCTION_MISMATCH"
+        )
+    return rebuilt

--- a/veritas_os/policy/live_adapter_dry_run_bind_authorization_gate_review.py
+++ b/veritas_os/policy/live_adapter_dry_run_bind_authorization_gate_review.py
@@ -464,10 +464,13 @@ def _packet_hash(raw: dict[str, Any]) -> str:
 
 def _source(
     value: Any,
+    *,
+    expected_source: Any = None,
+    expected_contract: Any = None,
 ) -> CanonicalLiveAdapterDryRunFinalBindAuthorizationReadinessPacket:
     try:
         return verify_live_adapter_dry_run_final_bind_authorization_readiness_packet(
-            value
+            value, expected_source=expected_source, expected_contract=expected_contract
         )
     except (
         LiveAdapterDryRunFinalBindAuthorizationReadinessError,
@@ -588,9 +591,16 @@ def build_live_adapter_dry_run_bind_authorization_gate_review_packet(
     source_final_bind_authorization_readiness_packet: Any,
     bind_authorization_gate_review_decision: Any,
     bind_authorization_gate_review_recorded_at: datetime,
+    *,
+    expected_source: Any = None,
+    expected_contract: Any = None,
 ) -> CanonicalLiveAdapterDryRunBindAuthorizationGateReviewPacket:
     """Build and self-verify deterministic, non-authorizing gate review evidence."""
-    source = _source(_json(source_final_bind_authorization_readiness_packet))
+    source = _source(
+        _json(source_final_bind_authorization_readiness_packet),
+        expected_source=expected_source,
+        expected_contract=expected_contract,
+    )
     _validate_source(source)
     decision = _decision(bind_authorization_gate_review_decision)
     recorded_at = _timestamp(bind_authorization_gate_review_recorded_at)
@@ -674,11 +684,18 @@ def build_live_adapter_dry_run_bind_authorization_gate_review_packet(
     raw["live_adapter_dry_run_bind_authorization_gate_review_id"] = (
         f"ladbagr:v1:sha256:{digest}"
     )
-    return verify_live_adapter_dry_run_bind_authorization_gate_review_packet(raw)
+    return verify_live_adapter_dry_run_bind_authorization_gate_review_packet(
+        raw,
+        expected_source=expected_source,
+        expected_contract=expected_contract,
+    )
 
 
 def verify_live_adapter_dry_run_bind_authorization_gate_review_packet(
     raw: Any,
+    *,
+    expected_source: Any = None,
+    expected_contract: Any = None,
 ) -> CanonicalLiveAdapterDryRunBindAuthorizationGateReviewPacket:
     """Reverify the embedded source and every deterministic derived field."""
     try:
@@ -697,7 +714,11 @@ def verify_live_adapter_dry_run_bind_authorization_gate_review_packet(
             "LADBAGR_PACKET_INVALID"
         ) from exc
     actual = packet.model_dump(mode="json")
-    source = _source(packet.source_final_bind_authorization_readiness_packet)
+    source = _source(
+        packet.source_final_bind_authorization_readiness_packet,
+        expected_source=expected_source,
+        expected_contract=expected_contract,
+    )
     _validate_source(source)
     source_raw = source.model_dump(mode="json")
     if (

--- a/veritas_os/policy/live_adapter_dry_run_final_bind_authorization_readiness.py
+++ b/veritas_os/policy/live_adapter_dry_run_final_bind_authorization_readiness.py
@@ -365,14 +365,18 @@ HumanApprovalLinkageSource = (
 )
 
 
-def _source(value: Any) -> HumanApprovalLinkageSource:
+def _source(
+    value: Any, *, expected_source: Any = None, expected_contract: Any = None
+) -> HumanApprovalLinkageSource:
     try:
         return verify_live_adapter_dry_run_human_approval_linkage_review_packet(value)
     except (LiveAdapterDryRunHumanApprovalLinkageError, TypeError, ValueError):
         try:
             return (
                 verify_live_adapter_dry_run_human_approval_requirement_satisfaction_packet(
-                    value
+                    value,
+                    expected_source=expected_source,
+                    expected_contract=expected_contract
                 )
             )
         except (
@@ -482,9 +486,16 @@ def build_live_adapter_dry_run_final_bind_authorization_readiness_packet(
     source_human_approval_linkage_review_packet: Any,
     final_bind_authorization_readiness_review_decision: Any,
     final_bind_authorization_readiness_recorded_at: datetime,
+    *,
+    expected_source: Any = None,
+    expected_contract: Any = None,
 ) -> CanonicalLiveAdapterDryRunFinalBindAuthorizationReadinessPacket:
     """Build and self-verify deterministic final readiness evidence."""
-    source = _source(_json(source_human_approval_linkage_review_packet))
+    source = _source(
+        _json(source_human_approval_linkage_review_packet),
+        expected_source=expected_source,
+        expected_contract=expected_contract,
+    )
     _validate_source(source)
     decision = _decision(final_bind_authorization_readiness_review_decision)
     recorded_at = _timestamp(final_bind_authorization_readiness_recorded_at)
@@ -533,11 +544,18 @@ def build_live_adapter_dry_run_final_bind_authorization_readiness_packet(
     digest = _packet_hash(raw)
     raw["live_adapter_dry_run_final_bind_authorization_readiness_hash"] = digest
     raw["live_adapter_dry_run_final_bind_authorization_readiness_id"] = f"ladfbar:v1:sha256:{digest}"
-    return verify_live_adapter_dry_run_final_bind_authorization_readiness_packet(raw)
+    return verify_live_adapter_dry_run_final_bind_authorization_readiness_packet(
+        raw,
+        expected_source=expected_source,
+        expected_contract=expected_contract,
+    )
 
 
 def verify_live_adapter_dry_run_final_bind_authorization_readiness_packet(
     raw: Any,
+    *,
+    expected_source: Any = None,
+    expected_contract: Any = None,
 ) -> CanonicalLiveAdapterDryRunFinalBindAuthorizationReadinessPacket:
     """Reverify source, derived content, digests, packet hash, and packet ID."""
     try:
@@ -546,7 +564,11 @@ def verify_live_adapter_dry_run_final_bind_authorization_readiness_packet(
     except (ValidationError, TypeError, LiveAdapterDryRunFinalBindAuthorizationReadinessError) as exc:
         raise LiveAdapterDryRunFinalBindAuthorizationReadinessError("LADFBAR_PACKET_INVALID") from exc
     actual = packet.model_dump(mode="json")
-    source = _source(packet.source_human_approval_linkage_review_packet)
+    source = _source(
+        packet.source_human_approval_linkage_review_packet,
+        expected_source=expected_source,
+        expected_contract=expected_contract,
+    )
     _validate_source(source)
     source_raw = source.model_dump(mode="json")
     identities = (

--- a/veritas_os/policy/live_adapter_dry_run_human_approval_requirement_satisfaction.py
+++ b/veritas_os/policy/live_adapter_dry_run_human_approval_requirement_satisfaction.py
@@ -684,14 +684,21 @@ def build_live_adapter_dry_run_human_approval_requirement_satisfaction_packet(
         f"ladhars:v1:sha256:{digest}"
     )
     return verify_live_adapter_dry_run_human_approval_requirement_satisfaction_packet(
-        raw
+        raw, expected_source=source, expected_contract=contract
     )
 
 
 def verify_live_adapter_dry_run_human_approval_requirement_satisfaction_packet(
     raw: Any,
+    *,
+    expected_source: Any,
+    expected_contract: ActionClassContract,
 ) -> CanonicalLiveAdapterDryRunHumanApprovalRequirementSatisfactionPacket:
-    """Reverify source, contract requirement, branch choice, and packet hash."""
+    """Reconstruct using independent trusted inputs, never embedded anchors.
+
+    Callers must obtain expected_source and expected_contract independently of
+    this packet. Embedded snapshots are compared, not used to select policy.
+    """
     try:
         value = raw.model_dump(mode="json") if isinstance(raw, BaseModel) else raw
         packet = CanonicalLiveAdapterDryRunHumanApprovalRequirementSatisfactionPacket.model_validate(
@@ -707,8 +714,16 @@ def verify_live_adapter_dry_run_human_approval_requirement_satisfaction_packet(
         ) from exc
 
     actual = packet.model_dump(mode="json")
-    source = _authority_source(packet.source_authority_evidence_linkage_review_packet)
-    contract = _contract(packet.action_contract_snapshot)
+    source = _authority_source(expected_source)
+    contract = _contract(expected_contract)
+    if _digest(
+        DOMAIN, packet.source_authority_evidence_linkage_review_packet
+    ) != _digest(DOMAIN, source.model_dump(mode="json")) or _digest(
+        DOMAIN, packet.action_contract_snapshot
+    ) != _digest(DOMAIN, contract.to_dict()):
+        raise LiveAdapterDryRunHumanApprovalRequirementSatisfactionError(
+            "LADHARS_EXPECTED_BINDING_MISMATCH"
+        )
     resolution = _resolution(
         packet.human_approval_requirement_resolution_packet, source, contract
     )

--- a/veritas_os/policy/live_adapter_dry_run_human_approval_requirement_satisfaction.py
+++ b/veritas_os/policy/live_adapter_dry_run_human_approval_requirement_satisfaction.py
@@ -52,7 +52,9 @@ FORMAT_VERSION = (
 MECHANISM = "satisfy_human_approval_requirement_without_authority_creation/v1"
 STATUS = "LIVE_ADAPTER_DRY_RUN_HUMAN_APPROVAL_REQUIREMENT_SATISFIED_NOT_APPROVED"
 CHECK_MODE = "deterministic_local_human_approval_requirement_satisfaction_only"
-DOMAIN = "veritas.live-adapter-dry-run-human-approval-requirement-satisfaction.packet/v1"
+DOMAIN = (
+    "veritas.live-adapter-dry-run-human-approval-requirement-satisfaction.packet/v1"
+)
 RESULT_DOMAIN = (
     "veritas.live-adapter-dry-run-human-approval-requirement-satisfaction.result/v1"
 )
@@ -231,9 +233,14 @@ def _json(value: Any) -> Any:
         value = value.model_dump(mode="python")
     if value is None or isinstance(value, (str, bool, int)):
         return value
-    if isinstance(value, float) and value == value and value not in (
-        float("inf"),
-        float("-inf"),
+    if (
+        isinstance(value, float)
+        and value == value
+        and value
+        not in (
+            float("inf"),
+            float("-inf"),
+        )
     ):
         return value
     if isinstance(value, datetime):
@@ -298,9 +305,13 @@ def _authority_source(
 
 def _resolution(
     value: Any,
+    source: CanonicalLiveAdapterDryRunAuthorityEvidenceLinkageReviewPacket,
+    contract: ActionClassContract,
 ) -> CanonicalHumanApprovalRequirementResolutionPacket:
     try:
-        return verify_human_approval_requirement_resolution_packet(value)
+        return verify_human_approval_requirement_resolution_packet(
+            value, source, contract
+        )
     except (
         HumanApprovalRequirementResolutionError,
         TypeError,
@@ -313,7 +324,9 @@ def _resolution(
 
 def _contract(value: Any) -> ActionClassContract:
     try:
-        raw = value.to_dict() if isinstance(value, ActionClassContract) else _json(value)
+        raw = (
+            value.to_dict() if isinstance(value, ActionClassContract) else _json(value)
+        )
         return validate_action_class_contract(raw)
     except (
         ActionClassContractValidationError,
@@ -349,9 +362,7 @@ def _validate_resolution_binding(
     expected_state = (
         "REQUIRED" if expected_required else "NOT_REQUIRED_BY_ACTION_CONTRACT"
     )
-    expected_scope = tuple(
-        source.authority_evidence_reference_bundle.bundle_scope
-    )
+    expected_scope = tuple(source.authority_evidence_reference_bundle.bundle_scope)
     checks = (
         resolution.source_authority_evidence_linkage_review_id
         == source.live_adapter_dry_run_authority_evidence_linkage_review_id,
@@ -463,15 +474,13 @@ def _derive(
         bundle = _json(child["human_approval_reference_bundle"])
         matrix = _json(child["human_approval_binding_matrix"])
         rejected = tuple(
-            child["human_approval_linkage_result"][
-                "rejected_approval_reference_ids"
-            ]
+            child["human_approval_linkage_result"]["rejected_approval_reference_ids"]
         )
-        reasons = tuple(
-            child["human_approval_linkage_result"]["rejection_reasons"]
-        )
+        reasons = tuple(child["human_approval_linkage_result"]["rejection_reasons"])
         satisfaction_state = "SATISFIED_BY_VERIFIED_HUMAN_APPROVAL_LINKAGE"
-        child_id = required_linkage.live_adapter_dry_run_human_approval_linkage_review_id
+        child_id = (
+            required_linkage.live_adapter_dry_run_human_approval_linkage_review_id
+        )
         child_hash = (
             required_linkage.live_adapter_dry_run_human_approval_linkage_review_hash
         )
@@ -573,8 +582,10 @@ def build_live_adapter_dry_run_human_approval_requirement_satisfaction_packet(
 ) -> CanonicalLiveAdapterDryRunHumanApprovalRequirementSatisfactionPacket:
     """Build a fail-closed bridge for both REQUIRED and NOT_REQUIRED paths."""
     source = _authority_source(_json(source_authority_evidence_linkage_review_packet))
-    resolution = _resolution(_json(human_approval_requirement_resolution_packet))
     contract = _contract(action_contract)
+    resolution = _resolution(
+        _json(human_approval_requirement_resolution_packet), source, contract
+    )
     _validate_resolution_binding(source, resolution, contract)
 
     required_linkage = (
@@ -683,9 +694,8 @@ def verify_live_adapter_dry_run_human_approval_requirement_satisfaction_packet(
     """Reverify source, contract requirement, branch choice, and packet hash."""
     try:
         value = raw.model_dump(mode="json") if isinstance(raw, BaseModel) else raw
-        packet = (
-            CanonicalLiveAdapterDryRunHumanApprovalRequirementSatisfactionPacket
-            .model_validate(_json(value))
+        packet = CanonicalLiveAdapterDryRunHumanApprovalRequirementSatisfactionPacket.model_validate(
+            _json(value)
         )
     except (
         ValidationError,
@@ -698,8 +708,10 @@ def verify_live_adapter_dry_run_human_approval_requirement_satisfaction_packet(
 
     actual = packet.model_dump(mode="json")
     source = _authority_source(packet.source_authority_evidence_linkage_review_packet)
-    resolution = _resolution(packet.human_approval_requirement_resolution_packet)
     contract = _contract(packet.action_contract_snapshot)
+    resolution = _resolution(
+        packet.human_approval_requirement_resolution_packet, source, contract
+    )
     _validate_resolution_binding(source, resolution, contract)
 
     child = (
@@ -755,18 +767,15 @@ def verify_live_adapter_dry_run_human_approval_requirement_satisfaction_packet(
 
     expected = (
         _json(packet.human_approval_reference_bundle) == _json(bundle),
-        packet.human_approval_reference_bundle_digest
-        == _digest(BUNDLE_DOMAIN, bundle),
+        packet.human_approval_reference_bundle_digest == _digest(BUNDLE_DOMAIN, bundle),
         _json(packet.human_approval_linkage_result)
         == _json(result.model_dump(mode="json")),
-        packet.human_approval_linkage_result_digest
-        == _digest(RESULT_DOMAIN, result),
+        packet.human_approval_linkage_result_digest == _digest(RESULT_DOMAIN, result),
         _json(packet.human_approval_binding_matrix) == _json(matrix),
         packet.human_approval_binding_matrix_digest == _digest(MATRIX_DOMAIN, matrix),
         _json(packet.human_approval_linkage_checks) == _json(checks),
         packet.human_approval_linkage_check_digest == _digest(CHECKS_DOMAIN, checks),
-        _json(packet.future_bind_authorization_requirements)
-        == _json(requirements),
+        _json(packet.future_bind_authorization_requirements) == _json(requirements),
         packet.future_bind_authorization_requirement_digest
         == _digest(REQUIREMENTS_DOMAIN, requirements),
         packet.scope_limitations == SCOPE_LIMITATIONS,

--- a/veritas_os/tests/test_human_approval_requirement_resolution.py
+++ b/veritas_os/tests/test_human_approval_requirement_resolution.py
@@ -9,7 +9,9 @@ from veritas_os.governance.action_contracts import ActionClassContract
 from veritas_os.policy import human_approval_requirement_resolution as resolution
 
 
-def _contract(*, required: bool, minimum_approvals: int = 0, level: str = "low") -> ActionClassContract:
+def _contract(
+    *, required: bool, minimum_approvals: int = 0, level: str = "low"
+) -> ActionClassContract:
     return ActionClassContract(
         id="payments.transfer",
         version="1",
@@ -48,9 +50,7 @@ def _source() -> SimpleNamespace:
         execution_intent={"intended_action": "payments.transfer"},
         execution_intent_id="execution-intent-1",
         execution_intent_hash="b" * 64,
-        authority_evidence_reference_bundle={
-            "bundle_scope": ["payments:transfer"]
-        },
+        authority_evidence_reference_bundle={"bundle_scope": ["payments:transfer"]},
     )
 
 
@@ -62,7 +62,9 @@ def _patch_source_verifier(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
-def test_explicit_required_contract_resolves_required(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_explicit_required_contract_resolves_required(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     _patch_source_verifier(monkeypatch)
     packet = resolution.build_human_approval_requirement_resolution_packet(
         _source(),
@@ -75,7 +77,12 @@ def test_explicit_required_contract_resolves_required(monkeypatch: pytest.Monkey
     assert packet.human_approval_created is False
     assert packet.bind_authorization_created is False
     assert packet.network_used is False
-    assert resolution.verify_human_approval_requirement_resolution_packet(packet) == packet
+    assert (
+        resolution.verify_human_approval_requirement_resolution_packet(
+            packet, _source(), _contract(required=True)
+        )
+        == packet
+    )
 
 
 def test_not_required_contract_resolves_without_fabricated_approval(
@@ -111,9 +118,7 @@ def test_high_irreversibility_with_minimum_approval_is_required(
 def test_contract_action_mismatch_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
     _patch_source_verifier(monkeypatch)
     contract = _contract(required=False)
-    mismatched = ActionClassContract(
-        **{**contract.to_dict(), "id": "payments.refund"}
-    )
+    mismatched = ActionClassContract(**{**contract.to_dict(), "id": "payments.refund"})
     with pytest.raises(
         resolution.HumanApprovalRequirementResolutionError,
         match="HARR_ACTION_CONTRACT_SOURCE_MISMATCH",
@@ -153,7 +158,10 @@ def test_hash_tamper_is_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
         resolution.HumanApprovalRequirementResolutionError,
         match="HARR_HASH_MISMATCH",
     ):
-        resolution.verify_human_approval_requirement_resolution_packet(raw)
+        resolution.verify_human_approval_requirement_resolution_packet(
+            raw, _source(), _contract(required=False)
+        )
+
 
 def test_typed_authority_bundle_scope_is_supported(
     monkeypatch: pytest.MonkeyPatch,
@@ -172,4 +180,3 @@ def test_typed_authority_bundle_scope_is_supported(
 
     assert packet.requested_scope == ("payments:transfer",)
     assert packet.requirement_state == "NOT_REQUIRED_BY_ACTION_CONTRACT"
-

--- a/veritas_os/tests/test_human_approval_requirement_resolution_integration.py
+++ b/veritas_os/tests/test_human_approval_requirement_resolution_integration.py
@@ -1,0 +1,161 @@
+"""Independent-source verification using the real nested linkage chain.
+
+These are metadata-linkage fixtures, not authenticated authority evidence.
+No source verifier is replaced with a mock.
+"""
+
+from copy import deepcopy
+from dataclasses import replace
+
+import pytest
+
+from veritas_os.policy import human_approval_requirement_resolution as resolution
+from veritas_os.tests.test_gate_bound_human_approval_issuance import _contract
+from veritas_os.tests.test_live_adapter_dry_run_authority_evidence_linkage import (
+    RECORDED_AT,
+    _packet,
+)
+
+pytestmark = pytest.mark.slow
+
+
+@pytest.fixture(scope="module")
+def chain():
+    source = _packet()
+    contract = _contract(source)
+    packet = resolution.build_human_approval_requirement_resolution_packet(
+        source, contract, RECORDED_AT
+    )
+    return source, contract, packet
+
+
+def _rehash(raw):
+    body = dict(raw)
+    body.pop("human_approval_requirement_resolution_hash")
+    body.pop("human_approval_requirement_resolution_id")
+    digest = resolution._digest(body)
+    raw["human_approval_requirement_resolution_hash"] = digest
+    raw["human_approval_requirement_resolution_id"] = f"harr:v1:sha256:{digest}"
+
+
+def test_real_chain_roundtrip(chain):
+    source, contract, packet = chain
+    verified = resolution.verify_human_approval_requirement_resolution_packet(
+        packet.model_dump(mode="json"), source.model_dump(mode="json"), contract
+    )
+    assert verified == packet
+    assert verified.required_human_approval
+    assert not verified.execution_authority_created
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        {"execution_authority_created": True},
+        {"unexpected_field": True},
+        {"required_human_approval": False},
+    ],
+)
+def test_invalid_schema_or_inconsistent_state(chain, change):
+    source, contract, packet = chain
+    raw = packet.model_dump(mode="json")
+    raw.update(change)
+    with pytest.raises(resolution.HumanApprovalRequirementResolutionError):
+        resolution.verify_human_approval_requirement_resolution_packet(
+            raw, source, contract
+        )
+
+
+def test_downgrade_with_recomputed_hash_is_rejected(chain):
+    source, contract, packet = chain
+    raw = packet.model_dump(mode="json")
+    raw.update(
+        required_human_approval=False,
+        requirement_state="NOT_REQUIRED_BY_ACTION_CONTRACT",
+        requirement_reason="action_contract_does_not_require_human_approval",
+    )
+    _rehash(raw)
+    with pytest.raises(
+        resolution.HumanApprovalRequirementResolutionError, match="RECONSTRUCTION"
+    ):
+        resolution.verify_human_approval_requirement_resolution_packet(
+            raw, source, contract
+        )
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("source_execution_intent_hash", "a" * 64),
+        ("source_authority_evidence_linkage_review_hash", "a" * 64),
+        ("action_contract_digest", "a" * 64),
+        ("requirement_reason", "invented"),
+        ("scope_limitations", []),
+        ("resolved_at", "not-a-time"),
+        ("required_human_approval", 1),
+    ],
+)
+def test_rehashed_substitution_rejected(chain, field, value):
+    source, contract, packet = chain
+    raw = packet.model_dump(mode="json")
+    raw[field] = value
+    _rehash(raw)
+    with pytest.raises(resolution.HumanApprovalRequirementResolutionError):
+        resolution.verify_human_approval_requirement_resolution_packet(
+            raw, source, contract
+        )
+
+
+def test_changed_contract_same_id_rejected(chain):
+    source, contract, packet = chain
+    changed = replace(
+        contract,
+        human_approval_rules={"required": False},
+        irreversibility={"level": "low"},
+    )
+    with pytest.raises(
+        resolution.HumanApprovalRequirementResolutionError, match="RECONSTRUCTION"
+    ):
+        resolution.verify_human_approval_requirement_resolution_packet(
+            packet, source, changed
+        )
+
+
+@pytest.mark.parametrize("source_value", [None, {}])
+def test_missing_source_rejected(chain, source_value):
+    _, contract, packet = chain
+    with pytest.raises(
+        resolution.HumanApprovalRequirementResolutionError, match="SOURCE_INVALID"
+    ):
+        resolution.verify_human_approval_requirement_resolution_packet(
+            packet, source_value, contract
+        )
+
+
+def test_nested_source_tamper_rejected(chain):
+    source, contract, packet = chain
+    raw = deepcopy(source.model_dump(mode="json"))
+    raw["execution_intent"]["intended_action"] = "another-action"
+    with pytest.raises(
+        resolution.HumanApprovalRequirementResolutionError, match="SOURCE_INVALID"
+    ):
+        resolution.verify_human_approval_requirement_resolution_packet(
+            packet, raw, contract
+        )
+
+
+def test_not_required_still_supported(chain):
+    source, contract, _ = chain
+    contract = replace(
+        contract,
+        human_approval_rules={"required": False},
+        irreversibility={"level": "low"},
+    )
+    packet = resolution.build_human_approval_requirement_resolution_packet(
+        source, contract, RECORDED_AT
+    )
+    verified = resolution.verify_human_approval_requirement_resolution_packet(
+        packet, source, contract
+    )
+    assert not verified.required_human_approval
+    assert not verified.human_approval_created

--- a/veritas_os/tests/test_live_adapter_dry_run_bind_authorization_gate_review.py
+++ b/veritas_os/tests/test_live_adapter_dry_run_bind_authorization_gate_review.py
@@ -75,9 +75,9 @@ def test_builder_creates_valid_verified_packet_and_reverifies_source(monkeypatch
     )
     calls = []
 
-    def recording(value):
+    def recording(value, **kwargs):
         calls.append(value)
-        return actual(value)
+        return actual(value, **kwargs)
 
     monkeypatch.setattr(
         module,

--- a/veritas_os/tests/test_live_adapter_dry_run_human_approval_requirement_satisfaction.py
+++ b/veritas_os/tests/test_live_adapter_dry_run_human_approval_requirement_satisfaction.py
@@ -223,7 +223,7 @@ def test_contract_snapshot_tamper_fails_closed() -> None:
 
     with pytest.raises(
         LiveAdapterDryRunHumanApprovalRequirementSatisfactionError,
-        match="LADHARS_REQUIREMENT_RESOLUTION_BINDING_MISMATCH",
+        match="LADHARS_REQUIREMENT_RESOLUTION_INVALID",
     ):
         verify_live_adapter_dry_run_human_approval_requirement_satisfaction_packet(
             raw

--- a/veritas_os/tests/test_live_adapter_dry_run_human_approval_requirement_satisfaction.py
+++ b/veritas_os/tests/test_live_adapter_dry_run_human_approval_requirement_satisfaction.py
@@ -88,34 +88,36 @@ def _build_satisfaction(*, required: bool):
         if required
         else None
     )
-    packet = (
-        build_live_adapter_dry_run_human_approval_requirement_satisfaction_packet(
-            source,
-            resolution,
-            contract,
-            linkage,
-            SATISFACTION_RECORDED_AT,
-        )
+    packet = build_live_adapter_dry_run_human_approval_requirement_satisfaction_packet(
+        source,
+        resolution,
+        contract,
+        linkage,
+        SATISFACTION_RECORDED_AT,
     )
     return source, contract, resolution, linkage, packet
 
 
-def _build_gate(satisfaction):
+def _build_gate(satisfaction, source, contract):
     final = build_live_adapter_dry_run_final_bind_authorization_readiness_packet(
         satisfaction,
         final_decision(),
         FINAL_RECORDED_AT,
+        expected_source=source,
+        expected_contract=contract,
     )
     gate = build_live_adapter_dry_run_bind_authorization_gate_review_packet(
         final,
         gate_decision(),
         GATE_RECORDED_AT,
+        expected_source=source,
+        expected_contract=contract,
     )
     return final, gate
 
 
 def test_not_required_path_reaches_native_gate_without_fabricated_approval() -> None:
-    _, _, _, linkage, satisfaction = _build_satisfaction(required=False)
+    source, contract, _, linkage, satisfaction = _build_satisfaction(required=False)
 
     assert linkage is None
     assert satisfaction.required_human_approval is False
@@ -126,14 +128,13 @@ def test_not_required_path_reaches_native_gate_without_fabricated_approval() -> 
     )
     assert satisfaction.source_required_human_approval_linkage_review_packet is None
     assert (
-        satisfaction.human_approval_reference_bundle["human_approval_references"]
-        == []
+        satisfaction.human_approval_reference_bundle["human_approval_references"] == []
     )
     assert satisfaction.human_approval_created is False
     assert satisfaction.execution_authority_created is False
     assert satisfaction.bind_authorization_created is False
 
-    final, gate = _build_gate(satisfaction)
+    final, gate = _build_gate(satisfaction, source, contract)
 
     assert final.final_readiness_state == "READY_FOR_FUTURE_BIND_AUTHORIZATION_GATE"
     assert gate.gate_review_state == "PASSED_FOR_FUTURE_BIND_AUTHORIZATION_ARTIFACT"
@@ -146,7 +147,7 @@ def test_not_required_path_reaches_native_gate_without_fabricated_approval() -> 
 
 
 def test_required_path_preserves_existing_verified_linkage_and_reaches_gate() -> None:
-    _, _, _, linkage, satisfaction = _build_satisfaction(required=True)
+    source, contract, _, linkage, satisfaction = _build_satisfaction(required=True)
 
     assert linkage is not None
     assert satisfaction.required_human_approval is True
@@ -161,7 +162,7 @@ def test_required_path_preserves_existing_verified_linkage_and_reaches_gate() ->
     )
     assert satisfaction.human_approval_reference_bundle["human_approval_references"]
 
-    final, gate = _build_gate(satisfaction)
+    final, gate = _build_gate(satisfaction, source, contract)
 
     assert final.final_readiness_state == "READY_FOR_FUTURE_BIND_AUTHORIZATION_GATE"
     assert gate.gate_review_state == "PASSED_FOR_FUTURE_BIND_AUTHORIZATION_ARTIFACT"
@@ -217,21 +218,21 @@ def test_required_contract_rejects_missing_human_approval_linkage() -> None:
 
 
 def test_contract_snapshot_tamper_fails_closed() -> None:
-    _, _, _, _, satisfaction = _build_satisfaction(required=False)
+    source, contract, _, _, satisfaction = _build_satisfaction(required=False)
     raw = satisfaction.model_dump(mode="json")
     raw["action_contract_snapshot"]["id"] = "tampered.action"
 
     with pytest.raises(
         LiveAdapterDryRunHumanApprovalRequirementSatisfactionError,
-        match="LADHARS_REQUIREMENT_RESOLUTION_INVALID",
+        match="LADHARS_EXPECTED_BINDING_MISMATCH",
     ):
         verify_live_adapter_dry_run_human_approval_requirement_satisfaction_packet(
-            raw
+            raw, expected_source=source, expected_contract=contract
         )
 
 
 def test_packet_hash_tamper_fails_closed() -> None:
-    _, _, _, _, satisfaction = _build_satisfaction(required=False)
+    source, contract, _, _, satisfaction = _build_satisfaction(required=False)
     raw = deepcopy(satisfaction.model_dump(mode="json"))
     raw["live_adapter_dry_run_human_approval_linkage_review_hash"] = "0" * 64
 
@@ -240,5 +241,5 @@ def test_packet_hash_tamper_fails_closed() -> None:
         match="LADHARS_HASH_MISMATCH",
     ):
         verify_live_adapter_dry_run_human_approval_requirement_satisfaction_packet(
-            raw
+            raw, expected_source=source, expected_contract=contract
         )

--- a/veritas_os/tests/test_requirement_satisfaction_trust_binding.py
+++ b/veritas_os/tests/test_requirement_satisfaction_trust_binding.py
@@ -1,0 +1,88 @@
+"""Whole-chain rehash attacks cannot replace independent policy/source inputs."""
+
+from dataclasses import replace
+
+import pytest
+
+from veritas_os.policy.human_approval_requirement_resolution import (
+    build_human_approval_requirement_resolution_packet,
+)
+from veritas_os.policy.live_adapter_dry_run_human_approval_requirement_satisfaction import (
+    build_live_adapter_dry_run_human_approval_requirement_satisfaction_packet as build,
+    verify_live_adapter_dry_run_human_approval_requirement_satisfaction_packet as verify,
+)
+from veritas_os.policy.live_adapter_dry_run_final_bind_authorization_readiness import (
+    verify_live_adapter_dry_run_final_bind_authorization_readiness_packet as verify_final,
+)
+from veritas_os.policy.live_adapter_dry_run_bind_authorization_gate_review import (
+    verify_live_adapter_dry_run_bind_authorization_gate_review_packet as verify_gate,
+)
+from veritas_os.tests.test_live_adapter_dry_run_human_approval_requirement_satisfaction import (
+    _build_satisfaction,
+    _build_gate,
+    HUMAN_RECORDED_AT,
+    SATISFACTION_RECORDED_AT,
+)
+from veritas_os.tests.test_live_adapter_dry_run_authority_evidence_linkage import (
+    _packet,
+    _bundle,
+)
+
+pytestmark = pytest.mark.slow
+
+
+@pytest.fixture(scope="module")
+def attack():
+    source, trusted, _, _, original = _build_satisfaction(required=True)
+    substituted = replace(
+        trusted, human_approval_rules={"required": False, "minimum_approvals": 0}
+    )
+    assert substituted.id == trusted.id and substituted.version == trusted.version
+    resolution = build_human_approval_requirement_resolution_packet(
+        source, substituted, HUMAN_RECORDED_AT
+    )
+    forged = build(source, resolution, substituted, None, SATISFACTION_RECORDED_AT)
+    final, gate = _build_gate(forged, source, substituted)
+    assert original.required_human_approval and not forged.required_human_approval
+    return source, trusted, substituted, (forged, final, gate)
+
+
+@pytest.mark.parametrize("stage", range(3))
+def test_full_rehash_same_id_version_contract_downgrade_rejected(attack, stage):
+    source, trusted, substituted, packets = attack
+    verifier = (verify, verify_final, verify_gate)[stage]
+    # Positive control: these are internally valid, fully rehashed packets.
+    verifier(packets[stage], expected_source=source, expected_contract=substituted)
+    with pytest.raises(ValueError):
+        verifier(packets[stage], expected_source=source, expected_contract=trusted)
+
+
+@pytest.mark.parametrize("stage", range(3))
+@pytest.mark.parametrize("missing", ["source", "contract", "both"])
+def test_no_embedded_fallback(attack, stage, missing):
+    source, _, contract, packets = attack
+    with pytest.raises(ValueError):
+        (verify, verify_final, verify_gate)[stage](
+            packets[stage],
+            expected_source=None if missing in ("source", "both") else source,
+            expected_contract=None if missing in ("contract", "both") else contract,
+        )
+
+
+def test_fully_rebuilt_source_substitution_rejected(attack):
+    original_source, _, contract, _ = attack
+    substituted = _packet(
+        bundle=_bundle(bundle_declared_by="different-source-declarer")
+    )
+    resolution = build_human_approval_requirement_resolution_packet(
+        substituted, contract, HUMAN_RECORDED_AT
+    )
+    forged = build(substituted, resolution, contract, None, SATISFACTION_RECORDED_AT)
+    final, gate = _build_gate(forged, substituted, contract)
+    for packet, verifier in zip(
+        (forged, final, gate), (verify, verify_final, verify_gate), strict=True
+    ):
+        with pytest.raises(ValueError):
+            verifier(
+                packet, expected_source=original_source, expected_contract=contract
+            )


### PR DESCRIPTION
# Summary

Harden HumanApprovalRequirementResolution verification from #2180 while preserving #2183 / v0.3 requirement satisfaction wiring.

## Scope

- Require the complete Authority Evidence Linkage source and expected ActionClassContract in the verifier.
- Independently reconstruct requirement_state, required_human_approval, contract digest, source bindings and all deterministic derived fields; compare the complete result.
- Reject REQUIRED → NOT_REQUIRED_BY_ACTION_CONTRACT downgrades even after recomputing the hash.
- Update both satisfaction builder and verifier to consume only the strengthened verifier's returned result.
- Add real nested metadata-linkage integration tests without mocking source verification.
- Document the required independent trust inputs and update affected tests.

## Type of change

- [x] Runtime
- [x] Tests
- [x] Docs
- [x] Governance / security-sensitive

## Why this change matters

A self-consistent content hash alone cannot validate a claimed approval requirement against the expected policy and source.

## Market / developer / user value

- Market value: improves evidence integrity without expanding execution claims.
- Developer value: explicit verification inputs and preserved v0.3 callers.
- User/operator value: rejects rehashed approval-requirement substitutions.

## Rebase and provenance

Fetched origin/main and verified it equals `3d9b8f85138fb0c5cde48915f10410861d015abc`. Ran `git rebase origin/main`; the branch was already directly based on this commit, so no rewrite or conflict was necessary.

Local tested commit: `4611d6e98c83fd548742f4b79526d324d7a3f00c`.
Git push lacked CLI credentials, so the connected GitHub API published an equivalent commit: `257c73f7d6e998d93a609c0628e76b4e942fd08d`.
The remote tree was independently checked against the tested local tree: `ec6904e1adf120f23057b1a0552cc115c697b787`.

## Tests run

- [x] Other: post-rebase related tests **30 passed**, 5 warnings, Python 3.12.13.
- [x] Other: target module coverage **91.24%**, 90% gate passed.
- [x] Other: Ruff for veritas_os, bilingual docs, responsibility boundaries and git diff checks passed.
- [ ] `make test`
- [ ] `make test-cov`
- [ ] `make quality-checks`

Reproducible test command:

```sh
python -m pytest -q \
  veritas_os/tests/test_human_approval_requirement_resolution.py \
  veritas_os/tests/test_human_approval_requirement_resolution_integration.py \
  veritas_os/tests/test_live_adapter_dry_run_human_approval_requirement_satisfaction.py \
  --cov=veritas_os.policy.human_approval_requirement_resolution \
  --cov-report=term-missing --cov-fail-under=90
```

Warnings concern NumPy reloading and jsonschema RefResolver deprecation. Full-suite and PR CI results are not claimed.

## AI assistance used

- [x] Codex

## Review status

- [ ] CI passed
- [ ] Independent review completed
- [ ] Human maintainer reviewed

## Risk checklist

- [x] Touches governance policy behavior
- [x] Touches bind/admissibility evidence
- [ ] Touches secrets or credentials
- [ ] Creates execution effects
- [ ] Changes public positioning

## Human approval required?

- [x] Yes

Reason: governance-sensitive verification and caller-interface changes.

## Notes for reviewer

- No benchmark ground-truth dependency.
- No Human Approval Receipt generation or inference.
- No execution authority, Bind authorization, BindReceipt, credentials, network or external effect creation.
- Existing required and not-required satisfaction paths remain tested.
- One prior downstream error expectation changes because rejection now occurs earlier in the strengthened verifier.
- Callers must select the expected source and contract independently. An embedded contract snapshot is not authenticated policy selection.
- recorded resolved_at remains a timestamp, not a current freshness attestation.
- These tests validate metadata-linkage integrity, not cryptographic authentication of authority evidence; that remains a separate boundary.
- Do not merge automatically.


## Downstream trust binding follow-up (supersedes earlier validation status)

Head: `4926e19e4265a098372fe7b157bd4ea08439555a`; tested tree: `bc79bd5ad9e71890d5b6fe4455fc56b356584d50` (identical to local commit `21b7c92dbce5cb0f4977d97d6c07f77af3aabbf8`).

- Satisfaction verification now requires independent keyword-only `expected_source` and `expected_contract`. Complete embedded snapshots must match these inputs; they cannot select the trusted policy.
- Final Bind Readiness and Bind Gate Review builders/verifiers propagate both inputs. Missing anchors fail closed for v0.3; legacy v1 remains compatible. Further consumers must explicitly provide trusted inputs to enable v0.3 rather than using embedded fallbacks.
- Added 13 adversarial cases: same-ID/version REQUIRED-to-NOT_REQUIRED contract substitution with rebuilt HARR/satisfaction/all downstream hashes, missing anchors across three verifier stages, and fully rebuilt source substitution. Positive controls verify internally valid attacker packets against substituted inputs before rejecting original trusted inputs.
- Related six-suite run: **183 passed**, 4 jsonschema deprecation warnings, 156.29 seconds. Ruff, diff check, responsibility boundaries and bilingual docs passed.
- Local `make quality-checks` passed checks through subprocess usage, then stopped because the required `audit/replay_reports` directory is absent. This is not a full local quality-checks pass. Deployment defaults and runtime pickle checks passed separately.
- New-head full CI: awaiting results; old-head green CI is not evidence for this change.
- No Human Approval Receipt generation/inference, execution authority, Bind authorization, BindReceipt, credential access or network/external-effect implementation added. No benchmark ground truth dependency.

**Do not merge: human review remains required.**
