### PR TITLE
fix(policy): carry independent v0.3 trust inputs into issuance

### DIFF
--- a/docs/en/development/approval-requirement-source-verification.md
+++ b/docs/en/development/approval-requirement-source-verification.md
@@ -37,11 +37,31 @@ Pass `result.authority_linkage_packet` and that same trusted contract as
 `derive_verified_real_bind_context_hash(result.verified_gate_review_packet, ...)`.
 The helper reverifies the whole gate before deriving its context digest.
 Missing anchors or same-ID/version policy substitution fail closed for v0.3.
-This connects only the non-effecting path: existing approval/authorization
-issuers have not been enabled for v0.3 and still reject gates without anchors.
+This composition itself remains non-effecting. The separate approval and
+authorization issuers accept v0.3 with the independent inputs described below.
 No trusted policy registry, credential access, or execution capability is added.
 
-Integration tests exercise the real nested metadata-linkage chain without
+## Explicit v0.3 issuance inputs
+
+`issue_gate_bound_human_approval_artifact` accepts `expected_source` separately
+from the gate and uses its existing `action_contract` argument as trusted policy.
+An explicit approval event, matching approval reference and deployment signer
+remain mandatory. NOT_REQUIRED does not generate or infer a Human Approval Receipt.
+
+For Bind authorization, set `RealBindAuthorizationGovernanceInputs.expected_source`
+to the independently acquired authority linkage source and `action_contract` to
+the trusted contract. The decision-to-authorization entry point, authorization
+builder, verifier and governance context derivation propagate those same inputs.
+Do not populate either from embedded snapshots in an untrusted gate or artifact.
+Legacy v1 inputs remain compatible; missing anchors fail closed for v0.3.
+
+These are prerequisites, not a replacement for signed authority verification,
+revocation/freshness checks, required signed Human Approval, explicit authorizer
+GO, approved issuer identity or signature checks. Local tests use ephemeral keys
+and real Ed25519 verification. Issuance produces an unconsumed authorization;
+it does not invoke Bind, resolve credentials, dispatch requests or create effects.
+
+Requirement-resolution integration tests exercise the nested metadata chain without
 mocking its verifier. They do not claim cryptographic authority authentication.
 Authority signature/revocation verification and human approval verification
-remain separate boundaries. No execution or approval authority is created.
+remain separate boundaries. The requirement-resolution layer creates no authority.

--- a/docs/ja/development/approval-requirement-source-verification.md
+++ b/docs/ja/development/approval-requirement-source-verification.md
@@ -16,9 +16,9 @@ embedded snapshotへのフォールバックはしません。さらに先の呼
 v0.3 gateを消費できません。有効化する際は信頼済み入力を明示的に渡す必要があります。
 検証対象packetから期待値を取り出してはいけません。解決時刻は記録値であり現在の鮮度の証明ではありません。
 
-統合テストではソース検証器をモックせず、実際の入れ子のmetadata-linkageチェーンを使います。
+承認要否の統合テストではソース検証器をモックせず、実際の入れ子のmetadata-linkageチェーンを使います。
 権限証拠の暗号学的認証を実証するものではありません。権限署名・失効検証、人間承認検証は
-別の境界として引き続き必要です。実行権限や承認は生成しません。
+別の境界として引き続き必要です。承認要否の解決層自体は実行権限や承認を生成しません。
 
 ## 非実行のfresh composition
 
@@ -32,6 +32,22 @@ REQUIREDでは呼び出し元の人間承認参照メタデータが必要です
 `derive_verified_real_bind_context_hash(result.verified_gate_review_packet, ...)`には
 `expected_source=result.authority_linkage_packet`と同じ信頼済み契約を`expected_contract`に渡します。
 gate全体を再検証してからcontext digestを導出します。v0.3の独立入力欠落や同一ID/versionでの
-契約差し替えは拒否します。接続対象は非実行経路のみです。既存の承認・authorization発行経路は
-v0.3向けに有効化せず、独立入力なしのgateを引き続き拒否します。
+契約差し替えは拒否します。このcomposition自体は非実行です。別の承認・authorization発行経路は
+下記の独立入力がある場合にv0.3を扱い、入力なしのgateは引き続き拒否します。
 trusted policy registry、credential access、実行機能は追加していません。
