### PR TITLE
fix: reconstruct stable intent at decision authorization boundary

### DIFF
--- a/docs/en/development/approval-requirement-source-verification.md
+++ b/docs/en/development/approval-requirement-source-verification.md
@@ -89,3 +89,36 @@ Requirement-resolution integration tests exercise the nested metadata chain with
 mocking its verifier. They do not claim cryptographic authority authentication.
 Authority signature/revocation verification and human approval verification
 remain separate boundaries. The requirement-resolution layer creates no authority.
+
+## Real decision connection: remaining source boundary
+
+`issue_verified_real_decision_bind_authorization` now reconstructs the intent
+with the existing canonical, content-addressed promotion builder. The previous
+generic promotion helper allocated a new UUID on each invocation, making exact
+comparison with a previously constructed source intent impossible. Policy
+freshness uses the independently supplied `governance_inputs.verification_now`.
+The policy ID and optional approval context are assertions against the verified
+promotion; caller policy-lineage overrides remain forbidden.
+
+An isolated HTTP integration test invokes the real authenticated `/v1/decide`
+route, kernel, compiled-policy signature verification and CDA construction.
+Only model output and cloud clients are controlled. The returned CDA and chosen
+candidate are used unchanged by canonical promotion, readiness, pre-bind,
+preflight and native adapter selection. No benchmark expected outcomes or
+accepting packet-verifier doubles supply this lineage.
+
+This test exposes an unfinished connection, not a completed execution proof:
+`build_fresh_bind_source_chain` still accepts handoff-native adapter selection;
+it rejects the promotion-native selection format even when a trusted contract
+is supplied. A separately valid v0.3 fixture gate is also rejected because its
+intent differs from the real decision. The tests require both refusals before
+authorization signing. They do not issue an authorization, create a Human
+Approval Receipt, consume credentials, invoke an adapter or create Bind/outcome
+receipts for this real decision.
+
+The next implementation must preserve the native promotion source through
+requirement resolution/satisfaction and the authorization verifier, including
+independent source/contract anchors. It must not relabel native packets as
+handoff packets or synthesize handoff replay/approval evidence to satisfy the
+older schema. Existing fixture-based v0.3 consumption tests remain separate
+from this real-decision connection test.

--- a/docs/ja/development/approval-requirement-source-verification.md
+++ b/docs/ja/development/approval-requirement-source-verification.md
@@ -70,3 +70,28 @@ runtime-authority評価もこの時刻を使用します。時刻によって変
 偽のTrustLog保存先を使用します。apply前の拒否はCONFIRMED_NO_EFFECT、汎用applyの成功だけでは
 独立した外部確認がないためEFFECT_UNKNOWNです。実際の/v1/decideから外部効果までの統合、
 本番監査保存の永続性、実顧客の操作を実証したものではありません。
+
+## 実decision接続：残っているsource境界
+
+`issue_verified_real_decision_bind_authorization`は、既存のcanonical promotion builderを使い、
+内容から決まる同一のExecutionIntentを再構築します。従来の汎用promotion helperは呼び出すたびに
+新しいUUIDを生成するため、事前に構築したsource intentとの完全一致が成立しませんでした。
+ポリシー鮮度は独立入力`governance_inputs.verification_now`で評価します。policy IDと任意の
+approval contextは検証済みpromotionとの比較用であり、policy lineageの上書きは禁止します。
+
+独立プロセスのHTTP統合テストで、実際の認証済み`/v1/decide`、kernel、コンパイル済みpolicyの
+署名検証、CDA生成を実行します。モデル出力とクラウドクライアントはテスト用です。返却された
+CDAとchosen candidateを変更せず、canonical promotion、readiness、pre-bind、preflight、
+native adapter selectionまで接続します。benchmarkの期待結果や、無条件に成功するpacket verifierは
+この対応関係の根拠にしません。
+
+このテストは未接続箇所を確認するもので、実行成功の証明ではありません。
+`build_fresh_bind_source_chain`はhandoff由来のselection形式のみ受け付けるため、独立したtrusted
+contractを渡してもpromotion由来のselection形式を拒否します。別途有効なv0.3 fixture gateも、
+実decisionのintentと異なるため署名前に拒否します。この実decisionについてauthorization発行、
+Human Approval Receipt生成、credential取得、adapter実行、Bind／outcome receipt生成は行いません。
+
+次の実装では、promotion由来のsourceと独立source／contractを、requirement resolution／satisfactionから
+authorization verifierまで維持する必要があります。native packetの形式名だけを書き換えたり、
+旧schemaを満たすためにhandoffのreplay／approval証拠を作ったりしてはいけません。
+既存のfixture起点のv0.3消費テストと、この実decision接続テストは別の検証です。

