### PR TITLE
feat: verify promotion-native human approval requirements

### DIFF
--- a/docs/en/development/approval-requirement-source-verification.md
+++ b/docs/en/development/approval-requirement-source-verification.md
@@ -90,7 +90,7 @@ mocking its verifier. They do not claim cryptographic authority authentication.
 Authority signature/revocation verification and human approval verification
 remain separate boundaries. The requirement-resolution layer creates no authority.
 
-## Real decision connection: remaining source boundary
+## Real decision connection: source boundary identified in #2189
 
 `issue_verified_real_decision_bind_authorization` now reconstructs the intent
 with the existing canonical, content-addressed promotion builder. The previous
@@ -116,9 +116,43 @@ authorization signing. They do not issue an authorization, create a Human
 Approval Receipt, consume credentials, invoke an adapter or create Bind/outcome
 receipts for this real decision.
 
-The next implementation must preserve the native promotion source through
-requirement resolution/satisfaction and the authorization verifier, including
-independent source/contract anchors. It must not relabel native packets as
+Further integration must preserve the native promotion source through
+the authorization verifier, including independent source/contract anchors.
+It must not relabel native packets as
 handoff packets or synthesize handoff replay/approval evidence to satisfy the
 older schema. Existing fixture-based v0.3 consumption tests remain separate
 from this real-decision connection test.
+
+## Native source requirement resolution and satisfaction
+
+The HARR builder/verifier now dispatches explicitly on the Authority Evidence
+Linkage source format and invokes the corresponding full native or legacy
+verifier. It retains the original source identity/hash; no handoff fields are
+invented. Native resolution cannot predate its source. Legacy packet identity
+and verification semantics are preserved.
+
+`build_promotion_human_approval_requirement_satisfaction_packet` connects this
+rebuilt resolution to native Human Approval linkage. REQUIRED needs a verified
+native linkage with the exact same complete authority source; NOT_REQUIRED
+requires no linkage. Both states are metadata evidence only, with
+`human_approval_proven=false` and `ready_for_real_bind=false`.
+
+`verify_promotion_human_approval_requirement_satisfaction_packet` requires
+keyword-only `expected_source` and `expected_contract` from independent trusted
+inputs. It reconstructs every field, including the full source, contract snapshot,
+contract digest, intent and requirement state, and returns the rebuilt packet.
+Embedded snapshots are never trust anchors. Fully rebuilt and rehashed same-ID/
+version contract substitutions and source/linkage substitutions are rejected.
+
+Real authenticated `/v1/decide` integration now reaches native authority linkage,
+HARR and satisfaction for both required and not-required inputs. The existing
+native linkage rule still requires the candidate's declared approval flag on
+the REQUIRED path; no flag is changed in returned CDA/candidate data. Model/cloud
+clients and reference metadata remain controlled test inputs. No Human Approval
+Receipt or execution authority is produced by this new boundary.
+
+This is a distinct native packet (`promotion-human-approval-requirement-satisfaction/v1`),
+not a relabeled legacy satisfaction packet. Native Final Bind Readiness/Gate and
+the authorization issuer do not yet consume it. That downstream propagation,
+followed by real-decision single-use execution/outcome integration, remains work
+to complete; the legacy fresh-source format-refusal test remains valid.

--- a/docs/ja/development/approval-requirement-source-verification.md
+++ b/docs/ja/development/approval-requirement-source-verification.md
@@ -71,7 +71,7 @@ runtime-authority評価もこの時刻を使用します。時刻によって変
 独立した外部確認がないためEFFECT_UNKNOWNです。実際の/v1/decideから外部効果までの統合、
 本番監査保存の永続性、実顧客の操作を実証したものではありません。
 
-## 実decision接続：残っているsource境界
+## 実decision接続：#2189で確認したsource境界
 
 `issue_verified_real_decision_bind_authorization`は、既存のcanonical promotion builderを使い、
 内容から決まる同一のExecutionIntentを再構築します。従来の汎用promotion helperは呼び出すたびに
@@ -91,7 +91,33 @@ contractを渡してもpromotion由来のselection形式を拒否します。別
 実decisionのintentと異なるため署名前に拒否します。この実decisionについてauthorization発行、
 Human Approval Receipt生成、credential取得、adapter実行、Bind／outcome receipt生成は行いません。
 
-次の実装では、promotion由来のsourceと独立source／contractを、requirement resolution／satisfactionから
-authorization verifierまで維持する必要があります。native packetの形式名だけを書き換えたり、
+続く統合では、promotion由来のsourceと独立source／contractを、authorization verifierまで
+維持する必要があります。native packetの形式名だけを書き換えたり、
 旧schemaを満たすためにhandoffのreplay／approval証拠を作ったりしてはいけません。
 既存のfixture起点のv0.3消費テストと、この実decision接続テストは別の検証です。
+
+## Native sourceの承認要件判定と充足検証
+
+HARRのbuilder／verifierはAuthority Evidence Linkageのsource形式を明示的に判別し、
+native／legacyそれぞれの完全なverifierを実行します。元のsource ID・hashを保持し、handoff用の
+項目を作りません。nativeの判定時刻がsourceより前なら拒否します。legacyのpacket IDと検証動作は維持します。
+
+`build_promotion_human_approval_requirement_satisfaction_packet`は、再構築済みの判定を
+native Human Approval linkageへ接続します。REQUIREDには完全に同じauthority sourceを持つ
+検証済みnative linkageが必要です。NOT_REQUIREDではlinkageを受け付けません。
+どちらもメタデータ証拠であり、`human_approval_proven=false`、`ready_for_real_bind=false`です。
+
+`verify_promotion_human_approval_requirement_satisfaction_packet`の`expected_source`と
+`expected_contract`は必須の独立入力です。完全なsource、契約snapshot・digest、intent、要件状態を
+すべて再構築し、その検証済み結果を返します。packet内のsnapshotを信頼の根拠にしません。
+同一ID・versionの契約差し替えやsource／linkage差し替えは、全hashを再計算しても拒否します。
+
+実際の認証済み`/v1/decide`からnative authority linkage、HARR、satisfactionまで、承認必須・不要の
+両方を統合テストで接続しました。REQUIRED経路では既存native linkageのcandidate承認フラグ要件も
+維持します。返却済みCDA／candidateのフラグは変更しません。モデル・クラウドクライアントと
+参照メタデータはテスト用です。新しい境界はHuman Approval Receiptや実行権限を生成しません。
+
+新packetは`promotion-human-approval-requirement-satisfaction/v1`であり、legacy packetの形式名変更では
+ありません。native Final Bind Readiness／Gateとauthorization issuerはまだこのpacketを受け取れません。
+そこへの独立入力の伝播と、その後の実decisionによる一回限りの実行・結果記録の統合が残っています。
+既存のlegacy fresh-source形式拒否テストも引き続き有効です。

