### PR TITLE
feat: connect trusted approval gates to final metadata rechecks

### DIFF
--- a/docs/en/development/approval-requirement-source-verification.md
+++ b/docs/en/development/approval-requirement-source-verification.md
@@ -178,8 +178,44 @@ v0.3 APIs. Real authenticated `/v1/decide` tests reach the new Gate for both sta
 with controlled model/cloud clients. Fully rehashed source/policy substitutions
 under identical contract ID/version are rejected at both review boundaries.
 
-The new Gate is **not yet consumed by Fresh Verified Source Gate, final endpoint/
-credential rechecks, or the authorization issuer**. Wiring those consumers with
-independent anchors and validating real-decision single-use execution/outcomes
-remains required. No authorization, credential access, network dispatch, or
+The new Gate feeds the requirement-aware fresh verification and final rechecks
+described below. No authorization, credential access, network dispatch, or
 external effect is created by these review stages.
+
+## Fresh source verification and final metadata rechecks
+
+`promotion_requirement_final_rechecks` consumes the verified requirement-aware
+Gate without converting it into the older linkage-only packet format.
+`PromotionRequirementFreshSourcePacket` re-verifies the full Gate chain against
+independent source and contract inputs, then derives an exact Bind context
+committing the Gate hash, authority source, requirement resolution, contract,
+intent, adapter, endpoint and credential bindings. Its verifier also requires
+the independently supplied verification time. A failed Gate cannot enter.
+
+`PromotionRequirementFinalRecheckPacket` consumes this rebuilt fresh packet and
+compares caller-supplied current endpoint metadata, credential reference and
+required credential scope with the fully verified source. All metadata must
+match exactly; scope containment is never inferred. Its verifier requires the
+same independent anchors and current metadata, plus the expected recheck time.
+Embedded endpoint/reference/time fields cannot substitute for these inputs.
+Changing endpoint identity or credential scope rejects an otherwise valid old
+packet. Rehashed context, source, same-ID/version contract, or time substitutions
+are also rejected. Both verifiers return rebuilt results.
+
+The fresh packet consumes fresh verification and exact context derivation;
+the final packet consumes endpoint and credential rechecks in that order.
+Remaining authorization work begins with runtime risk review. Approval-related
+future requirements remain conditional on the verified ActionClassContract;
+invocation requirements remain unchanged and unsatisfied.
+
+These are local metadata checks. Fresh verification does not establish live
+policy freshness or revocation status. Endpoint recheck does not contact a
+server or verify a TLS peer. Credential recheck does not access a credential
+provider or prove that its actual permissions match its reference metadata.
+All such claims and `ready_for_real_bind` remain false.
+
+Real authenticated `/v1/decide` tests reach final metadata rechecks for both
+approval states with controlled model/cloud clients and explicit test metadata.
+The older native and legacy APIs remain unchanged. The **runtime-risk and
+authorization issuer consumers are not yet wired to these new packet formats**;
+real-decision single-use execution and outcome validation remain incomplete.

--- a/docs/ja/development/approval-requirement-source-verification.md
+++ b/docs/ja/development/approval-requirement-source-verification.md
@@ -140,7 +140,36 @@ Human Approval Receiptではありません。
 モデル・クラウドクライアントを制御した実際の認証済み`/v1/decide`から、新Gateまで両状態を
 テストします。同一契約ID／versionでsourceやpolicyを差し替え、全hashを作り直しても両境界で拒否します。
 
-新Gateは**Fresh Verified Source Gate、最終endpoint／credential再検査、authorization issuerには
-まだ接続されていません**。これらへの独立入力の伝播と、実decisionによる一回限りの実行・結果記録の
-統合検証が残っています。このレビュー処理は実行許可、credentialアクセス、network dispatch、
+新Gateは以下の承認要件対応fresh検証と最終再検査へ接続します。
+このレビュー処理は実行許可、credentialアクセス、network dispatch、
 external effectを作りません。
+
+## Fresh source検証と最終メタデータ再検査
+
+`promotion_requirement_final_rechecks`は承認要件対応Gateを受け取り、旧linkage専用packetへ
+変換しません。`PromotionRequirementFreshSourcePacket`は独立したsourceとcontractを使って
+Gateの完全なチェーンを再検証し、Gate hash、authority source、要件判定、契約、intent、adapter、
+endpoint、credential bindingを結び付けた厳密なBind contextを再計算します。
+verifierには独立した検証時刻も必要です。拒否されたGateは受け付けません。
+
+`PromotionRequirementFinalRecheckPacket`は再構築済みfresh packetを受け取り、呼び出し元が
+渡した現在のendpointメタデータ、credential参照、必要scopeを検証済みsourceと比較します。
+完全一致が必要であり、scopeの包含関係は推測しません。verifierには同じ独立入力と現在の
+メタデータ、および期待する再検査時刻が必須です。packet内のendpoint／参照／時刻を代用しません。
+endpointやscopeが変化していれば、以前は有効だったpacketも拒否します。context、source、
+同一ID／versionの契約、時刻を書き換えて再ハッシュした場合も拒否します。
+両verifierとも再構築した結果を返します。
+
+fresh packetではfresh検証と厳密なcontext導出を完了し、final packetではendpoint、credentialの
+順に再検査します。残るauthorization要件の先頭はruntime risk reviewです。人間承認に関する
+後続要件は検証済みActionClassContractによって決まり、実行要件は未充足のまま維持します。
+
+これはローカルのメタデータ検査です。fresh検証は実際のpolicy更新や失効状態を確認しません。
+endpoint再検査はサーバーへ接続せずTLS peerも検証しません。credential再検査はproviderへ
+アクセスせず、実際の権限と参照メタデータの一致も証明しません。これらのフラグと
+`ready_for_real_bind`はfalseのままです。
+
+モデル・クラウドクライアントを制御し、明示的なテスト用メタデータを使う実際の認証済み
+`/v1/decide`から、承認必須／不要の両方で最終メタデータ再検査まで接続します。
+旧native／legacy APIは変更しません。**runtime riskとauthorization issuerはまだ新packet形式を
+受け取れません**。実decisionによる一回限りの実行・結果記録までの統合検証は未完了です。