--- a/veritas_os/policy/real_decision_bind_authorization.py
+++ b/veritas_os/policy/real_decision_bind_authorization.py
@@ -17,9 +17,10 @@ from veritas_os.governance.canonical_decision_artifact import (
     verify_canonical_decision_artifact,
 )
 from veritas_os.policy.bind_artifacts import ExecutionIntent, hash_execution_intent
-from veritas_os.policy.decision_candidate import (
-    DecisionCandidate,
-    try_promote_verified_canonical_decision_candidate_to_execution_intent,
+from veritas_os.policy.decision_candidate import DecisionCandidate
+from veritas_os.policy.canonical_verified_decision_promotion import (
+    CanonicalVerifiedDecisionPromotionError,
+    build_canonical_verified_decision_promotion_packet,
 )
 from veritas_os.policy.live_adapter_bind_authorization import (
     BindAuthorizationSigner,
@@ -99,6 +100,14 @@ def issue_verified_real_decision_bind_authorization(
     source packet and independently verified authorization must contain the
     exact same intent object, identity, and content-derived hash.
 
+    Promotion uses the existing content-addressed canonical promotion builder,
+    so reconstruction cannot mint a new random intent ID. The supplied trusted
+    governance clock checks policy freshness. Context arguments are assertions,
+    not replacements for CDA/candidate-derived policy or approval context.
+
+    The source verifier still accepts only its existing handoff-native gate
+    formats. This does not bridge promotion-native packets into that schema.
+
     Raises:
         RealDecisionBindAuthorizationError: If verification or lineage differs.
         LiveAdapterBindAuthorizationError: If existing governance fails closed.
@@ -108,18 +117,25 @@ def issue_verified_real_decision_bind_authorization(
         raise RealDecisionBindAuthorizationError("RDBA_CANONICAL_DECISION_INVALID")
     cda = cda_result.artifact
 
-    promotion = try_promote_verified_canonical_decision_candidate_to_execution_intent(
-        candidate,
-        canonical_decision_artifact=cda,
-        policy_snapshot_id=policy_snapshot_id,
-        ttl_seconds=ttl_seconds,
-        expected_state_fingerprint=expected_state_fingerprint,
-        approval_context=approval_context,
-        policy_lineage=policy_lineage,
-    )
-    if not promotion.promoted or promotion.execution_intent is None:
-        raise RealDecisionBindAuthorizationError("RDBA_PROMOTION_REFUSED")
-    intent = promotion.execution_intent
+    if not isinstance(governance_inputs, RealBindAuthorizationGovernanceInputs):
+        raise RealDecisionBindAuthorizationError("RDBA_GOVERNANCE_INPUTS_REQUIRED")
+    if policy_lineage is not None:
+        raise RealDecisionBindAuthorizationError("RDBA_POLICY_LINEAGE_OVERRIDE")
+    try:
+        promotion = build_canonical_verified_decision_promotion_packet(
+            cda,
+            candidate,
+            promoted_at=governance_inputs.verification_now,
+            ttl_seconds=ttl_seconds,
+            expected_state_fingerprint=expected_state_fingerprint,
+        )
+    except CanonicalVerifiedDecisionPromotionError as exc:
+        raise RealDecisionBindAuthorizationError("RDBA_PROMOTION_REFUSED") from exc
+    intent = ExecutionIntent(**promotion.exact_execution_intent)
+    if policy_snapshot_id != intent.policy_snapshot_id:
+        raise RealDecisionBindAuthorizationError("RDBA_POLICY_SNAPSHOT_MISMATCH")
+    if approval_context is not None and approval_context != intent.approval_context:
+        raise RealDecisionBindAuthorizationError("RDBA_APPROVAL_CONTEXT_OVERRIDE")
     if (
         intent.decision_id != cda.decision_id
         or intent.decision_hash != cda.decision_hash
@@ -128,8 +144,6 @@ def issue_verified_real_decision_bind_authorization(
     ):
         raise RealDecisionBindAuthorizationError("RDBA_DECISION_LINEAGE_MISMATCH")
 
-    if not isinstance(governance_inputs, RealBindAuthorizationGovernanceInputs):
-        raise RealDecisionBindAuthorizationError("RDBA_GOVERNANCE_INPUTS_REQUIRED")
     source = verify_live_adapter_dry_run_bind_authorization_gate_review_packet(
         source_gate_review_packet,
         expected_source=governance_inputs.expected_source,

--- a/veritas_os/tests/helpers/live_decision_capture.py
+++ b/veritas_os/tests/helpers/live_decision_capture.py
@@ -1,0 +1,66 @@
+"""Capture a real /v1/decide response in an isolated test interpreter.
+
+Only model output and cloud clients are controlled. Route, kernel, signed
+policy verification and CDA construction execute normally. This helper issues
+no execution authorization, human receipt, or adapter operation.
+"""
+
+from __future__ import annotations
+
+import base64
+from dataclasses import replace
+from datetime import UTC, datetime
+import json
+from pathlib import Path
+import secrets
+import sys
+from unittest.mock import patch
+
+from scripts import run_decision_to_external_bind_poc as poc
+
+
+def capture(output: Path) -> None:
+    """Write only the synthetic decision and infrastructure observations."""
+    runtime = output.parent / "runtime"
+    runtime.mkdir()
+    poc._configure_environment(
+        runtime,
+        "test-" + secrets.token_urlsafe(24),
+        base64.urlsafe_b64encode(secrets.token_bytes(32)).decode(),
+    )
+    key_id = poc._configure_secure_test_infrastructure(
+        runtime, "test-" + secrets.token_urlsafe(32)
+    )
+    bundle = poc._configure_verified_policy_bundle(runtime)
+    from veritas_os.core import pipeline
+
+    candidate = replace(
+        poc._candidate(), evidence_refs=["synthetic:local-review-input"]
+    )
+    with (
+        patch.object(poc, "_candidate", return_value=candidate),
+        patch.object(pipeline, "REPLAY_SOURCE_DIR", runtime / "replay-sources"),
+    ):
+        response, pipeline_ok, calls = poc._decide(
+            aws_clients=poc._DeterministicAwsClients(
+                poc._DeterministicKmsClient(key_id),
+                poc._DeterministicObjectLockClient(),
+            ),
+            policy_bundle_dir=bundle,
+        )
+    output.write_text(
+        json.dumps(
+            {
+                "canonical_decision_artifact": response["canonical_decision_artifact"],
+                "candidate": response["chosen"],
+                "observed_at": datetime.now(UTC).isoformat(),
+                "pipeline_ok": pipeline_ok,
+                "infrastructure_calls": calls,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    capture(Path(sys.argv[1]))

--- a/veritas_os/tests/test_live_decision_authorization_boundary.py
+++ b/veritas_os/tests/test_live_decision_authorization_boundary.py
@@ -1,0 +1,225 @@
+"""Real HTTP decision coverage of the currently incomplete v0.3 connection.
+
+The source-format refusal is intentional and observable. These tests do not
+claim successful authorization, consumption, or decision-to-effect integration.
+No packet verifier is replaced with an accepting test double.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import replace
+from datetime import datetime, timedelta
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+from veritas_os.governance.canonical_decision_artifact import (
+    verify_canonical_decision_artifact,
+)
+from veritas_os.policy.bind_artifacts import ExecutionIntent, hash_execution_intent
+from veritas_os.policy.bind_adapter_contract_selection import (
+    ADAPTER_METHODS,
+    DESCRIPTOR_SCOPE_LIMITATIONS,
+    EFFECT_PROFILE,
+    PROHIBITED_DURING_SELECTION,
+    BindAdapterContractSelectionError,
+)
+from veritas_os.policy.canonical_verified_decision_promotion import (
+    build_canonical_verified_decision_promotion_packet as promote,
+)
+from veritas_os.policy.canonical_promotion_execution_intent_readiness import (
+    build_canonical_promotion_execution_intent_readiness_packet as ready,
+)
+from veritas_os.policy.canonical_promotion_pre_bind_validation import (
+    build_canonical_promotion_pre_bind_validation_packet as validate_pre_bind,
+)
+from veritas_os.policy.canonical_promotion_bind_preflight_adjudication import (
+    build_canonical_promotion_bind_preflight_adjudication_packet as preflight,
+)
+from veritas_os.policy.canonical_promotion_bind_adapter_contract_selection import (
+    build_canonical_promotion_bind_adapter_contract_selection_packet as select,
+)
+from veritas_os.policy.fresh_bind_source_chain import (
+    FreshBindSourceChainInputs,
+    build_fresh_bind_source_chain,
+)
+from veritas_os.policy.real_decision_bind_authorization import (
+    RealDecisionBindAuthorizationError,
+    issue_verified_real_decision_bind_authorization,
+)
+from veritas_os.tests import test_v03_issuance_trust as v03_fixtures
+
+case = v03_fixtures.case
+
+pytestmark = pytest.mark.slow
+ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture(scope="module")
+def live_decision(tmp_path_factory):
+    output = tmp_path_factory.mktemp("live-decision") / "capture.json"
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "veritas_os.tests.helpers.live_decision_capture",
+            str(output),
+        ],
+        cwd=ROOT,
+        check=True,
+        timeout=180,
+        capture_output=True,
+        text=True,
+    )
+    captured = json.loads(output.read_text())
+    assert captured["pipeline_ok"] is True
+    assert all(count > 0 for count in captured["infrastructure_calls"].values())
+    verified = verify_canonical_decision_artifact(
+        captured["canonical_decision_artifact"]
+    )
+    assert verified.is_valid and verified.artifact is not None
+    cda = verified.artifact
+    assert cda.decision.policy_snapshot_evidence.signature_verified is True
+    now = datetime.fromisoformat(captured["observed_at"])
+    promotion = promote(cda, captured["candidate"], promoted_at=now)
+    return cda, captured["candidate"], now, promotion
+
+
+def _kwargs(case, live_decision):
+    gate, governance, decision, trust, signer = case
+    cda, candidate, now, _ = live_decision
+    return dict(
+        canonical_decision_artifact=cda,
+        candidate=candidate,
+        policy_snapshot_id=cda.decision.policy_snapshot_evidence.snapshot_id,
+        source_gate_review_packet=gate,
+        signed_authorization_decision_artifact=decision,
+        valid_from=now,
+        valid_until=now + timedelta(minutes=1),
+        governance_inputs=replace(governance, verification_now=now),
+        trust_inputs=trust,
+        authorization_issuer_signer=signer,
+    )
+
+
+def test_real_decision_reconstructs_identical_intent_and_refuses_foreign_v03_source(
+    case,
+    live_decision,
+    monkeypatch,
+):
+    import veritas_os.policy.real_decision_bind_authorization as module
+
+    cda, _, _, promotion = live_decision
+    original = module._require_exact_intent
+    observed = []
+
+    def observe(expected, *args, **kwargs):
+        observed.append(expected.to_dict())
+        return original(expected, *args, **kwargs)
+
+    def forbidden_sign(*args):
+        pytest.fail("a mismatched source must not reach authorization signing")
+
+    monkeypatch.setattr(module, "_require_exact_intent", observe)
+    monkeypatch.setattr(type(case[4]), "sign", forbidden_sign)
+    for _ in range(2):
+        with pytest.raises(
+            RealDecisionBindAuthorizationError,
+            match="RDBA_SOURCE_EXECUTION_INTENT_MISMATCH",
+        ):
+            issue_verified_real_decision_bind_authorization(
+                **_kwargs(case, live_decision)
+            )
+    assert observed == [promotion.exact_execution_intent] * 2
+    assert observed[0]["decision_id"] == cda.decision_id
+    assert observed[0]["decision_hash"] == cda.decision_hash
+    assert (
+        hash_execution_intent(ExecutionIntent(**observed[0]))
+        == promotion.execution_intent_hash
+    )
+
+
+def test_real_decision_native_selection_is_not_a_v03_handoff_source(
+    case, live_decision
+):
+    _, _, now, promotion = live_decision
+    validation = validate_pre_bind(ready(promotion, checked_at=now), checked_at=now)
+    intent = ExecutionIntent(**promotion.exact_execution_intent)
+    descriptor = {
+        "adapter_contract_version": "bind-adapter-contract/v1",
+        "adapter_kind": "reference",
+        "adapter_name": "local-inert-declaration",
+        "target_system": intent.target_system,
+        "target_resource_scope": intent.target_resource,
+        "supported_methods": list(ADAPTER_METHODS),
+        "required_methods": list(ADAPTER_METHODS),
+        "prohibited_during_selection": list(PROHIBITED_DURING_SELECTION),
+        "effect_profile": EFFECT_PROFILE,
+        "declared_by": "test:local",
+        "declared_at": now.isoformat(),
+        "descriptor_scope_limitations": list(DESCRIPTOR_SCOPE_LIMITATIONS),
+    }
+    selection = select(preflight(validation, now), descriptor, now)
+    assert selection.execution_intent == promotion.exact_execution_intent
+    # No fabricated handoff/replay/approval fields to disguise a native source.
+    inputs = FreshBindSourceChainInputs(
+        **{
+            name: selection if name == "adapter_contract_selection_packet" else None
+            for name in FreshBindSourceChainInputs.__annotations__
+        }
+    )
+    with pytest.raises(BindAdapterContractSelectionError):
+        build_fresh_bind_source_chain(
+            intent,
+            inputs,
+            built_at=now,
+            expected_contract=case[1].action_contract,
+        )
+
+
+@pytest.mark.parametrize(
+    "mutation", ["candidate", "cda", "policy", "approval", "lineage", "stale", "future"]
+)
+def test_live_decision_invalid_input_stops_before_source_or_signing(
+    case,
+    live_decision,
+    mutation,
+    monkeypatch,
+):
+    import veritas_os.policy.real_decision_bind_authorization as module
+
+    kwargs = _kwargs(case, live_decision)
+    if mutation == "candidate":
+        kwargs["candidate"] = {**kwargs["candidate"], "target_resource": "foreign"}
+    elif mutation == "cda":
+        raw = deepcopy(kwargs["canonical_decision_artifact"].model_dump(mode="json"))
+        raw["decision_hash"] = "0" * 64
+        kwargs["canonical_decision_artifact"] = raw
+    elif mutation == "policy":
+        kwargs["policy_snapshot_id"] = "foreign-policy"
+    elif mutation == "approval":
+        kwargs["approval_context"] = {"approved": True}
+    elif mutation == "lineage":
+        kwargs["policy_lineage"] = {"version": "foreign"}
+    else:
+        kwargs["governance_inputs"] = replace(
+            kwargs["governance_inputs"],
+            verification_now=live_decision[2]
+            + timedelta(minutes=10 if mutation == "stale" else -10),
+        )
+
+    def forbidden(*args, **kwargs):
+        pytest.fail("invalid decision must stop before source validation and signing")
+
+    monkeypatch.setattr(
+        module,
+        "verify_live_adapter_dry_run_bind_authorization_gate_review_packet",
+        forbidden,
+    )
+    monkeypatch.setattr(type(case[4]), "sign", forbidden)
+    with pytest.raises(RealDecisionBindAuthorizationError):
+        issue_verified_real_decision_bind_authorization(**kwargs)

--- a/veritas_os/tests/test_real_decision_bind_authorization.py
+++ b/veritas_os/tests/test_real_decision_bind_authorization.py
@@ -95,6 +95,8 @@ def test_public_boundary_has_no_caller_lineage_override_parameters() -> None:
 def test_decision_lineage_mismatch_stops_before_source_verification(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    from veritas_os.tests.test_live_adapter_bind_authorization import _governance_inputs
+
     cda = SimpleNamespace(
         decision_id="cda:v1:sha256:" + "a" * 64,
         decision_hash="a" * 64,
@@ -109,10 +111,9 @@ def test_decision_lineage_mismatch_stops_before_source_verification(
     )
     monkeypatch.setattr(
         "veritas_os.policy.real_decision_bind_authorization."
-        "try_promote_verified_canonical_decision_candidate_to_execution_intent",
+        "build_canonical_verified_decision_promotion_packet",
         lambda *args, **kwargs: SimpleNamespace(
-            promoted=True,
-            execution_intent=foreign,
+            exact_execution_intent=foreign.to_dict(),
         ),
     )
     source_called = False
@@ -139,7 +140,7 @@ def test_decision_lineage_mismatch_stops_before_source_verification(
             signed_authorization_decision_artifact={},
             valid_from="2026-08-25T00:00:00Z",
             valid_until="2026-08-25T00:05:00Z",
-            governance_inputs=SimpleNamespace(),
+            governance_inputs=_governance_inputs(),
             trust_inputs=SimpleNamespace(),
             authorization_issuer_signer=SimpleNamespace(),
         )
@@ -167,8 +168,8 @@ def test_decision_entry_forwards_independent_anchors_before_issuance(monkeypatch
     )
     monkeypatch.setattr(
         module
-        + "try_promote_verified_canonical_decision_candidate_to_execution_intent",
-        lambda *args, **kwargs: SimpleNamespace(promoted=True, execution_intent=intent),
+        + "build_canonical_verified_decision_promotion_packet",
+        lambda *args, **kwargs: SimpleNamespace(exact_execution_intent=intent.to_dict()),
     )
 
     class StopAtVerifiedBoundary(ValueError):


### PR DESCRIPTION
# Summary

Fix a prerequisite uncovered while connecting real /v1/decide output to v0.3 authorization. **This PR does not complete decision-to-consumption/effect integration.**

The decision authorization entry point used a generic promotion helper that minted a fresh UUID on every reconstruction. Its exact-intent comparison therefore could not match a previously built source. Reuse the existing canonical content-addressed promotion builder and the independently supplied governance verification clock.

## Scope

- Reconstruct deterministic intent identity from verified CDA/candidate inputs.
- Treat policy ID and optional approval context as assertions; reject policy-lineage overrides.
- Preserve exact source comparison and independent source/contract propagation.
- Add an isolated real HTTP decision capture and 18 connection-boundary regression cases.
- Document the remaining native-source incompatibility in EN/JA.

## Type of change

- [x] Runtime
- [x] Tests
- [x] Docs
- [x] Governance / security-sensitive

## Why this change matters

Repeated decision verification must reproduce the exact intent rather than allocate a different identity. The real API regression exercises authenticated /v1/decide, kernel, signed compiled-policy verification and CDA creation with controlled model output and synthetic cloud clients. Returned CDA/chosen values are not rewritten and no packet verifier is mocked to accept.

The native promotion, readiness, pre-bind, preflight and adapter-selection chain now has real API input coverage. The tests also expose that the fresh v0.3 source builder still accepts handoff-native selection only. A valid but unrelated v0.3 fixture gate remains rejected before signing.

## Market / developer / user value

- Market value: No new production or execution capability claim.
- Developer value: Real API reproduction of deterministic intent and source-format boundaries.
- User/operator value: Invalid candidate, CDA, policy, approval context, lineage or policy freshness cannot progress to source verification/signing.

## Tests run

- [x] 73 passed across real decision authorization, new real API boundary, canonical promotion, fresh source chain and v0.3 issuance trust.
- [x] New 18-case suite rerun after redirecting replay persistence into isolated temporary storage: 18 passed.
- [x] `ruff check veritas_os`
- [x] Bilingual documentation check
- [x] Responsibility boundary check
- [x] `git diff --check`

Existing jsonschema RefResolver deprecation warnings remain. Full GitHub CI pending.

## AI assistance used

- [x] Codex

## Review status

- [ ] CI passed
- [ ] Human maintainer reviewed

## Risk checklist

- [ ] Touches bind/admissibility logic
- [ ] Touches governance policy behavior
- [ ] Touches secrets or credentials
- [ ] Touches TrustLog persistence or encryption behavior
- [ ] Involves private user/customer data

## Human approval required?

- [ ] Yes

Reason: Security-sensitive decision-to-authorization composition. Draft only; do not merge automatically.

## Notes for reviewer

- No source schemas are relaxed or relabeled, and no fabricated handoff/replay/approval fields are used to disguise native packets.
- The real-decision tests stop before authorization signing. They do not claim authorization issuance, Human Approval Receipt creation, consumption, credential access, adapter execution or Bind/outcome receipts for this decision.
- The separate v0.3 fixture suites use ephemeral signing keys and controlled evidence; their successes are not a real-decision E2E claim.
- Canonical promotion preserves approval requirement metadata; it does not establish actual human approval.
- **Remaining work:** carry promotion-native source through requirement resolution/satisfaction and authorization verification with independent trusted source/contract anchors; then add allow/block/single-use/outcome integration. Existing fixture-based consumption coverage is separate.
- API behavior change: arbitrary approval_context overrides now fail; an equal canonical context is accepted as an assertion. Policy freshness uses governance_inputs.verification_now instead of an implicit wall clock.
- Published tree matches locally tested source: `4507391d6514938bee4a7f5a8644be6bd87df693`.
