### PR TITLE
feat: connect verified requirement rechecks to runtime risk review

### DIFF
--- a/docs/en/development/approval-requirement-source-verification.md
+++ b/docs/en/development/approval-requirement-source-verification.md
@@ -216,6 +216,38 @@ All such claims and `ready_for_real_bind` remain false.
 
 Real authenticated `/v1/decide` tests reach final metadata rechecks for both
 approval states with controlled model/cloud clients and explicit test metadata.
-The older native and legacy APIs remain unchanged. The **runtime-risk and
-authorization issuer consumers are not yet wired to these new packet formats**;
+The older native and legacy APIs remain unchanged. The requirement-aware
+runtime-risk boundary below consumes the final packet. Authorization issuance,
 real-decision single-use execution and outcome validation remain incomplete.
+
+## Runtime-risk review from verified final rechecks
+
+`promotion_requirement_runtime_risk` re-verifies the complete independently
+supplied final recheck using trusted source/contract, current endpoint/credential
+metadata, required scope, and expected verification/recheck times. Its compact
+packet references the exact source hash, Bind context, policy and intent.
+The full source is required separately for verification; it is not embedded.
+
+The review must bind that exact source/context/contract and the intent's expected
+state fingerprint. The existing runtime-risk evaluator is shared with the older
+native path: negative risk or state drift blocks; missing risk, state evidence,
+or TTL is indeterminate and fail-closed. The review window is at most 300 seconds
+and must fit within the intent's TTL for PASS. Verification also requires an
+independent expected risk decision, expected record time, and current time;
+an unchanged packet is rejected at or after review expiry. Embedded review
+evidence cannot replace the external expected decision.
+
+`require_promotion_requirement_runtime_risk_pass` returns only rebuilt PASS
+results and rejects BLOCK or INDETERMINATE before later composition. Only PASS
+consumes the runtime-risk requirement. Other authorization and all invocation
+requirements remain outstanding, including the independent Bind-time risk check.
+The actual authorization issuer does not yet call this guard.
+
+Risk signals, observed state and evidence references are caller-supplied inputs,
+not authenticated sensor results. This boundary neither obtains nor invents
+them. Real authenticated API tests explicitly supply TTL and synthetic state
+at the supported promotion boundary for PASS cases, without editing returned
+CDA/candidate data; cases without that metadata remain indeterminate. Controlled
+model/cloud clients and synthetic runtime observations are test fixtures only.
+No Human Approval Receipt, execution authority, Bind authorization, credential
+access, network dispatch, BindReceipt, or external effect is produced.

--- a/docs/ja/development/approval-requirement-source-verification.md
+++ b/docs/ja/development/approval-requirement-source-verification.md
@@ -171,5 +171,30 @@ endpoint再検査はサーバーへ接続せずTLS peerも検証しません。c
 
 モデル・クラウドクライアントを制御し、明示的なテスト用メタデータを使う実際の認証済み
 `/v1/decide`から、承認必須／不要の両方で最終メタデータ再検査まで接続します。
-旧native／legacy APIは変更しません。**runtime riskとauthorization issuerはまだ新packet形式を
-受け取れません**。実decisionによる一回限りの実行・結果記録までの統合検証は未完了です。
+旧native／legacy APIは変更しません。以下の承認要件対応runtime risk境界がfinal packetを受け取ります。
+authorization発行と、実decisionによる一回限りの実行・結果記録までの統合検証は未完了です。
+
+## 検証済み最終再検査からのruntime risk review
+
+`promotion_requirement_runtime_risk`は、独立入力の完全なfinal recheckを、trusted source／contract、
+現在のendpoint／credentialメタデータ、必要scope、期待する検証／再検査時刻で再検証します。
+コンパクトなpacketは厳密なsource hash、Bind context、契約、intentを参照します。
+完全なsourceは検証時に別途必要であり、packetには埋め込みません。
+
+レビューはそのsource／context／契約と、intentが持つ期待する状態fingerprintに一致する必要があります。
+旧native経路と共通のリスク判定を使い、否定的なリスク判定や状態変化はBLOCK、リスク・状態証拠・TTLの
+欠落は判定不能としてfail-closedにします。レビューの有効期間は最大300秒で、PASSにはintentのTTL内に
+収まることも必要です。verifierには独立した期待するリスク判定・記録時刻・現在時刻も必須です。
+packetを変更しなくてもレビューの期限到達後は拒否します。packet内のレビュー情報を外部入力の代用にしません。
+
+`require_promotion_requirement_runtime_risk_pass`は再構築済みPASSだけを返し、後続の処理に入る前に
+BLOCK／判定不能を拒否します。runtime risk要件を完了できるのはPASSだけで、他のauthorization要件と
+全実行要件は未充足のままです。Bind直前の独立したリスク再検査も必要です。
+実際のauthorization issuerは、まだこのguardを呼び出しません。
+
+リスク信号、観測状態、証拠参照は呼び出し元が提供する情報であり、認証済みセンサー結果ではありません。
+この境界はそれらを取得・推測しません。実際の認証済みAPIのPASSテストでは、サポートされているpromotion
+境界でTTLとテスト用状態を明示的に渡し、返却済みCDA／candidateを変更しません。
+そのメタデータを渡さないケースは判定不能のままです。モデル・クラウドクライアントと観測状態は
+テスト用に制御しています。Human Approval Receipt、実行権限、Bind authorization、credentialアクセス、
+network dispatch、BindReceipt、external effectは生成しません。