--- a/schemas/promotion-human-approval-requirement-satisfaction-v1.schema.json
+++ b/schemas/promotion-human-approval-requirement-satisfaction-v1.schema.json
@@ -1,0 +1,185 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Complete source/policy binding with explicit non-authorizing semantics.",
+  "properties": {
+    "format_version": {
+      "const": "promotion-human-approval-requirement-satisfaction/v1",
+      "title": "Format Version",
+      "type": "string"
+    },
+    "packet_id": {
+      "pattern": "^phars:v1:sha256:[0-9a-f]{64}$",
+      "title": "Packet Id",
+      "type": "string"
+    },
+    "packet_hash": {
+      "pattern": "^[0-9a-f]{64}$",
+      "title": "Packet Hash",
+      "type": "string"
+    },
+    "recorded_at": {
+      "title": "Recorded At",
+      "type": "string"
+    },
+    "source_authority_evidence_linkage_review_packet": {
+      "additionalProperties": true,
+      "title": "Source Authority Evidence Linkage Review Packet",
+      "type": "object"
+    },
+    "source_authority_evidence_linkage_review_id": {
+      "title": "Source Authority Evidence Linkage Review Id",
+      "type": "string"
+    },
+    "source_authority_evidence_linkage_review_hash": {
+      "title": "Source Authority Evidence Linkage Review Hash",
+      "type": "string"
+    },
+    "action_contract_snapshot": {
+      "additionalProperties": true,
+      "title": "Action Contract Snapshot",
+      "type": "object"
+    },
+    "action_contract_digest": {
+      "title": "Action Contract Digest",
+      "type": "string"
+    },
+    "human_approval_requirement_resolution_packet": {
+      "additionalProperties": true,
+      "title": "Human Approval Requirement Resolution Packet",
+      "type": "object"
+    },
+    "required_human_approval": {
+      "title": "Required Human Approval",
+      "type": "boolean"
+    },
+    "requirement_state": {
+      "enum": [
+        "REQUIRED",
+        "NOT_REQUIRED_BY_ACTION_CONTRACT"
+      ],
+      "title": "Requirement State",
+      "type": "string"
+    },
+    "satisfaction_state": {
+      "enum": [
+        "SATISFIED_BY_VERIFIED_HUMAN_APPROVAL_LINKAGE",
+        "SATISFIED_AS_NOT_REQUIRED_BY_ACTION_CONTRACT"
+      ],
+      "title": "Satisfaction State",
+      "type": "string"
+    },
+    "required_human_approval_linkage_packet": {
+      "anyOf": [
+        {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "title": "Required Human Approval Linkage Packet"
+    },
+    "execution_intent": {
+      "additionalProperties": true,
+      "title": "Execution Intent",
+      "type": "object"
+    },
+    "execution_intent_id": {
+      "title": "Execution Intent Id",
+      "type": "string"
+    },
+    "execution_intent_hash": {
+      "title": "Execution Intent Hash",
+      "type": "string"
+    },
+    "human_approval_created": {
+      "const": false,
+      "title": "Human Approval Created",
+      "type": "boolean"
+    },
+    "human_approval_proven": {
+      "const": false,
+      "title": "Human Approval Proven",
+      "type": "boolean"
+    },
+    "authority_evidence_proven": {
+      "const": false,
+      "title": "Authority Evidence Proven",
+      "type": "boolean"
+    },
+    "execution_authority_created": {
+      "const": false,
+      "title": "Execution Authority Created",
+      "type": "boolean"
+    },
+    "bind_authorization_created": {
+      "const": false,
+      "title": "Bind Authorization Created",
+      "type": "boolean"
+    },
+    "bind_invoked": {
+      "const": false,
+      "title": "Bind Invoked",
+      "type": "boolean"
+    },
+    "bind_receipt_created": {
+      "const": false,
+      "title": "Bind Receipt Created",
+      "type": "boolean"
+    },
+    "credential_material_accessed": {
+      "const": false,
+      "title": "Credential Material Accessed",
+      "type": "boolean"
+    },
+    "network_used": {
+      "const": false,
+      "title": "Network Used",
+      "type": "boolean"
+    },
+    "external_effect_occurred": {
+      "const": false,
+      "title": "External Effect Occurred",
+      "type": "boolean"
+    },
+    "ready_for_real_bind": {
+      "const": false,
+      "title": "Ready For Real Bind",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "format_version",
+    "packet_id",
+    "packet_hash",
+    "recorded_at",
+    "source_authority_evidence_linkage_review_packet",
+    "source_authority_evidence_linkage_review_id",
+    "source_authority_evidence_linkage_review_hash",
+    "action_contract_snapshot",
+    "action_contract_digest",
+    "human_approval_requirement_resolution_packet",
+    "required_human_approval",
+    "requirement_state",
+    "satisfaction_state",
+    "required_human_approval_linkage_packet",
+    "execution_intent",
+    "execution_intent_id",
+    "execution_intent_hash",
+    "human_approval_created",
+    "human_approval_proven",
+    "authority_evidence_proven",
+    "execution_authority_created",
+    "bind_authorization_created",
+    "bind_invoked",
+    "bind_receipt_created",
+    "credential_material_accessed",
+    "network_used",
+    "external_effect_occurred",
+    "ready_for_real_bind"
+  ],
+  "title": "PromotionHumanApprovalRequirementSatisfactionPacket",
+  "type": "object"
+}

--- a/veritas_os/policy/human_approval_requirement_resolution.py
+++ b/veritas_os/policy/human_approval_requirement_resolution.py
@@ -22,6 +22,16 @@ from veritas_os.policy.live_adapter_dry_run_authority_evidence_linkage import (
     LiveAdapterDryRunAuthorityEvidenceLinkageError,
     verify_live_adapter_dry_run_authority_evidence_linkage_review_packet,
 )
+from veritas_os.policy.canonical_promotion_live_adapter_dry_run_authority_evidence_linkage import (
+    FORMAT_VERSION as PROMOTION_SOURCE_FORMAT,
+    CanonicalPromotionLiveAdapterDryRunAuthorityEvidenceLinkageReviewPacket,
+    verify_canonical_promotion_live_adapter_dry_run_authority_evidence_linkage_review_packet,
+)
+
+AuthorityLinkageSource = (
+    CanonicalLiveAdapterDryRunAuthorityEvidenceLinkageReviewPacket
+    | CanonicalPromotionLiveAdapterDryRunAuthorityEvidenceLinkageReviewPacket
+)
 
 FORMAT_VERSION = "human-approval-requirement-resolution/v1"
 MECHANISM = "resolve_human_approval_requirement_from_action_contract/v1"
@@ -150,11 +160,17 @@ def _digest(value: Any) -> str:
 
 def _verified_source(
     value: Any,
-) -> CanonicalLiveAdapterDryRunAuthorityEvidenceLinkageReviewPacket:
+) -> AuthorityLinkageSource:
     try:
-        return verify_live_adapter_dry_run_authority_evidence_linkage_review_packet(
-            value
-        )
+        raw = value.model_dump(mode="json") if isinstance(value, BaseModel) else value
+        if (
+            isinstance(raw, dict)
+            and raw.get("format_version") == PROMOTION_SOURCE_FORMAT
+        ):
+            return verify_canonical_promotion_live_adapter_dry_run_authority_evidence_linkage_review_packet(
+                raw
+            )
+        return verify_live_adapter_dry_run_authority_evidence_linkage_review_packet(raw)
     except (
         LiveAdapterDryRunAuthorityEvidenceLinkageError,
         TypeError,
@@ -163,8 +179,23 @@ def _verified_source(
         raise HumanApprovalRequirementResolutionError("HARR_SOURCE_INVALID") from exc
 
 
+def _source_identity(source: AuthorityLinkageSource) -> tuple[str, str]:
+    """Read identities only from the corresponding independently verified type."""
+    if isinstance(
+        source, CanonicalPromotionLiveAdapterDryRunAuthorityEvidenceLinkageReviewPacket
+    ):
+        return (
+            source.promotion_live_adapter_dry_run_authority_evidence_linkage_review_id,
+            source.promotion_live_adapter_dry_run_authority_evidence_linkage_review_hash,
+        )
+    return (
+        source.live_adapter_dry_run_authority_evidence_linkage_review_id,
+        source.live_adapter_dry_run_authority_evidence_linkage_review_hash,
+    )
+
+
 def _validate_contract_binding(
-    source: CanonicalLiveAdapterDryRunAuthorityEvidenceLinkageReviewPacket,
+    source: AuthorityLinkageSource,
     contract: ActionClassContract,
 ) -> tuple[str, ...]:
     intent = source.execution_intent
@@ -205,6 +236,14 @@ def build_human_approval_requirement_resolution_packet(
 ) -> CanonicalHumanApprovalRequirementResolutionPacket:
     """Build a fail-closed, non-authorizing requirement-resolution packet."""
     source = _verified_source(source_authority_evidence_linkage_review_packet)
+    source_id, source_hash = _source_identity(source)
+    if isinstance(
+        source, CanonicalPromotionLiveAdapterDryRunAuthorityEvidenceLinkageReviewPacket
+    ):
+        if datetime.fromisoformat(_timestamp(resolved_at)) < datetime.fromisoformat(
+            source.authority_evidence_linkage_review_recorded_at
+        ):
+            raise HumanApprovalRequirementResolutionError("HARR_RESOLVED_BEFORE_SOURCE")
     if source.fail_closed:
         raise HumanApprovalRequirementResolutionError("HARR_SOURCE_FAIL_CLOSED")
     result = source.authority_evidence_linkage_result
@@ -232,12 +271,8 @@ def build_human_approval_requirement_resolution_packet(
         "format_version": FORMAT_VERSION,
         "resolution_mechanism": MECHANISM,
         "resolved_at": _timestamp(resolved_at),
-        "source_authority_evidence_linkage_review_id": (
-            source.live_adapter_dry_run_authority_evidence_linkage_review_id
-        ),
-        "source_authority_evidence_linkage_review_hash": (
-            source.live_adapter_dry_run_authority_evidence_linkage_review_hash
-        ),
+        "source_authority_evidence_linkage_review_id": source_id,
+        "source_authority_evidence_linkage_review_hash": source_hash,
         "source_execution_intent_id": source.execution_intent_id,
         "source_execution_intent_hash": source.execution_intent_hash,
         "action_contract_id": action_contract.id,

--- a/veritas_os/policy/promotion_human_approval_requirement_satisfaction.py
+++ b/veritas_os/policy/promotion_human_approval_requirement_satisfaction.py
@@ -1,0 +1,201 @@
+"""Non-authorizing requirement satisfaction for native promotion sources.
+
+Keep the complete native source; never synthesize legacy handoff or replay
+fields. Independent expected source and contract are mandatory for verification.
+Satisfaction here means metadata linkage, not a cryptographic Human Approval.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from veritas_os.governance.action_contracts import (
+    ActionClassContract,
+    validate_action_class_contract,
+)
+from veritas_os.policy.human_approval_requirement_resolution import (
+    _json,
+    _timestamp,
+    verify_human_approval_requirement_resolution_packet,
+)
+from veritas_os.policy.canonical_promotion_live_adapter_dry_run_authority_evidence_linkage import (
+    verify_canonical_promotion_live_adapter_dry_run_authority_evidence_linkage_review_packet as verify_source,
+)
+from veritas_os.policy.canonical_promotion_live_adapter_dry_run_human_approval_linkage import (
+    verify_canonical_promotion_live_adapter_dry_run_human_approval_linkage_review_packet as verify_linkage,
+)
+from veritas_os.security.hash import sha256_of_canonical_json
+
+FORMAT_VERSION = "promotion-human-approval-requirement-satisfaction/v1"
+DOMAIN = "veritas.promotion-human-approval-requirement-satisfaction/v1"
+REQUIRED_STATE = "SATISFIED_BY_VERIFIED_HUMAN_APPROVAL_LINKAGE"
+NOT_REQUIRED_STATE = "SATISFIED_AS_NOT_REQUIRED_BY_ACTION_CONTRACT"
+
+
+class PromotionHumanApprovalRequirementSatisfactionError(ValueError):
+    """Fail-closed native requirement satisfaction failure."""
+
+
+class PromotionHumanApprovalRequirementSatisfactionPacket(BaseModel):
+    """Complete source/policy binding with explicit non-authorizing semantics."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    format_version: Literal[FORMAT_VERSION]
+    packet_id: str = Field(pattern=r"^phars:v1:sha256:[0-9a-f]{64}$")
+    packet_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    recorded_at: str
+    source_authority_evidence_linkage_review_packet: dict[str, Any]
+    source_authority_evidence_linkage_review_id: str
+    source_authority_evidence_linkage_review_hash: str
+    action_contract_snapshot: dict[str, Any]
+    action_contract_digest: str
+    human_approval_requirement_resolution_packet: dict[str, Any]
+    required_human_approval: bool
+    requirement_state: Literal["REQUIRED", "NOT_REQUIRED_BY_ACTION_CONTRACT"]
+    satisfaction_state: Literal[REQUIRED_STATE, NOT_REQUIRED_STATE]
+    required_human_approval_linkage_packet: dict[str, Any] | None
+    execution_intent: dict[str, Any]
+    execution_intent_id: str
+    execution_intent_hash: str
+    human_approval_created: Literal[False]
+    human_approval_proven: Literal[False]
+    authority_evidence_proven: Literal[False]
+    execution_authority_created: Literal[False]
+    bind_authorization_created: Literal[False]
+    bind_invoked: Literal[False]
+    bind_receipt_created: Literal[False]
+    credential_material_accessed: Literal[False]
+    network_used: Literal[False]
+    external_effect_occurred: Literal[False]
+    ready_for_real_bind: Literal[False]
+
+
+def _packet_hash(raw: dict[str, Any]) -> str:
+    return sha256_of_canonical_json(
+        {
+            "domain": DOMAIN,
+            "value": {
+                key: value
+                for key, value in raw.items()
+                if key not in {"packet_id", "packet_hash"}
+            },
+        }
+    )
+
+
+def build_promotion_human_approval_requirement_satisfaction_packet(
+    source: Any,
+    resolution: Any,
+    contract: ActionClassContract,
+    required_linkage: Any | None,
+    recorded_at: datetime,
+) -> PromotionHumanApprovalRequirementSatisfactionPacket:
+    """Verify native inputs and derive solely from the rebuilt resolution."""
+    if not isinstance(contract, ActionClassContract):
+        raise PromotionHumanApprovalRequirementSatisfactionError(
+            "PHARS_CONTRACT_REQUIRED"
+        )
+    contract = validate_action_class_contract(contract.to_dict())
+    source = verify_source(source)
+    resolution = verify_human_approval_requirement_resolution_packet(
+        resolution, source, contract
+    )
+    recorded = _timestamp(recorded_at)
+    if datetime.fromisoformat(recorded) < datetime.fromisoformat(
+        resolution.resolved_at
+    ):
+        raise PromotionHumanApprovalRequirementSatisfactionError(
+            "PHARS_TIMESTAMP_ORDER"
+        )
+    source_raw = source.model_dump(mode="json")
+    linkage_raw = None
+    if resolution.required_human_approval:
+        if required_linkage is None:
+            raise PromotionHumanApprovalRequirementSatisfactionError(
+                "PHARS_REQUIRED_LINKAGE_MISSING"
+            )
+        linkage = verify_linkage(required_linkage)
+        if linkage.source_authority_evidence_linkage_review_packet != source_raw:
+            raise PromotionHumanApprovalRequirementSatisfactionError(
+                "PHARS_LINKAGE_SOURCE_MISMATCH"
+            )
+        if datetime.fromisoformat(recorded) < datetime.fromisoformat(
+            linkage.human_approval_linkage_review_recorded_at
+        ):
+            raise PromotionHumanApprovalRequirementSatisfactionError(
+                "PHARS_TIMESTAMP_ORDER"
+            )
+        linkage_raw = linkage.model_dump(mode="json")
+    elif required_linkage is not None:
+        raise PromotionHumanApprovalRequirementSatisfactionError(
+            "PHARS_UNEXPECTED_LINKAGE"
+        )
+    raw = {
+        "format_version": FORMAT_VERSION,
+        "recorded_at": recorded,
+        "source_authority_evidence_linkage_review_packet": source_raw,
+        "source_authority_evidence_linkage_review_id": resolution.source_authority_evidence_linkage_review_id,
+        "source_authority_evidence_linkage_review_hash": resolution.source_authority_evidence_linkage_review_hash,
+        "action_contract_snapshot": contract.to_dict(),
+        "action_contract_digest": resolution.action_contract_digest,
+        "human_approval_requirement_resolution_packet": resolution.model_dump(
+            mode="json"
+        ),
+        "required_human_approval": resolution.required_human_approval,
+        "requirement_state": resolution.requirement_state,
+        "satisfaction_state": REQUIRED_STATE
+        if resolution.required_human_approval
+        else NOT_REQUIRED_STATE,
+        "required_human_approval_linkage_packet": linkage_raw,
+        "execution_intent": source.execution_intent,
+        "execution_intent_id": source.execution_intent_id,
+        "execution_intent_hash": source.execution_intent_hash,
+        **{
+            name: False
+            for name in (
+                "human_approval_created",
+                "human_approval_proven",
+                "authority_evidence_proven",
+                "execution_authority_created",
+                "bind_authorization_created",
+                "bind_invoked",
+                "bind_receipt_created",
+                "credential_material_accessed",
+                "network_used",
+                "external_effect_occurred",
+                "ready_for_real_bind",
+            )
+        },
+    }
+    digest = _packet_hash(raw)
+    return PromotionHumanApprovalRequirementSatisfactionPacket(
+        packet_id=f"phars:v1:sha256:{digest}", packet_hash=digest, **raw
+    )
+
+
+def verify_promotion_human_approval_requirement_satisfaction_packet(
+    packet: Any,
+    *,
+    expected_source: Any,
+    expected_contract: ActionClassContract,
+) -> PromotionHumanApprovalRequirementSatisfactionPacket:
+    """Rebuild all fields against independent anchors; return the rebuilt result."""
+    candidate = PromotionHumanApprovalRequirementSatisfactionPacket.model_validate(
+        _json(packet)
+    )
+    rebuilt = build_promotion_human_approval_requirement_satisfaction_packet(
+        expected_source,
+        candidate.human_approval_requirement_resolution_packet,
+        expected_contract,
+        candidate.required_human_approval_linkage_packet,
+        datetime.fromisoformat(_timestamp(candidate.recorded_at)),
+    )
+    if _json(candidate) != _json(rebuilt):
+        raise PromotionHumanApprovalRequirementSatisfactionError(
+            "PHARS_RECONSTRUCTION_MISMATCH"
+        )
+    return rebuilt

--- a/veritas_os/tests/helpers/live_decision_capture.py
+++ b/veritas_os/tests/helpers/live_decision_capture.py
@@ -19,7 +19,7 @@ from unittest.mock import patch
 from scripts import run_decision_to_external_bind_poc as poc
 
 
-def capture(output: Path) -> None:
+def capture(output: Path, *, required_human_approval: bool = False) -> None:
     """Write only the synthetic decision and infrastructure observations."""
     runtime = output.parent / "runtime"
     runtime.mkdir()
@@ -35,7 +35,9 @@ def capture(output: Path) -> None:
     from veritas_os.core import pipeline
 
     candidate = replace(
-        poc._candidate(), evidence_refs=["synthetic:local-review-input"]
+        poc._candidate(),
+        evidence_refs=["synthetic:local-review-input"],
+        required_human_approval=required_human_approval,
     )
     with (
         patch.object(poc, "_candidate", return_value=candidate),
@@ -63,4 +65,6 @@ def capture(output: Path) -> None:
 
 
 if __name__ == "__main__":
-    capture(Path(sys.argv[1]))
+    capture(
+        Path(sys.argv[1]), required_human_approval="--human-required" in sys.argv[2:]
+    )

--- a/veritas_os/tests/helpers/native_approval_source.py
+++ b/veritas_os/tests/helpers/native_approval_source.py
@@ -1,0 +1,141 @@
+"""Build native reference metadata from a real promotion, without effects.
+
+Fixture helpers provide explicit local metadata only. All packet construction
+and verification uses production code; no legacy handoff fields are fabricated.
+"""
+
+from datetime import timedelta
+
+from veritas_os.policy.bind_adapter_contract_selection import (
+    ADAPTER_METHODS,
+    DESCRIPTOR_SCOPE_LIMITATIONS,
+    EFFECT_PROFILE,
+    PROHIBITED_DURING_SELECTION,
+)
+from veritas_os.policy.canonical_promotion_execution_intent_readiness import (
+    build_canonical_promotion_execution_intent_readiness_packet as ready,
+)
+from veritas_os.policy.canonical_promotion_pre_bind_validation import (
+    build_canonical_promotion_pre_bind_validation_packet as pre_bind,
+)
+from veritas_os.policy.canonical_promotion_bind_preflight_adjudication import (
+    build_canonical_promotion_bind_preflight_adjudication_packet as preflight,
+)
+from veritas_os.policy.canonical_promotion_bind_adapter_contract_selection import (
+    build_canonical_promotion_bind_adapter_contract_selection_packet as select,
+)
+from veritas_os.policy.canonical_promotion_adapter_dry_run_plan import (
+    build_canonical_promotion_adapter_dry_run_plan_packet as plan,
+)
+from veritas_os.policy.canonical_promotion_adapter_dry_run_fixture_result import (
+    build_canonical_promotion_adapter_dry_run_fixture_result_packet as fixture_result,
+)
+from veritas_os.policy.canonical_promotion_reference_adapter_rehearsal import (
+    build_canonical_promotion_reference_adapter_in_memory_rehearsal_packet as rehearse,
+)
+from veritas_os.policy.canonical_promotion_live_adapter_dry_run_readiness import (
+    build_canonical_promotion_live_adapter_dry_run_request_readiness_packet as request_ready,
+)
+from veritas_os.policy.canonical_promotion_live_adapter_dry_run_request import (
+    build_canonical_promotion_live_adapter_dry_run_request_packet as request,
+)
+from veritas_os.policy.canonical_promotion_live_adapter_dry_run_dispatch_readiness import (
+    build_canonical_promotion_live_adapter_dry_run_dispatch_readiness_packet as dispatch_ready,
+)
+from veritas_os.policy.canonical_promotion_live_adapter_dry_run_endpoint_allowlist import (
+    build_canonical_promotion_live_adapter_dry_run_endpoint_allowlist_evaluation_packet as endpoint,
+)
+from veritas_os.policy.canonical_promotion_live_adapter_dry_run_credential_authorization import (
+    build_canonical_promotion_live_adapter_dry_run_credential_authorization_evaluation_packet as credential,
+)
+from veritas_os.policy.canonical_promotion_live_adapter_dry_run_operator_dispatch_review import (
+    build_canonical_promotion_live_adapter_dry_run_operator_dispatch_review_packet as operator,
+)
+from veritas_os.policy.canonical_promotion_live_adapter_dry_run_bind_pre_dispatch_review import (
+    build_canonical_promotion_live_adapter_dry_run_bind_pre_dispatch_review_packet as review,
+)
+from veritas_os.policy.canonical_promotion_live_adapter_dry_run_authority_evidence_linkage import (
+    build_canonical_promotion_live_adapter_dry_run_authority_evidence_linkage_review_packet as authority,
+)
+from veritas_os.tests.test_canonical_promotion_adapter_dry_run_fixture_result import (
+    _fixtures,
+)
+from veritas_os.tests import (
+    test_canonical_promotion_live_adapter_dry_run_endpoint_allowlist as endpoints,
+)
+from veritas_os.tests import (
+    test_canonical_promotion_live_adapter_dry_run_credential_authorization as credentials,
+)
+from veritas_os.tests import (
+    test_canonical_promotion_live_adapter_dry_run_operator_dispatch_review as operators,
+)
+from veritas_os.tests import (
+    test_canonical_promotion_live_adapter_dry_run_bind_pre_dispatch_review as reviews,
+)
+from veritas_os.tests import (
+    test_canonical_promotion_live_adapter_dry_run_authority_evidence_linkage as authorities,
+)
+
+
+def build_native_authority_source(promotion, now):
+    """Preserve the actual API promotion through every native source stage."""
+    intent = promotion.exact_execution_intent
+    descriptor = {
+        "adapter_contract_version": "bind-adapter-contract/v1",
+        "adapter_kind": "reference",
+        "adapter_name": "local-inert-declaration",
+        "target_system": intent["target_system"],
+        "target_resource_scope": intent["target_resource"],
+        "supported_methods": list(ADAPTER_METHODS),
+        "required_methods": list(ADAPTER_METHODS),
+        "prohibited_during_selection": list(PROHIBITED_DURING_SELECTION),
+        "effect_profile": EFFECT_PROFILE,
+        "declared_by": "test:local",
+        "declared_at": now.isoformat(),
+        "descriptor_scope_limitations": list(DESCRIPTOR_SCOPE_LIMITATIONS),
+    }
+    selection = select(
+        preflight(pre_bind(ready(promotion, checked_at=now), checked_at=now), now),
+        descriptor,
+        now,
+    )
+    planned = plan(selection, now)
+    rehearsed = rehearse(
+        fixture_result(planned, _fixtures(planned), now),
+        {"scenario": "local-native-api"},
+        now,
+    )
+    dispatch = dispatch_ready(request(request_ready(rehearsed, now), now), now)
+    candidate = endpoints._candidate(
+        adapter_contract_id=selection.adapter_contract_id,
+        target_system=intent["target_system"],
+        target_resource_scope=intent["target_resource"],
+        declared_at=now.isoformat(),
+    )
+    allowed = endpoint(dispatch, candidate, endpoints._snapshot(candidate), now)
+    reference = credentials._reference(
+        adapter_contract_id=selection.adapter_contract_id,
+        endpoint_candidate_id=candidate["endpoint_candidate_id"],
+        target_system=intent["target_system"],
+        target_resource_scope=intent["target_resource"],
+        declared_at=now.isoformat(),
+    )
+    authorized_metadata = credential(
+        allowed, reference, credentials._snapshot(reference), now
+    )
+    operator_decision = {
+        **operators._decision(authorized_metadata),
+        "reviewed_at": now.isoformat(),
+    }
+    reviewed = review(
+        operator(authorized_metadata, operator_decision, now),
+        {**reviews._decision(), "reviewed_at": now.isoformat()},
+        now,
+    )
+    bundle = authorities._bundle(reviewed)
+    bundle["bundle_declared_at"] = now.isoformat()
+    for item in bundle["authority_evidence_references"]:
+        item["authority_subject"] = intent["actor_identity"]
+        item["authority_issued_at"] = (now - timedelta(seconds=1)).isoformat()
+        item["authority_expires_at"] = (now + timedelta(minutes=5)).isoformat()
+    return authority(reviewed, bundle, now)

--- a/veritas_os/tests/test_promotion_human_approval_requirement_satisfaction.py
+++ b/veritas_os/tests/test_promotion_human_approval_requirement_satisfaction.py
@@ -1,0 +1,393 @@
+"""Independent anchors and adversarial native approval-requirement tests."""
+
+from copy import deepcopy
+from dataclasses import replace
+from datetime import datetime, timedelta
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from veritas_os.governance.action_contracts import ActionClassContract
+from veritas_os.policy.human_approval_requirement_resolution import (
+    build_human_approval_requirement_resolution_packet as resolve,
+    verify_human_approval_requirement_resolution_packet as verify_resolution,
+    _digest as resolution_digest,
+)
+from veritas_os.policy.promotion_human_approval_requirement_satisfaction import (
+    build_promotion_human_approval_requirement_satisfaction_packet as satisfy,
+    verify_promotion_human_approval_requirement_satisfaction_packet as verify,
+    _packet_hash,
+)
+from veritas_os.policy.canonical_promotion_live_adapter_dry_run_human_approval_linkage import (
+    build_canonical_promotion_live_adapter_dry_run_human_approval_linkage_review_packet as link,
+)
+from veritas_os.policy.canonical_promotion_live_adapter_dry_run_authority_evidence_linkage import (
+    build_canonical_promotion_live_adapter_dry_run_authority_evidence_linkage_review_packet as authority,
+)
+from veritas_os.tests import (
+    test_canonical_promotion_live_adapter_dry_run_authority_evidence_linkage as sources,
+)
+from veritas_os.tests import (
+    test_canonical_promotion_live_adapter_dry_run_human_approval_linkage as humans,
+)
+from veritas_os.governance.canonical_decision_artifact import (
+    verify_canonical_decision_artifact,
+)
+from veritas_os.policy.canonical_verified_decision_promotion import (
+    build_canonical_verified_decision_promotion_packet,
+)
+from veritas_os.tests.helpers.native_approval_source import (
+    build_native_authority_source,
+)
+
+pytestmark = pytest.mark.slow
+
+
+def _contract(action="set_state:one", required=True):
+    return ActionClassContract(
+        id=action,
+        version="1",
+        domain="local-native-test",
+        action_class=action,
+        description="Independent local action policy",
+        declared_intent="Test one declared operation",
+        allowed_scope=["bind-request"],
+        prohibited_scope=["admin"],
+        authority_sources=["authority:local-reference-only"],
+        required_evidence=[],
+        evidence_freshness={},
+        irreversibility={"level": "low"},
+        human_approval_rules={
+            "required": required,
+            "minimum_approvals": 1 if required else 0,
+        },
+        refusal_conditions=[],
+        escalation_conditions=[],
+        default_failure_mode="deny",
+        metadata={},
+    )
+
+
+def _link(source, now):
+    bundle = humans._bundle(source)
+    bundle["bundle_declared_at"] = now.isoformat()
+    for item in bundle["human_approval_references"]:
+        item["approval_issued_at"] = (now - timedelta(seconds=1)).isoformat()
+        item["approval_expires_at"] = (now + timedelta(minutes=5)).isoformat()
+    return link(source, bundle, now)
+
+
+@pytest.fixture(scope="module")
+def native():
+    source = sources._packet()
+    now = humans.RECORDED_AT + timedelta(seconds=1)
+    return source, _contract(), _link(source, now), now
+
+
+@pytest.mark.parametrize("required", [False, True])
+def test_native_requirement_preserves_complete_source_and_no_authority(
+    native, required
+):
+    source, _, linkage, now = native
+    contract = _contract(required=required)
+    resolution = resolve(source, contract, now)
+    assert verify_resolution(resolution, source, contract) == resolution
+    packet = satisfy(source, resolution, contract, linkage if required else None, now)
+    verified = verify(packet, expected_source=source, expected_contract=contract)
+    schema_path = (
+        Path(__file__).resolve().parents[2]
+        / "schemas/promotion-human-approval-requirement-satisfaction-v1.schema.json"
+    )
+    Draft202012Validator(json.loads(schema_path.read_text())).validate(
+        verified.model_dump(mode="json")
+    )
+    assert verified == packet and verified is not packet
+    assert verified.execution_intent == source.execution_intent
+    assert verified.execution_intent_id == source.execution_intent_id
+    assert verified.execution_intent_hash == source.execution_intent_hash
+    assert (
+        verified.source_authority_evidence_linkage_review_packet
+        == source.model_dump(mode="json")
+    )
+    assert verified.required_human_approval is required
+    assert (
+        verified.human_approval_requirement_resolution_packet
+        == resolution.model_dump(mode="json")
+    )
+    for field in (
+        "human_approval_created",
+        "human_approval_proven",
+        "authority_evidence_proven",
+        "execution_authority_created",
+        "bind_authorization_created",
+        "bind_invoked",
+        "bind_receipt_created",
+        "credential_material_accessed",
+        "network_used",
+        "external_effect_occurred",
+        "ready_for_real_bind",
+    ):
+        assert getattr(verified, field) is False
+
+
+@pytest.mark.parametrize(
+    "rules",
+    [
+        {"required": False, "minimum_approvals": 0},
+        {"required": True, "minimum_approvals": 2},
+        {"required": True, "minimum_approvals": 1, "approver_role": "attacker"},
+    ],
+)
+def test_fully_rebuilt_same_id_version_policy_substitution_fails(native, rules):
+    source, trusted, linkage, now = native
+    forged_contract = replace(trusted, human_approval_rules=rules)
+    assert (forged_contract.id, forged_contract.version) == (
+        trusted.id,
+        trusted.version,
+    )
+    forged_resolution = resolve(source, forged_contract, now)
+    forged = satisfy(
+        source,
+        forged_resolution,
+        forged_contract,
+        linkage if forged_resolution.required_human_approval else None,
+        now,
+    )
+    with pytest.raises(ValueError):
+        verify(forged, expected_source=source, expected_contract=trusted)
+    with pytest.raises(ValueError):
+        verify_resolution(forged_resolution, source, trusted)
+
+
+def test_fully_rebuilt_source_substitution_fails(native):
+    original, contract, _, now = native
+    bundle = original.authority_evidence_reference_bundle.model_dump(mode="json")
+    bundle["bundle_declared_by"] = "attacker"
+    forged_source = authority(
+        original.source_bind_pre_dispatch_review_packet, bundle, sources.RECORDED_AT
+    )
+    forged = satisfy(
+        forged_source,
+        resolve(forged_source, contract, now),
+        contract,
+        _link(forged_source, now),
+        now,
+    )
+    with pytest.raises(ValueError):
+        verify(forged, expected_source=original, expected_contract=contract)
+
+
+def test_valid_linkage_for_another_source_cannot_satisfy_requirement(native):
+    source, contract, _, now = native
+    bundle = source.authority_evidence_reference_bundle.model_dump(mode="json")
+    bundle["bundle_declared_by"] = "different-reviewer"
+    other = authority(
+        source.source_bind_pre_dispatch_review_packet, bundle, sources.RECORDED_AT
+    )
+    with pytest.raises(ValueError, match="PHARS_LINKAGE_SOURCE_MISMATCH"):
+        satisfy(
+            source, resolve(source, contract, now), contract, _link(other, now), now
+        )
+
+
+@pytest.mark.parametrize("change", ["format", "nested_hash"])
+def test_native_source_cannot_be_relabeled_or_tampered(native, change):
+    source, contract, _, now = native
+    raw = source.model_dump(mode="json")
+    if change == "format":
+        raw["format_version"] = (
+            "canonical-live-adapter-dry-run-authority-evidence-linkage-review/v1"
+        )
+    else:
+        raw["source_bind_pre_dispatch_review_packet"]["execution_intent_hash"] = (
+            "0" * 64
+        )
+    with pytest.raises(ValueError):
+        resolve(raw, contract, now)
+
+
+def test_high_irreversibility_policy_rule_remains_required(native):
+    source, contract, _, now = native
+    contract = replace(
+        contract,
+        irreversibility={"level": "high"},
+        human_approval_rules={"required": False, "minimum_approvals": 1},
+    )
+    assert resolve(source, contract, now).required_human_approval is True
+
+
+def test_satisfaction_cannot_predate_required_linkage(native):
+    source, contract, linkage, _ = native
+    earlier = sources.RECORDED_AT + timedelta(seconds=1)
+    with pytest.raises(ValueError, match="PHARS_TIMESTAMP_ORDER"):
+        satisfy(source, resolve(source, contract, earlier), contract, linkage, earlier)
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "required_human_approval",
+        "requirement_state",
+        "requirement_reason",
+        "action_contract_digest",
+        "source_execution_intent_hash",
+    ],
+)
+def test_rehashed_resolution_fields_are_reconstructed(native, field):
+    source, contract, linkage, now = native
+    raw = resolve(source, contract, now).model_dump(mode="json")
+    raw[field] = (
+        False
+        if field == "required_human_approval"
+        else "NOT_REQUIRED_BY_ACTION_CONTRACT"
+        if field == "requirement_state"
+        else "0" * 64
+    )
+    payload = {
+        k: v
+        for k, v in raw.items()
+        if k
+        not in {
+            "human_approval_requirement_resolution_id",
+            "human_approval_requirement_resolution_hash",
+        }
+    }
+    digest = resolution_digest(payload)
+    raw.update(
+        human_approval_requirement_resolution_hash=digest,
+        human_approval_requirement_resolution_id=f"harr:v1:sha256:{digest}",
+    )
+    with pytest.raises(ValueError):
+        satisfy(source, raw, contract, linkage, now)
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "execution_intent_id",
+        "execution_intent_hash",
+        "action_contract_digest",
+        "source_authority_evidence_linkage_review_hash",
+        "satisfaction_state",
+        "required_human_approval",
+    ],
+)
+def test_rehashed_downstream_copies_do_not_override_rebuilt_resolution(native, field):
+    source, contract, linkage, now = native
+    raw = satisfy(
+        source, resolve(source, contract, now), contract, linkage, now
+    ).model_dump(mode="json")
+    raw[field] = (
+        False
+        if field == "required_human_approval"
+        else "SATISFIED_AS_NOT_REQUIRED_BY_ACTION_CONTRACT"
+        if field == "satisfaction_state"
+        else "0" * 64
+    )
+    digest = _packet_hash(raw)
+    raw.update(packet_hash=digest, packet_id=f"phars:v1:sha256:{digest}")
+    with pytest.raises(ValueError):
+        verify(raw, expected_source=source, expected_contract=contract)
+
+
+@pytest.mark.parametrize("anchor", ["source", "contract", "missing_keywords"])
+def test_independent_anchors_are_mandatory(native, anchor):
+    source, contract, linkage, now = native
+    packet = satisfy(source, resolve(source, contract, now), contract, linkage, now)
+    kwargs = dict(expected_source=source, expected_contract=contract)
+    if anchor == "missing_keywords":
+        kwargs = {}
+    else:
+        kwargs["expected_" + anchor] = None
+    with pytest.raises((TypeError, ValueError)):
+        verify(packet, **kwargs)
+
+
+@pytest.mark.parametrize("required", [False, True])
+def test_missing_or_unexpected_linkage_is_rejected(native, required):
+    source, _, linkage, now = native
+    contract = _contract(required=required)
+    with pytest.raises(ValueError):
+        satisfy(
+            source,
+            resolve(source, contract, now),
+            contract,
+            None if required else linkage,
+            now,
+        )
+
+
+@pytest.mark.parametrize("stage", ["resolution", "satisfaction", "naive"])
+def test_invalid_timestamp_order_fails(native, stage):
+    source, contract, linkage, now = native
+    with pytest.raises(ValueError):
+        if stage == "resolution":
+            resolve(source, contract, sources.RECORDED_AT - timedelta(seconds=1))
+        else:
+            satisfy(
+                source,
+                resolve(source, contract, now),
+                contract,
+                linkage,
+                now.replace(tzinfo=None)
+                if stage == "naive"
+                else now - timedelta(seconds=1),
+            )
+
+
+@pytest.fixture(scope="module", params=[False, True])
+def api_source(request, tmp_path_factory):
+    output = tmp_path_factory.mktemp("native-api") / "capture.json"
+    command = [
+        sys.executable,
+        "-m",
+        "veritas_os.tests.helpers.live_decision_capture",
+        str(output),
+    ]
+    if request.param:
+        command.append("--human-required")
+    subprocess.run(
+        command,
+        cwd=Path(__file__).resolve().parents[2],
+        check=True,
+        timeout=180,
+        capture_output=True,
+        text=True,
+    )
+    captured = json.loads(output.read_text())
+    assert captured["pipeline_ok"]
+    assert all(value > 0 for value in captured["infrastructure_calls"].values())
+    verification = verify_canonical_decision_artifact(
+        captured["canonical_decision_artifact"]
+    )
+    assert verification.is_valid and verification.artifact is not None
+    cda = verification.artifact
+    now = datetime.fromisoformat(captured["observed_at"])
+    promotion = build_canonical_verified_decision_promotion_packet(
+        cda, captured["candidate"], promoted_at=now
+    )
+    source = build_native_authority_source(promotion, now)
+    assert source.execution_intent == promotion.exact_execution_intent
+    assert source.execution_intent["decision_id"] == cda.decision_id
+    assert source.execution_intent["decision_hash"] == cda.decision_hash
+    return source, now, request.param
+
+
+def test_real_api_native_source_reaches_requirement_satisfaction(api_source):
+    source, now, required = api_source
+    contract = _contract(action="post_synthetic_review", required=required)
+    resolution = resolve(source, contract, now)
+    packet = satisfy(
+        source, resolution, contract, _link(source, now) if required else None, now
+    )
+    before = deepcopy(packet.model_dump(mode="json"))
+    verified = verify(packet, expected_source=source, expected_contract=contract)
+    assert verified.required_human_approval is required
+    assert verified.execution_intent == source.execution_intent
+    assert packet.model_dump(mode="json") == before
+    assert verified.human_approval_proven is False
+    assert verified.ready_for_real_bind is False


### PR DESCRIPTION
# Summary

Connect promotion-native Authority Evidence linkage to HumanApprovalRequirementResolution and a distinct native requirement-satisfaction packet. Real authenticated /v1/decide output now reaches requirement satisfaction for both required and not-required cases.

This is a non-authorizing source-validation change. **Native Final Bind Readiness/Gate and the authorization issuer do not yet consume the new packet.**

## Scope

- HARR explicitly selects the full native or legacy source verifier and preserves the original source identity/hash.
- Reject native resolution timestamps before the source.
- Add native satisfaction builder/verifier and closed JSON schema.
- Require independent expected_source and expected_contract; reconstruct every field and return rebuilt results.
- REQUIRED requires existing verified native linkage bound to the complete same source. NOT_REQUIRED rejects supplied linkage.
- Add native adversarial and real HTTP integration tests, plus EN/JA implementation notes.

## Type of change

- [x] Runtime
- [x] Tests
- [x] Docs
- [x] Governance / security-sensitive

## Why this change matters

#2189 exposed the incompatible source formats. Relabeling a native packet as a legacy handoff would lose its original verification path. This PR retains the native source and its complete recursive verification, without inventing handoff, replay, or approval evidence.

Contract snapshots inside a candidate packet are never trust anchors. Tests rebuild HARR, satisfaction, and all hashes after changing human_approval_rules under the same contract ID/version; verification against the original trusted contract fails closed. Rebuilt source substitutions, foreign linkage, timestamp errors, and rehashed downstream field tampering also fail.

## Market / developer / user value

- Market value: No production-execution claim.
- Developer value: Real API-to-native-approval-requirement coverage and explicit source contract.
- User/operator value: Approval requirements cannot be downgraded using attacker-controlled snapshots.

## Tests run

- [x] **93 passed**, including **32 new tests**.
- [x] Existing HARR unit/integration, legacy satisfaction, v0.3 issuance trust, and #2189 real decision boundary tests.
- [x] Real authenticated /v1/decide → native promotion → readiness/preflight/selection → native authority source → HARR → native satisfaction, for both approval cases.
- [x] Published JSON schema validates both packet states.
- [x] `ruff check veritas_os`
- [x] Bilingual documentation check
- [x] Responsibility boundary check
- [x] `git diff --check`

Existing jsonschema RefResolver deprecation warnings remain. Full GitHub CI pending.

## AI assistance used

- [x] Codex

## Review status

- [ ] CI passed
- [ ] Human maintainer reviewed

## Risk checklist

- [x] Touches governance policy behavior
- [ ] Touches secrets or credentials
- [ ] Touches TrustLog persistence or encryption behavior
- [ ] Involves private user/customer data

## Human approval required?

- [x] Yes

Reason: Security-sensitive requirement/source verification. Draft only; do not merge automatically.

## Notes for reviewer

- Both satisfaction states explicitly keep human_approval_proven=false and ready_for_real_bind=false.
- The new boundary produces no Human Approval Receipt, execution authority, Bind authorization, BindReceipt, credential access, network dispatch, or external effect.
- The real HTTP route/kernel/policy-signature/CDA chain runs with controlled model/cloud clients, temporary storage, and explicit test-only reference metadata. Returned CDA/candidate data is not rewritten; the required-approval variant is supplied in the original request.
- The existing native human linkage requirement on the candidate's declared approval flag is preserved. No accepting packet-verifier doubles or benchmark ground truth drive the new requirement logic.
- The existing legacy source builder still rejects native selection; its regression remains valid. This PR adds a distinct native packet, not a fallback that weakens legacy validation.
- **Remaining integration:** propagate native satisfaction and independent anchors through Final Bind Readiness/Gate and authorization issuance, then validate single-use execution and outcome lineage for a real decision.
- Published tree matches locally tested source: `72481b2a09a1113fc903cfc1c396bccf53290d3c`.