--- a/schemas/promotion-requirement-final-recheck-v1.schema.json
+++ b/schemas/promotion-requirement-final-recheck-v1.schema.json
@@ -1,0 +1,308 @@
+{
+  "$defs": {
+    "ExactRequirementBindContext": {
+      "additionalProperties": false,
+      "description": "Commit native identities and independent policy without legacy fields.",
+      "properties": {
+        "action_contract_digest": {
+          "title": "Action Contract Digest",
+          "type": "string"
+        },
+        "adapter_contract_hash": {
+          "title": "Adapter Contract Hash",
+          "type": "string"
+        },
+        "adapter_contract_id": {
+          "title": "Adapter Contract Id",
+          "type": "string"
+        },
+        "adapter_contract_version": {
+          "title": "Adapter Contract Version",
+          "type": "string"
+        },
+        "authority_source_hash": {
+          "title": "Authority Source Hash",
+          "type": "string"
+        },
+        "credential_authorization_result_digest": {
+          "title": "Credential Authorization Result Digest",
+          "type": "string"
+        },
+        "credential_policy_snapshot_hash": {
+          "title": "Credential Policy Snapshot Hash",
+          "type": "string"
+        },
+        "credential_reference_digest": {
+          "title": "Credential Reference Digest",
+          "type": "string"
+        },
+        "credential_scope_binding_digest": {
+          "title": "Credential Scope Binding Digest",
+          "type": "string"
+        },
+        "endpoint_candidate_digest": {
+          "title": "Endpoint Candidate Digest",
+          "type": "string"
+        },
+        "endpoint_identity_binding_digest": {
+          "title": "Endpoint Identity Binding Digest",
+          "type": "string"
+        },
+        "execution_intent_hash": {
+          "title": "Execution Intent Hash",
+          "type": "string"
+        },
+        "execution_intent_id": {
+          "title": "Execution Intent Id",
+          "type": "string"
+        },
+        "gate_packet_hash": {
+          "title": "Gate Packet Hash",
+          "type": "string"
+        },
+        "required_human_approval": {
+          "title": "Required Human Approval",
+          "type": "boolean"
+        },
+        "requirement_resolution_hash": {
+          "title": "Requirement Resolution Hash",
+          "type": "string"
+        }
+      },
+      "required": [
+        "gate_packet_hash",
+        "authority_source_hash",
+        "action_contract_digest",
+        "requirement_resolution_hash",
+        "required_human_approval",
+        "execution_intent_id",
+        "execution_intent_hash",
+        "adapter_contract_id",
+        "adapter_contract_hash",
+        "adapter_contract_version",
+        "endpoint_candidate_digest",
+        "endpoint_identity_binding_digest",
+        "credential_reference_digest",
+        "credential_scope_binding_digest",
+        "credential_policy_snapshot_hash",
+        "credential_authorization_result_digest"
+      ],
+      "title": "ExactRequirementBindContext",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false,
+  "description": "Exact local endpoint and credential checks against fresh bound context.",
+  "properties": {
+    "authority_evidence_proven": {
+      "const": false,
+      "title": "Authority Evidence Proven",
+      "type": "boolean"
+    },
+    "bind_authorization_created": {
+      "const": false,
+      "title": "Bind Authorization Created",
+      "type": "boolean"
+    },
+    "bind_context_hash": {
+      "title": "Bind Context Hash",
+      "type": "string"
+    },
+    "bind_invoked": {
+      "const": false,
+      "title": "Bind Invoked",
+      "type": "boolean"
+    },
+    "bind_receipt_created": {
+      "const": false,
+      "title": "Bind Receipt Created",
+      "type": "boolean"
+    },
+    "credential_material_accessed": {
+      "const": false,
+      "title": "Credential Material Accessed",
+      "type": "boolean"
+    },
+    "credential_provider_verified": {
+      "const": false,
+      "title": "Credential Provider Verified",
+      "type": "boolean"
+    },
+    "credential_scope_rechecked": {
+      "const": true,
+      "title": "Credential Scope Rechecked",
+      "type": "boolean"
+    },
+    "endpoint_rechecked": {
+      "const": true,
+      "title": "Endpoint Rechecked",
+      "type": "boolean"
+    },
+    "exact_bind_context": {
+      "$ref": "#/$defs/ExactRequirementBindContext"
+    },
+    "execution_authority_created": {
+      "const": false,
+      "title": "Execution Authority Created",
+      "type": "boolean"
+    },
+    "execution_intent": {
+      "additionalProperties": true,
+      "title": "Execution Intent",
+      "type": "object"
+    },
+    "external_effect_occurred": {
+      "const": false,
+      "title": "External Effect Occurred",
+      "type": "boolean"
+    },
+    "external_policy_freshness_verified": {
+      "const": false,
+      "title": "External Policy Freshness Verified",
+      "type": "boolean"
+    },
+    "fail_closed": {
+      "const": false,
+      "title": "Fail Closed",
+      "type": "boolean"
+    },
+    "format_version": {
+      "const": "promotion-requirement-final-recheck/v1",
+      "title": "Format Version",
+      "type": "string"
+    },
+    "future_authorization_requirements": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Future Authorization Requirements",
+      "type": "array"
+    },
+    "future_invocation_requirements": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Future Invocation Requirements",
+      "type": "array"
+    },
+    "human_approval_created": {
+      "const": false,
+      "title": "Human Approval Created",
+      "type": "boolean"
+    },
+    "human_approval_proven": {
+      "const": false,
+      "title": "Human Approval Proven",
+      "type": "boolean"
+    },
+    "network_used": {
+      "const": false,
+      "title": "Network Used",
+      "type": "boolean"
+    },
+    "packet_hash": {
+      "pattern": "^[0-9a-f]{64}$",
+      "title": "Packet Hash",
+      "type": "string"
+    },
+    "packet_id": {
+      "title": "Packet Id",
+      "type": "string"
+    },
+    "ready_for_real_bind": {
+      "const": false,
+      "title": "Ready For Real Bind",
+      "type": "boolean"
+    },
+    "rechecked_at": {
+      "title": "Rechecked At",
+      "type": "string"
+    },
+    "rechecked_credential_reference": {
+      "additionalProperties": true,
+      "title": "Rechecked Credential Reference",
+      "type": "object"
+    },
+    "rechecked_endpoint_candidate": {
+      "additionalProperties": true,
+      "title": "Rechecked Endpoint Candidate",
+      "type": "object"
+    },
+    "required_credential_scope": {
+      "title": "Required Credential Scope",
+      "type": "string"
+    },
+    "required_human_approval": {
+      "title": "Required Human Approval",
+      "type": "boolean"
+    },
+    "revocation_verified": {
+      "const": false,
+      "title": "Revocation Verified",
+      "type": "boolean"
+    },
+    "scope_containment_inferred": {
+      "const": false,
+      "title": "Scope Containment Inferred",
+      "type": "boolean"
+    },
+    "source_packet": {
+      "additionalProperties": true,
+      "title": "Source Packet",
+      "type": "object"
+    },
+    "source_packet_hash": {
+      "title": "Source Packet Hash",
+      "type": "string"
+    },
+    "source_packet_id": {
+      "title": "Source Packet Id",
+      "type": "string"
+    },
+    "tls_peer_verified": {
+      "const": false,
+      "title": "Tls Peer Verified",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "packet_id",
+    "packet_hash",
+    "source_packet",
+    "source_packet_id",
+    "source_packet_hash",
+    "exact_bind_context",
+    "bind_context_hash",
+    "execution_intent",
+    "required_human_approval",
+    "future_authorization_requirements",
+    "future_invocation_requirements",
+    "fail_closed",
+    "human_approval_created",
+    "human_approval_proven",
+    "authority_evidence_proven",
+    "execution_authority_created",
+    "bind_authorization_created",
+    "bind_invoked",
+    "bind_receipt_created",
+    "credential_material_accessed",
+    "network_used",
+    "external_effect_occurred",
+    "ready_for_real_bind",
+    "external_policy_freshness_verified",
+    "revocation_verified",
+    "tls_peer_verified",
+    "credential_provider_verified",
+    "format_version",
+    "rechecked_at",
+    "rechecked_endpoint_candidate",
+    "rechecked_credential_reference",
+    "required_credential_scope",
+    "endpoint_rechecked",
+    "credential_scope_rechecked",
+    "scope_containment_inferred"
+  ],
+  "title": "PromotionRequirementFinalRecheckPacket",
+  "type": "object",
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
+}

--- a/schemas/promotion-requirement-fresh-source-v1.schema.json
+++ b/schemas/promotion-requirement-fresh-source-v1.schema.json
@@ -1,0 +1,297 @@
+{
+  "$defs": {
+    "ExactRequirementBindContext": {
+      "additionalProperties": false,
+      "description": "Commit native identities and independent policy without legacy fields.",
+      "properties": {
+        "action_contract_digest": {
+          "title": "Action Contract Digest",
+          "type": "string"
+        },
+        "adapter_contract_hash": {
+          "title": "Adapter Contract Hash",
+          "type": "string"
+        },
+        "adapter_contract_id": {
+          "title": "Adapter Contract Id",
+          "type": "string"
+        },
+        "adapter_contract_version": {
+          "title": "Adapter Contract Version",
+          "type": "string"
+        },
+        "authority_source_hash": {
+          "title": "Authority Source Hash",
+          "type": "string"
+        },
+        "credential_authorization_result_digest": {
+          "title": "Credential Authorization Result Digest",
+          "type": "string"
+        },
+        "credential_policy_snapshot_hash": {
+          "title": "Credential Policy Snapshot Hash",
+          "type": "string"
+        },
+        "credential_reference_digest": {
+          "title": "Credential Reference Digest",
+          "type": "string"
+        },
+        "credential_scope_binding_digest": {
+          "title": "Credential Scope Binding Digest",
+          "type": "string"
+        },
+        "endpoint_candidate_digest": {
+          "title": "Endpoint Candidate Digest",
+          "type": "string"
+        },
+        "endpoint_identity_binding_digest": {
+          "title": "Endpoint Identity Binding Digest",
+          "type": "string"
+        },
+        "execution_intent_hash": {
+          "title": "Execution Intent Hash",
+          "type": "string"
+        },
+        "execution_intent_id": {
+          "title": "Execution Intent Id",
+          "type": "string"
+        },
+        "gate_packet_hash": {
+          "title": "Gate Packet Hash",
+          "type": "string"
+        },
+        "required_human_approval": {
+          "title": "Required Human Approval",
+          "type": "boolean"
+        },
+        "requirement_resolution_hash": {
+          "title": "Requirement Resolution Hash",
+          "type": "string"
+        }
+      },
+      "required": [
+        "gate_packet_hash",
+        "authority_source_hash",
+        "action_contract_digest",
+        "requirement_resolution_hash",
+        "required_human_approval",
+        "execution_intent_id",
+        "execution_intent_hash",
+        "adapter_contract_id",
+        "adapter_contract_hash",
+        "adapter_contract_version",
+        "endpoint_candidate_digest",
+        "endpoint_identity_binding_digest",
+        "credential_reference_digest",
+        "credential_scope_binding_digest",
+        "credential_policy_snapshot_hash",
+        "credential_authorization_result_digest"
+      ],
+      "title": "ExactRequirementBindContext",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false,
+  "description": "Full Gate reverification and exact context derivation at caller time.",
+  "properties": {
+    "authority_evidence_proven": {
+      "const": false,
+      "title": "Authority Evidence Proven",
+      "type": "boolean"
+    },
+    "bind_authorization_created": {
+      "const": false,
+      "title": "Bind Authorization Created",
+      "type": "boolean"
+    },
+    "bind_context_hash": {
+      "title": "Bind Context Hash",
+      "type": "string"
+    },
+    "bind_context_hash_derived": {
+      "const": true,
+      "title": "Bind Context Hash Derived",
+      "type": "boolean"
+    },
+    "bind_invoked": {
+      "const": false,
+      "title": "Bind Invoked",
+      "type": "boolean"
+    },
+    "bind_receipt_created": {
+      "const": false,
+      "title": "Bind Receipt Created",
+      "type": "boolean"
+    },
+    "credential_material_accessed": {
+      "const": false,
+      "title": "Credential Material Accessed",
+      "type": "boolean"
+    },
+    "credential_provider_verified": {
+      "const": false,
+      "title": "Credential Provider Verified",
+      "type": "boolean"
+    },
+    "credential_scope_rechecked": {
+      "const": false,
+      "title": "Credential Scope Rechecked",
+      "type": "boolean"
+    },
+    "endpoint_rechecked": {
+      "const": false,
+      "title": "Endpoint Rechecked",
+      "type": "boolean"
+    },
+    "exact_bind_context": {
+      "$ref": "#/$defs/ExactRequirementBindContext"
+    },
+    "execution_authority_created": {
+      "const": false,
+      "title": "Execution Authority Created",
+      "type": "boolean"
+    },
+    "execution_intent": {
+      "additionalProperties": true,
+      "title": "Execution Intent",
+      "type": "object"
+    },
+    "external_effect_occurred": {
+      "const": false,
+      "title": "External Effect Occurred",
+      "type": "boolean"
+    },
+    "external_policy_freshness_verified": {
+      "const": false,
+      "title": "External Policy Freshness Verified",
+      "type": "boolean"
+    },
+    "fail_closed": {
+      "const": false,
+      "title": "Fail Closed",
+      "type": "boolean"
+    },
+    "format_version": {
+      "const": "promotion-requirement-fresh-source/v1",
+      "title": "Format Version",
+      "type": "string"
+    },
+    "fresh_source_reverified": {
+      "const": true,
+      "title": "Fresh Source Reverified",
+      "type": "boolean"
+    },
+    "fresh_verified_at": {
+      "title": "Fresh Verified At",
+      "type": "string"
+    },
+    "future_authorization_requirements": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Future Authorization Requirements",
+      "type": "array"
+    },
+    "future_invocation_requirements": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Future Invocation Requirements",
+      "type": "array"
+    },
+    "human_approval_created": {
+      "const": false,
+      "title": "Human Approval Created",
+      "type": "boolean"
+    },
+    "human_approval_proven": {
+      "const": false,
+      "title": "Human Approval Proven",
+      "type": "boolean"
+    },
+    "network_used": {
+      "const": false,
+      "title": "Network Used",
+      "type": "boolean"
+    },
+    "packet_hash": {
+      "pattern": "^[0-9a-f]{64}$",
+      "title": "Packet Hash",
+      "type": "string"
+    },
+    "packet_id": {
+      "title": "Packet Id",
+      "type": "string"
+    },
+    "ready_for_real_bind": {
+      "const": false,
+      "title": "Ready For Real Bind",
+      "type": "boolean"
+    },
+    "required_human_approval": {
+      "title": "Required Human Approval",
+      "type": "boolean"
+    },
+    "revocation_verified": {
+      "const": false,
+      "title": "Revocation Verified",
+      "type": "boolean"
+    },
+    "source_packet": {
+      "additionalProperties": true,
+      "title": "Source Packet",
+      "type": "object"
+    },
+    "source_packet_hash": {
+      "title": "Source Packet Hash",
+      "type": "string"
+    },
+    "source_packet_id": {
+      "title": "Source Packet Id",
+      "type": "string"
+    },
+    "tls_peer_verified": {
+      "const": false,
+      "title": "Tls Peer Verified",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "packet_id",
+    "packet_hash",
+    "source_packet",
+    "source_packet_id",
+    "source_packet_hash",
+    "exact_bind_context",
+    "bind_context_hash",
+    "execution_intent",
+    "required_human_approval",
+    "future_authorization_requirements",
+    "future_invocation_requirements",
+    "fail_closed",
+    "human_approval_created",
+    "human_approval_proven",
+    "authority_evidence_proven",
+    "execution_authority_created",
+    "bind_authorization_created",
+    "bind_invoked",
+    "bind_receipt_created",
+    "credential_material_accessed",
+    "network_used",
+    "external_effect_occurred",
+    "ready_for_real_bind",
+    "external_policy_freshness_verified",
+    "revocation_verified",
+    "tls_peer_verified",
+    "credential_provider_verified",
+    "format_version",
+    "fresh_verified_at",
+    "fresh_source_reverified",
+    "bind_context_hash_derived",
+    "endpoint_rechecked",
+    "credential_scope_rechecked"
+  ],
+  "title": "PromotionRequirementFreshSourcePacket",
+  "type": "object",
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
+}

--- a/veritas_os/policy/promotion_requirement_final_rechecks.py
+++ b/veritas_os/policy/promotion_requirement_final_rechecks.py
@@ -1,0 +1,340 @@
+"""Reverify requirement-aware Gate and exact endpoint/credential metadata.
+
+Freshness means local verification at an independently supplied time, not a
+claim of live policy, revocation, TLS, or credential-provider verification.
+The caller supplies trusted source/policy and current reference metadata.
+No credential material, network access, authorization, or effect is produced.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from veritas_os.governance.action_contracts import ActionClassContract
+from veritas_os.policy.human_approval_requirement_resolution import _json, _timestamp
+from veritas_os.policy.promotion_requirement_bind_readiness import (
+    verify_promotion_requirement_bind_gate_packet as verify_gate,
+)
+from veritas_os.policy.canonical_promotion_live_adapter_dry_run_authority_evidence_linkage import (
+    verify_canonical_promotion_live_adapter_dry_run_authority_evidence_linkage_review_packet as verify_authority_source,
+)
+from veritas_os.policy.canonical_promotion_live_adapter_dry_run_final_endpoint_identity_recheck import (
+    _candidate as validate_endpoint,
+)
+from veritas_os.policy.canonical_promotion_live_adapter_dry_run_final_credential_scope_recheck import (
+    _reference as validate_reference,
+    _scope as validate_scope,
+)
+from veritas_os.security.hash import sha256_of_canonical_json
+
+CONTEXT_FIELDS = (
+    "execution_intent_id",
+    "execution_intent_hash",
+    "adapter_contract_id",
+    "adapter_contract_hash",
+    "adapter_contract_version",
+    "endpoint_candidate_digest",
+    "endpoint_identity_binding_digest",
+    "credential_reference_digest",
+    "credential_scope_binding_digest",
+    "credential_policy_snapshot_hash",
+    "credential_authorization_result_digest",
+)
+ABSENT_FIELDS = (
+    "human_approval_created",
+    "human_approval_proven",
+    "authority_evidence_proven",
+    "execution_authority_created",
+    "bind_authorization_created",
+    "bind_invoked",
+    "bind_receipt_created",
+    "credential_material_accessed",
+    "network_used",
+    "external_effect_occurred",
+    "ready_for_real_bind",
+)
+
+
+class PromotionRequirementRecheckError(ValueError):
+    """Invalid or mismatched independently supplied verification inputs."""
+
+
+class ExactRequirementBindContext(BaseModel):
+    """Commit native identities and independent policy without legacy fields."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+    gate_packet_hash: str
+    authority_source_hash: str
+    action_contract_digest: str
+    requirement_resolution_hash: str
+    required_human_approval: bool
+    execution_intent_id: str
+    execution_intent_hash: str
+    adapter_contract_id: str
+    adapter_contract_hash: str
+    adapter_contract_version: str
+    endpoint_candidate_digest: str
+    endpoint_identity_binding_digest: str
+    credential_reference_digest: str
+    credential_scope_binding_digest: str
+    credential_policy_snapshot_hash: str
+    credential_authorization_result_digest: str
+
+
+class _RecheckPacket(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+    packet_id: str
+    packet_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    source_packet: dict[str, Any]
+    source_packet_id: str
+    source_packet_hash: str
+    exact_bind_context: ExactRequirementBindContext
+    bind_context_hash: str
+    execution_intent: dict[str, Any]
+    required_human_approval: bool
+    future_authorization_requirements: list[str]
+    future_invocation_requirements: list[str]
+    fail_closed: Literal[False]
+    human_approval_created: Literal[False]
+    human_approval_proven: Literal[False]
+    authority_evidence_proven: Literal[False]
+    execution_authority_created: Literal[False]
+    bind_authorization_created: Literal[False]
+    bind_invoked: Literal[False]
+    bind_receipt_created: Literal[False]
+    credential_material_accessed: Literal[False]
+    network_used: Literal[False]
+    external_effect_occurred: Literal[False]
+    ready_for_real_bind: Literal[False]
+    external_policy_freshness_verified: Literal[False]
+    revocation_verified: Literal[False]
+    tls_peer_verified: Literal[False]
+    credential_provider_verified: Literal[False]
+
+
+class PromotionRequirementFreshSourcePacket(_RecheckPacket):
+    """Full Gate reverification and exact context derivation at caller time."""
+
+    format_version: Literal["promotion-requirement-fresh-source/v1"]
+    fresh_verified_at: str
+    fresh_source_reverified: Literal[True]
+    bind_context_hash_derived: Literal[True]
+    endpoint_rechecked: Literal[False]
+    credential_scope_rechecked: Literal[False]
+
+
+class PromotionRequirementFinalRecheckPacket(_RecheckPacket):
+    """Exact local endpoint and credential checks against fresh bound context."""
+
+    format_version: Literal["promotion-requirement-final-recheck/v1"]
+    rechecked_at: str
+    rechecked_endpoint_candidate: dict[str, Any]
+    rechecked_credential_reference: dict[str, Any]
+    required_credential_scope: str
+    endpoint_rechecked: Literal[True]
+    credential_scope_rechecked: Literal[True]
+    scope_containment_inferred: Literal[False]
+
+
+def _digest(domain: str, value: Any) -> str:
+    return sha256_of_canonical_json({"domain": domain, "value": _json(value)})
+
+
+def _packet_hash(raw: dict[str, Any]) -> str:
+    return _digest(
+        "veritas." + raw["format_version"],
+        {k: v for k, v in raw.items() if k not in {"packet_id", "packet_hash"}},
+    )
+
+
+def _seal(raw: dict[str, Any]) -> dict[str, Any]:
+    digest = _packet_hash(raw)
+    return {
+        **raw,
+        "packet_hash": digest,
+        "packet_id": f"{raw['format_version']}:sha256:{digest}",
+    }
+
+
+def _ordered(*timestamps: Any) -> None:
+    times = [datetime.fromisoformat(_timestamp(value)) for value in timestamps]
+    if any(left > right for left, right in zip(times, times[1:], strict=False)):
+        raise PromotionRequirementRecheckError("PRRC_TIMESTAMP_ORDER")
+
+
+def _remaining(requirements: list[str], completed: tuple[str, ...]) -> list[str]:
+    if requirements[: len(completed)] != list(completed):
+        raise PromotionRequirementRecheckError("PRRC_REQUIREMENT_ORDER")
+    return requirements[len(completed) :]
+
+
+def _common(source: Any, context: ExactRequirementBindContext) -> dict[str, Any]:
+    return {
+        "source_packet": source.model_dump(mode="json"),
+        "source_packet_id": source.packet_id,
+        "source_packet_hash": source.packet_hash,
+        "exact_bind_context": context.model_dump(mode="json"),
+        "bind_context_hash": _digest(
+            "veritas.requirement-exact-bind-context/v1", context
+        ),
+        "execution_intent": source.execution_intent,
+        "required_human_approval": source.required_human_approval,
+        "future_invocation_requirements": source.future_invocation_requirements,
+        "fail_closed": False,
+        **{name: getattr(source, name) for name in ABSENT_FIELDS},
+        "external_policy_freshness_verified": False,
+        "revocation_verified": False,
+        "tls_peer_verified": False,
+        "credential_provider_verified": False,
+    }
+
+
+def build_promotion_requirement_fresh_source_packet(
+    gate: Any,
+    fresh_verified_at: datetime,
+    *,
+    expected_source: Any,
+    expected_contract: ActionClassContract,
+) -> PromotionRequirementFreshSourcePacket:
+    """Reverify Gate using external anchors and derive its exact Bind context."""
+    verified = verify_gate(
+        gate, expected_source=expected_source, expected_contract=expected_contract
+    )
+    if verified.fail_closed or not verified.ready_for_fresh_verified_source_gate:
+        raise PromotionRequirementRecheckError("PRRC_GATE_REJECTED")
+    source = verify_authority_source(expected_source)
+    _ordered(verified.recorded_at, fresh_verified_at)
+    context = ExactRequirementBindContext(
+        gate_packet_hash=verified.packet_hash,
+        authority_source_hash=verified.source_authority_evidence_linkage_review_hash,
+        action_contract_digest=verified.action_contract_digest,
+        requirement_resolution_hash=verified.requirement_resolution_hash,
+        required_human_approval=verified.required_human_approval,
+        **{name: getattr(source, name) for name in CONTEXT_FIELDS},
+    )
+    return PromotionRequirementFreshSourcePacket.model_validate(
+        _seal(
+            {
+                **_common(verified, context),
+                "format_version": "promotion-requirement-fresh-source/v1",
+                "fresh_verified_at": _timestamp(fresh_verified_at),
+                "future_authorization_requirements": _remaining(
+                    verified.future_authorization_requirements,
+                    (
+                        "fresh_verified_source_gate",
+                        "exact_bind_context_hash_derivation",
+                    ),
+                ),
+                "fresh_source_reverified": True,
+                "bind_context_hash_derived": True,
+                "endpoint_rechecked": False,
+                "credential_scope_rechecked": False,
+            }
+        )
+    )
+
+
+def verify_promotion_requirement_fresh_source_packet(
+    packet: Any,
+    *,
+    expected_source: Any,
+    expected_contract: ActionClassContract,
+    expected_verified_at: datetime,
+) -> PromotionRequirementFreshSourcePacket:
+    """Return reconstruction against external source, policy, and time."""
+    candidate = PromotionRequirementFreshSourcePacket.model_validate(_json(packet))
+    rebuilt = build_promotion_requirement_fresh_source_packet(
+        candidate.source_packet,
+        expected_verified_at,
+        expected_source=expected_source,
+        expected_contract=expected_contract,
+    )
+    if _json(candidate) != _json(rebuilt):
+        raise PromotionRequirementRecheckError("PRRC_RECONSTRUCTION_MISMATCH")
+    return rebuilt
+
+
+def build_promotion_requirement_final_recheck_packet(
+    fresh: Any,
+    rechecked_at: datetime,
+    *,
+    expected_source: Any,
+    expected_contract: ActionClassContract,
+    expected_verified_at: datetime,
+    current_endpoint: Any,
+    current_credential_reference: Any,
+    required_credential_scope: str,
+) -> PromotionRequirementFinalRecheckPacket:
+    """Compare external current metadata exactly; never resolve credentials."""
+    verified = verify_promotion_requirement_fresh_source_packet(
+        fresh,
+        expected_source=expected_source,
+        expected_contract=expected_contract,
+        expected_verified_at=expected_verified_at,
+    )
+    source = verify_authority_source(expected_source)
+    endpoint = validate_endpoint(current_endpoint)
+    reference = validate_reference(current_credential_reference)
+    scope = validate_scope(required_credential_scope)
+    if endpoint.model_dump(mode="json") != _json(source.endpoint_candidate):
+        raise PromotionRequirementRecheckError("PRRC_ENDPOINT_MISMATCH")
+    if reference.model_dump(mode="json") != _json(source.credential_reference):
+        raise PromotionRequirementRecheckError("PRRC_CREDENTIAL_MISMATCH")
+    if scope != reference.credential_scope:
+        raise PromotionRequirementRecheckError("PRRC_SCOPE_MISMATCH")
+    _ordered(verified.fresh_verified_at, rechecked_at)
+    _ordered(endpoint.declared_at, rechecked_at)
+    _ordered(reference.declared_at, rechecked_at)
+    return PromotionRequirementFinalRecheckPacket.model_validate(
+        _seal(
+            {
+                **_common(verified, verified.exact_bind_context),
+                "format_version": "promotion-requirement-final-recheck/v1",
+                "rechecked_at": _timestamp(rechecked_at),
+                "rechecked_endpoint_candidate": endpoint.model_dump(mode="json"),
+                "rechecked_credential_reference": reference.model_dump(mode="json"),
+                "required_credential_scope": scope,
+                "future_authorization_requirements": _remaining(
+                    verified.future_authorization_requirements,
+                    (
+                        "final_endpoint_identity_recheck",
+                        "final_credential_scope_recheck",
+                    ),
+                ),
+                "endpoint_rechecked": True,
+                "credential_scope_rechecked": True,
+                "scope_containment_inferred": False,
+            }
+        )
+    )
+
+
+def verify_promotion_requirement_final_recheck_packet(
+    packet: Any,
+    *,
+    expected_source: Any,
+    expected_contract: ActionClassContract,
+    expected_verified_at: datetime,
+    expected_rechecked_at: datetime,
+    current_endpoint: Any,
+    current_credential_reference: Any,
+    required_credential_scope: str,
+) -> PromotionRequirementFinalRecheckPacket:
+    """Rebuild all fields without treating embedded recheck values as current."""
+    candidate = PromotionRequirementFinalRecheckPacket.model_validate(_json(packet))
+    rebuilt = build_promotion_requirement_final_recheck_packet(
+        candidate.source_packet,
+        expected_rechecked_at,
+        expected_source=expected_source,
+        expected_contract=expected_contract,
+        expected_verified_at=expected_verified_at,
+        current_endpoint=current_endpoint,
+        current_credential_reference=current_credential_reference,
+        required_credential_scope=required_credential_scope,
+    )
+    if _json(candidate) != _json(rebuilt):
+        raise PromotionRequirementRecheckError("PRRC_RECONSTRUCTION_MISMATCH")
+    return rebuilt

--- a/veritas_os/tests/test_promotion_requirement_final_rechecks.py
+++ b/veritas_os/tests/test_promotion_requirement_final_rechecks.py
@@ -1,0 +1,357 @@
+"""Independent policy, time, endpoint and credential anchors at final recheck."""
+
+from copy import deepcopy
+from dataclasses import replace
+from datetime import timedelta
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+import pytest
+
+from veritas_os.policy import promotion_requirement_final_rechecks as module
+from veritas_os.policy import promotion_requirement_bind_readiness as reviews
+from veritas_os.tests.test_promotion_requirement_bind_readiness import _chain, _decision
+from veritas_os.tests.test_promotion_human_approval_requirement_satisfaction import (
+    api_source as captured_api_source,
+    native as native_source,
+    _contract,
+    authority,
+    sources,
+)
+
+pytestmark = pytest.mark.slow
+api_source = captured_api_source
+native = native_source
+
+
+def _inputs(source, contract, now):
+    reference = deepcopy(source.credential_reference)
+    return {
+        "expected_source": source,
+        "expected_contract": contract,
+        "expected_verified_at": now,
+        "current_endpoint": deepcopy(source.endpoint_candidate),
+        "current_credential_reference": reference,
+        "required_credential_scope": reference["credential_scope"],
+    }
+
+
+def _complete(source, contract, now):
+    _, gate = _chain(source, contract, now)
+    fresh = module.build_promotion_requirement_fresh_source_packet(
+        gate, now, expected_source=source, expected_contract=contract
+    )
+    inputs = _inputs(source, contract, now)
+    final = module.build_promotion_requirement_final_recheck_packet(
+        fresh, now, **inputs
+    )
+    return gate, fresh, final, inputs
+
+
+@pytest.fixture(scope="module")
+def complete(native):
+    source, contract, _, now = native
+    return _complete(source, contract, now)
+
+
+def _verify(stage, packet, inputs):
+    if stage == "fresh":
+        return module.verify_promotion_requirement_fresh_source_packet(
+            packet,
+            **{
+                k: inputs[k]
+                for k in (
+                    "expected_source",
+                    "expected_contract",
+                    "expected_verified_at",
+                )
+            },
+        )
+    return module.verify_promotion_requirement_final_recheck_packet(
+        packet, expected_rechecked_at=inputs["expected_verified_at"], **inputs
+    )
+
+
+@pytest.mark.parametrize("required", [False, True])
+def test_both_approval_states_reach_exact_final_rechecks(native, complete, required):
+    source, _, _, now = native
+    gate, fresh, final, inputs = (
+        complete if required else _complete(source, _contract(required=False), now)
+    )
+    for stage, packet in (("fresh", fresh), ("final", final)):
+        verified = _verify(stage, packet.model_dump(mode="json"), inputs)
+        assert verified == packet and verified is not packet
+        assert verified.required_human_approval is required
+        assert verified.execution_intent == source.execution_intent
+        for name in (
+            *module.ABSENT_FIELDS,
+            "external_policy_freshness_verified",
+            "revocation_verified",
+            "tls_peer_verified",
+            "credential_provider_verified",
+        ):
+            assert getattr(verified, name) is False
+        schema = (
+            Path(__file__).resolve().parents[2]
+            / "schemas"
+            / (packet.format_version.replace("/", "-") + ".schema.json")
+        )
+        Draft202012Validator(json.loads(schema.read_text())).validate(
+            verified.model_dump(mode="json")
+        )
+    assert fresh.source_packet == gate.model_dump(mode="json")
+    assert final.source_packet == fresh.model_dump(mode="json")
+    assert final.bind_context_hash == fresh.bind_context_hash
+    assert final.exact_bind_context == fresh.exact_bind_context
+    assert final.exact_bind_context.gate_packet_hash == gate.packet_hash
+    assert fresh.future_authorization_requirements[:2] == [
+        "final_endpoint_identity_recheck",
+        "final_credential_scope_recheck",
+    ]
+    assert final.future_authorization_requirements[0] == "runtime_risk_review"
+    assert (
+        "human_approval_receipt_verification" in final.future_authorization_requirements
+    ) is required
+    assert final.future_invocation_requirements == gate.future_invocation_requirements
+    assert final.endpoint_rechecked and final.credential_scope_rechecked
+
+
+@pytest.mark.parametrize(
+    "rules",
+    [
+        {"required": False, "minimum_approvals": 0},
+        {"required": True, "minimum_approvals": 2},
+        {"required": True, "minimum_approvals": 1, "approver_role": "attacker"},
+    ],
+)
+def test_full_chain_rehash_cannot_replace_same_id_version_contract(native, rules):
+    source, trusted, _, now = native
+    attacker = replace(trusted, human_approval_rules=rules)
+    assert (attacker.id, attacker.version) == (trusted.id, trusted.version)
+    _, fresh, final, inputs = _complete(source, attacker, now)
+    inputs["expected_contract"] = trusted
+    for stage, packet in (("fresh", fresh), ("final", final)):
+        with pytest.raises(ValueError):
+            _verify(stage, packet, inputs)
+
+
+def test_full_chain_rehash_cannot_replace_external_source(native):
+    source, contract, _, now = native
+    bundle = source.authority_evidence_reference_bundle.model_dump(mode="json")
+    bundle["bundle_declared_by"] = "attacker"
+    other = authority(
+        source.source_bind_pre_dispatch_review_packet, bundle, sources.RECORDED_AT
+    )
+    _, fresh, final, inputs = _complete(other, contract, now)
+    inputs["expected_source"] = source
+    for stage, packet in (("fresh", fresh), ("final", final)):
+        with pytest.raises(ValueError):
+            _verify(stage, packet, inputs)
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "endpoint_candidate_id",
+        "adapter_contract_id",
+        "target_system",
+        "target_resource_scope",
+        "declared_by",
+    ],
+)
+def test_current_endpoint_drift_rejects_previously_valid_packet(complete, field):
+    _, fresh, final, original = complete
+    inputs = dict(original)
+    inputs["current_endpoint"] = {**original["current_endpoint"], field: "changed"}
+    with pytest.raises(ValueError):
+        _verify("final", final, inputs)
+    with pytest.raises(ValueError):
+        module.build_promotion_requirement_final_recheck_packet(
+            fresh, inputs["expected_verified_at"], **inputs
+        )
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("endpoint_kind", "changed"),
+        ("endpoint_scheme", "http"),
+        ("endpoint_host", "changed.invalid"),
+        ("endpoint_port", 4444),
+        ("endpoint_path_prefix", "/changed"),
+        ("endpoint_environment", "changed"),
+        ("endpoint_purpose", "changed"),
+    ],
+)
+def test_current_endpoint_transport_change_fails(complete, field, value):
+    _, _, final, original = complete
+    assert original["current_endpoint"][field] != value
+    inputs = {
+        **original,
+        "current_endpoint": {**original["current_endpoint"], field: value},
+    }
+    with pytest.raises(ValueError, match="PRRC_ENDPOINT_MISMATCH"):
+        _verify("final", final, inputs)
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "credential_reference_id",
+        "credential_kind",
+        "credential_provider_type",
+        "credential_scope",
+        "credential_environment",
+        "credential_purpose",
+        "adapter_contract_id",
+        "endpoint_candidate_id",
+        "target_system",
+        "target_resource_scope",
+    ],
+)
+def test_current_credential_drift_rejects_previously_valid_packet(complete, field):
+    _, _, final, original = complete
+    inputs = dict(original)
+    inputs["current_credential_reference"] = {
+        **original["current_credential_reference"],
+        field: "changed",
+    }
+    with pytest.raises(ValueError, match="PRRC_CREDENTIAL_MISMATCH"):
+        _verify("final", final, inputs)
+
+
+@pytest.mark.parametrize("scope", ["*", "read", "write", "", None])
+def test_exact_required_scope_never_infers_containment(complete, scope):
+    _, _, final, inputs = complete
+    with pytest.raises(ValueError):
+        _verify("final", final, {**inputs, "required_credential_scope": scope})
+
+
+@pytest.mark.parametrize(
+    "missing",
+    [
+        "expected_source",
+        "expected_contract",
+        "expected_verified_at",
+        "expected_rechecked_at",
+        "current_endpoint",
+        "current_credential_reference",
+        "required_credential_scope",
+    ],
+)
+def test_final_verifier_requires_every_independent_input(complete, missing):
+    _, _, final, original = complete
+    inputs = {**original, "expected_rechecked_at": original["expected_verified_at"]}
+    del inputs[missing]
+    with pytest.raises(TypeError):
+        module.verify_promotion_requirement_final_recheck_packet(final, **inputs)
+    inputs[missing] = None
+    with pytest.raises(ValueError):
+        module.verify_promotion_requirement_final_recheck_packet(final, **inputs)
+
+
+@pytest.mark.parametrize("stage", ["fresh", "final"])
+@pytest.mark.parametrize(
+    "field",
+    [
+        "required_human_approval",
+        "bind_context_hash",
+        "source_packet_hash",
+        "future_authorization_requirements",
+        "execution_intent",
+    ],
+)
+def test_rehashed_derived_fields_fail_closed(complete, stage, field):
+    _, fresh, final, inputs = complete
+    raw = (fresh if stage == "fresh" else final).model_dump(mode="json")
+    raw[field] = (
+        False
+        if isinstance(raw[field], bool)
+        else []
+        if isinstance(raw[field], list)
+        else {}
+        if isinstance(raw[field], dict)
+        else "0" * 64
+    )
+    raw = module._seal(raw)
+    with pytest.raises(ValueError, match="PRRC_RECONSTRUCTION_MISMATCH"):
+        _verify(stage, raw, inputs)
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "action_contract_digest",
+        "credential_scope_binding_digest",
+        "endpoint_identity_binding_digest",
+    ],
+)
+def test_rehashed_bind_context_cannot_replace_verified_bindings(complete, field):
+    _, _, final, inputs = complete
+    raw = final.model_dump(mode="json")
+    raw["exact_bind_context"][field] = "0" * 64
+    raw["bind_context_hash"] = module._digest(
+        "veritas.requirement-exact-bind-context/v1", raw["exact_bind_context"]
+    )
+    with pytest.raises(ValueError, match="PRRC_RECONSTRUCTION_MISMATCH"):
+        _verify("final", module._seal(raw), inputs)
+
+
+@pytest.mark.parametrize("field", ["fresh_verified_at", "rechecked_at"])
+def test_rehashed_time_is_bound_to_external_time(complete, field):
+    _, fresh, final, inputs = complete
+    stage = "fresh" if field == "fresh_verified_at" else "final"
+    raw = (fresh if stage == "fresh" else final).model_dump(mode="json")
+    raw[field] = (inputs["expected_verified_at"] + timedelta(seconds=1)).isoformat()
+    with pytest.raises(ValueError):
+        _verify(stage, module._seal(raw), inputs)
+
+
+def test_rejected_gate_and_backwards_or_naive_times_fail(complete):
+    gate, fresh, _, inputs = complete
+    now = inputs["expected_verified_at"]
+    anchors = {k: inputs[k] for k in ("expected_source", "expected_contract")}
+    rejected = reviews.build_promotion_requirement_bind_gate_packet(
+        gate.source_packet, _decision(now, False), now, **anchors
+    )
+    with pytest.raises(ValueError, match="PRRC_GATE_REJECTED"):
+        module.build_promotion_requirement_fresh_source_packet(rejected, now, **anchors)
+    for invalid in (now - timedelta(seconds=1), now.replace(tzinfo=None)):
+        with pytest.raises(ValueError):
+            module.build_promotion_requirement_fresh_source_packet(
+                gate, invalid, **anchors
+            )
+        with pytest.raises(ValueError):
+            module.build_promotion_requirement_final_recheck_packet(
+                fresh, invalid, **inputs
+            )
+
+
+@pytest.mark.parametrize("key", ["current_endpoint", "current_credential_reference"])
+def test_sensitive_metadata_is_rejected(complete, key):
+    _, _, final, original = complete
+    inputs = {
+        **original,
+        key: {**original[key], "authorization": "test-only-forbidden"},
+    }
+    with pytest.raises(ValueError):
+        _verify("final", final, inputs)
+
+
+def test_requirement_order_helper_rejects_skipped_checks():
+    with pytest.raises(ValueError, match="PRRC_REQUIREMENT_ORDER"):
+        module._remaining(["runtime_risk_review"], ("final_credential_scope_recheck",))
+
+
+def test_real_authenticated_decision_reaches_final_metadata_rechecks(api_source):
+    source, now, required = api_source
+    before = source.model_dump(mode="json")
+    contract = _contract(action="post_synthetic_review", required=required)
+    _, _, final, inputs = _complete(source, contract, now)
+    verified = _verify("final", final, inputs)
+    assert verified.execution_intent == source.execution_intent
+    assert verified.required_human_approval is required
+    assert verified.endpoint_rechecked and verified.credential_scope_rechecked
+    assert not verified.ready_for_real_bind
+    assert source.model_dump(mode="json") == before