--- a/schemas/promotion-requirement-runtime-risk-v1.schema.json
+++ b/schemas/promotion-requirement-runtime-risk-v1.schema.json
@@ -1,0 +1,444 @@
+{
+  "$defs": {
+    "RequirementRuntimeRiskDecision": {
+      "additionalProperties": false,
+      "description": "Closed caller evidence bound to one exact verified recheck result.",
+      "properties": {
+        "acknowledged_bind_time_risk_recheck_required": {
+          "const": true,
+          "title": "Acknowledged Bind Time Risk Recheck Required",
+          "type": "boolean"
+        },
+        "acknowledged_caller_evidence_only": {
+          "const": true,
+          "title": "Acknowledged Caller Evidence Only",
+          "type": "boolean"
+        },
+        "acknowledged_no_authorization": {
+          "const": true,
+          "title": "Acknowledged No Authorization",
+          "type": "boolean"
+        },
+        "action_contract_digest": {
+          "title": "Action Contract Digest",
+          "type": "string"
+        },
+        "bind_context_hash": {
+          "title": "Bind Context Hash",
+          "type": "string"
+        },
+        "expected_state_fingerprint": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Expected State Fingerprint"
+        },
+        "observed_state_fingerprint": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Observed State Fingerprint"
+        },
+        "review_id": {
+          "minLength": 1,
+          "title": "Review Id",
+          "type": "string"
+        },
+        "reviewed_at": {
+          "title": "Reviewed At",
+          "type": "string"
+        },
+        "reviewer_id": {
+          "minLength": 1,
+          "title": "Reviewer Id",
+          "type": "string"
+        },
+        "risk_reason": {
+          "minLength": 1,
+          "title": "Risk Reason",
+          "type": "string"
+        },
+        "runtime_risk_evidence_refs": {
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Runtime Risk Evidence Refs",
+          "type": "array"
+        },
+        "runtime_risk_signal": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Runtime Risk Signal"
+        },
+        "source_final_recheck_hash": {
+          "title": "Source Final Recheck Hash",
+          "type": "string"
+        },
+        "source_final_recheck_id": {
+          "title": "Source Final Recheck Id",
+          "type": "string"
+        },
+        "valid_until": {
+          "title": "Valid Until",
+          "type": "string"
+        }
+      },
+      "required": [
+        "review_id",
+        "reviewer_id",
+        "risk_reason",
+        "reviewed_at",
+        "valid_until",
+        "source_final_recheck_id",
+        "source_final_recheck_hash",
+        "bind_context_hash",
+        "action_contract_digest",
+        "expected_state_fingerprint",
+        "observed_state_fingerprint",
+        "runtime_risk_signal",
+        "runtime_risk_evidence_refs",
+        "acknowledged_caller_evidence_only",
+        "acknowledged_no_authorization",
+        "acknowledged_bind_time_risk_recheck_required"
+      ],
+      "title": "RequirementRuntimeRiskDecision",
+      "type": "object"
+    },
+    "RuntimeRiskReviewResult": {
+      "additionalProperties": false,
+      "description": "Deterministic, fail-closed interpretation of supplied risk evidence.",
+      "properties": {
+        "bind_time_runtime_risk_recheck_required": {
+          "const": true,
+          "title": "Bind Time Runtime Risk Recheck Required",
+          "type": "boolean"
+        },
+        "caller_supplied_evidence_only": {
+          "const": true,
+          "title": "Caller Supplied Evidence Only",
+          "type": "boolean"
+        },
+        "creates_bind_authorization": {
+          "const": false,
+          "title": "Creates Bind Authorization",
+          "type": "boolean"
+        },
+        "creates_execution_authority": {
+          "const": false,
+          "title": "Creates Execution Authority",
+          "type": "boolean"
+        },
+        "dispatches_request": {
+          "const": false,
+          "title": "Dispatches Request",
+          "type": "boolean"
+        },
+        "evidence_refs_present": {
+          "const": true,
+          "title": "Evidence Refs Present",
+          "type": "boolean"
+        },
+        "exact_context_binding_verified": {
+          "const": true,
+          "title": "Exact Context Binding Verified",
+          "type": "boolean"
+        },
+        "expected_state_fingerprint_present": {
+          "title": "Expected State Fingerprint Present",
+          "type": "boolean"
+        },
+        "external_evidence_authenticity_claimed": {
+          "const": false,
+          "title": "External Evidence Authenticity Claimed",
+          "type": "boolean"
+        },
+        "intent_expires_at": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Intent Expires At"
+        },
+        "intent_fresh_for_review_window": {
+          "title": "Intent Fresh For Review Window",
+          "type": "boolean"
+        },
+        "intent_ttl_present": {
+          "title": "Intent Ttl Present",
+          "type": "boolean"
+        },
+        "invokes_bind": {
+          "const": false,
+          "title": "Invokes Bind",
+          "type": "boolean"
+        },
+        "observed_state_fingerprint_present": {
+          "title": "Observed State Fingerprint Present",
+          "type": "boolean"
+        },
+        "outcome": {
+          "enum": [
+            "PASS_FOR_REMAINING_AUTHORIZATION",
+            "BLOCKED_BY_RUNTIME_RISK",
+            "INDETERMINATE_FAIL_CLOSED"
+          ],
+          "title": "Outcome",
+          "type": "string"
+        },
+        "reason_codes": {
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Reason Codes",
+          "type": "array"
+        },
+        "review_window_verified": {
+          "const": true,
+          "title": "Review Window Verified",
+          "type": "boolean"
+        },
+        "runtime_risk_acceptable": {
+          "title": "Runtime Risk Acceptable",
+          "type": "boolean"
+        },
+        "runtime_risk_signal_passed": {
+          "title": "Runtime Risk Signal Passed",
+          "type": "boolean"
+        },
+        "runtime_risk_signal_present": {
+          "title": "Runtime Risk Signal Present",
+          "type": "boolean"
+        },
+        "source_projection_verified": {
+          "const": true,
+          "title": "Source Projection Verified",
+          "type": "boolean"
+        },
+        "state_fingerprint_matches": {
+          "title": "State Fingerprint Matches",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "outcome",
+        "runtime_risk_acceptable",
+        "reason_codes",
+        "runtime_risk_signal_present",
+        "runtime_risk_signal_passed",
+        "expected_state_fingerprint_present",
+        "observed_state_fingerprint_present",
+        "state_fingerprint_matches",
+        "intent_ttl_present",
+        "intent_fresh_for_review_window",
+        "intent_expires_at",
+        "source_projection_verified",
+        "exact_context_binding_verified",
+        "review_window_verified",
+        "evidence_refs_present",
+        "caller_supplied_evidence_only",
+        "external_evidence_authenticity_claimed",
+        "creates_execution_authority",
+        "creates_bind_authorization",
+        "invokes_bind",
+        "dispatches_request",
+        "bind_time_runtime_risk_recheck_required"
+      ],
+      "title": "RuntimeRiskReviewResult",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false,
+  "description": "Compact evidence requiring the independent complete source to verify.",
+  "properties": {
+    "action_contract_digest": {
+      "title": "Action Contract Digest",
+      "type": "string"
+    },
+    "authority_evidence_proven": {
+      "const": false,
+      "title": "Authority Evidence Proven",
+      "type": "boolean"
+    },
+    "bind_authorization_created": {
+      "const": false,
+      "title": "Bind Authorization Created",
+      "type": "boolean"
+    },
+    "bind_context_hash": {
+      "title": "Bind Context Hash",
+      "type": "string"
+    },
+    "bind_invoked": {
+      "const": false,
+      "title": "Bind Invoked",
+      "type": "boolean"
+    },
+    "bind_receipt_created": {
+      "const": false,
+      "title": "Bind Receipt Created",
+      "type": "boolean"
+    },
+    "bind_time_runtime_risk_recheck_required": {
+      "const": true,
+      "title": "Bind Time Runtime Risk Recheck Required",
+      "type": "boolean"
+    },
+    "credential_material_accessed": {
+      "const": false,
+      "title": "Credential Material Accessed",
+      "type": "boolean"
+    },
+    "execution_authority_created": {
+      "const": false,
+      "title": "Execution Authority Created",
+      "type": "boolean"
+    },
+    "execution_intent_hash": {
+      "title": "Execution Intent Hash",
+      "type": "string"
+    },
+    "execution_intent_id": {
+      "title": "Execution Intent Id",
+      "type": "string"
+    },
+    "external_effect_occurred": {
+      "const": false,
+      "title": "External Effect Occurred",
+      "type": "boolean"
+    },
+    "fail_closed": {
+      "title": "Fail Closed",
+      "type": "boolean"
+    },
+    "format_version": {
+      "const": "promotion-requirement-runtime-risk/v1",
+      "title": "Format Version",
+      "type": "string"
+    },
+    "future_authorization_requirements": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Future Authorization Requirements",
+      "type": "array"
+    },
+    "future_invocation_requirements": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Future Invocation Requirements",
+      "type": "array"
+    },
+    "human_approval_created": {
+      "const": false,
+      "title": "Human Approval Created",
+      "type": "boolean"
+    },
+    "human_approval_proven": {
+      "const": false,
+      "title": "Human Approval Proven",
+      "type": "boolean"
+    },
+    "network_used": {
+      "const": false,
+      "title": "Network Used",
+      "type": "boolean"
+    },
+    "packet_hash": {
+      "pattern": "^[0-9a-f]{64}$",
+      "title": "Packet Hash",
+      "type": "string"
+    },
+    "packet_id": {
+      "title": "Packet Id",
+      "type": "string"
+    },
+    "ready_for_real_bind": {
+      "const": false,
+      "title": "Ready For Real Bind",
+      "type": "boolean"
+    },
+    "ready_for_remaining_authorization_requirements": {
+      "title": "Ready For Remaining Authorization Requirements",
+      "type": "boolean"
+    },
+    "recorded_at": {
+      "title": "Recorded At",
+      "type": "string"
+    },
+    "required_human_approval": {
+      "title": "Required Human Approval",
+      "type": "boolean"
+    },
+    "risk_decision": {
+      "$ref": "#/$defs/RequirementRuntimeRiskDecision"
+    },
+    "risk_result": {
+      "$ref": "#/$defs/RuntimeRiskReviewResult"
+    },
+    "source_final_recheck_hash": {
+      "title": "Source Final Recheck Hash",
+      "type": "string"
+    },
+    "source_final_recheck_id": {
+      "title": "Source Final Recheck Id",
+      "type": "string"
+    }
+  },
+  "required": [
+    "format_version",
+    "packet_id",
+    "packet_hash",
+    "recorded_at",
+    "source_final_recheck_id",
+    "source_final_recheck_hash",
+    "bind_context_hash",
+    "action_contract_digest",
+    "execution_intent_id",
+    "execution_intent_hash",
+    "required_human_approval",
+    "risk_decision",
+    "risk_result",
+    "future_authorization_requirements",
+    "future_invocation_requirements",
+    "fail_closed",
+    "ready_for_remaining_authorization_requirements",
+    "bind_time_runtime_risk_recheck_required",
+    "human_approval_created",
+    "human_approval_proven",
+    "authority_evidence_proven",
+    "execution_authority_created",
+    "bind_authorization_created",
+    "bind_invoked",
+    "bind_receipt_created",
+    "credential_material_accessed",
+    "network_used",
+    "external_effect_occurred",
+    "ready_for_real_bind"
+  ],
+  "title": "PromotionRequirementRuntimeRiskPacket",
+  "type": "object",
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
+}

