### PR TITLE
fix: recheck governance at authorization consumption time

### DIFF
--- a/docs/en/development/approval-requirement-source-verification.md
+++ b/docs/en/development/approval-requirement-source-verification.md
@@ -61,6 +61,30 @@ GO, approved issuer identity or signature checks. Local tests use ephemeral keys
 and real Ed25519 verification. Issuance produces an unconsumed authorization;
 it does not invoke Bind, resolve credentials, dispatch requests or create effects.
 
+## Consumption-time governance recheck
+
+The temporal validator separates two evaluations. `governance_inputs.verification_now`
+reconstructs and verifies the signed issuance proofs unchanged. After checking
+the authorization validity window, it revalidates the same independent source,
+contract, signed authority and required Human Approval at the explicit consumption
+`now`, including revocation freshness and runtime-authority evaluation. New
+time-dependent proof hashes are not compared to or written over historical hashes.
+Backdating consumption before the issuance verification time is rejected.
+
+The caller must obtain `now` from its trusted execution clock, not packet data.
+This function does not authenticate a caller's clock or re-read policy from a
+registry. Independent trust inputs and live verification dependencies remain the
+deployment's responsibility. Any failed recheck stops before consumption and
+credential resolution; no historical pass can substitute for the new evaluation.
+
+Local v0.3 integration tests connect issued authorization to single-use consumption,
+Bind adjudication, OutcomeReceipt lineage and effect-state recording. They use
+ephemeral signing keys, in-memory stores, a synthetic adapter/credential provider,
+and a fake TrustLog sink. Blocked apply records CONFIRMED_NO_EFFECT; a successful
+generic apply remains EFFECT_UNKNOWN without an independently verified external
+acknowledgement. These tests do not prove live /v1/decide-to-effect integration,
+durable production audit storage or a real customer operation.
+
 Requirement-resolution integration tests exercise the nested metadata chain without
 mocking its verifier. They do not claim cryptographic authority authentication.
 Authority signature/revocation verification and human approval verification

--- a/docs/ja/development/approval-requirement-source-verification.md
+++ b/docs/ja/development/approval-requirement-source-verification.md
@@ -51,3 +51,22 @@ v0.3の独立入力欠落は拒否します。
 これらは前提条件であり、権限署名、失効・鮮度、必要な署名済み人間承認、明示的なauthorizer GO、
 許可されたissuerと署名検証の代わりにはなりません。テストは一時鍵と実際のEd25519検証を使用します。
 発行結果は未消費のauthorizationです。Bind呼び出し、credential解決、request送信、外部効果は行いません。
+
+## 消費時点のgovernance再検証
+
+temporal validatorは二段階の評価を行います。`governance_inputs.verification_now`では署名済みの
+発行時証跡を変更せず再構築・検証します。authorizationの有効期間を確認した後、同じ独立source、
+契約、署名済み権限証拠、必要な人間承認を消費時刻`now`で再検証します。失効情報の鮮度と
+runtime-authority評価もこの時刻を使用します。時刻によって変わる新しいproof hashを発行時hashと
+比較したり、発行時hashへ上書きしたりしません。発行時の検証より前への時刻巻き戻しは拒否します。
+
+`now`はpacketからではなく、呼び出し元の信頼できる実行時計から取得してください。この関数自体は
+時計の真正性を認証せず、registryから最新ポリシーを取得するものでもありません。独立した信頼入力と
+検証サービスはdeployment側の責任です。再検証失敗時は消費・credential取得より前に拒否し、
+過去の検証成功を現在の評価の代用にしません。
+
+ローカルv0.3統合テストは、発行済みauthorizationから一回限りの消費、Bind判定、OutcomeReceiptの
+対応関係、effect-state記録まで接続します。一時鍵、メモリ内store、テスト用adapter／credential provider、
+偽のTrustLog保存先を使用します。apply前の拒否はCONFIRMED_NO_EFFECT、汎用applyの成功だけでは
+独立した外部確認がないためEFFECT_UNKNOWNです。実際の/v1/decideから外部効果までの統合、
+本番監査保存の永続性、実顧客の操作を実証したものではありません。