+
+## v0.3発行経路の明示的な信頼入力
+
+`issue_gate_bound_human_approval_artifact`へ`expected_source`をgateと独立して渡し、
+既存の`action_contract`には信頼できる契約を渡します。明示的な承認イベント、一致する承認参照、
+deployment管理のsignerは引き続き必須です。NOT_REQUIREDからHuman Approval Receiptを生成・推測しません。
+
+Bind authorizationでは`RealBindAuthorizationGovernanceInputs.expected_source`へ独立取得した
+authority linkage source、`action_contract`へ信頼できる契約を設定します。decisionからの発行入口、
+authorization builder、verifier、governanceのcontext導出まで同じ入力を伝播します。
+未信頼のgateやartifact内のsnapshotから期待値を取り出してはいけません。既存v1は互換性を維持し、
+v0.3の独立入力欠落は拒否します。
+
+これらは前提条件であり、権限署名、失効・鮮度、必要な署名済み人間承認、明示的なauthorizer GO、
+許可されたissuerと署名検証の代わりにはなりません。テストは一時鍵と実際のEd25519検証を使用します。
+発行結果は未消費のauthorizationです。Bind呼び出し、credential解決、request送信、外部効果は行いません。

--- a/veritas_os/policy/gate_bound_human_approval_issuance.py
+++ b/veritas_os/policy/gate_bound_human_approval_issuance.py
@@ -95,6 +95,7 @@ def issue_gate_bound_human_approval_artifact(
     action_contract: ActionClassContract,
     event: HumanApprovalEvent,
     signer: HumanApprovalArtifactSigner,
+    expected_source: Any = None,
 ) -> dict[str, Any]:
     """Construct and sign approval derived only from an exact verified gate.
 
@@ -104,7 +105,9 @@ def issue_gate_bound_human_approval_artifact(
 
     Args:
         source_gate_review_packet: Exact source gate to verify and approve.
-        action_contract: Contract used only to resolve gate action semantics.
+        action_contract: Independently trusted policy, also the v0.3 gate anchor.
+        expected_source: Independent Authority Evidence Linkage source required
+            for v0.3. Never obtain this from the candidate gate's snapshot.
         event: Approval decision, timing, basis, and non-security metadata.
         signer: Deployment-controlled signing backend and signer provenance.
 
@@ -117,9 +120,13 @@ def issue_gate_bound_human_approval_artifact(
     """
     try:
         source = verify_live_adapter_dry_run_bind_authorization_gate_review_packet(
-            source_gate_review_packet
+            source_gate_review_packet,
+            expected_source=expected_source,
+            expected_contract=action_contract,
         )
-        bind_context_hash = derive_verified_real_bind_context_hash(source)
+        bind_context_hash = derive_verified_real_bind_context_hash(
+            source, expected_source=expected_source, expected_contract=action_contract
+        )
     except (TypeError, ValueError) as exc:
         raise GateBoundHumanApprovalIssuanceError("GBHA_SOURCE_GATE_INVALID") from exc
 

--- a/veritas_os/policy/live_adapter_bind_authorization_contracts.py
+++ b/veritas_os/policy/live_adapter_bind_authorization_contracts.py
@@ -189,7 +189,12 @@ class BindAuthorizationVerifierPolicy:
 
 @dataclass(frozen=True)
 class RealBindAuthorizationGovernanceInputs:
-    """Original signed governance artifacts plus deployment verification dependencies."""
+    """Original artifacts and independent deployment trust inputs.
+
+    For v0.3, expected_source must be acquired independently of the candidate
+    gate, and action_contract must come from trusted policy configuration.
+    These anchors are not reconstructed from embedded artifact snapshots.
+    """
 
     action_contract: ActionClassContract
     signed_authority_evidence_artifact: dict[str, Any]