--- a/veritas_os/policy/canonical_promotion_live_adapter_dry_run_runtime_risk_review.py
+++ b/veritas_os/policy/canonical_promotion_live_adapter_dry_run_runtime_risk_review.py
@@ -437,19 +437,42 @@ def _result(
     reviewed_at: datetime,
     valid_until: datetime,
 ) -> dict[str, Any]:
-    expected = decision.expected_state_fingerprint
-    observed = decision.observed_state_fingerprint
+    return _evaluate_runtime_risk_inputs(
+        projection.execution_intent,
+        expected=decision.expected_state_fingerprint,
+        observed=decision.observed_state_fingerprint,
+        signal=decision.runtime_risk_signal,
+        reviewed_at=reviewed_at,
+        valid_until=valid_until,
+    )
+
+
+def _evaluate_runtime_risk_inputs(
+    execution_intent: dict[str, Any],
+    *,
+    expected: str | None,
+    observed: str | None,
+    signal: bool | None,
+    reviewed_at: datetime,
+    valid_until: datetime,
+) -> dict[str, Any]:
+    """Shared interpretation after callers verify source, bindings and window.
+
+    This internal helper does not verify evidence authenticity. Both native
+    source formats must establish the returned source/context preconditions
+    before calling it; no accepting source conversion is performed here.
+    """
     expected_present = isinstance(expected, str) and bool(expected.strip())
     observed_present = isinstance(observed, str) and bool(observed.strip())
     fingerprint_matches = expected_present and observed_present and expected == observed
 
-    ttl = projection.execution_intent.get("ttl_seconds")
+    ttl = execution_intent.get("ttl_seconds")
     ttl_present = isinstance(ttl, int) and not isinstance(ttl, bool) and ttl > 0
     intent_expires_at = None
     intent_fresh = False
     if ttl_present:
         decision_at = _aware(
-            projection.execution_intent.get("decision_ts"),
+            execution_intent.get("decision_ts"),
             "CPLADRRR_INTENT_DECISION_TIME_INVALID",
         )
         expiry = decision_at + timedelta(seconds=ttl)
