### PR TITLE
feat: bind native readiness and gate to trusted approval requirements

### DIFF
--- a/docs/en/development/approval-requirement-source-verification.md
+++ b/docs/en/development/approval-requirement-source-verification.md
@@ -152,7 +152,34 @@ clients and reference metadata remain controlled test inputs. No Human Approval
 Receipt or execution authority is produced by this new boundary.
 
 This is a distinct native packet (`promotion-human-approval-requirement-satisfaction/v1`),
-not a relabeled legacy satisfaction packet. Native Final Bind Readiness/Gate and
-the authorization issuer do not yet consume it. That downstream propagation,
-followed by real-decision single-use execution/outcome integration, remains work
-to complete; the legacy fresh-source format-refusal test remains valid.
+not a relabeled legacy satisfaction packet. The dedicated requirement-aware
+Final Readiness/Gate path below consumes it. The legacy fresh-source
+format-refusal test remains valid.
+
+## Requirement-aware native Final Readiness and Gate
+
+`promotion_requirement_bind_readiness` connects verified satisfaction to
+`PromotionRequirementFinalReadinessPacket` and `PromotionRequirementBindGatePacket`.
+Every builder and verifier requires independent `expected_source` and
+`expected_contract`. Gate verification propagates those inputs through readiness,
+satisfaction, and resolution; no embedded snapshot becomes a trust anchor.
+All derived fields are reconstructed, and verifiers return the rebuilt objects.
+The complete source chain retains the original intent, endpoint, credential scope,
+authority linkage, and optional human linkage without synthesizing legacy fields.
+
+Both REQUIRED and NOT_REQUIRED states are supported. Conditional future human
+approval requirements come only from the verified resolution; other authorization
+and invocation prerequisites remain outstanding. Rejected readiness cannot enter
+Gate review. Rejected Gate review remains fail-closed. Local review acknowledgements
+are explicit metadata, not signed Human Approval Receipts.
+
+The separate closed schemas preserve existing linkage-only native v1 and legacy
+v0.3 APIs. Real authenticated `/v1/decide` tests reach the new Gate for both states
+with controlled model/cloud clients. Fully rehashed source/policy substitutions
+under identical contract ID/version are rejected at both review boundaries.
+
+The new Gate is **not yet consumed by Fresh Verified Source Gate, final endpoint/
+credential rechecks, or the authorization issuer**. Wiring those consumers with
+independent anchors and validating real-decision single-use execution/outcomes
+remains required. No authorization, credential access, network dispatch, or
+external effect is created by these review stages.

--- a/docs/ja/development/approval-requirement-source-verification.md
+++ b/docs/ja/development/approval-requirement-source-verification.md
@@ -118,6 +118,29 @@ native Human Approval linkageへ接続します。REQUIREDには完全に同じa
 参照メタデータはテスト用です。新しい境界はHuman Approval Receiptや実行権限を生成しません。
 
 新packetは`promotion-human-approval-requirement-satisfaction/v1`であり、legacy packetの形式名変更では
-ありません。native Final Bind Readiness／Gateとauthorization issuerはまだこのpacketを受け取れません。
-そこへの独立入力の伝播と、その後の実decisionによる一回限りの実行・結果記録の統合が残っています。
+ありません。以下の承認要件対応Final Readiness／Gate経路がこのpacketを受け取ります。
 既存のlegacy fresh-source形式拒否テストも引き続き有効です。
+
+## 承認要件に対応するnative Final ReadinessとGate
+
+`promotion_requirement_bind_readiness`は検証済みsatisfactionを
+`PromotionRequirementFinalReadinessPacket`と`PromotionRequirementBindGatePacket`へ接続します。
+全builder／verifierで独立した`expected_source`と`expected_contract`が必須です。
+Gateからreadiness、satisfaction、resolutionまで同じ独立入力を渡し、embedded snapshotを
+信頼の根拠に戻しません。派生項目を再構築し、verifierは再構築したオブジェクトを返します。
+完全なsource chainで元のintent、endpoint、credential scope、authority linkage、必要な場合の
+human linkageを保持し、legacy用の項目を作りません。
+
+REQUIRED／NOT_REQUIREDの両方に対応します。後続の人間承認要件は検証済みresolutionだけから
+決まり、他のauthorization／invocation前提は未充足として残ります。readiness拒否時はGateへ進めず、
+Gate拒否もfail-closedです。明示的なローカルレビュー確認事項はメタデータであり、署名済み
+Human Approval Receiptではありません。
+
+専用の閉じたschemaにより、既存のlinkage専用native v1とlegacy v0.3 APIを維持します。
+モデル・クラウドクライアントを制御した実際の認証済み`/v1/decide`から、新Gateまで両状態を
+テストします。同一契約ID／versionでsourceやpolicyを差し替え、全hashを作り直しても両境界で拒否します。
+
+新Gateは**Fresh Verified Source Gate、最終endpoint／credential再検査、authorization issuerには
+まだ接続されていません**。これらへの独立入力の伝播と、実decisionによる一回限りの実行・結果記録の
+統合検証が残っています。このレビュー処理は実行許可、credentialアクセス、network dispatch、
+external effectを作りません。