--- a/veritas_os/policy/live_adapter_bind_authorization_verification.py
+++ b/veritas_os/policy/live_adapter_bind_authorization_verification.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import datetime, timezone
 from typing import Any
 
@@ -235,17 +236,43 @@ def validate_live_adapter_bind_authorization_temporal_validity(
     governance_inputs: RealBindAuthorizationGovernanceInputs,
     trust_inputs: BindAuthorizationTrustInputs,
 ) -> CanonicalLiveAdapterBindAuthorizationArtifact:
-    """Verify an authorization and enforce its validity window at a supplied time."""
+    """Verify immutable issuance evidence, then recheck governance at consumption.
+
+    verification_now belongs to reproducible issuance proof reconstruction.
+    The independently supplied consumption clock must also drive a fresh
+    authority/revocation, Human Approval and runtime-authority evaluation.
+    Fresh time-dependent proof hashes must not replace the signed historical
+    hashes. Failure occurs before atomic consumption or credential access.
+    The caller must supply now from its trusted execution clock.
+    """
+    current = datetime.fromisoformat(_timestamp(now))
+    if not isinstance(governance_inputs, RealBindAuthorizationGovernanceInputs):
+        raise LiveAdapterBindAuthorizationError("LABA_GOVERNANCE_INPUTS_REQUIRED")
+    if current < datetime.fromisoformat(
+        _timestamp(governance_inputs.verification_now)
+    ):
+        raise LiveAdapterBindAuthorizationError("LABA_CONSUMPTION_BEFORE_VERIFICATION")
     verified = verify_live_adapter_bind_authorization_artifact(
         artifact,
         governance_inputs=governance_inputs,
         trust_inputs=trust_inputs,
     )
-    current = datetime.fromisoformat(_timestamp(now))
     if not (
         datetime.fromisoformat(verified.valid_from)
         <= current
         < datetime.fromisoformat(verified.valid_until)
     ):
         raise LiveAdapterBindAuthorizationError("LABA_NOT_CURRENTLY_VALID")
+    current_inputs = replace(governance_inputs, verification_now=current)
+    source = _source(
+        verified.source_gate_review_packet, governance_inputs=current_inputs
+    )
+    _validate_source(source)
+    current_governance = _validate_real_governance_inputs(source, current_inputs)
+    if (
+        current_governance.bind_context_hash != verified.bind_context_hash
+        or current_governance.human_approval_status
+        != verified.human_approval_requirement_status
+    ):
+        raise LiveAdapterBindAuthorizationError("LABA_CURRENT_GOVERNANCE_MISMATCH")
     return verified