@@ -458,9 +481,9 @@ def _result(
 
     block_reasons = []
     missing_reasons = []
-    if decision.runtime_risk_signal is False:
+    if signal is False:
         block_reasons.append("CPLADRRR_RUNTIME_RISK_UNACCEPTABLE")
-    elif decision.runtime_risk_signal is None:
+    elif signal is None:
         missing_reasons.append("CPLADRRR_RUNTIME_RISK_SIGNAL_MISSING")
     if not expected_present:
         missing_reasons.append("CPLADRRR_EXPECTED_STATE_FINGERPRINT_MISSING")
@@ -487,8 +510,8 @@ def _result(
         "outcome": outcome,
         "runtime_risk_acceptable": outcome == PASS_OUTCOME,
         "reason_codes": reasons,
-        "runtime_risk_signal_present": decision.runtime_risk_signal is not None,
-        "runtime_risk_signal_passed": decision.runtime_risk_signal is True,
+        "runtime_risk_signal_present": signal is not None,
+        "runtime_risk_signal_passed": signal is True,
         "expected_state_fingerprint_present": expected_present,
         "observed_state_fingerprint_present": observed_present,
         "state_fingerprint_matches": fingerprint_matches,

--- a/veritas_os/policy/promotion_requirement_runtime_risk.py
+++ b/veritas_os/policy/promotion_requirement_runtime_risk.py
@@ -1,0 +1,248 @@
+"""Bind caller-supplied runtime risk review to verified requirement rechecks.
+
+This is a pre-authorization evidence boundary, not a risk sensor or issuer.
+External source/policy, metadata, clocks, and expected review remain mandatory.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from veritas_os.governance.action_contracts import ActionClassContract
+from veritas_os.policy.human_approval_requirement_resolution import _json, _timestamp
+from veritas_os.policy.promotion_requirement_final_rechecks import (
+    ABSENT_FIELDS,
+    verify_promotion_requirement_final_recheck_packet as verify_rechecks,
+)
+from veritas_os.policy.canonical_promotion_live_adapter_dry_run_runtime_risk_review import (
+    PASS_OUTCOME,
+    RuntimeRiskReviewResult,
+    _evaluate_runtime_risk_inputs,
+    _validate_times,
+)
+from veritas_os.security.hash import sha256_of_canonical_json
+
+
+class PromotionRequirementRuntimeRiskError(ValueError):
+    """Missing, mismatched, rejected, or expired risk evidence."""
+
+
+class RequirementRuntimeRiskDecision(BaseModel):
+    """Closed caller evidence bound to one exact verified recheck result."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+    review_id: str = Field(min_length=1)
+    reviewer_id: str = Field(min_length=1)
+    risk_reason: str = Field(min_length=1)
+    reviewed_at: str
+    valid_until: str
+    source_final_recheck_id: str
+    source_final_recheck_hash: str
+    bind_context_hash: str
+    action_contract_digest: str
+    expected_state_fingerprint: str | None
+    observed_state_fingerprint: str | None
+    runtime_risk_signal: bool | None
+    runtime_risk_evidence_refs: list[str] = Field(min_length=1)
+    acknowledged_caller_evidence_only: Literal[True]
+    acknowledged_no_authorization: Literal[True]
+    acknowledged_bind_time_risk_recheck_required: Literal[True]
+
+
+class PromotionRequirementRuntimeRiskPacket(BaseModel):
+    """Compact evidence requiring the independent complete source to verify."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+    format_version: Literal["promotion-requirement-runtime-risk/v1"]
+    packet_id: str
+    packet_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    recorded_at: str
+    source_final_recheck_id: str
+    source_final_recheck_hash: str
+    bind_context_hash: str
+    action_contract_digest: str
+    execution_intent_id: str
+    execution_intent_hash: str
+    required_human_approval: bool
+    risk_decision: RequirementRuntimeRiskDecision
+    risk_result: RuntimeRiskReviewResult
+    future_authorization_requirements: list[str]
+    future_invocation_requirements: list[str]
+    fail_closed: bool
+    ready_for_remaining_authorization_requirements: bool
+    bind_time_runtime_risk_recheck_required: Literal[True]
+    human_approval_created: Literal[False]
+    human_approval_proven: Literal[False]
+    authority_evidence_proven: Literal[False]
+    execution_authority_created: Literal[False]
+    bind_authorization_created: Literal[False]
+    bind_invoked: Literal[False]
+    bind_receipt_created: Literal[False]
+    credential_material_accessed: Literal[False]
+    network_used: Literal[False]
+    external_effect_occurred: Literal[False]
+    ready_for_real_bind: Literal[False]
+
+
+def _seal(raw: dict[str, Any]) -> dict[str, Any]:
+    value = {k: v for k, v in raw.items() if k not in {"packet_id", "packet_hash"}}
+    digest = sha256_of_canonical_json(
+        {
+            "domain": "veritas.promotion-requirement-runtime-risk/v1",
+            "value": value,
+        }
+    )
+    return {**value, "packet_hash": digest, "packet_id": f"prrr:v1:sha256:{digest}"}
+
+
+def _assemble(
+    source: Any, decision: Any, recorded_at: datetime
+) -> PromotionRequirementRuntimeRiskPacket:
+    decision = RequirementRuntimeRiskDecision.model_validate(_json(decision))
+    refs = decision.runtime_risk_evidence_refs
+    if any(not ref.strip() for ref in refs) or len(set(refs)) != len(refs):
+        raise PromotionRequirementRuntimeRiskError("PRRR_EVIDENCE_REFS_INVALID")
+    expected = {
+        "source_final_recheck_id": source.packet_id,
+        "source_final_recheck_hash": source.packet_hash,
+        "bind_context_hash": source.bind_context_hash,
+        "action_contract_digest": source.exact_bind_context.action_contract_digest,
+        "expected_state_fingerprint": source.execution_intent.get(
+            "expected_state_fingerprint"
+        ),
+    }
+    if any(getattr(decision, key) != value for key, value in expected.items()):
+        raise PromotionRequirementRuntimeRiskError("PRRR_DECISION_BINDING_MISMATCH")
+    reviewed, valid_until, recorded = _validate_times(
+        source.rechecked_at, decision, recorded_at
+    )
+    if source.future_authorization_requirements[0:1] != ["runtime_risk_review"]:
+        raise PromotionRequirementRuntimeRiskError("PRRR_REQUIREMENT_ORDER")
+    result = _evaluate_runtime_risk_inputs(
+        source.execution_intent,
+        expected=decision.expected_state_fingerprint,
+        observed=decision.observed_state_fingerprint,
+        signal=decision.runtime_risk_signal,
+        reviewed_at=reviewed,
+        valid_until=valid_until,
+    )
+    accepted = result["outcome"] == PASS_OUTCOME
+    decision = decision.model_copy(
+        update={
+            "reviewed_at": reviewed.isoformat(),
+            "valid_until": valid_until.isoformat(),
+        }
+    )
+    raw = {
+        "format_version": "promotion-requirement-runtime-risk/v1",
+        "recorded_at": recorded.isoformat(),
+        **{k: v for k, v in expected.items() if k != "expected_state_fingerprint"},
+        "execution_intent_id": source.exact_bind_context.execution_intent_id,
+        "execution_intent_hash": source.exact_bind_context.execution_intent_hash,
+        "required_human_approval": source.required_human_approval,
+        "risk_decision": decision.model_dump(mode="json"),
+        "risk_result": result,
+        "future_authorization_requirements": source.future_authorization_requirements[
+            1:
+        ]
+        if accepted
+        else source.future_authorization_requirements,
+        "future_invocation_requirements": source.future_invocation_requirements,
+        "fail_closed": not accepted,
+        "ready_for_remaining_authorization_requirements": accepted,
+        "bind_time_runtime_risk_recheck_required": True,
+        **{name: getattr(source, name) for name in ABSENT_FIELDS},
+    }
+    return PromotionRequirementRuntimeRiskPacket.model_validate(_seal(raw))
+
+
+def build_promotion_requirement_runtime_risk_packet(
+    final_recheck: Any,
+    risk_decision: Any,
+    recorded_at: datetime,
+    *,
+    expected_source: Any,
+    expected_contract: ActionClassContract,
+    expected_verified_at: datetime,
+    expected_rechecked_at: datetime,
+    current_endpoint: Any,
+    current_credential_reference: Any,
+    required_credential_scope: str,
+) -> PromotionRequirementRuntimeRiskPacket:
+    """Review only the final recheck rebuilt against the independent inputs."""
+    source = verify_rechecks(
+        final_recheck,
+        expected_source=expected_source,
+        expected_contract=expected_contract,
+        expected_verified_at=expected_verified_at,
+        expected_rechecked_at=expected_rechecked_at,
+        current_endpoint=current_endpoint,
+        current_credential_reference=current_credential_reference,
+        required_credential_scope=required_credential_scope,
+    )
+    return _assemble(source, risk_decision, recorded_at)
+
+
+def verify_promotion_requirement_runtime_risk_packet(
+    packet: Any,
+    final_recheck: Any,
+    *,
+    expected_risk_decision: Any,
+    expected_recorded_at: datetime,
+    verification_now: datetime,
+    expected_source: Any,
+    expected_contract: ActionClassContract,
+    expected_verified_at: datetime,
+    expected_rechecked_at: datetime,
+    current_endpoint: Any,
+    current_credential_reference: Any,
+    required_credential_scope: str,
+) -> PromotionRequirementRuntimeRiskPacket:
+    """Rebuild against independent review/source and reject expired consumption."""
+    candidate = PromotionRequirementRuntimeRiskPacket.model_validate(_json(packet))
+    rebuilt = build_promotion_requirement_runtime_risk_packet(
+        final_recheck,
+        expected_risk_decision,
+        expected_recorded_at,
+        expected_source=expected_source,
+        expected_contract=expected_contract,
+        expected_verified_at=expected_verified_at,
+        expected_rechecked_at=expected_rechecked_at,
+        current_endpoint=current_endpoint,
+        current_credential_reference=current_credential_reference,
+        required_credential_scope=required_credential_scope,
+    )
+    if _json(candidate) != _json(rebuilt):
+        raise PromotionRequirementRuntimeRiskError("PRRR_RECONSTRUCTION_MISMATCH")
+    now = datetime.fromisoformat(_timestamp(verification_now))
+    if not (
+        datetime.fromisoformat(rebuilt.recorded_at)
+        <= now
+        < datetime.fromisoformat(rebuilt.risk_decision.valid_until)
+    ):
+        raise PromotionRequirementRuntimeRiskError("PRRR_REVIEW_NOT_CURRENT")
+    return rebuilt
+
+
+def require_promotion_requirement_runtime_risk_pass(
+    packet: Any,
+    final_recheck: Any,
+    **verification_inputs: Any,
+) -> PromotionRequirementRuntimeRiskPacket:
+    """Admission guard: BLOCK and INDETERMINATE cannot enter later composition.
+
+    The verifier enforces all mandatory keyword inputs. This guard grants no
+    execution authority and does not replace the independent Bind-time check.
+    """
+    verified = verify_promotion_requirement_runtime_risk_packet(
+        packet, final_recheck, **verification_inputs
+    )
+    if (
+        verified.fail_closed
+        or not verified.ready_for_remaining_authorization_requirements
+    ):
+        raise PromotionRequirementRuntimeRiskError("PRRR_RISK_NOT_ACCEPTABLE")
+    return verified

--- a/veritas_os/tests/test_promotion_requirement_runtime_risk.py
+++ b/veritas_os/tests/test_promotion_requirement_runtime_risk.py
@@ -1,0 +1,412 @@
+"""Trusted risk evidence and full requirement chain remain mandatory."""
+
+from copy import deepcopy
+from dataclasses import replace
+from datetime import datetime, timedelta
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+from jsonschema import Draft202012Validator
+import pytest
+
+from veritas_os.policy import promotion_requirement_runtime_risk as module
+from veritas_os.policy.canonical_verified_decision_promotion import (
+    build_canonical_verified_decision_promotion_packet,
+)
+from veritas_os.tests.helpers.native_approval_source import (
+    build_native_authority_source,
+)
+from veritas_os.tests.test_promotion_requirement_final_rechecks import _complete
+from veritas_os.tests.test_promotion_human_approval_requirement_satisfaction import (
+    native as native_fixture,
+    _contract,
+    authority,
+    sources,
+)
+
+pytestmark = pytest.mark.slow
+native = native_fixture
+
+
+def _decision(final, now, **changes):
+    expected = final.execution_intent.get("expected_state_fingerprint")
+    value = {
+        "review_id": "risk:test:1",
+        "reviewer_id": "reviewer:test",
+        "risk_reason": "Explicit synthetic pre-authorization risk input.",
+        "reviewed_at": (now + timedelta(seconds=1)).isoformat(),
+        "valid_until": (now + timedelta(seconds=30)).isoformat(),
+        "source_final_recheck_id": final.packet_id,
+        "source_final_recheck_hash": final.packet_hash,
+        "bind_context_hash": final.bind_context_hash,
+        "action_contract_digest": final.exact_bind_context.action_contract_digest,
+        "expected_state_fingerprint": expected,
+        "observed_state_fingerprint": expected,
+        "runtime_risk_signal": True,
+        "runtime_risk_evidence_refs": ["synthetic:risk:1"],
+        "acknowledged_caller_evidence_only": True,
+        "acknowledged_no_authorization": True,
+        "acknowledged_bind_time_risk_recheck_required": True,
+    }
+    return {**value, **changes}
+
+
+def _risk_chain(source, contract, now):
+    _, _, final, anchors = _complete(source, contract, now)
+    anchors = {**anchors, "expected_rechecked_at": now}
+    decision = _decision(final, now)
+    recorded = now + timedelta(seconds=2)
+    packet = module.build_promotion_requirement_runtime_risk_packet(
+        final, decision, recorded, **anchors
+    )
+    verification = {
+        **anchors,
+        "expected_risk_decision": decision,
+        "expected_recorded_at": recorded,
+        "verification_now": now + timedelta(seconds=3),
+    }
+    return final, packet, verification
+
+
+@pytest.fixture(scope="module")
+def chain(native):
+    source, contract, _, now = native
+    return _risk_chain(source, contract, now)
+
+
+def test_pass_preserves_compact_source_binding_and_schema(chain):
+    final, packet, inputs = chain
+    verified = module.require_promotion_requirement_runtime_risk_pass(
+        packet, final, **inputs
+    )
+    assert verified == packet and verified is not packet
+    assert "source_packet" not in verified.model_dump(mode="json")
+    assert verified.source_final_recheck_hash == final.packet_hash
+    assert (
+        verified.future_authorization_requirements
+        == final.future_authorization_requirements[1:]
+    )
+    assert (
+        verified.future_invocation_requirements == final.future_invocation_requirements
+    )
+    assert verified.bind_time_runtime_risk_recheck_required
+    for name in module.ABSENT_FIELDS:
+        assert getattr(verified, name) is False
+    assert not verified.risk_result.external_evidence_authenticity_claimed
+    schema = (
+        Path(__file__).resolve().parents[2]
+        / "schemas/promotion-requirement-runtime-risk-v1.schema.json"
+    )
+    Draft202012Validator(json.loads(schema.read_text())).validate(
+        verified.model_dump(mode="json")
+    )
+
+
+@pytest.mark.parametrize(
+    "changes,outcome",
+    [
+        ({"runtime_risk_signal": False}, "BLOCKED_BY_RUNTIME_RISK"),
+        ({"runtime_risk_signal": None}, "INDETERMINATE_FAIL_CLOSED"),
+        ({"observed_state_fingerprint": None}, "INDETERMINATE_FAIL_CLOSED"),
+        ({"observed_state_fingerprint": "changed-state"}, "BLOCKED_BY_RUNTIME_RISK"),
+    ],
+)
+def test_risk_block_and_missing_evidence_cannot_enter_downstream(
+    chain, changes, outcome
+):
+    final, _, inputs = chain
+    decision = {**inputs["expected_risk_decision"], **changes}
+    anchors = {
+        k: v
+        for k, v in inputs.items()
+        if k
+        not in {"expected_risk_decision", "expected_recorded_at", "verification_now"}
+    }
+    packet = module.build_promotion_requirement_runtime_risk_packet(
+        final, decision, inputs["expected_recorded_at"], **anchors
+    )
+    current = {**inputs, "expected_risk_decision": decision}
+    verified = module.verify_promotion_requirement_runtime_risk_packet(
+        packet, final, **current
+    )
+    assert verified.fail_closed and verified.risk_result.outcome == outcome
+    assert (
+        verified.future_authorization_requirements
+        == final.future_authorization_requirements
+    )
+    with pytest.raises(ValueError, match="PRRR_RISK_NOT_ACCEPTABLE"):
+        module.require_promotion_requirement_runtime_risk_pass(packet, final, **current)
+
+
+def test_rehashed_positive_decision_cannot_replace_external_negative_decision(chain):
+    final, passing, inputs = chain
+    trusted_negative = {
+        **inputs["expected_risk_decision"],
+        "runtime_risk_signal": False,
+    }
+    with pytest.raises(ValueError, match="PRRR_RECONSTRUCTION_MISMATCH"):
+        module.require_promotion_requirement_runtime_risk_pass(
+            passing, final, **{**inputs, "expected_risk_decision": trusted_negative}
+        )
+
+
+@pytest.mark.parametrize(
+    "rules",
+    [
+        {"required": False, "minimum_approvals": 0},
+        {"required": True, "minimum_approvals": 2},
+        {"required": True, "minimum_approvals": 1, "approver_role": "attacker"},
+    ],
+)
+def test_fully_rebuilt_same_id_version_policy_substitution_is_rejected(native, rules):
+    source, trusted, _, now = native
+    attacker = replace(trusted, human_approval_rules=rules)
+    assert (attacker.id, attacker.version) == (trusted.id, trusted.version)
+    final, packet, inputs = _risk_chain(source, attacker, now)
+    with pytest.raises(ValueError):
+        module.verify_promotion_requirement_runtime_risk_packet(
+            packet, final, **{**inputs, "expected_contract": trusted}
+        )
+
+
+def test_fully_rebuilt_source_substitution_is_rejected(native):
+    source, contract, _, now = native
+    bundle = source.authority_evidence_reference_bundle.model_dump(mode="json")
+    bundle["bundle_declared_by"] = "attacker"
+    other = authority(
+        source.source_bind_pre_dispatch_review_packet, bundle, sources.RECORDED_AT
+    )
+    final, packet, inputs = _risk_chain(other, contract, now)
+    with pytest.raises(ValueError):
+        module.verify_promotion_requirement_runtime_risk_packet(
+            packet, final, **{**inputs, "expected_source": source}
+        )
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "bind_context_hash",
+        "action_contract_digest",
+        "source_final_recheck_hash",
+        "required_human_approval",
+        "fail_closed",
+        "future_authorization_requirements",
+        "risk_result",
+    ],
+)
+def test_rehashed_packet_tampering_is_rejected(chain, field):
+    final, packet, inputs = chain
+    raw = packet.model_dump(mode="json")
+    if field == "risk_result":
+        raw[field]["reason_codes"] = ["attacker"]
+    elif isinstance(raw[field], bool):
+        raw[field] = not raw[field]
+    elif isinstance(raw[field], list):
+        raw[field] = []
+    else:
+        raw[field] = "0" * 64
+    with pytest.raises(ValueError):
+        module.verify_promotion_requirement_runtime_risk_packet(
+            module._seal(raw), final, **inputs
+        )
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "source_final_recheck_id",
+        "source_final_recheck_hash",
+        "bind_context_hash",
+        "action_contract_digest",
+        "expected_state_fingerprint",
+    ],
+)
+def test_review_must_bind_exact_verified_source(chain, field):
+    final, packet, inputs = chain
+    decision = {**inputs["expected_risk_decision"], field: "wrong"}
+    with pytest.raises(ValueError, match="PRRR_DECISION_BINDING_MISMATCH"):
+        module.verify_promotion_requirement_runtime_risk_packet(
+            packet, final, **{**inputs, "expected_risk_decision": decision}
+        )
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("runtime_risk_signal", 1),
+        ("runtime_risk_signal", "true"),
+        ("runtime_risk_evidence_refs", []),
+        ("runtime_risk_evidence_refs", [" "]),
+        ("runtime_risk_evidence_refs", ["duplicate", "duplicate"]),
+        ("acknowledged_no_authorization", False),
+    ],
+)
+def test_ambiguous_or_missing_review_inputs_fail(chain, field, value):
+    final, packet, inputs = chain
+    with pytest.raises(ValueError):
+        module.verify_promotion_requirement_runtime_risk_packet(
+            packet,
+            final,
+            **{
+                **inputs,
+                "expected_risk_decision": {
+                    **inputs["expected_risk_decision"],
+                    field: value,
+                },
+            },
+        )
+
+
+@pytest.mark.parametrize("which", ["before_record", "expiry", "after_expiry", "naive"])
+def test_verification_clock_rechecks_validity_without_rehash(chain, which):
+    final, packet, inputs = chain
+    expiry = datetime.fromisoformat(packet.risk_decision.valid_until)
+    now = {
+        "before_record": inputs["expected_recorded_at"] - timedelta(seconds=1),
+        "expiry": expiry,
+        "after_expiry": expiry + timedelta(seconds=1),
+        "naive": inputs["verification_now"].replace(tzinfo=None),
+    }[which]
+    with pytest.raises(ValueError):
+        module.verify_promotion_requirement_runtime_risk_packet(
+            packet, final, **{**inputs, "verification_now": now}
+        )
+
+
+@pytest.mark.parametrize(
+    "missing",
+    [
+        "expected_source",
+        "expected_contract",
+        "current_endpoint",
+        "current_credential_reference",
+        "required_credential_scope",
+        "expected_verified_at",
+        "expected_rechecked_at",
+        "expected_risk_decision",
+        "expected_recorded_at",
+        "verification_now",
+    ],
+)
+def test_all_independent_verifier_inputs_are_mandatory(chain, missing):
+    final, packet, original = chain
+    inputs = dict(original)
+    del inputs[missing]
+    with pytest.raises(TypeError):
+        module.verify_promotion_requirement_runtime_risk_packet(packet, final, **inputs)
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["current_endpoint", "current_credential_reference", "required_credential_scope"],
+)
+def test_current_metadata_is_rechecked_through_risk_boundary(chain, field):
+    final, packet, inputs = chain
+    value = deepcopy(inputs[field])
+    if field == "current_endpoint":
+        value["endpoint_host"] = "changed.invalid"
+    elif field == "current_credential_reference":
+        value["credential_scope"] = "changed"
+    else:
+        value = "*"
+    with pytest.raises(ValueError):
+        module.verify_promotion_requirement_runtime_risk_packet(
+            packet, final, **{**inputs, field: value}
+        )
+
+
+@pytest.fixture(scope="module", params=[False, True])
+def api_risk_source(request, tmp_path_factory):
+    output = tmp_path_factory.mktemp("risk-api") / "capture.json"
+    command = [
+        sys.executable,
+        "-m",
+        "veritas_os.tests.helpers.live_decision_capture",
+        str(output),
+    ]
+    if request.param:
+        command.append("--human-required")
+    subprocess.run(
+        command,
+        cwd=Path(__file__).resolve().parents[2],
+        check=True,
+        timeout=180,
+        capture_output=True,
+        text=True,
+    )
+    captured = json.loads(output.read_text())
+    assert captured["pipeline_ok"]
+    assert all(value > 0 for value in captured["infrastructure_calls"].values())
+    now = datetime.fromisoformat(captured["observed_at"])
+    # Explicit caller inputs at the supported promotion boundary; returned API
+    # CDA/candidate data is never edited and no actual state sensor is claimed.
+    promotion = build_canonical_verified_decision_promotion_packet(
+        captured["canonical_decision_artifact"],
+        captured["candidate"],
+        promoted_at=now,
+        ttl_seconds=300,
+        expected_state_fingerprint="synthetic:observed-state:one",
+    )
+    return build_native_authority_source(promotion, now), now, request.param, captured
+
+
+def test_real_api_with_explicit_runtime_inputs_reaches_risk_pass(api_risk_source):
+    source, now, required, _ = api_risk_source
+    before = source.model_dump(mode="json")
+    final, packet, inputs = _risk_chain(
+        source, _contract(action="post_synthetic_review", required=required), now
+    )
+    verified = module.require_promotion_requirement_runtime_risk_pass(
+        packet, final, **inputs
+    )
+    assert verified.required_human_approval is required
+    assert (
+        "human_approval_receipt_verification"
+        in verified.future_authorization_requirements
+    ) is required
+    assert verified.execution_intent_id == source.execution_intent_id
+    assert not verified.ready_for_real_bind
+    assert source.model_dump(mode="json") == before
+
+
+def test_real_api_missing_runtime_metadata_stays_indeterminate(api_risk_source):
+    _, now, required, captured = api_risk_source
+    promotion = build_canonical_verified_decision_promotion_packet(
+        captured["canonical_decision_artifact"], captured["candidate"], promoted_at=now
+    )
+    source = build_native_authority_source(promotion, now)
+    final, packet, inputs = _risk_chain(
+        source, _contract(action="post_synthetic_review", required=required), now
+    )
+    assert packet.risk_result.outcome == "INDETERMINATE_FAIL_CLOSED"
+    assert "CPLADRRR_INTENT_TTL_MISSING" in packet.risk_result.reason_codes
+    assert "CPLADRRR_EXPECTED_STATE_FINGERPRINT_MISSING" in packet.risk_result.reason_codes
+    with pytest.raises(ValueError, match="PRRR_RISK_NOT_ACCEPTABLE"):
+        module.require_promotion_requirement_runtime_risk_pass(packet, final, **inputs)
+
+
+@pytest.mark.parametrize("case", ["before_source", "too_long", "expired", "naive"])
+def test_review_window_binding_is_enforced(chain, case):
+    final, packet, inputs = chain
+    decision = dict(inputs["expected_risk_decision"])
+    if case == "before_source":
+        decision["reviewed_at"] = (
+            inputs["expected_rechecked_at"] - timedelta(seconds=1)
+        ).isoformat()
+    elif case == "too_long":
+        decision["valid_until"] = (
+            datetime.fromisoformat(decision["reviewed_at"]) + timedelta(seconds=301)
+        ).isoformat()
+    elif case == "expired":
+        decision["valid_until"] = inputs["expected_recorded_at"].isoformat()
+    else:
+        decision["reviewed_at"] = datetime.fromisoformat(
+            decision["reviewed_at"]
+        ).replace(tzinfo=None).isoformat()
+    with pytest.raises(ValueError):
+        module.verify_promotion_requirement_runtime_risk_packet(
+            packet, final, **{**inputs, "expected_risk_decision": decision}
+        )


### PR DESCRIPTION
# Summary

Connect #2192 requirement-aware final rechecks to a compact runtime-risk review and a fail-closed admission guard. Full independent source/policy, metadata, time and expected risk-decision inputs remain mandatory throughout verification.

## Scope

- Reverify the complete final recheck with external source/ActionClassContract, current endpoint/credential reference, required scope, and expected timestamps.
- Bind risk evidence to the exact final source hash, Bind context, contract and expected state fingerprint.
- Reuse the existing runtime-risk interpretation through a shared internal helper; preserve the old native packet API and results.
- Require the full final source separately when verifying the compact risk packet.
- Require an independently expected risk decision and record time, plus verification_now. Rehashed embedded review substitutions cannot replace external evidence; unchanged packets fail at review expiry.
- Add an admission guard returning only rebuilt PASS results. BLOCK and INDETERMINATE cannot enter later composition; only PASS consumes runtime_risk_review.
- Preserve all remaining authorization/invocation prerequisites and the independent Bind-time risk recheck.
- Add closed schema and bilingual implementation notes.

## Type of change

- [x] Runtime
- [x] Tests
- [x] Docs
- [x] Governance / security-sensitive

## Why this change matters

A verified metadata recheck alone does not establish acceptable runtime risk. Missing signals/state/TTL, drift, negative risk or stale review must stop progress. A packet must not supply its own expected risk decision or trusted policy. Both REQUIRED and NOT_REQUIRED source paths retain the same fail-closed checks.

## Market / developer / user value

- Market value: No production execution or authenticated sensor claim.
- Developer value: Reuse of existing risk semantics, compact source-bound evidence, and explicit admission API.
- User/operator value: Stale or substituted reviews and changed current metadata are rejected before later authorization composition.

## Tests run

- [x] **117 distinct related tests passed**: 53 new (47 main cases plus 6 missing-runtime-metadata/review-window cases), 64 existing regressions.
- [x] Full existing native runtime-risk test module, v0.3 issuance trust, and HARR integration regressions.
- [x] Actual authenticated /v1/decide → native source → final recheck → runtime-risk PASS for both approval states, using explicit caller TTL/state inputs at promotion and controlled model/cloud clients.
- [x] Real API cases without TTL/state metadata remain INDETERMINATE and are rejected by the admission guard. Returned CDA/candidate values are never edited.
- [x] Full-chain rehashed same-ID/version contract/source substitutions, external-negative versus embedded-positive risk, field tampering, current metadata drift, missing anchors, and expiry rejection.
- [x] Schema validation and non-authorizing flags.
- [x] Focused coverage rerun: 9 passed; new module **98.96% statement coverage** (95/96), 90% gate passed.
- [x] Ruff, bilingual documentation, responsibility boundary, git diff --check.
- Full GitHub CI pending. Existing jsonschema deprecation and NumPy reload warnings occurred in test infrastructure.

## AI assistance used

- [x] Codex

## Review status

- [ ] CI passed
- [ ] Human maintainer reviewed

## Risk checklist

- [x] Touches bind/admissibility logic
- [x] Touches governance policy behavior

## Human approval required?

- [x] Yes

Reason: Security-sensitive runtime-risk/source trust binding. Draft only; do not merge automatically.

## Notes for reviewer

Risk signal, observed state and evidence references are **caller-supplied**, not authenticated sensor output. This module does not obtain or invent them, access credentials/network, generate Human Approval Receipts, create execution authority/Bind authorization/BindReceipt, or cause external effects. ready_for_real_bind remains false even on PASS. No benchmark ground truth drives evaluation.

Review validity is capped at 300 seconds and PASS requires the window to fit the intent TTL. The external verification clock must be at or after record time and strictly before expiry. The Bind-time independent risk check remains mandatory.

**Remaining integration:** the actual authorization issuer does not yet call the new admission guard. Wiring authorization, single-use execution, and outcome lineage for real decisions remains incomplete.

Base: d24c90b49ee7ca38b4a012011ce6fb1c504bcf0b (#2192 merged).
Published source tree matches locally tested code: eb9be18812914d0eeeba75d73e6c216d20948882.