### PR TITLE
fix(policy): propagate trusted inputs through non-effecting source context

### DIFF
--- a/docs/en/development/approval-requirement-source-verification.md
+++ b/docs/en/development/approval-requirement-source-verification.md
@@ -22,6 +22,25 @@ trusted inputs before enabling that path. Never extract expected inputs from
 the packet under verification.
 Resolution time is a recorded timestamp, not a live freshness attestation.
 
+## Non-effecting fresh composition
+
+`build_fresh_bind_source_chain(..., expected_contract=trusted_contract)` selects
+v0.3 requirement satisfaction. Supply the contract from trusted configuration
+outside `FreshBindSourceChainInputs`; do not select it from a candidate gate.
+The authority source is freshly constructed from the checked prerequisite chain.
+REQUIRED needs caller-supplied human reference metadata; NOT_REQUIRED may use
+`human_approval_reference_bundle=None`. No receipt is inferred. Omitting the
+contract retains legacy v1 composition.
+
+Pass `result.authority_linkage_packet` and that same trusted contract as
+`expected_source` and `expected_contract` to
+`derive_verified_real_bind_context_hash(result.verified_gate_review_packet, ...)`.
+The helper reverifies the whole gate before deriving its context digest.
+Missing anchors or same-ID/version policy substitution fail closed for v0.3.
+This connects only the non-effecting path: existing approval/authorization
+issuers have not been enabled for v0.3 and still reject gates without anchors.
+No trusted policy registry, credential access, or execution capability is added.
+
 Integration tests exercise the real nested metadata-linkage chain without
 mocking its verifier. They do not claim cryptographic authority authentication.
 Authority signature/revocation verification and human approval verification

--- a/docs/ja/development/approval-requirement-source-verification.md
+++ b/docs/ja/development/approval-requirement-source-verification.md
@@ -19,3 +19,19 @@ v0.3 gateを消費できません。有効化する際は信頼済み入力を�
 統合テストではソース検証器をモックせず、実際の入れ子のmetadata-linkageチェーンを使います。
 権限証拠の暗号学的認証を実証するものではありません。権限署名・失効検証、人間承認検証は
 別の境界として引き続き必要です。実行権限や承認は生成しません。
+
+## 非実行のfresh composition
+
+`build_fresh_bind_source_chain(..., expected_contract=trusted_contract)`でv0.3の
+承認要否検証を選択します。契約は`FreshBindSourceChainInputs`の外の信頼できる設定から渡し、
+検証対象gateから選択しません。authority sourceは検証済みの前提チェーンから内部で新規構築します。
+REQUIREDでは呼び出し元の人間承認参照メタデータが必要です。NOT_REQUIREDでは
+`human_approval_reference_bundle=None`を渡せます。Receiptを推測しません。
+契約を省略すると既存v1経路を維持します。
+
+`derive_verified_real_bind_context_hash(result.verified_gate_review_packet, ...)`には
+`expected_source=result.authority_linkage_packet`と同じ信頼済み契約を`expected_contract`に渡します。
+gate全体を再検証してからcontext digestを導出します。v0.3の独立入力欠落や同一ID/versionでの
+契約差し替えは拒否します。接続対象は非実行経路のみです。既存の承認・authorization発行経路は
+v0.3向けに有効化せず、独立入力なしのgateを引き続き拒否します。
+trusted policy registry、credential access、実行機能は追加していません。