--- a/veritas_os/tests/test_consumption_governance_recheck.py
+++ b/veritas_os/tests/test_consumption_governance_recheck.py
@@ -1,0 +1,260 @@
+"""Consumption-clock regression and v0.3 local runtime integration.
+
+Real packet/signature verifiers, ephemeral keys and in-memory stores are used.
+The adapter, credential provider and TrustLog sink are test doubles: this is
+not a live decision, real network effect or durable production audit proof.
+"""
+
+from dataclasses import replace
+from datetime import timedelta
+
+import pytest
+
+from veritas_os.policy.live_adapter_bind_authorization_verification import (
+    validate_live_adapter_bind_authorization_temporal_validity as validate,
+)
+from veritas_os.policy.live_adapter_bind_authorization_consumption import (
+    consume_live_adapter_bind_authorization_and_invoke_bind as consume,
+    LiveAdapterBindAuthorizationConsumptionError,
+)
+from veritas_os.policy.live_adapter_bind_authorization_consumption_store import (
+    InMemoryAtomicAuthorizationConsumptionStore,
+)
+from veritas_os.policy.bind_effect_runtime import (
+    consume_bind_record_lineage_and_effect_state,
+)
+from veritas_os.policy.bind_effect_reconciliation import (
+    EffectExecutionState,
+    InMemoryAtomicEffectStateStore,
+)
+from veritas_os.tests.test_v03_issuance_trust import case, _issue
+from veritas_os.tests.test_live_adapter_bind_authorization_consumption import (
+    _Factory,
+    _Resolver,
+    _HeaderConstructor,
+)
+from veritas_os.tests.test_bind_outcome_lineage import (
+    _BlockedFactory,
+    _install_fake_trustlog,
+)
+
+pytestmark = pytest.mark.slow
+
+
+@pytest.fixture(scope="module")
+def authorized(case):
+    return _issue(case), case[1], case[3]
+
+
+class _TimedRevocation:
+    """Return authentic fixture status at issuance, then change at consumption."""
+
+    def __init__(self, governance, mode="valid"):
+        self.original = governance.authority_revocation_checker
+        self.issued = governance.verification_now
+        self.mode = mode
+        self.times = []
+
+    def check(self, evidence_id, *, now):
+        self.times.append(now)
+        result = self.original.check(evidence_id, now=now)
+        if now <= self.issued:
+            return result
+        if self.mode == "revoked":
+            return replace(result, revoked=True, reason="revoked_after_issuance")
+        if self.mode == "stale":
+            return replace(result, checked_at=self.issued.isoformat())
+        if self.mode == "unavailable":
+            raise ValueError("revocation_status_unavailable")
+        if self.mode == "future":
+            return replace(result, checked_at=(now + timedelta(seconds=1)).isoformat())
+        return result
+
+
+def test_later_consumption_rechecks_governance_without_rewriting_signed_proofs(
+    authorized,
+    monkeypatch,
+):
+    import veritas_os.policy.live_adapter_bind_authorization_governance as module
+
+    artifact, governance, trust = authorized
+    before = artifact.model_dump(mode="json")
+    checker = _TimedRevocation(governance)
+    current = governance.verification_now + timedelta(seconds=90)
+    approval_times = []
+    real_verify = module.verify_human_approval_receipt_artifact_to_proof
+
+    def record_approval(*args, **kwargs):
+        approval_times.append(kwargs["now"])
+        return real_verify(*args, **kwargs)
+
+    monkeypatch.setattr(
+        module, "verify_human_approval_receipt_artifact_to_proof", record_approval
+    )
+    supplied = replace(governance, authority_revocation_checker=checker)
+    verified = validate(
+        artifact, now=current, governance_inputs=supplied, trust_inputs=trust
+    )
+    assert checker.times == [governance.verification_now, current]
+    if governance.signed_human_approval_artifact is not None:
+        assert approval_times == [governance.verification_now, current]
+    else:
+        assert approval_times == []
+    assert verified.model_dump(mode="json") == before
+    assert artifact.model_dump(mode="json") == before
+    assert supplied.verification_now == governance.verification_now
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["revoked", "stale", "unavailable", "future"])
+async def test_changed_revocation_rejects_before_consumption_or_secret_access(
+    authorized, mode
+):
+    artifact, governance, trust = authorized
+    checker = _TimedRevocation(governance, mode)
+    current = governance.verification_now + timedelta(seconds=90)
+    store = InMemoryAtomicAuthorizationConsumptionStore()
+    resolver, headers, factory = _Resolver(), _HeaderConstructor(), _Factory()
+    with pytest.raises(
+        LiveAdapterBindAuthorizationConsumptionError,
+        match="AUTHORIZATION_VERIFICATION_FAILED",
+    ):
+        await consume(
+            artifact,
+            now=current,
+            governance_inputs=replace(governance, authority_revocation_checker=checker),
+            trust_inputs=trust,
+            consumption_store=store,
+            credential_resolver=resolver,
+            authorization_header_constructor=headers,
+            adapter_factory=factory,
+            append_trustlog=False,
+        )
+    assert current in checker.times
+    assert await store.get(artifact.live_adapter_bind_authorization_id) is None
+    assert resolver.calls == headers.calls == factory.calls == 0
+
+
+@pytest.mark.parametrize("time_case", ["backdated", "naive", "expired"])
+def test_invalid_consumption_clock_or_expired_authorization_fails_closed(
+    authorized, time_case
+):
+    artifact, governance, trust = authorized
+    if time_case == "backdated":
+        current = governance.verification_now - timedelta(microseconds=1)
+    elif time_case == "naive":
+        current = governance.verification_now.replace(tzinfo=None)
+    else:
+        current = artifact.valid_until
+    with pytest.raises(ValueError):
+        validate(
+            artifact, now=current, governance_inputs=governance, trust_inputs=trust
+        )
+
+
+@pytest.mark.asyncio
+async def test_current_human_signature_trust_is_required_before_consumption(authorized):
+    artifact, governance, trust = authorized
+    checker = _TimedRevocation(governance)
+    current = governance.verification_now + timedelta(seconds=30)
+    calls = []
+
+    class WithdrawnHumanVerifier:
+        def verify(self, envelope):
+            # Simulate signing trust withdrawn after the historical evaluation.
+            calls.append(checker.times[-1])
+            assert governance.human_approval_signature_verifier is not None
+            result = governance.human_approval_signature_verifier.verify(envelope)
+            if checker.times[-1] == current:
+                return replace(
+                    result, verified=False, reason="test_signing_trust_withdrawn"
+                )
+            return result
+
+    store = InMemoryAtomicAuthorizationConsumptionStore()
+    resolver, headers, factory = _Resolver(), _HeaderConstructor(), _Factory()
+    kwargs = dict(
+        now=current,
+        governance_inputs=replace(
+            governance,
+            authority_revocation_checker=checker,
+            human_approval_signature_verifier=WithdrawnHumanVerifier(),
+        ),
+        trust_inputs=trust,
+        consumption_store=store,
+        credential_resolver=resolver,
+        authorization_header_constructor=headers,
+        adapter_factory=factory,
+        append_trustlog=False,
+    )
+    if governance.signed_human_approval_artifact is None:
+        await consume(artifact, **kwargs)
+        assert calls == []
+        assert resolver.calls == 1
+    else:
+        with pytest.raises(
+            LiveAdapterBindAuthorizationConsumptionError,
+            match="AUTHORIZATION_VERIFICATION_FAILED",
+        ):
+            await consume(artifact, **kwargs)
+        assert calls == [governance.verification_now, current]
+        assert await store.get(artifact.live_adapter_bind_authorization_id) is None
+        assert resolver.calls == headers.calls == factory.calls == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("blocked", [False, True])
+async def test_v03_local_operation_records_outcome_and_never_reexecutes(
+    authorized,
+    monkeypatch,
+    blocked,
+):
+    _install_fake_trustlog(monkeypatch)
+    artifact, governance, trust = authorized
+    before = artifact.model_dump(mode="json")
+    consumptions = InMemoryAtomicAuthorizationConsumptionStore()
+    effects = InMemoryAtomicEffectStateStore()
+    resolver, headers = _Resolver(), _HeaderConstructor()
+    factory = _BlockedFactory() if blocked else _Factory()
+    current = governance.verification_now + timedelta(seconds=30)
+    kwargs = dict(
+        governance_inputs=governance,
+        trust_inputs=trust,
+        now=current,
+        consumption_store=consumptions,
+        effect_store=effects,
+        credential_resolver=resolver,
+        authorization_header_constructor=headers,
+        adapter_factory=factory,
+    )
+    result = await consume_bind_record_lineage_and_effect_state(artifact, **kwargs)
+    lineage = result.lineage
+    record = lineage.consumption_result.consumption_record
+    assert await consumptions.get(artifact.live_adapter_bind_authorization_id) == record
+    assert await effects.get(record.consumption_id) == result.effect_state
+    assert lineage.consumption_result.adapter_apply_attempted is not blocked
+    assert factory.adapter.apply_calls == (0 if blocked else 1)
+    assert result.effect_state.state == (
+        EffectExecutionState.CONFIRMED_NO_EFFECT
+        if blocked
+        else EffectExecutionState.EFFECT_UNKNOWN
+    )
+    assert lineage.bind_receipt.execution_intent_id == artifact.execution_intent_id
+    assert (
+        lineage.outcome_receipt.bind_receipt_id == lineage.bind_receipt.bind_receipt_id
+    )
+    assert (
+        lineage.outcome_receipt.outcome_hash
+        == lineage.outcome_receipt.deterministic_digest()
+    )
+    assert (
+        lineage.outcome_receipt.metadata["external_effect_claim"]
+        == "NOT_INFERRED_FROM_GENERIC_ADAPTER_APPLY"
+    )
+    with pytest.raises(
+        LiveAdapterBindAuthorizationConsumptionError, match="ALREADY_CONSUMED"
+    ):
+        await consume_bind_record_lineage_and_effect_state(artifact, **kwargs)
+    assert resolver.calls == headers.calls == factory.calls == 1
+    assert factory.adapter.apply_calls == (0 if blocked else 1)
+    assert artifact.model_dump(mode="json") == before