### PR DESCRIPTION
# Summary

Connect the requirement-aware Gate from #2191 to fresh source verification, exact Bind context derivation, and final endpoint/credential metadata rechecks. Preserve independent source and ActionClassContract anchors through the complete verifier chain for both approval states.

## Scope

- Add two closed packet formats: requirement-aware fresh source/context and final metadata recheck.
- Reverify Gate → Readiness → Satisfaction → HARR against external trusted source and contract; use only rebuilt results.
- Commit Gate/source/policy/requirement/intent/adapter/endpoint/credential bindings into the exact context hash.
- Require independent current endpoint metadata, credential reference, required scope, verification time, and recheck time. Embedded values cannot substitute for these inputs.
- Reject failed Gate, backwards/naive times, full-chain rehashed source/policy substitutions, context tampering, endpoint drift, credential drift, and inferred scope containment.
- Preserve conditional human approval requirements and leave runtime risk review and later authorization/invocation requirements outstanding.
- Keep older native and legacy APIs unchanged; document the new boundary in English and Japanese.

## Type of change

- [x] Runtime
- [x] Tests
- [x] Docs
- [x] Governance / security-sensitive

## Why this change matters

A valid earlier Gate must not permit a packet to provide its own current endpoint, credential scope, or policy trust anchor. Final verification reconstructs the complete result using caller-supplied trusted inputs. The native NOT_REQUIRED path needs no invented human approval evidence.