--- a/schemas/promotion-requirement-bind-gate-v1.schema.json
+++ b/schemas/promotion-requirement-bind-gate-v1.schema.json
@@ -1,0 +1,274 @@
+{
+  "$defs": {
+    "RequirementBindReviewDecision": {
+      "additionalProperties": false,
+      "description": "Explicit local review; no signed human approval is asserted.",
+      "properties": {
+        "review_id": {
+          "minLength": 1,
+          "title": "Review Id",
+          "type": "string"
+        },
+        "reviewer_id": {
+          "minLength": 1,
+          "title": "Reviewer Id",
+          "type": "string"
+        },
+        "review_reason": {
+          "minLength": 1,
+          "title": "Review Reason",
+          "type": "string"
+        },
+        "reviewed_at": {
+          "title": "Reviewed At",
+          "type": "string"
+        },
+        "accepted": {
+          "title": "Accepted",
+          "type": "boolean"
+        },
+        "acknowledged_no_authorization": {
+          "const": true,
+          "title": "Acknowledged No Authorization",
+          "type": "boolean"
+        },
+        "acknowledged_no_human_approval_proof": {
+          "const": true,
+          "title": "Acknowledged No Human Approval Proof",
+          "type": "boolean"
+        },
+        "acknowledged_no_authority_evidence_proof": {
+          "const": true,
+          "title": "Acknowledged No Authority Evidence Proof",
+          "type": "boolean"
+        },
+        "acknowledged_no_external_effect": {
+          "const": true,
+          "title": "Acknowledged No External Effect",
+          "type": "boolean"
+        },
+        "acknowledged_independent_policy_binding": {
+          "const": true,
+          "title": "Acknowledged Independent Policy Binding",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "review_id",
+        "reviewer_id",
+        "review_reason",
+        "reviewed_at",
+        "accepted",
+        "acknowledged_no_authorization",
+        "acknowledged_no_human_approval_proof",
+        "acknowledged_no_authority_evidence_proof",
+        "acknowledged_no_external_effect",
+        "acknowledged_independent_policy_binding"
+      ],
+      "title": "RequirementBindReviewDecision",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false,
+  "description": "Gate review retaining the complete independently verified readiness.",
+  "properties": {
+    "packet_id": {
+      "title": "Packet Id",
+      "type": "string"
+    },
+    "packet_hash": {
+      "pattern": "^[0-9a-f]{64}$",
+      "title": "Packet Hash",
+      "type": "string"
+    },
+    "recorded_at": {
+      "title": "Recorded At",
+      "type": "string"
+    },
+    "review_decision": {
+      "$ref": "#/$defs/RequirementBindReviewDecision"
+    },
+    "source_packet": {
+      "additionalProperties": true,
+      "title": "Source Packet",
+      "type": "object"
+    },
+    "source_packet_id": {
+      "title": "Source Packet Id",
+      "type": "string"
+    },
+    "source_packet_hash": {
+      "title": "Source Packet Hash",
+      "type": "string"
+    },
+    "source_authority_evidence_linkage_review_id": {
+      "title": "Source Authority Evidence Linkage Review Id",
+      "type": "string"
+    },
+    "source_authority_evidence_linkage_review_hash": {
+      "title": "Source Authority Evidence Linkage Review Hash",
+      "type": "string"
+    },
+    "action_contract_digest": {
+      "title": "Action Contract Digest",
+      "type": "string"
+    },
+    "requirement_resolution_hash": {
+      "title": "Requirement Resolution Hash",
+      "type": "string"
+    },
+    "required_human_approval": {
+      "title": "Required Human Approval",
+      "type": "boolean"
+    },
+    "requirement_state": {
+      "enum": [
+        "REQUIRED",
+        "NOT_REQUIRED_BY_ACTION_CONTRACT"
+      ],
+      "title": "Requirement State",
+      "type": "string"
+    },
+    "satisfaction_state": {
+      "enum": [
+        "SATISFIED_BY_VERIFIED_HUMAN_APPROVAL_LINKAGE",
+        "SATISFIED_AS_NOT_REQUIRED_BY_ACTION_CONTRACT"
+      ],
+      "title": "Satisfaction State",
+      "type": "string"
+    },
+    "execution_intent": {
+      "additionalProperties": true,
+      "title": "Execution Intent",
+      "type": "object"
+    },
+    "execution_intent_id": {
+      "title": "Execution Intent Id",
+      "type": "string"
+    },
+    "execution_intent_hash": {
+      "title": "Execution Intent Hash",
+      "type": "string"
+    },
+    "future_authorization_requirements": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Future Authorization Requirements",
+      "type": "array"
+    },
+    "future_invocation_requirements": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Future Invocation Requirements",
+      "type": "array"
+    },
+    "fail_closed": {
+      "title": "Fail Closed",
+      "type": "boolean"
+    },
+    "human_approval_created": {
+      "const": false,
+      "title": "Human Approval Created",
+      "type": "boolean"
+    },
+    "human_approval_proven": {
+      "const": false,
+      "title": "Human Approval Proven",
+      "type": "boolean"
+    },
+    "authority_evidence_proven": {
+      "const": false,
+      "title": "Authority Evidence Proven",
+      "type": "boolean"
+    },
+    "execution_authority_created": {
+      "const": false,
+      "title": "Execution Authority Created",
+      "type": "boolean"
+    },
+    "bind_authorization_created": {
+      "const": false,
+      "title": "Bind Authorization Created",
+      "type": "boolean"
+    },
+    "bind_invoked": {
+      "const": false,
+      "title": "Bind Invoked",
+      "type": "boolean"
+    },
+    "bind_receipt_created": {
+      "const": false,
+      "title": "Bind Receipt Created",
+      "type": "boolean"
+    },
+    "credential_material_accessed": {
+      "const": false,
+      "title": "Credential Material Accessed",
+      "type": "boolean"
+    },
+    "network_used": {
+      "const": false,
+      "title": "Network Used",
+      "type": "boolean"
+    },
+    "external_effect_occurred": {
+      "const": false,
+      "title": "External Effect Occurred",
+      "type": "boolean"
+    },
+    "ready_for_real_bind": {
+      "const": false,
+      "title": "Ready For Real Bind",
+      "type": "boolean"
+    },
+    "format_version": {
+      "const": "promotion-requirement-bind-gate/v1",
+      "title": "Format Version",
+      "type": "string"
+    },
+    "ready_for_fresh_verified_source_gate": {
+      "title": "Ready For Fresh Verified Source Gate",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "packet_id",
+    "packet_hash",
+    "recorded_at",
+    "review_decision",
+    "source_packet",
+    "source_packet_id",
+    "source_packet_hash",
+    "source_authority_evidence_linkage_review_id",
+    "source_authority_evidence_linkage_review_hash",
+    "action_contract_digest",
+    "requirement_resolution_hash",
+    "required_human_approval",
+    "requirement_state",
+    "satisfaction_state",
+    "execution_intent",
+    "execution_intent_id",
+    "execution_intent_hash",
+    "future_authorization_requirements",
+    "future_invocation_requirements",
+    "fail_closed",
+    "human_approval_created",
+    "human_approval_proven",
+    "authority_evidence_proven",
+    "execution_authority_created",
+    "bind_authorization_created",
+    "bind_invoked",
+    "bind_receipt_created",
+    "credential_material_accessed",
+    "network_used",
+    "external_effect_occurred",
+    "ready_for_real_bind",
+    "format_version",
+    "ready_for_fresh_verified_source_gate"
+  ],
+  "title": "PromotionRequirementBindGatePacket",
+  "type": "object",
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
+}

--- a/schemas/promotion-requirement-final-readiness-v1.schema.json
+++ b/schemas/promotion-requirement-final-readiness-v1.schema.json
@@ -1,0 +1,274 @@
+{
+  "$defs": {
+    "RequirementBindReviewDecision": {
+      "additionalProperties": false,
+      "description": "Explicit local review; no signed human approval is asserted.",
+      "properties": {
+        "review_id": {
+          "minLength": 1,
+          "title": "Review Id",
+          "type": "string"
+        },
+        "reviewer_id": {
+          "minLength": 1,
+          "title": "Reviewer Id",
+          "type": "string"
+        },
+        "review_reason": {
+          "minLength": 1,
+          "title": "Review Reason",
+          "type": "string"
+        },
+        "reviewed_at": {
+          "title": "Reviewed At",
+          "type": "string"
+        },
+        "accepted": {
+          "title": "Accepted",
+          "type": "boolean"
+        },
+        "acknowledged_no_authorization": {
+          "const": true,
+          "title": "Acknowledged No Authorization",
+          "type": "boolean"
+        },
+        "acknowledged_no_human_approval_proof": {
+          "const": true,
+          "title": "Acknowledged No Human Approval Proof",
+          "type": "boolean"
+        },
+        "acknowledged_no_authority_evidence_proof": {
+          "const": true,
+          "title": "Acknowledged No Authority Evidence Proof",
+          "type": "boolean"
+        },
+        "acknowledged_no_external_effect": {
+          "const": true,
+          "title": "Acknowledged No External Effect",
+          "type": "boolean"
+        },
+        "acknowledged_independent_policy_binding": {
+          "const": true,
+          "title": "Acknowledged Independent Policy Binding",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "review_id",
+        "reviewer_id",
+        "review_reason",
+        "reviewed_at",
+        "accepted",
+        "acknowledged_no_authorization",
+        "acknowledged_no_human_approval_proof",
+        "acknowledged_no_authority_evidence_proof",
+        "acknowledged_no_external_effect",
+        "acknowledged_independent_policy_binding"
+      ],
+      "title": "RequirementBindReviewDecision",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false,
+  "description": "Final readiness derived from verified native requirement satisfaction.",
+  "properties": {
+    "packet_id": {
+      "title": "Packet Id",
+      "type": "string"
+    },
+    "packet_hash": {
+      "pattern": "^[0-9a-f]{64}$",
+      "title": "Packet Hash",
+      "type": "string"
+    },
+    "recorded_at": {
+      "title": "Recorded At",
+      "type": "string"
+    },
+    "review_decision": {
+      "$ref": "#/$defs/RequirementBindReviewDecision"
+    },
+    "source_packet": {
+      "additionalProperties": true,
+      "title": "Source Packet",
+      "type": "object"
+    },
+    "source_packet_id": {
+      "title": "Source Packet Id",
+      "type": "string"
+    },
+    "source_packet_hash": {
+      "title": "Source Packet Hash",
+      "type": "string"
+    },
+    "source_authority_evidence_linkage_review_id": {
+      "title": "Source Authority Evidence Linkage Review Id",
+      "type": "string"
+    },
+    "source_authority_evidence_linkage_review_hash": {
+      "title": "Source Authority Evidence Linkage Review Hash",
+      "type": "string"
+    },
+    "action_contract_digest": {
+      "title": "Action Contract Digest",
+      "type": "string"
+    },
+    "requirement_resolution_hash": {
+      "title": "Requirement Resolution Hash",
+      "type": "string"
+    },
+    "required_human_approval": {
+      "title": "Required Human Approval",
+      "type": "boolean"
+    },
+    "requirement_state": {
+      "enum": [
+        "REQUIRED",
+        "NOT_REQUIRED_BY_ACTION_CONTRACT"
+      ],
+      "title": "Requirement State",
+      "type": "string"
+    },
+    "satisfaction_state": {
+      "enum": [
+        "SATISFIED_BY_VERIFIED_HUMAN_APPROVAL_LINKAGE",
+        "SATISFIED_AS_NOT_REQUIRED_BY_ACTION_CONTRACT"
+      ],
+      "title": "Satisfaction State",
+      "type": "string"
+    },
+    "execution_intent": {
+      "additionalProperties": true,
+      "title": "Execution Intent",
+      "type": "object"
+    },
+    "execution_intent_id": {
+      "title": "Execution Intent Id",
+      "type": "string"
+    },
+    "execution_intent_hash": {
+      "title": "Execution Intent Hash",
+      "type": "string"
+    },
+    "future_authorization_requirements": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Future Authorization Requirements",
+      "type": "array"
+    },
+    "future_invocation_requirements": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Future Invocation Requirements",
+      "type": "array"
+    },
+    "fail_closed": {
+      "title": "Fail Closed",
+      "type": "boolean"
+    },
+    "human_approval_created": {
+      "const": false,
+      "title": "Human Approval Created",
+      "type": "boolean"
+    },
+    "human_approval_proven": {
+      "const": false,
+      "title": "Human Approval Proven",
+      "type": "boolean"
+    },
+    "authority_evidence_proven": {
+      "const": false,
+      "title": "Authority Evidence Proven",
+      "type": "boolean"
+    },
+    "execution_authority_created": {
+      "const": false,
+      "title": "Execution Authority Created",
+      "type": "boolean"
+    },
+    "bind_authorization_created": {
+      "const": false,
+      "title": "Bind Authorization Created",
+      "type": "boolean"
+    },
+    "bind_invoked": {
+      "const": false,
+      "title": "Bind Invoked",
+      "type": "boolean"
+    },
+    "bind_receipt_created": {
+      "const": false,
+      "title": "Bind Receipt Created",
+      "type": "boolean"
+    },
+    "credential_material_accessed": {
+      "const": false,
+      "title": "Credential Material Accessed",
+      "type": "boolean"
+    },
+    "network_used": {
+      "const": false,
+      "title": "Network Used",
+      "type": "boolean"
+    },
+    "external_effect_occurred": {
+      "const": false,
+      "title": "External Effect Occurred",
+      "type": "boolean"
+    },
+    "ready_for_real_bind": {
+      "const": false,
+      "title": "Ready For Real Bind",
+      "type": "boolean"
+    },
+    "format_version": {
+      "const": "promotion-requirement-final-readiness/v1",
+      "title": "Format Version",
+      "type": "string"
+    },
+    "ready_for_bind_authorization_gate_review": {
+      "title": "Ready For Bind Authorization Gate Review",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "packet_id",
+    "packet_hash",
+    "recorded_at",
+    "review_decision",
+    "source_packet",
+    "source_packet_id",
+    "source_packet_hash",
+    "source_authority_evidence_linkage_review_id",
+    "source_authority_evidence_linkage_review_hash",
+    "action_contract_digest",
+    "requirement_resolution_hash",
+    "required_human_approval",
+    "requirement_state",
+    "satisfaction_state",
+    "execution_intent",
+    "execution_intent_id",
+    "execution_intent_hash",
+    "future_authorization_requirements",
+    "future_invocation_requirements",
+    "fail_closed",
+    "human_approval_created",
+    "human_approval_proven",
+    "authority_evidence_proven",
+    "execution_authority_created",
+    "bind_authorization_created",
+    "bind_invoked",
+    "bind_receipt_created",
+    "credential_material_accessed",
+    "network_used",
+    "external_effect_occurred",
+    "ready_for_real_bind",
+    "format_version",
+    "ready_for_bind_authorization_gate_review"
+  ],
+  "title": "PromotionRequirementFinalReadinessPacket",
+  "type": "object",
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
+}

--- a/veritas_os/policy/promotion_requirement_bind_readiness.py
+++ b/veritas_os/policy/promotion_requirement_bind_readiness.py
@@ -1,0 +1,226 @@
+"""Policy-bound native final readiness and gate review, without authorization.
+
+Both stages consume rebuilt requirement satisfaction and require independent
+source/policy anchors. These formats do not masquerade as linkage-only v1
+packets and are not yet inputs to the real authorization issuer.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from veritas_os.governance.action_contracts import ActionClassContract
+from veritas_os.policy.human_approval_requirement_resolution import _json, _timestamp
+from veritas_os.policy.promotion_human_approval_requirement_satisfaction import (
+    PromotionHumanApprovalRequirementSatisfactionPacket,
+    verify_promotion_human_approval_requirement_satisfaction_packet as verify_satisfaction,
+)
+from veritas_os.policy.canonical_promotion_live_adapter_dry_run_bind_authorization_gate_review import (
+    AUTHORIZATION_REQUIREMENTS,
+    INVOCATION_REQUIREMENTS,
+)
+from veritas_os.security.hash import sha256_of_canonical_json
+
+
+class PromotionRequirementBindReviewError(ValueError):
+    """Invalid source, review ordering, or reconstructed policy binding."""
+
+
+class RequirementBindReviewDecision(BaseModel):
+    """Explicit local review; no signed human approval is asserted."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+    review_id: str = Field(min_length=1)
+    reviewer_id: str = Field(min_length=1)
+    review_reason: str = Field(min_length=1)
+    reviewed_at: str
+    accepted: bool
+    acknowledged_no_authorization: Literal[True]
+    acknowledged_no_human_approval_proof: Literal[True]
+    acknowledged_no_authority_evidence_proof: Literal[True]
+    acknowledged_no_external_effect: Literal[True]
+    acknowledged_independent_policy_binding: Literal[True]
+
+
+class _ReviewPacket(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+    packet_id: str
+    packet_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    recorded_at: str
+    review_decision: RequirementBindReviewDecision
+    source_packet: dict[str, Any]
+    source_packet_id: str
+    source_packet_hash: str
+    source_authority_evidence_linkage_review_id: str
+    source_authority_evidence_linkage_review_hash: str
+    action_contract_digest: str
+    requirement_resolution_hash: str
+    required_human_approval: bool
+    requirement_state: Literal["REQUIRED", "NOT_REQUIRED_BY_ACTION_CONTRACT"]
+    satisfaction_state: Literal[
+        "SATISFIED_BY_VERIFIED_HUMAN_APPROVAL_LINKAGE",
+        "SATISFIED_AS_NOT_REQUIRED_BY_ACTION_CONTRACT",
+    ]
+    execution_intent: dict[str, Any]
+    execution_intent_id: str
+    execution_intent_hash: str
+    future_authorization_requirements: list[str]
+    future_invocation_requirements: list[str]
+    fail_closed: bool
+    human_approval_created: Literal[False]
+    human_approval_proven: Literal[False]
+    authority_evidence_proven: Literal[False]
+    execution_authority_created: Literal[False]
+    bind_authorization_created: Literal[False]
+    bind_invoked: Literal[False]
+    bind_receipt_created: Literal[False]
+    credential_material_accessed: Literal[False]
+    network_used: Literal[False]
+    external_effect_occurred: Literal[False]
+    ready_for_real_bind: Literal[False]
+
+
+class PromotionRequirementFinalReadinessPacket(_ReviewPacket):
+    """Final readiness derived from verified native requirement satisfaction."""
+
+    format_version: Literal["promotion-requirement-final-readiness/v1"]
+    ready_for_bind_authorization_gate_review: bool
+
+
+class PromotionRequirementBindGatePacket(_ReviewPacket):
+    """Gate review retaining the complete independently verified readiness."""
+
+    format_version: Literal["promotion-requirement-bind-gate/v1"]
+    ready_for_fresh_verified_source_gate: bool
+
+
+def _packet_hash(raw: dict[str, Any]) -> str:
+    return sha256_of_canonical_json({
+        "domain": "veritas." + raw["format_version"],
+        "value": {k: v for k, v in raw.items() if k not in {"packet_id", "packet_hash"}},
+    })
+
+
+def _assemble(
+    source: BaseModel,
+    satisfaction: PromotionHumanApprovalRequirementSatisfactionPacket,
+    decision: Any,
+    recorded_at: datetime,
+    *,
+    gate: bool,
+) -> dict[str, Any]:
+    decision = RequirementBindReviewDecision.model_validate(_json(decision))
+    reviewed = _timestamp(decision.reviewed_at)
+    recorded = _timestamp(recorded_at)
+    if not (
+        datetime.fromisoformat(source.recorded_at)
+        <= datetime.fromisoformat(reviewed)
+        <= datetime.fromisoformat(recorded)
+    ):
+        raise PromotionRequirementBindReviewError("PRBR_TIMESTAMP_ORDER")
+    decision = decision.model_copy(update={"reviewed_at": reviewed})
+    requirements = list(AUTHORIZATION_REQUIREMENTS)
+    if not satisfaction.required_human_approval:
+        requirements = [name for name in requirements if name not in {
+            "signed_gate_bound_human_approval_issuance",
+            "human_approval_receipt_verification",
+        }]
+    if not gate:
+        requirements.insert(0, "promotion_native_bind_authorization_gate_review")
+    sat = satisfaction.model_dump(mode="json")
+    resolution = sat["human_approval_requirement_resolution_packet"]
+    raw = {
+        "format_version": "promotion-requirement-bind-gate/v1" if gate
+        else "promotion-requirement-final-readiness/v1",
+        "recorded_at": recorded,
+        "review_decision": decision.model_dump(mode="json"),
+        "source_packet": source.model_dump(mode="json"),
+        "source_packet_id": source.packet_id,
+        "source_packet_hash": source.packet_hash,
+        **{name: sat[name] for name in (
+            "source_authority_evidence_linkage_review_id",
+            "source_authority_evidence_linkage_review_hash",
+            "action_contract_digest", "required_human_approval",
+            "requirement_state", "satisfaction_state", "execution_intent",
+            "execution_intent_id", "execution_intent_hash",
+            "human_approval_created", "human_approval_proven",
+            "authority_evidence_proven", "execution_authority_created",
+            "bind_authorization_created", "bind_invoked", "bind_receipt_created",
+            "credential_material_accessed", "network_used",
+            "external_effect_occurred", "ready_for_real_bind",
+        )},
+        "requirement_resolution_hash": resolution["human_approval_requirement_resolution_hash"],
+        "future_authorization_requirements": requirements,
+        "future_invocation_requirements": list(INVOCATION_REQUIREMENTS),
+        "fail_closed": not decision.accepted,
+        ("ready_for_fresh_verified_source_gate" if gate
+         else "ready_for_bind_authorization_gate_review"): decision.accepted,
+    }
+    digest = _packet_hash(raw)
+    return {**raw, "packet_hash": digest,
+            "packet_id": f"{raw['format_version']}:sha256:{digest}"}
+
+
+def build_promotion_requirement_final_readiness_packet(
+    satisfaction: Any, decision: Any, recorded_at: datetime, *,
+    expected_source: Any, expected_contract: ActionClassContract,
+) -> PromotionRequirementFinalReadinessPacket:
+    """Consume only satisfaction rebuilt against external source and policy."""
+    verified = verify_satisfaction(
+        satisfaction, expected_source=expected_source, expected_contract=expected_contract
+    )
+    return PromotionRequirementFinalReadinessPacket.model_validate(
+        _assemble(verified, verified, decision, recorded_at, gate=False)
+    )
+
+
+def verify_promotion_requirement_final_readiness_packet(
+    packet: Any, *, expected_source: Any, expected_contract: ActionClassContract,
+) -> PromotionRequirementFinalReadinessPacket:
+    """Reconstruct every field; embedded source/contract never supply anchors."""
+    candidate = PromotionRequirementFinalReadinessPacket.model_validate(_json(packet))
+    rebuilt = build_promotion_requirement_final_readiness_packet(
+        candidate.source_packet, candidate.review_decision,
+        datetime.fromisoformat(_timestamp(candidate.recorded_at)),
+        expected_source=expected_source, expected_contract=expected_contract,
+    )
+    if _json(candidate) != _json(rebuilt):
+        raise PromotionRequirementBindReviewError("PRBR_RECONSTRUCTION_MISMATCH")
+    return rebuilt
+
+
+def build_promotion_requirement_bind_gate_packet(
+    readiness: Any, decision: Any, recorded_at: datetime, *,
+    expected_source: Any, expected_contract: ActionClassContract,
+) -> PromotionRequirementBindGatePacket:
+    """Propagate independent anchors through readiness and satisfaction."""
+    verified = verify_promotion_requirement_final_readiness_packet(
+        readiness, expected_source=expected_source, expected_contract=expected_contract
+    )
+    if verified.fail_closed or not verified.ready_for_bind_authorization_gate_review:
+        raise PromotionRequirementBindReviewError("PRBR_READINESS_REJECTED")
+    satisfaction = verify_satisfaction(
+        verified.source_packet,
+        expected_source=expected_source, expected_contract=expected_contract,
+    )
+    return PromotionRequirementBindGatePacket.model_validate(
+        _assemble(verified, satisfaction, decision, recorded_at, gate=True)
+    )
+
+
+def verify_promotion_requirement_bind_gate_packet(
+    packet: Any, *, expected_source: Any, expected_contract: ActionClassContract,
+) -> PromotionRequirementBindGatePacket:
+    """Return only the gate rebuilt using the complete external trust chain."""
+    candidate = PromotionRequirementBindGatePacket.model_validate(_json(packet))
+    rebuilt = build_promotion_requirement_bind_gate_packet(
+        candidate.source_packet, candidate.review_decision,
+        datetime.fromisoformat(_timestamp(candidate.recorded_at)),
+        expected_source=expected_source, expected_contract=expected_contract,
+    )
+    if _json(candidate) != _json(rebuilt):
+        raise PromotionRequirementBindReviewError("PRBR_RECONSTRUCTION_MISMATCH")
+    return rebuilt

--- a/veritas_os/tests/test_promotion_requirement_bind_readiness.py
+++ b/veritas_os/tests/test_promotion_requirement_bind_readiness.py
@@ -1,0 +1,199 @@
+"""External trust anchors survive both native review stages and full rehashing."""
+
+from copy import deepcopy
+from dataclasses import replace
+from datetime import timedelta
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+import pytest
+
+from veritas_os.policy import promotion_requirement_bind_readiness as module
+from veritas_os.tests.test_promotion_human_approval_requirement_satisfaction import (
+    api_source as captured_api_source,
+    native as native_source,
+    _contract,
+    _link,
+    authority,
+    resolve,
+    satisfy,
+    sources,
+)
+
+pytestmark = pytest.mark.slow
+api_source = captured_api_source
+native = native_source
+
+
+def _decision(now, accepted=True):
+    return {
+        "review_id": "local-review:1",
+        "reviewer_id": "reviewer:alice",
+        "review_reason": "Review independently bound prerequisite evidence only.",
+        "reviewed_at": now.isoformat(),
+        "accepted": accepted,
+        "acknowledged_no_authorization": True,
+        "acknowledged_no_human_approval_proof": True,
+        "acknowledged_no_authority_evidence_proof": True,
+        "acknowledged_no_external_effect": True,
+        "acknowledged_independent_policy_binding": True,
+    }
+
+
+def _chain(source, contract, now):
+    resolution = resolve(source, contract, now)
+    sat = satisfy(
+        source, resolution, contract,
+        _link(source, now) if resolution.required_human_approval else None, now,
+    )
+    anchors = {"expected_source": source, "expected_contract": contract}
+    ready = module.build_promotion_requirement_final_readiness_packet(
+        sat, _decision(now), now, **anchors
+    )
+    gate = module.build_promotion_requirement_bind_gate_packet(
+        ready, _decision(now), now, **anchors
+    )
+    return ready, gate
+
+
+STAGES = (
+    (0, module.verify_promotion_requirement_final_readiness_packet),
+    (1, module.verify_promotion_requirement_bind_gate_packet),
+)
+
+
+@pytest.mark.parametrize("required", [False, True])
+@pytest.mark.parametrize("stage,verify", STAGES)
+def test_both_states_preserve_complete_source_and_return_rebuilt(native, required, stage, verify):
+    source, _, _, now = native
+    contract = _contract(required=required)
+    packet = _chain(source, contract, now)[stage]
+    result = verify(packet, expected_source=source, expected_contract=contract)
+    assert result == packet and result is not packet
+    assert result.required_human_approval is required
+    assert result.execution_intent == source.execution_intent
+    assert result.fail_closed is False
+    assert ("human_approval_receipt_verification" in result.future_authorization_requirements) is required
+    assert "fresh_verified_source_gate" in result.future_authorization_requirements
+    assert "single_use_consumption" in result.future_invocation_requirements
+    sat = result.source_packet if stage == 0 else result.source_packet["source_packet"]
+    assert sat["source_authority_evidence_linkage_review_packet"] == source.model_dump(mode="json")
+    assert (sat["required_human_approval_linkage_packet"] is not None) is required
+    for name in (
+        "human_approval_created", "human_approval_proven", "authority_evidence_proven",
+        "execution_authority_created", "bind_authorization_created", "bind_invoked",
+        "bind_receipt_created", "credential_material_accessed", "network_used",
+        "external_effect_occurred", "ready_for_real_bind",
+    ):
+        assert getattr(result, name) is False
+    schema = Path(__file__).resolve().parents[2] / "schemas" / (result.format_version.replace("/", "-") + ".schema.json")
+    Draft202012Validator(json.loads(schema.read_text())).validate(result.model_dump(mode="json"))
+
+
+@pytest.mark.parametrize("rules", [
+    {"required": False, "minimum_approvals": 0},
+    {"required": True, "minimum_approvals": 2},
+    {"required": True, "minimum_approvals": 1, "approver_role": "attacker"},
+])
+@pytest.mark.parametrize("stage,verify", STAGES)
+def test_entire_chain_rebuilt_with_same_id_version_contract_is_rejected(native, rules, stage, verify):
+    source, trusted, _, now = native
+    attacker = replace(trusted, human_approval_rules=rules)
+    assert (attacker.id, attacker.version) == (trusted.id, trusted.version)
+    forged = _chain(source, attacker, now)[stage]
+    with pytest.raises(ValueError):
+        verify(forged, expected_source=source, expected_contract=trusted)
+
+
+@pytest.mark.parametrize("stage,verify", STAGES)
+def test_entire_chain_rebuilt_for_substituted_source_is_rejected(native, stage, verify):
+    source, contract, _, now = native
+    bundle = source.authority_evidence_reference_bundle.model_dump(mode="json")
+    bundle["bundle_declared_by"] = "attacker"
+    other = authority(source.source_bind_pre_dispatch_review_packet, bundle, sources.RECORDED_AT)
+    forged = _chain(other, contract, now)[stage]
+    with pytest.raises(ValueError):
+        verify(forged, expected_source=source, expected_contract=contract)
+
+
+@pytest.mark.parametrize("field", [
+    "action_contract_digest", "source_authority_evidence_linkage_review_hash",
+    "requirement_resolution_hash", "required_human_approval",
+    "future_authorization_requirements", "execution_intent_hash", "fail_closed",
+])
+@pytest.mark.parametrize("stage,verify", STAGES)
+def test_rehashed_derived_fields_are_rejected(native, stage, verify, field):
+    source, contract, _, now = native
+    raw = _chain(source, contract, now)[stage].model_dump(mode="json")
+    raw[field] = not raw[field] if isinstance(raw[field], bool) else [] if isinstance(raw[field], list) else "0" * 64
+    raw["packet_hash"] = module._packet_hash(raw)
+    raw["packet_id"] = f"{raw['format_version']}:sha256:{raw['packet_hash']}"
+    with pytest.raises(ValueError, match="PRBR_RECONSTRUCTION_MISMATCH"):
+        verify(raw, expected_source=source, expected_contract=contract)
+
+
+@pytest.mark.parametrize("stage,verify", STAGES)
+@pytest.mark.parametrize("missing", ["expected_source", "expected_contract"])
+def test_independent_anchors_are_mandatory(native, stage, verify, missing):
+    source, contract, _, now = native
+    packet = _chain(source, contract, now)[stage]
+    anchors = {"expected_source": source, "expected_contract": contract}
+    del anchors[missing]
+    with pytest.raises(TypeError):
+        verify(packet, **anchors)
+    anchors[missing] = None
+    with pytest.raises(ValueError):
+        verify(packet, **anchors)
+
+
+def test_rejected_readiness_cannot_reach_gate(native):
+    source, contract, _, now = native
+    ready, _ = _chain(source, contract, now)
+    anchors = {"expected_source": source, "expected_contract": contract}
+    rejected = module.build_promotion_requirement_final_readiness_packet(
+        ready.source_packet, _decision(now, False), now, **anchors
+    )
+    assert module.verify_promotion_requirement_final_readiness_packet(rejected, **anchors).fail_closed
+    with pytest.raises(ValueError, match="PRBR_READINESS_REJECTED"):
+        module.build_promotion_requirement_bind_gate_packet(rejected, _decision(now), now, **anchors)
+    gate = module.build_promotion_requirement_bind_gate_packet(ready, _decision(now, False), now, **anchors)
+    assert module.verify_promotion_requirement_bind_gate_packet(gate, **anchors).fail_closed
+    assert not gate.ready_for_fresh_verified_source_gate
+
+
+@pytest.mark.parametrize("stage", [0, 1])
+@pytest.mark.parametrize("error", ["before_source", "before_review", "naive", "acknowledgement"])
+def test_invalid_review_or_timestamp_fails_closed(native, stage, error):
+    source, contract, _, now = native
+    ready, _ = _chain(source, contract, now)
+    decision = _decision(now)
+    recorded = now
+    if error == "before_source":
+        decision["reviewed_at"] = (now - timedelta(seconds=1)).isoformat()
+    elif error == "before_review":
+        recorded -= timedelta(seconds=1)
+    elif error == "naive":
+        decision["reviewed_at"] = now.replace(tzinfo=None).isoformat()
+    else:
+        decision["acknowledged_independent_policy_binding"] = False
+    builder = (module.build_promotion_requirement_final_readiness_packet,
+               module.build_promotion_requirement_bind_gate_packet)[stage]
+    with pytest.raises(ValueError):
+        builder(ready.source_packet if stage == 0 else ready, decision, recorded,
+                expected_source=source, expected_contract=contract)
+
+
+def test_real_authenticated_api_reaches_policy_bound_gate(api_source):
+    source, now, required = api_source
+    contract = _contract(action="post_synthetic_review", required=required)
+    before = deepcopy(source.model_dump(mode="json"))
+    _, gate = _chain(source, contract, now)
+    result = module.verify_promotion_requirement_bind_gate_packet(
+        gate, expected_source=source, expected_contract=contract
+    )
+    assert result.required_human_approval is required
+    assert result.execution_intent == source.execution_intent
+    assert result.ready_for_fresh_verified_source_gate
+    assert not result.ready_for_real_bind
+    assert source.model_dump(mode="json") == before


### PR DESCRIPTION
# Summary

Connect #2190 native requirement satisfaction to dedicated Final Readiness and Bind Gate review packets. Both REQUIRED and NOT_REQUIRED paths require independent source and ActionClassContract anchors throughout reconstruction.

## Scope

- Add requirement-aware readiness/gate builders, verifiers, and closed schemas.
- Propagate external anchors through Gate → Readiness → Satisfaction → HARR. Never substitute embedded source or policy snapshots.
- Derive downstream fields only from rebuilt, verified packets and preserve the complete native source chain.
- Reject failed readiness, invalid review acknowledgements, and invalid timestamp ordering.
- Retain conditional future approval requirements from the trusted resolution; all other execution prerequisites remain outstanding.
- Preserve existing linkage-only native v1 and legacy v0.3 APIs.

## Type of change

- [x] Runtime
- [x] Tests
- [x] Docs
- [x] Governance / security-sensitive

## Why this change matters

The existing linkage-only readiness path requires human linkage even when the independently verified contract says approval is not required. This dedicated path supports both states without fabricated approval metadata or relaxing the old schema. Fully rebuilt same-ID/version policy substitutions and source substitutions fail at both review boundaries.

## Market / developer / user value

- Market value: No production-execution claim.
- Developer value: Real authenticated /v1/decide reaches the new Gate with controlled model/cloud clients.
- User/operator value: Approval requirements remain bound to independently trusted policy across downstream reviews.

## Tests run

- [x] New related tests: **41 passed** (including both actual HTTP decision paths, schema validation, complete-chain adversarial rehashing, and fail-closed reviews).
- [x] Ruff, bilingual documentation checker, responsibility boundary checker, git diff --check.
- [x] Existing HARR, satisfaction, v0.3 issuance, real-decision boundary, and linkage-only native readiness/gate regression suite: **258 passed** (669.47s). Existing jsonschema/Pydantic deprecation warnings remain.
- [x] **299 related tests passed total**, across the new 41-test suite and 258-test regression suite.
- Full GitHub CI is still running: last check observed 26 successful checks and 9 running, no failures. This is not yet a full-CI pass.

## AI assistance used

- [x] Codex

## Review status

- [ ] CI passed
- [ ] Human maintainer reviewed

## Risk checklist

- [x] Touches bind/admissibility logic
- [x] Touches governance policy behavior

## Human approval required?

- [x] Yes

Reason: Security-sensitive source/policy binding. Draft PR only; do not merge automatically.

## Notes for reviewer

These are distinct requirement-aware packet formats. **Fresh Verified Source Gate, final endpoint/credential rechecks, and the authorization issuer do not yet consume the new Gate.** That integration and real-decision single-use execution/outcome validation remain work to complete.

Local review decisions are explicit metadata, not cryptographic human approval. These stages create no Human Approval Receipt, execution authority, Bind authorization, BindReceipt, credential access, network dispatch, or external effect. ready_for_real_bind remains false in every state.

Base: bf54f52d5618c10c5134410f7908e7bf88ae3a41 (#2190 merged).
Published source tree matches the tested local tree: ec6f77ef234c28f3c0858a916050c054ab735e2e.