### PR DESCRIPTION
# Summary

Recheck governance using the independently supplied consumption time before authorization consumption, credential access, or adapter invocation.

## Scope

Preserve immutable issuance proof reconstruction at `verification_now`, then revalidate independent source/contract, authority/revocation, Human Approval, and runtime authority at consumption `now`. Reject backdated consumption; do not rewrite historical signed proof hashes.

Add v0.3 required/optional-approval local runtime regression tests and matching EN/JA implementation notes.

## Type of change

- [x] Runtime
- [x] Tests
- [x] Docs
- [x] Governance / security-sensitive

## Why this change matters

Previously, a later consumption time enforced the authorization window but governance checks continued to use the issuance-time verification clock. Newly revoked, stale, unavailable, or future-dated authority status must fail before consumption or secret access.

## Market / developer / user value

- Market value: No new production capability claim.
- Developer value: Explicit issuance-versus-consumption clock semantics and regressions.
- User/operator value: Current governance rejection before credential resolution or side effects.

## Tests run

- [x] New consumption governance suite: **22 passed**.
- [x] Existing authorization, consumption, consumption semantics, outcome lineage, effect runtime, and v0.3 issuance trust suites: **38 passed**.
- [x] `ruff check veritas_os`
- [x] Bilingual documentation check
- [x] Responsibility boundary check
- [x] `git diff --check`