--- a/veritas_os/policy/fresh_bind_source_chain.py
+++ b/veritas_os/policy/fresh_bind_source_chain.py
@@ -6,6 +6,14 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 
+from veritas_os.governance.action_contracts import ActionClassContract
+from veritas_os.policy.human_approval_requirement_resolution import (
+    build_human_approval_requirement_resolution_packet,
+)
+from veritas_os.policy.live_adapter_dry_run_human_approval_requirement_satisfaction import (
+    build_live_adapter_dry_run_human_approval_requirement_satisfaction_packet,
+)
+
 from veritas_os.policy.adapter_dry_run_plan import build_adapter_dry_run_plan_packet
 from veritas_os.policy.adapter_dry_run_result import (
     build_adapter_dry_run_fixture_result_packet,
@@ -104,6 +112,7 @@ def build_fresh_bind_source_chain(
     inputs: FreshBindSourceChainInputs,
     *,
     built_at: datetime,
+    expected_contract: ActionClassContract | None = None,
 ) -> FreshBindSourceChainResult:
     """Construct and independently verify a new root and prerequisite chain.
 
@@ -111,6 +120,12 @@ def build_fresh_bind_source_chain(
     adapter-contract selection is independently verified and required to carry
     the exact supplied intent; the production plan, fixture-result, and
     rehearsal builders then create a new content-addressed root.
+
+    Supplying a contract from independent trusted policy configuration selects
+    v0.3 requirement satisfaction. Its source anchor is the authority packet
+    freshly built here, never a snapshot extracted from a candidate gate.
+    Omitting the contract preserves legacy v1. This creates no approval receipt
+    or authorization; human references remain caller-supplied metadata.
     """
     selection = verify_bind_adapter_contract_selection_packet(
         inputs.adapter_contract_selection_packet
@@ -152,16 +167,37 @@ def build_fresh_bind_source_chain(
     authority = build_live_adapter_dry_run_authority_evidence_linkage_review_packet(
         pre_dispatch, inputs.authority_evidence_reference_bundle, built_at
     )
-    human = build_live_adapter_dry_run_human_approval_linkage_review_packet(
-        authority, inputs.human_approval_reference_bundle, built_at
-    )
+    anchors: dict[str, Any] = {}
+    if expected_contract is None:
+        human = build_live_adapter_dry_run_human_approval_linkage_review_packet(
+            authority, inputs.human_approval_reference_bundle, built_at
+        )
+    else:
+        resolution = build_human_approval_requirement_resolution_packet(
+            authority, expected_contract, built_at
+        )
+        child = (
+            build_live_adapter_dry_run_human_approval_linkage_review_packet(
+                authority, inputs.human_approval_reference_bundle, built_at
+            )
+            if inputs.human_approval_reference_bundle is not None
+            else None
+        )
+        human = (
+            build_live_adapter_dry_run_human_approval_requirement_satisfaction_packet(
+                authority, resolution, expected_contract, child, built_at
+            )
+        )
+        anchors = {"expected_source": authority, "expected_contract": expected_contract}
     final = build_live_adapter_dry_run_final_bind_authorization_readiness_packet(
-        human, inputs.final_readiness_review_decision, built_at
+        human, inputs.final_readiness_review_decision, built_at, **anchors
     )
     gate = build_live_adapter_dry_run_bind_authorization_gate_review_packet(
-        final, inputs.gate_review_decision, built_at
+        final, inputs.gate_review_decision, built_at, **anchors
     )
-    verified = verify_live_adapter_dry_run_bind_authorization_gate_review_packet(gate)
+    verified = verify_live_adapter_dry_run_bind_authorization_gate_review_packet(
+        gate, **anchors
+    )
     _require_exact_intent(
         execution_intent, verified, "FBS_FINAL_EXECUTION_INTENT_MISMATCH"
     )

--- a/veritas_os/policy/real_bind_context.py
+++ b/veritas_os/policy/real_bind_context.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from veritas_os.governance.action_contracts import ActionClassContract
+
 from veritas_os.policy.live_adapter_bind_authorization_codec import _digest
 from veritas_os.policy.live_adapter_bind_authorization_contracts import DOMAINS
 from veritas_os.policy.live_adapter_dry_run_bind_authorization_gate_review import (
@@ -11,7 +13,12 @@ from veritas_os.policy.live_adapter_dry_run_bind_authorization_gate_review impor
 )
 
 
-def derive_verified_real_bind_context_hash(source_gate_review_packet: Any) -> str:
+def derive_verified_real_bind_context_hash(
+    source_gate_review_packet: Any,
+    *,
+    expected_source: Any = None,
+    expected_contract: ActionClassContract | None = None,
+) -> str:
     """Verify a Real Bind source gate and derive its canonical context hash.
 
     The verification boundary is deliberately part of this helper so callers
@@ -19,6 +26,10 @@ def derive_verified_real_bind_context_hash(source_gate_review_packet: Any) -> st
 
     Args:
         source_gate_review_packet: Candidate production source-gate packet.
+        expected_source: Independent Authority Evidence Linkage source for v0.3.
+        expected_contract: Contract from trusted policy configuration for v0.3.
+            Neither input may be selected from the candidate packet. Both may
+            be omitted only for legacy v1 gates.
 
     Returns:
         The canonical Real Bind context digest for the verified packet.
@@ -27,7 +38,9 @@ def derive_verified_real_bind_context_hash(source_gate_review_packet: Any) -> st
         ValueError: If the packet is malformed or fails integrity verification.
     """
     source = verify_live_adapter_dry_run_bind_authorization_gate_review_packet(
-        source_gate_review_packet
+        source_gate_review_packet,
+        expected_source=expected_source,
+        expected_contract=expected_contract,
     )
     return _digest(
         DOMAINS["bind_context"],
@@ -43,9 +56,7 @@ def derive_verified_real_bind_context_hash(source_gate_review_packet: Any) -> st
                 source.endpoint_identity_binding_digest
             ),
             "credential_reference_digest": source.credential_reference_digest,
-            "credential_scope_binding_digest": (
-                source.credential_scope_binding_digest
-            ),
+            "credential_scope_binding_digest": (source.credential_scope_binding_digest),
         },
     )
 

--- a/veritas_os/tests/test_fresh_approval_trust_context.py
+++ b/veritas_os/tests/test_fresh_approval_trust_context.py
@@ -1,0 +1,114 @@
+"""Non-effecting v0.3 composition preserves independent policy anchors."""
+
+from dataclasses import replace
+
+import pytest
+
+from veritas_os.governance.action_contracts import ActionClassContract
+from veritas_os.policy.fresh_bind_source_chain import (
+    build_fresh_bind_source_chain,
+    fresh_bind_proof_report,
+)
+from veritas_os.policy.real_bind_context import derive_verified_real_bind_context_hash
+from veritas_os.tests.test_fresh_bind_source_chain import _inputs, RECORDED_AT
+
+pytestmark = pytest.mark.slow
+
+
+def _policy(intent, inputs, required):
+    return ActionClassContract(
+        id=intent.intended_action,
+        version="1",
+        domain="test",
+        action_class="test_action",
+        description="Independent test policy",
+        declared_intent="Review action",
+        allowed_scope=list(inputs.authority_evidence_reference_bundle["bundle_scope"]),
+        prohibited_scope=[],
+        authority_sources=["test-authority"],
+        required_evidence=[],
+        evidence_freshness={},
+        irreversibility={"level": "low"},
+        human_approval_rules={"required": required, "minimum_approvals": int(required)},
+        refusal_conditions=[],
+        escalation_conditions=[],
+        default_failure_mode="deny",
+        metadata={},
+    )
+
+
+@pytest.fixture(scope="module", params=[True, False])
+def chain(request):
+    intent, inputs = _inputs()
+    contract = _policy(intent, inputs, request.param)
+    if not request.param:
+        inputs = replace(inputs, human_approval_reference_bundle=None)
+    result = build_fresh_bind_source_chain(
+        intent, inputs, built_at=RECORDED_AT, expected_contract=contract
+    )
+    return contract, result
+
+
+def test_fresh_v03_to_context_preserves_anchors_without_effects(chain):
+    contract, result = chain
+    gate = result.verified_gate_review_packet
+    digest = derive_verified_real_bind_context_hash(
+        gate,
+        expected_source=result.authority_linkage_packet,
+        expected_contract=contract,
+    )
+    assert len(digest) == 64
+    assert (
+        result.human_approval_linkage_packet.required_human_approval
+        is (contract.human_approval_rules["required"])
+    )
+    report = fresh_bind_proof_report(result)
+    assert not report["real_bind_authorization_issued"]
+    assert not report["external_effect_performed"]
+    assert not report["human_approval_proven"]
+    assert not gate.bind_receipt_created and not gate.network_used
+
+
+@pytest.mark.parametrize("missing", ["source", "contract", "both"])
+def test_context_never_falls_back_to_embedded_anchors(chain, missing):
+    contract, result = chain
+    with pytest.raises(ValueError):
+        derive_verified_real_bind_context_hash(
+            result.verified_gate_review_packet,
+            expected_source=None
+            if missing != "contract"
+            else result.authority_linkage_packet,
+            expected_contract=None if missing != "source" else contract,
+        )
+
+
+def test_fully_rebuilt_policy_downgrade_rejected_at_context_boundary():
+    intent, inputs = _inputs()
+    trusted = _policy(intent, inputs, True)
+    substituted = replace(
+        trusted, human_approval_rules={"required": False, "minimum_approvals": 0}
+    )
+    forged = build_fresh_bind_source_chain(
+        intent,
+        replace(inputs, human_approval_reference_bundle=None),
+        built_at=RECORDED_AT,
+        expected_contract=substituted,
+    )
+    assert substituted.id == trusted.id and substituted.version == trusted.version
+    with pytest.raises(ValueError):
+        derive_verified_real_bind_context_hash(
+            forged.verified_gate_review_packet,
+            expected_source=forged.authority_linkage_packet,
+            expected_contract=trusted,
+        )
+
+
+def test_required_policy_cannot_infer_missing_human_reference():
+    intent, inputs = _inputs()
+    with pytest.raises(ValueError):
+        build_fresh_bind_source_chain(
+            intent,
+            replace(inputs, human_approval_reference_bundle=None),
+            built_at=RECORDED_AT,
+            expected_contract=_policy(intent, inputs, True),
+        )


### PR DESCRIPTION
# Summary

Connect the non-effecting fresh source composition and context-hash derivation to the independent trust inputs introduced by #2185.

## Scope

- Fresh composition accepts an independent trusted ActionClassContract. It builds its authority source internally and propagates both anchors through satisfaction, readiness and gate self-verification.
- Context derivation accepts those same independent anchors and reverifies the complete gate.
- Preserve legacy v1 composition when no contract is supplied.
- Add REQUIRED/NOT_REQUIRED positive cases, absent-anchor rejection, same-ID/version fully rebuilt contract downgrade rejection, and missing-human-reference rejection.
- Document trust input provenance in English and Japanese.

## Type of change

- [x] Runtime
- [x] Tests
- [x] Docs
- [x] Governance / security-sensitive

## Why this change matters

After #2185, the non-effecting callers could not consume v0.3 gates because they omitted the independent anchors. This adds explicit propagation without selecting policy from embedded snapshots.

## Market / developer / user value

- Market value: no expansion of execution claims.
- Developer value: explicit non-effecting v0.3 composition and context interface.
- User/operator value: substituted policy cannot produce a trusted context hash.

## Tests run

- [x] Other: 36 related tests passed (fresh composition, fresh trust context, satisfaction attacks), 70.36s.
- [x] Other: 16 existing approval issuance / bind authorization regression tests passed, 90.77s.
- [x] Other: Ruff, bilingual docs, git diff checks passed.
- [ ] Full CI (not yet confirmed)
- [ ] make test
- [ ] make test-cov
- [ ] make quality-checks

Both pytest runs reported four existing jsonschema RefResolver deprecation warnings.

## AI assistance used

- [x] Codex

## Review status

- [ ] CI passed
- [ ] Independent review completed
- [ ] Human maintainer reviewed

## Risk checklist

- [x] Touches bind/admissibility logic
- [x] Touches governance policy behavior
- [ ] Touches secrets or credentials
- [ ] Creates execution effects

## Human approval required?

- [x] Yes

Reason: governance-sensitive caller wiring.

## Notes for reviewer

This is deliberately limited to the non-effecting chain through context derivation. Approval and authorization issuers are not enabled for v0.3; they still fail closed without anchors. No policy registry is implemented: the embedding application must supply a contract from trusted configuration. Human references are metadata, not generated or inferred receipts. No execution authority, Bind authorization, BindReceipt, credential access or network/effect implementation is added. Tests have no benchmark ground-truth dependency.

Based on merged main a6519f04c99e79732689da55bda6796a9c6d3c03.
Remote head: 988deb4335cf5f03f3e348cefedbed713264e776.
Tested local commit: 386959d061caba6e6e46fe6aee24b8e2a9529b7e.
Published with the connected GitHub API; identical local/remote tree verified: d078d36ab65e83ee1d4bd1d91d95b856437d3319.

Do not merge automatically.