## Market / developer / user value

- Market value: No production-execution claim.
- Developer value: Real authenticated /v1/decide reaches final metadata rechecks in both approval states.
- User/operator value: Changed endpoint or credential reference metadata invalidates an otherwise valid old packet.

## Tests run

- [x] **163 distinct related tests passed**: 61 new (54 main cases plus 7 endpoint transport cases), 102 existing regression cases.
- [x] Existing requirement-aware Gate, v0.3 issuance trust, HARR integration, legacy satisfaction, and selected old fresh-source/endpoint/credential regression cases.
- [x] Actual authenticated /v1/decide integration for REQUIRED and NOT_REQUIRED, with controlled model/cloud clients and explicit synthetic reference metadata.
- [x] Both serialized packet schemas validated.
- [x] Final-source focused coverage rerun: 9 passed; **100% statement coverage** of the new module, 130 statements, 90% gate passed.
- [x] Ruff, bilingual documentation checker, responsibility boundary checker, git diff --check.
- Full GitHub CI pending. Existing deprecation warnings and a NumPy reload warning occurred in test infrastructure.

## AI assistance used

- [x] Codex

## Review status

- [ ] CI passed
- [ ] Human maintainer reviewed

## Risk checklist

- [x] Touches bind/admissibility logic
- [x] Touches governance policy behavior

## Human approval required?

- [x] Yes

Reason: Security-sensitive source/policy/context verification. Draft only; no automatic merge.

## Notes for reviewer

These are local, exact metadata checks. They do **not** verify live policy freshness, revocation, TLS peers, or actual credential-provider permissions. Those claims remain false, as does ready_for_real_bind. The new boundary creates no Human Approval Receipt, execution authority, Bind authorization, BindReceipt, credential access, network dispatch, or external effect. No benchmark ground truth drives the checks.

Fresh verification also derives the exact context. The final packet checks endpoint first, then credential metadata/scope, and preserves the frozen context. Its remaining authorization requirements begin with runtime_risk_review.

**Remaining integration:** runtime-risk and authorization issuer consumers do not yet accept these new packet formats. Independent anchors must be propagated there before real-decision single-use execution and outcome lineage can be claimed.

Base: b3a21f6b03a8a5a7a07409eb664ff9493b7d17c0 (#2191 merged).
Published tree matches the final local source: f776e4cc12f35340aef814554cebb73288b0605d.