Total relevant tests: **60 passed**. Existing jsonschema RefResolver deprecation warnings remain. Full GitHub CI pending; not claimed complete.

## AI assistance used

- [x] Codex

## Review status

- [ ] CI passed
- [ ] External advisory review completed
- [ ] Human maintainer reviewed

## Risk checklist

- [x] Touches bind/admissibility logic
- [x] Touches governance policy behavior
- [ ] Touches secrets or credentials
- [ ] Touches TrustLog persistence or encryption behavior
- [ ] Involves private user/customer data

## Human approval required?

- [x] Yes

Reason: Security-sensitive consumption-time governance behavior. Draft only; do not merge automatically.

## Notes for reviewer

- Trusted source/contract propagation from #2185–#2187 is retained. Embedded snapshots are not substituted for independent anchors.
- Consumption `now` must come from the caller's trusted execution clock. This change does not authenticate clocks or implement a trusted policy registry.
- Tests exercise real packet/signature verification with ephemeral keys, in-memory consumption/effect stores, and synthetic credential/adapter/TrustLog dependencies. Human signing-trust withdrawal is simulated, not a new production revocation service.
- Local allow/block paths record Bind/outcome lineage, and reconsumption never calls the adapter twice. Generic adapter success remains EFFECT_UNKNOWN; it is not confirmation of external effect.
- This is **not** a live /v1/decide-to-effect E2E or durable production audit proof. No production credentials, network effects, or customer operations were exercised.
- Published tree matches the locally tested tree: `d281c4554a398b60e9e02c402b3475d89cddc38b`.