@@ -203,6 +208,9 @@ class RealBindAuthorizationGovernanceInputs:
     human_approval_signature_verifier: HumanApprovalSignatureVerifier | None = None
     human_approval_signer_policy: HumanApprovalSignerPolicy | None = None
     human_approval_verifier_policy: HumanApprovalVerifierPolicy | None = None
+    # Independent source anchor for v0.3; never extract from the candidate gate.
+    # action_contract above is the corresponding trusted policy anchor.
+    expected_source: Any = None
 
 
 @dataclass(frozen=True)

--- a/veritas_os/policy/live_adapter_bind_authorization_governance.py
+++ b/veritas_os/policy/live_adapter_bind_authorization_governance.py
@@ -37,9 +37,24 @@ _bind_context_hash = derive_verified_real_bind_context_hash
 
 def _source(
     value: Any,
+    *,
+    governance_inputs: RealBindAuthorizationGovernanceInputs | None = None,
 ) -> CanonicalLiveAdapterDryRunBindAuthorizationGateReviewPacket:
+    """Verify with deployment-supplied anchors; None permits only legacy v1."""
+    if governance_inputs is not None and not isinstance(
+        governance_inputs, RealBindAuthorizationGovernanceInputs
+    ):
+        raise LiveAdapterBindAuthorizationError("LABA_GOVERNANCE_INPUTS_REQUIRED")
     try:
-        return verify_live_adapter_dry_run_bind_authorization_gate_review_packet(value)
+        return verify_live_adapter_dry_run_bind_authorization_gate_review_packet(
+            value,
+            expected_source=(
+                governance_inputs.expected_source if governance_inputs else None
+            ),
+            expected_contract=(
+                governance_inputs.action_contract if governance_inputs else None
+            ),
+        )
     except (
         LiveAdapterDryRunBindAuthorizationGateReviewError,
         TypeError,
@@ -274,7 +289,11 @@ def _validate_real_governance_inputs(
             "LABA_AUTHORITY_REFERENCE_SOURCE_MISMATCH"
         )
 
-    bind_context_hash = derive_verified_real_bind_context_hash(source)
+    bind_context_hash = derive_verified_real_bind_context_hash(
+        source,
+        expected_source=inputs.expected_source,
+        expected_contract=contract,
+    )
     human_proof: VerifiedHumanApprovalReceipt | None = None
     human_status: Literal["VERIFIED", "NOT_REQUIRED"] = "NOT_REQUIRED"
     needs_human = _requires_human_approval(contract)

--- a/veritas_os/policy/live_adapter_bind_authorization_issuance.py
+++ b/veritas_os/policy/live_adapter_bind_authorization_issuance.py
@@ -61,7 +61,9 @@ def build_live_adapter_bind_authorization_artifact(
     authorization_issuer_signer: BindAuthorizationSigner,
 ) -> CanonicalLiveAdapterBindAuthorizationArtifact:
     """Issue one signed authorization without consuming it or invoking Bind."""
-    source = _source(_json(source_gate_review_packet))
+    source = _source(
+        _json(source_gate_review_packet), governance_inputs=governance_inputs
+    )
     _validate_source(source)
     governance = _validate_real_governance_inputs(source, governance_inputs)
 

--- a/veritas_os/policy/live_adapter_bind_authorization_verification.py
+++ b/veritas_os/policy/live_adapter_bind_authorization_verification.py
@@ -66,7 +66,9 @@ def verify_live_adapter_bind_authorization_artifact(
     except (ValidationError, TypeError, LiveAdapterBindAuthorizationError) as exc:
         raise LiveAdapterBindAuthorizationError("LABA_ARTIFACT_INVALID") from exc
 
-    source = _source(artifact.source_gate_review_packet)
+    source = _source(
+        artifact.source_gate_review_packet, governance_inputs=governance_inputs
+    )
     _validate_source(source)
     _compare_exact_source(artifact, source)
 

--- a/veritas_os/policy/real_decision_bind_authorization.py
+++ b/veritas_os/policy/real_decision_bind_authorization.py
@@ -128,8 +128,12 @@ def issue_verified_real_decision_bind_authorization(
     ):
         raise RealDecisionBindAuthorizationError("RDBA_DECISION_LINEAGE_MISMATCH")
 
+    if not isinstance(governance_inputs, RealBindAuthorizationGovernanceInputs):
+        raise RealDecisionBindAuthorizationError("RDBA_GOVERNANCE_INPUTS_REQUIRED")
     source = verify_live_adapter_dry_run_bind_authorization_gate_review_packet(
-        source_gate_review_packet
+        source_gate_review_packet,
+        expected_source=governance_inputs.expected_source,
+        expected_contract=governance_inputs.action_contract,
     )
     _require_exact_intent(
         intent,

--- a/veritas_os/tests/test_real_decision_bind_authorization.py
+++ b/veritas_os/tests/test_real_decision_bind_authorization.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import inspect
+from dataclasses import replace
 from types import SimpleNamespace
 
 import pytest
@@ -143,3 +144,56 @@ def test_decision_lineage_mismatch_stops_before_source_verification(
             authorization_issuer_signer=SimpleNamespace(),
         )
     assert source_called is False
+
+
+def test_decision_entry_forwards_independent_anchors_before_issuance(monkeypatch):
+    """Unit-level wiring check; signature integration is tested separately."""
+    from veritas_os.tests.test_live_adapter_bind_authorization import _governance_inputs
+
+    intent = _intent()
+    cda = SimpleNamespace(
+        decision_id=intent.decision_id,
+        decision_hash=intent.decision_hash,
+        decision_ts=intent.decision_ts,
+        request_id=intent.request_id,
+    )
+    independent_source = object()
+    candidate_gate = object()
+    governance = replace(_governance_inputs(), expected_source=independent_source)
+    module = "veritas_os.policy.real_decision_bind_authorization."
+    monkeypatch.setattr(
+        module + "verify_canonical_decision_artifact",
+        lambda value: SimpleNamespace(is_valid=True, artifact=cda),
+    )
+    monkeypatch.setattr(
+        module
+        + "try_promote_verified_canonical_decision_candidate_to_execution_intent",
+        lambda *args, **kwargs: SimpleNamespace(promoted=True, execution_intent=intent),
+    )
+
+    class StopAtVerifiedBoundary(ValueError):
+        pass
+
+    def check_source(value, *, expected_source, expected_contract):
+        assert value is candidate_gate
+        assert expected_source is independent_source
+        assert expected_contract is governance.action_contract
+        raise StopAtVerifiedBoundary()
+
+    monkeypatch.setattr(
+        module + "verify_live_adapter_dry_run_bind_authorization_gate_review_packet",
+        check_source,
+    )
+    with pytest.raises(StopAtVerifiedBoundary):
+        issue_verified_real_decision_bind_authorization(
+            canonical_decision_artifact={},
+            candidate={},
+            policy_snapshot_id="policy-live-v1",
+            source_gate_review_packet=candidate_gate,
+            signed_authorization_decision_artifact={},
+            valid_from="2026-08-25T00:00:00Z",
+            valid_until="2026-08-25T00:05:00Z",
+            governance_inputs=governance,
+            trust_inputs=SimpleNamespace(),
+            authorization_issuer_signer=SimpleNamespace(),
+        )

--- a/veritas_os/tests/test_v03_issuance_trust.py
+++ b/veritas_os/tests/test_v03_issuance_trust.py
@@ -1,0 +1,255 @@
+"""Real local signature verification for v0.3 issuance trust propagation."""
+
+import base64
+from dataclasses import replace
+
+import pytest
+from veritas_os.governance.human_approval_receipt import (
+    ApprovedHumanApprovalVerifier,
+    HumanApprovalSignerPolicy,
+    HumanApprovalVerifierPolicy,
+)
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from veritas_os.governance.human_approval_receipt_signing import (
+    human_approval_signature_payload,
+)
+
+from veritas_os.policy.human_approval_requirement_resolution import (
+    build_human_approval_requirement_resolution_packet as resolve,
+)
+from veritas_os.policy.live_adapter_dry_run_human_approval_linkage import (
+    build_live_adapter_dry_run_human_approval_linkage_review_packet as link,
+)
+from veritas_os.policy.live_adapter_dry_run_human_approval_requirement_satisfaction import (
+    build_live_adapter_dry_run_human_approval_requirement_satisfaction_packet as satisfy,
+)
+from veritas_os.policy.live_adapter_bind_authorization import (
+    build_live_adapter_bind_authorization_artifact as issue,
+    verify_live_adapter_bind_authorization_artifact as verify,
+)
+from veritas_os.policy.gate_bound_human_approval_issuance import (
+    issue_gate_bound_human_approval_artifact as approve,
+)
+from veritas_os.policy.real_bind_context import derive_verified_real_bind_context_hash
+from veritas_os.tests.test_live_adapter_dry_run_human_approval_requirement_satisfaction import (
+    authority_source_packet,
+    human_bundle,
+    HUMAN_RECORDED_AT,
+    SATISFACTION_RECORDED_AT,
+    _build_gate,
+)
+from veritas_os.tests.test_live_adapter_bind_authorization import (
+    _governance_inputs,
+    _bind_signature_setup,
+    _signed_decision,
+    VALID_FROM,
+    VALID_UNTIL,
+)
+from veritas_os.tests.test_gate_bound_human_approval_issuance import (
+    _Ed25519Signer,
+    _event,
+    KEY_ID,
+    IDENTITY,
+    ROLE,
+    _trusted_verifier,
+)
+
+pytestmark = pytest.mark.slow
+
+
+def _gate(source, contract, required):
+    resolution = resolve(source, contract, HUMAN_RECORDED_AT)
+    child = link(source, human_bundle(source), HUMAN_RECORDED_AT) if required else None
+    satisfaction = satisfy(
+        source, resolution, contract, child, SATISFACTION_RECORDED_AT
+    )
+    return _build_gate(satisfaction, source, contract)[1]
+
+
+@pytest.fixture(scope="module", params=[False, True])
+def case(request):
+    governance = _governance_inputs(human_required=request.param)
+    source = authority_source_packet()
+    gate = _gate(source, governance.action_contract, request.param)
+    governance = replace(governance, expected_source=source)
+    if request.param:
+        key = Ed25519PrivateKey.generate()
+        human_signer = _Ed25519Signer(KEY_ID, IDENTITY, ROLE, key)
+        receipt = approve(
+            gate,
+            expected_source=source,
+            action_contract=governance.action_contract,
+            event=_event(),
+            signer=human_signer,
+        )
+        human_verifier = _trusted_verifier(key)
+        signer_policy = HumanApprovalSignerPolicy(
+            policy_id="v03-test-signers",
+            allowed_key_ids=[KEY_ID],
+            allowed_algorithms=["Ed25519"],
+            required_signer_identities=[IDENTITY],
+            required_signer_roles=[ROLE],
+            allowed_action_classes=[governance.action_contract.action_class],
+            allowed_policy_snapshot_ids=[gate.execution_intent["policy_snapshot_id"]],
+        )
+        verifier_policy = HumanApprovalVerifierPolicy(
+            [
+                ApprovedHumanApprovalVerifier(
+                    verifier_id=human_verifier.verifier_id,
+                    trust_level="production",
+                    verifier_key_id=KEY_ID,
+                    policy_id=human_verifier.verifier_policy_id,
+                    policy_hash=human_verifier.policy_hash(),
+                )
+            ]
+        )
+        governance = replace(
+            governance,
+            signed_human_approval_artifact=receipt,
+            human_approval_signature_verifier=human_verifier,
+            human_approval_signer_policy=signer_policy,
+            human_approval_verifier_policy=verifier_policy,
+        )
+    private, trust, signer = _bind_signature_setup()
+    decision = _signed_decision(private, source=gate)
+    return gate, governance, decision, trust, signer
+
+
+def _issue(case, governance=None):
+    gate, original, decision, trust, signer = case
+    return issue(
+        gate,
+        decision,
+        VALID_FROM,
+        VALID_UNTIL,
+        governance_inputs=governance or original,
+        trust_inputs=trust,
+        authorization_issuer_signer=signer,
+    )
+
+
+def test_v03_authorization_reverifies_real_signatures_without_execution(
+    case, monkeypatch
+):
+    monkeypatch.setenv("VERITAS_POSTURE", "secure")
+    artifact = _issue(case)
+    _, governance, _, trust, _ = case
+    assert (
+        verify(artifact, governance_inputs=governance, trust_inputs=trust) == artifact
+    )
+    assert artifact.human_approval_requirement_status == (
+        "VERIFIED" if governance.signed_human_approval_artifact else "NOT_REQUIRED"
+    )
+    assert artifact.bind_authorization_state == "AUTHORIZED"
+    for field in (
+        "bind_invoked",
+        "bind_receipt_created",
+        "credential_material_accessed",
+        "network_used",
+        "operation_committed",
+        "request_dispatched",
+    ):
+        assert not getattr(artifact, field)
+    with pytest.raises(ValueError):
+        verify(
+            artifact,
+            governance_inputs=replace(governance, expected_source=None),
+            trust_inputs=trust,
+        )
+
+
+@pytest.mark.parametrize(
+    "mutation", ["missing_source", "contract", "authority_signature", "human_presence"]
+)
+def test_issuance_rejects_invalid_trust_before_signing(case, mutation, monkeypatch):
+    monkeypatch.setenv("VERITAS_POSTURE", "secure")
+    gate, governance, decision, trust, signer = case
+    if mutation == "missing_source":
+        governance = replace(governance, expected_source=None)
+    elif mutation == "contract":
+        governance = replace(
+            governance,
+            action_contract=replace(
+                governance.action_contract,
+                human_approval_rules={"required": False, "minimum_approvals": 9},
+            ),
+        )
+    elif mutation == "authority_signature":
+        governance = replace(
+            governance,
+            signed_authority_evidence_artifact={
+                **governance.signed_authority_evidence_artifact,
+                "signature": "invalid",
+            },
+        )
+    else:
+        governance = replace(
+            governance,
+            signed_human_approval_artifact=(
+                {} if governance.signed_human_approval_artifact is None else None
+            ),
+        )
+
+    def forbidden_sign(self, payload):
+        pytest.fail("issuer signing must not run after failed verification")
+
+    monkeypatch.setattr(type(signer), "sign", forbidden_sign)
+    with pytest.raises(ValueError):
+        issue(
+            gate,
+            decision,
+            VALID_FROM,
+            VALID_UNTIL,
+            governance_inputs=governance,
+            trust_inputs=trust,
+            authorization_issuer_signer=signer,
+        )
+
+
+def test_receipt_issuance_requires_independent_source_and_explicit_reference(case):
+    gate, governance, _, _, _ = case
+    signer = _Ed25519Signer(KEY_ID, IDENTITY, ROLE, Ed25519PrivateKey.generate())
+    kwargs = dict(
+        action_contract=governance.action_contract, event=_event(), signer=signer
+    )
+    with pytest.raises(ValueError):
+        approve(gate, **kwargs)
+    if governance.signed_human_approval_artifact is None:
+        with pytest.raises(ValueError):
+            approve(gate, expected_source=governance.expected_source, **kwargs)
+    else:
+        artifact = approve(gate, expected_source=governance.expected_source, **kwargs)
+        signer.private_key.public_key().verify(
+            base64.urlsafe_b64decode(artifact["signature"]),
+            human_approval_signature_payload(artifact).encode("utf-8"),
+        )
+        assert artifact["receipt"][
+            "bind_context_hash"
+        ] == derive_verified_real_bind_context_hash(
+            gate,
+            expected_source=governance.expected_source,
+            expected_contract=governance.action_contract,
+        )
+
+
+def test_fully_rebuilt_same_id_version_downgrade_cannot_reach_issuance(monkeypatch):
+    monkeypatch.setenv("VERITAS_POSTURE", "secure")
+    original = _governance_inputs(human_required=True)
+    source = authority_source_packet()
+    substituted = replace(
+        original.action_contract,
+        human_approval_rules={"required": False, "minimum_approvals": 0},
+    )
+    forged = _gate(source, substituted, False)
+    private, trust, signer = _bind_signature_setup()
+    decision = _signed_decision(private, source=forged)
+    with pytest.raises(ValueError):
+        issue(
+            forged,
+            decision,
+            VALID_FROM,
+            VALID_UNTIL,
+            governance_inputs=replace(original, expected_source=source),
+            trust_inputs=trust,
+            authorization_issuer_signer=signer,
+        )


### PR DESCRIPTION
# Summary

Connect independent v0.3 source/contract trust inputs from #2185 / #2186 to the existing Human Approval and Bind authorization issuance boundaries.

## Scope

- Human Approval issuer takes independent expected_source and uses the existing action_contract as policy anchor, including context re-verification.
- RealBindAuthorizationGovernanceInputs adds expected_source; existing action_contract remains the independent trusted policy.
- Authorization builder, verifier, governance context derivation and decision-to-authorization entry propagate the same inputs.
- No embedded snapshot fallback; legacy v1 remains compatible.
- Update English/Japanese caller documentation.

## Type of change

- [x] Runtime
- [x] Tests
- [x] Docs
- [x] Governance / security-sensitive

## Why this change matters

The non-effecting v0.3 chain was connected by #2186, but issuers still omitted independent anchors. This explicitly connects them without weakening the existing cryptographic or policy gates.

## Market / developer / user value

- Market value: tighter trust continuity, no production deployment claims.
- Developer value: explicit independent source input through public issuance/reverification.
- User/operator value: rehashed contract substitution and missing trust inputs reject before issuer signing.

## Tests run

- [x] Six-suite related/regression run: 59 passed, 4 existing jsonschema deprecation warnings, 167.19s.
- [x] Final updated v0.3 integration suite: 13 passed, 4 warnings, 38.49s. REQUIRED case now consumes a receipt generated by the production gate-bound issuer, with actual Ed25519 verification through authorization issuance and reverification.
- [x] Final decision-entry suite with added forwarding case: 8 passed, 4 warnings, 4.61s. 60 distinct related cases across the final suites.
- [x] Ruff, bilingual documentation, responsibility boundaries and git diff checks passed.
- [ ] Full CI (not yet confirmed)
- [ ] make test
- [ ] make test-cov
- [ ] make quality-checks

The decision-entry forwarding case is an isolated unit test with mocked upstream CDA/promotion, not a claim of complete live decision-to-effect E2E.

## AI assistance used

- [x] Codex

## Review status

- [ ] CI passed
- [ ] Independent review completed
- [ ] Human maintainer reviewed

## Risk checklist

- [x] Touches bind/admissibility logic
- [x] Touches governance policy behavior
- [ ] Changes credential handling
- [ ] Changes execution/dispatch behavior

## Human approval required?

- [x] Yes

Reason: security-sensitive issuance and trust-root propagation.

## Notes for reviewer

Existing authority signature, revocation/freshness, required Human Approval signature/context, explicit authorizer GO and issuer signature checks remain intact. NOT_REQUIRED does not infer or generate a Human Approval Receipt; calling the receipt issuer without a human reference rejects. Authorization remains unconsumed and no Bind invocation, credential material access, network dispatch, BindReceipt or external effect is performed.

No new signing keys, policy registry or deployment integration is implemented. Tests create ephemeral test keys and local artifacts only. The embedding application must supply independently trusted source and contract, never derive them from the candidate gate.

Base main: 976e5dab1d4a8734fff027ec73cd10097d2883a8.
Remote head: 25bc0337a3b5e300fd7a8397159304af758e7ade.
Local tested commit: 97bbf0fbc9204a5aa70053a3f038a19b5d3a03eb.
Connected GitHub API publication; identical tested tree verified: 171faff8edfdf05cd339c50e607ce11a09e33611.

Do not merge automatically.
