### PR TITLE
feat: issue native Bind Authorization v2 from verified runtime risk

### DIFF
--- a/docs/en/development/approval-requirement-source-verification.md
+++ b/docs/en/development/approval-requirement-source-verification.md
@@ -218,7 +218,8 @@ Real authenticated `/v1/decide` tests reach final metadata rechecks for both
 approval states with controlled model/cloud clients and explicit test metadata.
 The older native and legacy APIs remain unchanged. The requirement-aware
 runtime-risk boundary below consumes the final packet. Authorization issuance,
-real-decision single-use execution and outcome validation remain incomplete.
+real-decision single-use execution and outcome validation are separate boundaries;
+native v2 issuance is described below, while consumption remains incomplete.
 
 ## Runtime-risk review from verified final rechecks
 
@@ -241,7 +242,7 @@ evidence cannot replace the external expected decision.
 results and rejects BLOCK or INDETERMINATE before later composition. Only PASS
 consumes the runtime-risk requirement. Other authorization and all invocation
 requirements remain outstanding, including the independent Bind-time risk check.
-The actual authorization issuer does not yet call this guard.
+The native v2 authorization issuer below calls this guard before issuance.
 
 Risk signals, observed state and evidence references are caller-supplied inputs,
 not authenticated sensor results. This boundary neither obtains nor invents
@@ -251,3 +252,44 @@ CDA/candidate data; cases without that metadata remain indeterminate. Controlled
 model/cloud clients and synthetic runtime observations are test fixtures only.
 No Human Approval Receipt, execution authority, Bind authorization, credential
 access, network dispatch, BindReceipt, or external effect is produced.
+
+## Native authorization v2 (issuance only)
+
+`native_bind_authorization.issue_native_bind_authorization` composes this PASS
+guard with existing cryptographic Authority Evidence, revocation, signed Human
+Approval Receipt, RuntimeAuthority, signed GO decision, grant and idempotency
+checks. The complete final recheck and independent expected review, times and
+current metadata are mandatory `NativeAuthorizationSourceInputs`. Trusted
+Authority Evidence Linkage source, ActionClassContract and verification clock
+come independently from `RealBindAuthorizationGovernanceInputs`, never from an
+embedded snapshot. Only rebuilt verifier outputs feed downstream derivation.
+
+The issuer requires an existing signed receipt for REQUIRED and rejects supplied
+receipts for NOT_REQUIRED. It creates no human approval. Authority/receipt/GO
+signatures use the existing deployment-owned verifier policies. The GO signer
+must differ from both gate and risk reviewers. The authorization validity window
+must fit the current risk review, intent and signed evidence windows.
+Only boolean `required` and integer `minimum_approvals` (0 or 1) are supported
+here. Quorum requirements and additional approval rules are rejected, not
+silently treated as satisfied by a single receipt.
+
+The closed `native-live-adapter-bind-authorization/v2` artifact preserves native
+source hashes and signs all fields using a distinct v2 domain. Its internal
+context projection only reuses existing check interfaces: it is not a fabricated
+legacy packet and contains no invented handoff/replay evidence. Ed25519 issuer
+verification requires explicit `authorization_artifact_version="v2"` and a
+matching deployment policy hash. The default v1 verifier and v1 artifact schema
+reject v2; existing v1/v0.3 paths are retained.
+
+`verify_native_bind_authorization` re-verifies signatures and reconstructs every
+field at the independently supplied issuance verification time. This is not a
+consumer or a current execution permission. The v2 consumer is not implemented.
+Idempotency commits the signed decision/context, risk hash, contract and window;
+single-use policy is signed, but unused-key status is **not** proven. Atomic
+consumption and fresh Bind-time governance/risk checks remain mandatory future
+work. No credential resolution, header construction, network, Bind invocation,
+BindReceipt or external effect is performed by this issuance boundary.
+
+Test keys and signed authority/approval artifacts are synthetic; they do not
+represent operational human consent. Caller risk evidence remains unauthenticated
+sensor input, and the injected cryptographic backends must be non-effecting.

--- a/docs/ja/development/approval-requirement-source-verification.md
+++ b/docs/ja/development/approval-requirement-source-verification.md
@@ -172,7 +172,7 @@ endpoint再検査はサーバーへ接続せずTLS peerも検証しません。c
 モデル・クラウドクライアントを制御し、明示的なテスト用メタデータを使う実際の認証済み
 `/v1/decide`から、承認必須／不要の両方で最終メタデータ再検査まで接続します。
 旧native／legacy APIは変更しません。以下の承認要件対応runtime risk境界がfinal packetを受け取ります。
-authorization発行と、実decisionによる一回限りの実行・結果記録までの統合検証は未完了です。
+native v2のauthorization発行は下記の別境界です。実decisionによる単回消費・実行・結果記録の統合は未完了です。
 
 ## 検証済み最終再検査からのruntime risk review
 
@@ -190,7 +190,7 @@ packetを変更しなくてもレビューの期限到達後は拒否します�
 `require_promotion_requirement_runtime_risk_pass`は再構築済みPASSだけを返し、後続の処理に入る前に
 BLOCK／判定不能を拒否します。runtime risk要件を完了できるのはPASSだけで、他のauthorization要件と
 全実行要件は未充足のままです。Bind直前の独立したリスク再検査も必要です。
-実際のauthorization issuerは、まだこのguardを呼び出しません。
+下記のnative v2 authorization issuerは、発行前にこのguardを呼び出します。
 
 リスク信号、観測状態、証拠参照は呼び出し元が提供する情報であり、認証済みセンサー結果ではありません。
 この境界はそれらを取得・推測しません。実際の認証済みAPIのPASSテストでは、サポートされているpromotion
@@ -198,3 +198,38 @@ BLOCK／判定不能を拒否します。runtime risk要件を完了できるの
 そのメタデータを渡さないケースは判定不能のままです。モデル・クラウドクライアントと観測状態は
 テスト用に制御しています。Human Approval Receipt、実行権限、Bind authorization、credentialアクセス、
 network dispatch、BindReceipt、external effectは生成しません。
+
+## Native authorization v2（発行のみ）
+
+`native_bind_authorization.issue_native_bind_authorization`は、このPASS guardを既存の
+暗号学的Authority Evidence・失効・署名済みHuman Approval Receipt・RuntimeAuthority・
+署名済みGO判断・grant・idempotency検証へ接続します。`NativeAuthorizationSourceInputs`には
+完全なfinal recheckと、独立した期待するレビュー・時刻・現在のメタデータが必須です。
+trusted Authority Evidence Linkage source、ActionClassContract、検証時計は
+`RealBindAuthorizationGovernanceInputs`で独立して渡し、埋め込みsnapshotで代用しません。
+後続の導出にはverifierが再構築した結果だけを使用します。
+
+REQUIREDには既存の署名済みReceiptが必須で、NOT_REQUIREDへのReceipt供給は拒否します。
+人間承認は生成しません。Authority／Receipt／GOの署名は既存のdeployment側検証ポリシーを使います。
+GO署名者はgate reviewerおよびrisk reviewerと別人である必要があります。有効期間は現在の
+risk review、intent、署名済み証拠の有効期間内に限定します。
+対応する承認ルールはbooleanの`required`と、整数0／1の`minimum_approvals`だけです。
+複数人承認や追加ルールは拒否し、Receipt一枚で充足した扱いにしません。
+
+閉じた`native-live-adapter-bind-authorization/v2` artifactはnative source hashを保持し、
+専用v2 domainで全項目を署名します。内部context projectionは既存の検証インターフェースを
+再利用するためだけのもので、legacy packetやhandoff／replay証拠を捏造しません。
+Ed25519 issuer verifierには明示的な`authorization_artifact_version="v2"`と、それに一致する
+deployment policy hashが必要です。既定v1 verifierとv1 artifact schemaはv2を拒否します。
+既存v1／v0.3経路は維持します。
+
+`verify_native_bind_authorization`は独立入力の発行検証時刻で署名・全項目を再検証・再構築します。
+これはconsumerでも現在の実行許可でもなく、v2 consumerは未実装です。idempotencyは署名済み
+判断／context・risk hash・契約・有効期間を固定しますが、未使用keyであることは証明しません。
+単回消費ポリシーを署名しても、atomic consumptionとBind直前の最新governance／risk再検査は
+今後の必須作業です。この発行境界でcredential取得・header構築・network・Bind実行・
+BindReceipt・外部効果は行いません。
+
+テスト用鍵・署名済みAuthority／Approval artifactは合成fixtureであり、実運用の人間同意を
+意味しません。呼び出し元のrisk evidenceは認証済みセンサー入力ではありません。
+注入する暗号処理backendには、外部効果を起こさない実装が必要です。

--- a/schemas/native-live-adapter-bind-authorization-v2.schema.json
+++ b/schemas/native-live-adapter-bind-authorization-v2.schema.json
@@ -1,0 +1,771 @@
+{
+  "$defs": {
+    "AuthorizationHeaderConstructionGrant": {
+      "additionalProperties": false,
+      "description": "Permission to construct auth material later, after authorization consumption.",
+      "properties": {
+        "grant_version": {
+          "const": "authorization-header-construction-grant/v1",
+          "title": "Grant Version",
+          "type": "string"
+        },
+        "allowed": {
+          "const": true,
+          "title": "Allowed",
+          "type": "boolean"
+        },
+        "credential_reference_digest": {
+          "minLength": 1,
+          "title": "Credential Reference Digest",
+          "type": "string"
+        },
+        "credential_scope_binding_digest": {
+          "minLength": 1,
+          "title": "Credential Scope Binding Digest",
+          "type": "string"
+        },
+        "execution_intent_hash": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Execution Intent Hash",
+          "type": "string"
+        },
+        "adapter_contract_hash": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Adapter Contract Hash",
+          "type": "string"
+        },
+        "endpoint_identity_binding_digest": {
+          "minLength": 1,
+          "title": "Endpoint Identity Binding Digest",
+          "type": "string"
+        },
+        "policy_snapshot_id": {
+          "minLength": 1,
+          "title": "Policy Snapshot Id",
+          "type": "string"
+        },
+        "source_gate_review_hash": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Source Gate Review Hash",
+          "type": "string"
+        },
+        "bind_context_hash": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Bind Context Hash",
+          "type": "string"
+        },
+        "consumption_required": {
+          "const": true,
+          "title": "Consumption Required",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "grant_version",
+        "allowed",
+        "credential_reference_digest",
+        "credential_scope_binding_digest",
+        "execution_intent_hash",
+        "adapter_contract_hash",
+        "endpoint_identity_binding_digest",
+        "policy_snapshot_id",
+        "source_gate_review_hash",
+        "bind_context_hash",
+        "consumption_required"
+      ],
+      "title": "AuthorizationHeaderConstructionGrant",
+      "type": "object"
+    },
+    "BindAuthorizationDecision": {
+      "additionalProperties": false,
+      "description": "Exact signed GO decision for one reviewed future Bind context.",
+      "properties": {
+        "source_gate_review_id": {
+          "minLength": 1,
+          "title": "Source Gate Review Id",
+          "type": "string"
+        },
+        "source_gate_review_hash": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Source Gate Review Hash",
+          "type": "string"
+        },
+        "execution_intent_id": {
+          "minLength": 1,
+          "title": "Execution Intent Id",
+          "type": "string"
+        },
+        "execution_intent_hash": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Execution Intent Hash",
+          "type": "string"
+        },
+        "adapter_contract_id": {
+          "minLength": 1,
+          "title": "Adapter Contract Id",
+          "type": "string"
+        },
+        "adapter_contract_hash": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Adapter Contract Hash",
+          "type": "string"
+        },
+        "endpoint_identity_binding_digest": {
+          "minLength": 1,
+          "title": "Endpoint Identity Binding Digest",
+          "type": "string"
+        },
+        "credential_reference_digest": {
+          "minLength": 1,
+          "title": "Credential Reference Digest",
+          "type": "string"
+        },
+        "credential_scope_binding_digest": {
+          "minLength": 1,
+          "title": "Credential Scope Binding Digest",
+          "type": "string"
+        },
+        "policy_snapshot_id": {
+          "minLength": 1,
+          "title": "Policy Snapshot Id",
+          "type": "string"
+        },
+        "valid_from": {
+          "title": "Valid From",
+          "type": "string"
+        },
+        "valid_until": {
+          "title": "Valid Until",
+          "type": "string"
+        },
+        "authorizer_id": {
+          "minLength": 1,
+          "title": "Authorizer Id",
+          "type": "string"
+        },
+        "authorizer_role": {
+          "minLength": 1,
+          "title": "Authorizer Role",
+          "type": "string"
+        },
+        "authorizer_attestation": {
+          "minLength": 1,
+          "title": "Authorizer Attestation",
+          "type": "string"
+        },
+        "authorized_at": {
+          "title": "Authorized At",
+          "type": "string"
+        },
+        "authorization_reason": {
+          "minLength": 1,
+          "title": "Authorization Reason",
+          "type": "string"
+        },
+        "explicit_go_no_go_confirmation": {
+          "const": "GO_AUTHORIZED",
+          "title": "Explicit Go No Go Confirmation",
+          "type": "string"
+        },
+        "acknowledged_exact_source_context_only": {
+          "const": true,
+          "title": "Acknowledged Exact Source Context Only",
+          "type": "boolean"
+        },
+        "acknowledged_authorization_does_not_invoke_bind": {
+          "const": true,
+          "title": "Acknowledged Authorization Does Not Invoke Bind",
+          "type": "boolean"
+        },
+        "acknowledged_authorization_does_not_dispatch_request": {
+          "const": true,
+          "title": "Acknowledged Authorization Does Not Dispatch Request",
+          "type": "boolean"
+        },
+        "acknowledged_authorization_does_not_access_credentials": {
+          "const": true,
+          "title": "Acknowledged Authorization Does Not Access Credentials",
+          "type": "boolean"
+        },
+        "acknowledged_authorization_does_not_construct_authorization_header": {
+          "const": true,
+          "title": "Acknowledged Authorization Does Not Construct Authorization Header",
+          "type": "boolean"
+        },
+        "acknowledged_authorization_does_not_create_bind_receipt": {
+          "const": true,
+          "title": "Acknowledged Authorization Does Not Create Bind Receipt",
+          "type": "boolean"
+        },
+        "acknowledged_authorization_does_not_write_trustlog": {
+          "const": true,
+          "title": "Acknowledged Authorization Does Not Write Trustlog",
+          "type": "boolean"
+        },
+        "acknowledged_semantic_match_is_not_authority": {
+          "const": true,
+          "title": "Acknowledged Semantic Match Is Not Authority",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "source_gate_review_id",
+        "source_gate_review_hash",
+        "execution_intent_id",
+        "execution_intent_hash",
+        "adapter_contract_id",
+        "adapter_contract_hash",
+        "endpoint_identity_binding_digest",
+        "credential_reference_digest",
+        "credential_scope_binding_digest",
+        "policy_snapshot_id",
+        "valid_from",
+        "valid_until",
+        "authorizer_id",
+        "authorizer_role",
+        "authorizer_attestation",
+        "authorized_at",
+        "authorization_reason",
+        "explicit_go_no_go_confirmation",
+        "acknowledged_exact_source_context_only",
+        "acknowledged_authorization_does_not_invoke_bind",
+        "acknowledged_authorization_does_not_dispatch_request",
+        "acknowledged_authorization_does_not_access_credentials",
+        "acknowledged_authorization_does_not_construct_authorization_header",
+        "acknowledged_authorization_does_not_create_bind_receipt",
+        "acknowledged_authorization_does_not_write_trustlog",
+        "acknowledged_semantic_match_is_not_authority"
+      ],
+      "title": "BindAuthorizationDecision",
+      "type": "object"
+    },
+    "CredentialResolutionGrant": {
+      "additionalProperties": false,
+      "description": "Permission to resolve one exact credential reference only after consumption.",
+      "properties": {
+        "grant_version": {
+          "const": "credential-resolution-grant/v1",
+          "title": "Grant Version",
+          "type": "string"
+        },
+        "allowed": {
+          "const": true,
+          "title": "Allowed",
+          "type": "boolean"
+        },
+        "credential_reference_digest": {
+          "minLength": 1,
+          "title": "Credential Reference Digest",
+          "type": "string"
+        },
+        "credential_scope_binding_digest": {
+          "minLength": 1,
+          "title": "Credential Scope Binding Digest",
+          "type": "string"
+        },
+        "execution_intent_id": {
+          "minLength": 1,
+          "title": "Execution Intent Id",
+          "type": "string"
+        },
+        "execution_intent_hash": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Execution Intent Hash",
+          "type": "string"
+        },
+        "adapter_contract_hash": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Adapter Contract Hash",
+          "type": "string"
+        },
+        "endpoint_identity_binding_digest": {
+          "minLength": 1,
+          "title": "Endpoint Identity Binding Digest",
+          "type": "string"
+        },
+        "policy_snapshot_id": {
+          "minLength": 1,
+          "title": "Policy Snapshot Id",
+          "type": "string"
+        },
+        "source_gate_review_hash": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Source Gate Review Hash",
+          "type": "string"
+        },
+        "bind_context_hash": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Bind Context Hash",
+          "type": "string"
+        },
+        "consumption_required": {
+          "const": true,
+          "title": "Consumption Required",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "grant_version",
+        "allowed",
+        "credential_reference_digest",
+        "credential_scope_binding_digest",
+        "execution_intent_id",
+        "execution_intent_hash",
+        "adapter_contract_hash",
+        "endpoint_identity_binding_digest",
+        "policy_snapshot_id",
+        "source_gate_review_hash",
+        "bind_context_hash",
+        "consumption_required"
+      ],
+      "title": "CredentialResolutionGrant",
+      "type": "object"
+    },
+    "SignatureSignerDescriptor": {
+      "additionalProperties": false,
+      "properties": {
+        "key_id": {
+          "minLength": 1,
+          "title": "Key Id",
+          "type": "string"
+        },
+        "algorithm": {
+          "minLength": 1,
+          "title": "Algorithm",
+          "type": "string"
+        },
+        "identity": {
+          "minLength": 1,
+          "title": "Identity",
+          "type": "string"
+        },
+        "role": {
+          "minLength": 1,
+          "title": "Role",
+          "type": "string"
+        }
+      },
+      "required": [
+        "key_id",
+        "algorithm",
+        "identity",
+        "role"
+      ],
+      "title": "SignatureSignerDescriptor",
+      "type": "object"
+    },
+    "SignedBindAuthorizationDecisionArtifact": {
+      "additionalProperties": false,
+      "properties": {
+        "artifact_type": {
+          "const": "bind_authorizer_decision",
+          "title": "Artifact Type",
+          "type": "string"
+        },
+        "artifact_version": {
+          "const": "v1",
+          "title": "Artifact Version",
+          "type": "string"
+        },
+        "decision": {
+          "$ref": "#/$defs/BindAuthorizationDecision"
+        },
+        "decision_hash": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Decision Hash",
+          "type": "string"
+        },
+        "signer": {
+          "$ref": "#/$defs/SignatureSignerDescriptor"
+        },
+        "signed_at": {
+          "title": "Signed At",
+          "type": "string"
+        },
+        "signature": {
+          "minLength": 16,
+          "title": "Signature",
+          "type": "string"
+        }
+      },
+      "required": [
+        "artifact_type",
+        "artifact_version",
+        "decision",
+        "decision_hash",
+        "signer",
+        "signed_at",
+        "signature"
+      ],
+      "title": "SignedBindAuthorizationDecisionArtifact",
+      "type": "object"
+    },
+    "VerifiedSignatureBinding": {
+      "additionalProperties": false,
+      "description": "Verifier-derived signer identity stored as evidence, not caller authority.",
+      "properties": {
+        "purpose": {
+          "enum": [
+            "authorizer_decision",
+            "authorization_issuer"
+          ],
+          "title": "Purpose",
+          "type": "string"
+        },
+        "key_id": {
+          "minLength": 1,
+          "title": "Key Id",
+          "type": "string"
+        },
+        "algorithm": {
+          "minLength": 1,
+          "title": "Algorithm",
+          "type": "string"
+        },
+        "signer_identity": {
+          "minLength": 1,
+          "title": "Signer Identity",
+          "type": "string"
+        },
+        "signer_role": {
+          "minLength": 1,
+          "title": "Signer Role",
+          "type": "string"
+        },
+        "signer_policy_id": {
+          "minLength": 1,
+          "title": "Signer Policy Id",
+          "type": "string"
+        },
+        "signer_policy_hash": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Signer Policy Hash",
+          "type": "string"
+        },
+        "verifier_id": {
+          "minLength": 1,
+          "title": "Verifier Id",
+          "type": "string"
+        },
+        "verifier_trust_level": {
+          "const": "production",
+          "title": "Verifier Trust Level",
+          "type": "string"
+        },
+        "verifier_key_id": {
+          "minLength": 1,
+          "title": "Verifier Key Id",
+          "type": "string"
+        },
+        "verifier_policy_id": {
+          "minLength": 1,
+          "title": "Verifier Policy Id",
+          "type": "string"
+        },
+        "verifier_policy_hash": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Verifier Policy Hash",
+          "type": "string"
+        },
+        "verified_at": {
+          "title": "Verified At",
+          "type": "string"
+        }
+      },
+      "required": [
+        "purpose",
+        "key_id",
+        "algorithm",
+        "signer_identity",
+        "signer_role",
+        "signer_policy_id",
+        "signer_policy_hash",
+        "verifier_id",
+        "verifier_trust_level",
+        "verifier_key_id",
+        "verifier_policy_id",
+        "verifier_policy_hash",
+        "verified_at"
+      ],
+      "title": "VerifiedSignatureBinding",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false,
+  "description": "Signed, unconsumed native permission; rejected by the v1 consumer.",
+  "properties": {
+    "format_version": {
+      "const": "native-live-adapter-bind-authorization/v2",
+      "title": "Format Version",
+      "type": "string"
+    },
+    "artifact_type": {
+      "const": "live_adapter_bind_authorization",
+      "title": "Artifact Type",
+      "type": "string"
+    },
+    "artifact_version": {
+      "const": "v2",
+      "title": "Artifact Version",
+      "type": "string"
+    },
+    "authorization_id": {
+      "pattern": "^laba:v2:sha256:[0-9a-f]{64}$",
+      "title": "Authorization Id",
+      "type": "string"
+    },
+    "authorization_hash": {
+      "pattern": "^[0-9a-f]{64}$",
+      "title": "Authorization Hash",
+      "type": "string"
+    },
+    "source_runtime_risk_packet": {
+      "additionalProperties": true,
+      "title": "Source Runtime Risk Packet",
+      "type": "object"
+    },
+    "source_final_recheck_hash": {
+      "title": "Source Final Recheck Hash",
+      "type": "string"
+    },
+    "source_gate_hash": {
+      "title": "Source Gate Hash",
+      "type": "string"
+    },
+    "bind_context_hash": {
+      "title": "Bind Context Hash",
+      "type": "string"
+    },
+    "action_contract_digest": {
+      "title": "Action Contract Digest",
+      "type": "string"
+    },
+    "execution_intent": {
+      "additionalProperties": true,
+      "title": "Execution Intent",
+      "type": "object"
+    },
+    "execution_intent_id": {
+      "title": "Execution Intent Id",
+      "type": "string"
+    },
+    "execution_intent_hash": {
+      "title": "Execution Intent Hash",
+      "type": "string"
+    },
+    "signed_authority_evidence_artifact": {
+      "additionalProperties": true,
+      "title": "Signed Authority Evidence Artifact",
+      "type": "object"
+    },
+    "authority_verification_proof_digest": {
+      "title": "Authority Verification Proof Digest",
+      "type": "string"
+    },
+    "signed_human_approval_artifact": {
+      "anyOf": [
+        {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "title": "Signed Human Approval Artifact"
+    },
+    "human_approval_verification_proof_digest": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "title": "Human Approval Verification Proof Digest"
+    },
+    "human_approval_requirement_status": {
+      "enum": [
+        "VERIFIED",
+        "NOT_REQUIRED"
+      ],
+      "title": "Human Approval Requirement Status",
+      "type": "string"
+    },
+    "runtime_authority_result_digest": {
+      "title": "Runtime Authority Result Digest",
+      "type": "string"
+    },
+    "authorization_decision_artifact": {
+      "$ref": "#/$defs/SignedBindAuthorizationDecisionArtifact"
+    },
+    "authorizer_verification": {
+      "$ref": "#/$defs/VerifiedSignatureBinding"
+    },
+    "credential_resolution_grant": {
+      "$ref": "#/$defs/CredentialResolutionGrant"
+    },
+    "authorization_header_construction_grant": {
+      "$ref": "#/$defs/AuthorizationHeaderConstructionGrant"
+    },
+    "authorized_at": {
+      "title": "Authorized At",
+      "type": "string"
+    },
+    "valid_from": {
+      "title": "Valid From",
+      "type": "string"
+    },
+    "valid_until": {
+      "title": "Valid Until",
+      "type": "string"
+    },
+    "idempotency_key": {
+      "pattern": "^laba-idem:v2:sha256:[0-9a-f]{64}$",
+      "title": "Idempotency Key",
+      "type": "string"
+    },
+    "single_use": {
+      "const": true,
+      "title": "Single Use",
+      "type": "boolean"
+    },
+    "authorization_consumption_required": {
+      "const": true,
+      "title": "Authorization Consumption Required",
+      "type": "boolean"
+    },
+    "duplicate_dispatch_prohibited": {
+      "const": true,
+      "title": "Duplicate Dispatch Prohibited",
+      "type": "boolean"
+    },
+    "duplicate_absence_verified": {
+      "const": false,
+      "title": "Duplicate Absence Verified",
+      "type": "boolean"
+    },
+    "bind_time_runtime_risk_recheck_required": {
+      "const": true,
+      "title": "Bind Time Runtime Risk Recheck Required",
+      "type": "boolean"
+    },
+    "bind_authorization_created": {
+      "const": true,
+      "title": "Bind Authorization Created",
+      "type": "boolean"
+    },
+    "authorization_consumption_state": {
+      "const": "NOT_CONSUMED",
+      "title": "Authorization Consumption State",
+      "type": "string"
+    },
+    "execution_authority_created": {
+      "const": false,
+      "title": "Execution Authority Created",
+      "type": "boolean"
+    },
+    "human_approval_created": {
+      "const": false,
+      "title": "Human Approval Created",
+      "type": "boolean"
+    },
+    "bind_invoked": {
+      "const": false,
+      "title": "Bind Invoked",
+      "type": "boolean"
+    },
+    "bind_receipt_created": {
+      "const": false,
+      "title": "Bind Receipt Created",
+      "type": "boolean"
+    },
+    "credential_material_accessed": {
+      "const": false,
+      "title": "Credential Material Accessed",
+      "type": "boolean"
+    },
+    "authorization_header_constructed": {
+      "const": false,
+      "title": "Authorization Header Constructed",
+      "type": "boolean"
+    },
+    "network_used": {
+      "const": false,
+      "title": "Network Used",
+      "type": "boolean"
+    },
+    "external_effect_occurred": {
+      "const": false,
+      "title": "External Effect Occurred",
+      "type": "boolean"
+    },
+    "authorization_issuer_signer": {
+      "$ref": "#/$defs/SignatureSignerDescriptor"
+    },
+    "authorization_issuer_verification": {
+      "$ref": "#/$defs/VerifiedSignatureBinding"
+    },
+    "authorization_signed_at": {
+      "title": "Authorization Signed At",
+      "type": "string"
+    },
+    "authorization_signature": {
+      "minLength": 16,
+      "title": "Authorization Signature",
+      "type": "string"
+    }
+  },
+  "required": [
+    "format_version",
+    "artifact_type",
+    "artifact_version",
+    "authorization_id",
+    "authorization_hash",
+    "source_runtime_risk_packet",
+    "source_final_recheck_hash",
+    "source_gate_hash",
+    "bind_context_hash",
+    "action_contract_digest",
+    "execution_intent",
+    "execution_intent_id",
+    "execution_intent_hash",
+    "signed_authority_evidence_artifact",
+    "authority_verification_proof_digest",
+    "signed_human_approval_artifact",
+    "human_approval_verification_proof_digest",
+    "human_approval_requirement_status",
+    "runtime_authority_result_digest",
+    "authorization_decision_artifact",
+    "authorizer_verification",
+    "credential_resolution_grant",
+    "authorization_header_construction_grant",
+    "authorized_at",
+    "valid_from",
+    "valid_until",
+    "idempotency_key",
+    "single_use",
+    "authorization_consumption_required",
+    "duplicate_dispatch_prohibited",
+    "duplicate_absence_verified",
+    "bind_time_runtime_risk_recheck_required",
+    "bind_authorization_created",
+    "authorization_consumption_state",
+    "execution_authority_created",
+    "human_approval_created",
+    "bind_invoked",
+    "bind_receipt_created",
+    "credential_material_accessed",
+    "authorization_header_constructed",
+    "network_used",
+    "external_effect_occurred",
+    "authorization_issuer_signer",
+    "authorization_issuer_verification",
+    "authorization_signed_at",
+    "authorization_signature"
+  ],
+  "title": "NativeBindAuthorizationArtifact",
+  "type": "object",
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
+}

--- a/veritas_os/policy/live_adapter_bind_authorization_codec.py
+++ b/veritas_os/policy/live_adapter_bind_authorization_codec.py
@@ -10,10 +10,13 @@ from typing import Any
 from pydantic import BaseModel
 
 from veritas_os.policy.live_adapter_bind_authorization_contracts import (
-    AUTHORIZATION_SIGNATURE_DOMAIN, AUTHORIZER_SIGNATURE_DOMAIN, DOMAINS,
+    AUTHORIZATION_SIGNATURE_DOMAIN,
+    AUTHORIZER_SIGNATURE_DOMAIN,
+    DOMAINS,
     LiveAdapterBindAuthorizationError,
 )
 from veritas_os.security.hash import canonical_json_dumps
+
 
 def _json(value: Any) -> Any:
     if isinstance(value, BaseModel):
@@ -86,4 +89,16 @@ def bind_authorization_artifact_signature_payload(artifact: dict[str, Any]) -> s
     }
     return canonical_json_dumps(
         {"domain": AUTHORIZATION_SIGNATURE_DOMAIN, "artifact": unsigned}
+    )
+
+
+def native_bind_authorization_signature_payload(artifact: dict[str, Any]) -> str:
+    """Separate native v2 signatures from all legacy authorization payloads."""
+    return canonical_json_dumps(
+        {
+            "domain": "VERITAS:live-adapter-bind-authorization:v2:",
+            "artifact": {
+                k: v for k, v in artifact.items() if k != "authorization_signature"
+            },
+        }
     )

--- a/veritas_os/policy/live_adapter_bind_authorization_governance.py
+++ b/veritas_os/policy/live_adapter_bind_authorization_governance.py
@@ -200,6 +200,30 @@ def _validate_real_governance_inputs(
     source: CanonicalLiveAdapterDryRunBindAuthorizationGateReviewPacket,
     inputs: RealBindAuthorizationGovernanceInputs,
 ) -> _GovernanceOutcome:
+    """Legacy entry point: derive context with the existing source verifier."""
+    if not isinstance(inputs, RealBindAuthorizationGovernanceInputs):
+        raise LiveAdapterBindAuthorizationError("LABA_GOVERNANCE_INPUTS_REQUIRED")
+    return _validate_governance_for_verified_context(
+        source, inputs,
+        bind_context_hash=derive_verified_real_bind_context_hash(
+            source,
+            expected_source=inputs.expected_source,
+            expected_contract=inputs.action_contract,
+        ),
+    )
+
+
+def _validate_governance_for_verified_context(
+    source: Any,
+    inputs: RealBindAuthorizationGovernanceInputs,
+    *,
+    bind_context_hash: str,
+) -> _GovernanceOutcome:
+    """Shared cryptographic checks, internal to independently verified issuers.
+
+    This function is not a source verifier. Each issuer must reconstruct its
+    own source and context from external trust anchors before calling it.
+    """
     if not isinstance(inputs, RealBindAuthorizationGovernanceInputs):
         raise LiveAdapterBindAuthorizationError("LABA_GOVERNANCE_INPUTS_REQUIRED")
     now = inputs.verification_now
@@ -289,11 +313,6 @@ def _validate_real_governance_inputs(
             "LABA_AUTHORITY_REFERENCE_SOURCE_MISMATCH"
         )
 
-    bind_context_hash = derive_verified_real_bind_context_hash(
-        source,
-        expected_source=inputs.expected_source,
-        expected_contract=contract,
-    )
     human_proof: VerifiedHumanApprovalReceipt | None = None
     human_status: Literal["VERIFIED", "NOT_REQUIRED"] = "NOT_REQUIRED"
     needs_human = _requires_human_approval(contract)

--- a/veritas_os/policy/live_adapter_bind_authorization_signing.py
+++ b/veritas_os/policy/live_adapter_bind_authorization_signing.py
@@ -21,6 +21,9 @@ from veritas_os.policy.live_adapter_bind_authorization import (
     bind_authorizer_decision_signature_payload,
 )
 from veritas_os.security.hash import sha256_of_canonical_json
+from veritas_os.policy.live_adapter_bind_authorization_codec import (
+    native_bind_authorization_signature_payload,
+)
 
 Purpose = Literal["authorizer_decision", "authorization_issuer"]
 
@@ -36,6 +39,7 @@ class TrustedEd25519BindAuthorizationVerifier:
     purpose: Purpose
     trust_level: str = "production"
     verifier_policy_id: str = "bind-authorization-verifier-v1"
+    authorization_artifact_version: Literal["v1", "v2"] = "v1"
 
     def policy_hash(self) -> str:
         """Bind verifier policy identity to the exact trusted public-key bytes."""
@@ -60,6 +64,11 @@ class TrustedEd25519BindAuthorizationVerifier:
                 "verifier_id": self.verifier_id,
                 "trust_level": self.trust_level,
                 "keys": keys,
+                **(
+                    {"authorization_artifact_version": "v2"}
+                    if self.authorization_artifact_version == "v2"
+                    else {}
+                ),
             }
         )
 
@@ -72,6 +81,14 @@ class TrustedEd25519BindAuthorizationVerifier:
             return bind_authorizer_decision_signature_payload(artifact)
         if artifact.get("artifact_type") != AUTHORIZATION_ARTIFACT_TYPE:
             return None
+        if self.authorization_artifact_version == "v2":
+            if (
+                artifact.get("artifact_version") != "v2"
+                or artifact.get("format_version")
+                != "native-live-adapter-bind-authorization/v2"
+            ):
+                return None
+            return native_bind_authorization_signature_payload(artifact)
         if artifact.get("artifact_version") != AUTHORIZATION_ARTIFACT_VERSION:
             return None
         return bind_authorization_artifact_signature_payload(artifact)
@@ -99,9 +116,7 @@ class TrustedEd25519BindAuthorizationVerifier:
             else "authorization_signature"
         )
         try:
-            signature = base64.urlsafe_b64decode(
-                str(artifact.get(signature_field, ""))
-            )
+            signature = base64.urlsafe_b64decode(str(artifact.get(signature_field, "")))
             Ed25519PublicKey.from_public_bytes(key).verify(
                 signature, payload.encode("utf-8")
             )

--- a/veritas_os/policy/native_bind_authorization.py
+++ b/veritas_os/policy/native_bind_authorization.py
@@ -1,0 +1,453 @@
+"""Native v2 authorization issuance, never consumption or execution.
+
+Reconstruct the requirement-aware chain using deployment-owned anchors, then
+reuse the existing authority, human receipt, authorizer and grant primitives.
+No native artifact is relabelled as a legacy handoff. The private context is
+only a non-serializable projection for existing cryptographic checks.
+"""
+
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from veritas_os.policy.live_adapter_bind_authorization_contracts import (
+    BindAuthorizationSigner,
+    BindAuthorizationTrustInputs,
+    RealBindAuthorizationGovernanceInputs,
+    LiveAdapterBindAuthorizationError,
+)
+from veritas_os.policy.live_adapter_bind_authorization_models import (
+    SignedBindAuthorizationDecisionArtifact,
+    VerifiedSignatureBinding,
+    SignatureSignerDescriptor,
+    CredentialResolutionGrant,
+    AuthorizationHeaderConstructionGrant,
+)
+from veritas_os.policy.live_adapter_bind_authorization_codec import (
+    _json,
+    _digest,
+    _timestamp,
+    native_bind_authorization_signature_payload,
+)
+from veritas_os.policy.live_adapter_bind_authorization_checks import (
+    _verify_signed_decision,
+    _window,
+    _grants,
+    _idempotency_key,
+    _decision_hash,
+    _signature_binding,
+)
+from veritas_os.policy.live_adapter_bind_authorization_governance import (
+    _validate_governance_for_verified_context,
+)
+from veritas_os.policy.live_adapter_bind_authorization_requirements import (
+    _approved_issuer_binding,
+)
+from veritas_os.policy.promotion_requirement_final_rechecks import (
+    verify_promotion_requirement_final_recheck_packet,
+)
+from veritas_os.policy.promotion_requirement_runtime_risk import (
+    require_promotion_requirement_runtime_risk_pass,
+)
+
+DOMAIN = "veritas.native-live-adapter-bind-authorization/v2"
+
+
+def _supported_approval_rules(rules: dict[str, Any]) -> None:
+    """Never claim one receipt satisfies quorum or unimplemented policy rules."""
+    minimum = rules.get("minimum_approvals", 0)
+    if (
+        set(rules) - {"required", "minimum_approvals"}
+        or type(rules.get("required", False)) is not bool
+        or type(minimum) is not int
+        or minimum not in (0, 1)
+    ):
+        raise LiveAdapterBindAuthorizationError("NABA_UNSUPPORTED_HUMAN_RULES")
+
+
+@dataclass(frozen=True)
+class NativeAuthorizationSourceInputs:
+    """Independent deployment inputs, never populated from candidate snapshots.
+
+    Source and contract live in governance_inputs; verification_now is its
+    trusted current clock. No candidate-supplied defaults are permitted.
+    """
+
+    final_recheck: Any
+    expected_risk_decision: Any
+    expected_recorded_at: datetime
+    expected_verified_at: datetime
+    expected_rechecked_at: datetime
+    current_endpoint: Any
+    current_credential_reference: Any
+    required_credential_scope: str
+
+
+@dataclass(frozen=True)
+class _VerifiedContext:
+    """Internal projection; attribute aliases reuse v1 checks, not its schema."""
+
+    execution_intent: dict[str, Any]
+    execution_intent_id: str
+    execution_intent_hash: str
+    adapter_contract_id: str
+    adapter_contract_hash: str
+    endpoint_identity_binding_digest: str
+    credential_reference_digest: str
+    credential_scope_binding_digest: str
+    authority_evidence_reference_bundle: dict[str, Any]
+    human_approval_reference_bundle: dict[str, Any]
+    live_adapter_dry_run_bind_authorization_gate_review_id: str
+    live_adapter_dry_run_bind_authorization_gate_review_hash: str
+    bind_authorization_gate_review_decision: Any
+
+
+class NativeBindAuthorizationArtifact(BaseModel):
+    """Signed, unconsumed native permission; rejected by the v1 consumer."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    format_version: Literal["native-live-adapter-bind-authorization/v2"]
+    artifact_type: Literal["live_adapter_bind_authorization"]
+    artifact_version: Literal["v2"]
+    authorization_id: str = Field(pattern=r"^laba:v2:sha256:[0-9a-f]{64}$")
+    authorization_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    source_runtime_risk_packet: dict[str, Any]
+    source_final_recheck_hash: str
+    source_gate_hash: str
+    bind_context_hash: str
+    action_contract_digest: str
+    execution_intent: dict[str, Any]
+    execution_intent_id: str
+    execution_intent_hash: str
+    signed_authority_evidence_artifact: dict[str, Any]
+    authority_verification_proof_digest: str
+    signed_human_approval_artifact: dict[str, Any] | None
+    human_approval_verification_proof_digest: str | None
+    human_approval_requirement_status: Literal["VERIFIED", "NOT_REQUIRED"]
+    runtime_authority_result_digest: str
+    authorization_decision_artifact: SignedBindAuthorizationDecisionArtifact
+    authorizer_verification: VerifiedSignatureBinding
+    credential_resolution_grant: CredentialResolutionGrant
+    authorization_header_construction_grant: AuthorizationHeaderConstructionGrant
+    authorized_at: str
+    valid_from: str
+    valid_until: str
+    idempotency_key: str = Field(pattern=r"^laba-idem:v2:sha256:[0-9a-f]{64}$")
+    single_use: Literal[True]
+    authorization_consumption_required: Literal[True]
+    duplicate_dispatch_prohibited: Literal[True]
+    duplicate_absence_verified: Literal[False]
+    bind_time_runtime_risk_recheck_required: Literal[True]
+    bind_authorization_created: Literal[True]
+    authorization_consumption_state: Literal["NOT_CONSUMED"]
+    execution_authority_created: Literal[False]
+    human_approval_created: Literal[False]
+    bind_invoked: Literal[False]
+    bind_receipt_created: Literal[False]
+    credential_material_accessed: Literal[False]
+    authorization_header_constructed: Literal[False]
+    network_used: Literal[False]
+    external_effect_occurred: Literal[False]
+    authorization_issuer_signer: SignatureSignerDescriptor
+    authorization_issuer_verification: VerifiedSignatureBinding
+    authorization_signed_at: str
+    authorization_signature: str = Field(min_length=16)
+
+
+def _verified_source(
+    risk: Any,
+    source_inputs: NativeAuthorizationSourceInputs,
+    governance_inputs: RealBindAuthorizationGovernanceInputs,
+) -> tuple[Any, Any, _VerifiedContext]:
+    """Rebuild every source before projecting fields for shared checks."""
+    if not isinstance(source_inputs, NativeAuthorizationSourceInputs) or not isinstance(
+        governance_inputs, RealBindAuthorizationGovernanceInputs
+    ):
+        raise LiveAdapterBindAuthorizationError("NABA_INDEPENDENT_INPUTS_REQUIRED")
+    anchors = dict(
+        expected_source=governance_inputs.expected_source,
+        expected_contract=governance_inputs.action_contract,
+        expected_verified_at=source_inputs.expected_verified_at,
+        expected_rechecked_at=source_inputs.expected_rechecked_at,
+        current_endpoint=source_inputs.current_endpoint,
+        current_credential_reference=source_inputs.current_credential_reference,
+        required_credential_scope=source_inputs.required_credential_scope,
+    )
+    verified_risk = require_promotion_requirement_runtime_risk_pass(
+        risk,
+        source_inputs.final_recheck,
+        expected_risk_decision=source_inputs.expected_risk_decision,
+        expected_recorded_at=source_inputs.expected_recorded_at,
+        verification_now=governance_inputs.verification_now,
+        **anchors,
+    )
+    final = verify_promotion_requirement_final_recheck_packet(
+        source_inputs.final_recheck,
+        **anchors,
+    )
+    # Traverse only the freshly reconstructed chain, not the input objects.
+    gate = final.source_packet["source_packet"]
+    satisfaction = gate["source_packet"]["source_packet"]
+    authority = satisfaction["source_authority_evidence_linkage_review_packet"]
+    linkage = satisfaction["required_human_approval_linkage_packet"]
+    from veritas_os.policy.promotion_requirement_bind_readiness import (
+        RequirementBindReviewDecision,
+    )
+
+    context = final.exact_bind_context
+    projected = _VerifiedContext(
+        execution_intent=final.execution_intent,
+        execution_intent_id=context.execution_intent_id,
+        execution_intent_hash=context.execution_intent_hash,
+        adapter_contract_id=context.adapter_contract_id,
+        adapter_contract_hash=context.adapter_contract_hash,
+        endpoint_identity_binding_digest=context.endpoint_identity_binding_digest,
+        credential_reference_digest=context.credential_reference_digest,
+        credential_scope_binding_digest=context.credential_scope_binding_digest,
+        authority_evidence_reference_bundle=authority[
+            "authority_evidence_reference_bundle"
+        ],
+        human_approval_reference_bundle=(
+            linkage["human_approval_reference_bundle"] if linkage is not None else {}
+        ),
+        live_adapter_dry_run_bind_authorization_gate_review_id=gate["packet_id"],
+        live_adapter_dry_run_bind_authorization_gate_review_hash=gate["packet_hash"],
+        bind_authorization_gate_review_decision=RequirementBindReviewDecision.model_validate(
+            gate["review_decision"]
+        ),
+    )
+    return verified_risk, final, projected
+
+
+def _unsigned(
+    risk: Any,
+    signed_decision: Any,
+    valid_from: Any,
+    valid_until: Any,
+    *,
+    source_inputs: NativeAuthorizationSourceInputs,
+    governance_inputs: RealBindAuthorizationGovernanceInputs,
+    trust_inputs: BindAuthorizationTrustInputs,
+    issuer_signer: SignatureSignerDescriptor,
+    issuer_binding: VerifiedSignatureBinding,
+) -> dict[str, Any]:
+    risk, final, source = _verified_source(risk, source_inputs, governance_inputs)
+    _supported_approval_rules(governance_inputs.action_contract.human_approval_rules)
+    governance = _validate_governance_for_verified_context(
+        source,
+        governance_inputs,
+        bind_context_hash=final.bind_context_hash,
+    )
+    if (governance.human_approval_status == "VERIFIED") != risk.required_human_approval:
+        raise LiveAdapterBindAuthorizationError("NABA_APPROVAL_REQUIREMENT_MISMATCH")
+    start, end = _timestamp(valid_from), _timestamp(valid_until)
+    decision, authorizer = _verify_signed_decision(
+        signed_decision,
+        source=source,
+        trust=trust_inputs,
+        now=governance_inputs.verification_now,
+        expected_valid_from=start,
+        expected_valid_until=end,
+    )
+    authorized_at, start, end = _window(
+        source, governance, decision.decision, start, end
+    )
+    now = _timestamp(governance_inputs.verification_now)
+    dt = datetime.fromisoformat
+    if not (
+        dt(risk.recorded_at)
+        <= dt(start)
+        <= dt(now)
+        < dt(end)
+        <= dt(risk.risk_decision.valid_until)
+    ):
+        raise LiveAdapterBindAuthorizationError("NABA_VALIDITY_OUTSIDE_CURRENT_RISK")
+    if risk.risk_decision.reviewer_id.strip() == authorizer.signer_identity.strip():
+        raise LiveAdapterBindAuthorizationError("NABA_RISK_REVIEWER_AUTHORIZER_OVERLAP")
+    credential, header = _grants(
+        source, governance.policy_snapshot_id, final.bind_context_hash
+    )
+    base_key = _idempotency_key(
+        source,
+        _decision_hash(decision.decision),
+        start,
+        end,
+        governance.policy_snapshot_id,
+        final.bind_context_hash,
+    )
+    raw = dict(
+        format_version="native-live-adapter-bind-authorization/v2",
+        artifact_type="live_adapter_bind_authorization",
+        artifact_version="v2",
+        source_runtime_risk_packet=_json(risk),
+        source_final_recheck_hash=final.packet_hash,
+        source_gate_hash=final.exact_bind_context.gate_packet_hash,
+        bind_context_hash=final.bind_context_hash,
+        action_contract_digest=governance.action_contract_digest,
+        execution_intent=source.execution_intent,
+        execution_intent_id=source.execution_intent_id,
+        execution_intent_hash=source.execution_intent_hash,
+        signed_authority_evidence_artifact=_json(
+            governance_inputs.signed_authority_evidence_artifact
+        ),
+        authority_verification_proof_digest=governance.authority_proof.verification_proof_hash,
+        signed_human_approval_artifact=_json(
+            governance_inputs.signed_human_approval_artifact
+        ),
+        human_approval_verification_proof_digest=(
+            governance.human_approval_proof.verification_proof_hash
+            if governance.human_approval_proof
+            else None
+        ),
+        human_approval_requirement_status=governance.human_approval_status,
+        runtime_authority_result_digest=governance.runtime_result_digest,
+        authorization_decision_artifact=_json(decision),
+        authorizer_verification=_json(authorizer),
+        credential_resolution_grant=_json(credential),
+        authorization_header_construction_grant=_json(header),
+        authorized_at=authorized_at,
+        valid_from=start,
+        valid_until=end,
+        idempotency_key="laba-idem:v2:sha256:"
+        + _digest(
+            DOMAIN + ".idempotency",
+            {
+                "base_key": base_key,
+                "risk_hash": risk.packet_hash,
+                "action_contract_digest": governance.action_contract_digest,
+            },
+        ),
+        single_use=True,
+        authorization_consumption_required=True,
+        duplicate_dispatch_prohibited=True,
+        duplicate_absence_verified=False,
+        bind_time_runtime_risk_recheck_required=True,
+        bind_authorization_created=True,
+        authorization_consumption_state="NOT_CONSUMED",
+        **{
+            name: False
+            for name in (
+                "execution_authority_created",
+                "human_approval_created",
+                "bind_invoked",
+                "bind_receipt_created",
+                "credential_material_accessed",
+                "authorization_header_constructed",
+                "network_used",
+                "external_effect_occurred",
+            )
+        },
+        authorization_issuer_signer=_json(issuer_signer),
+        authorization_issuer_verification=_json(issuer_binding),
+        authorization_signed_at=now,
+    )
+    digest = _digest(DOMAIN, raw)
+    return {
+        **raw,
+        "authorization_hash": digest,
+        "authorization_id": "laba:v2:sha256:" + digest,
+    }
+
+
+def issue_native_bind_authorization(
+    runtime_risk_packet: Any,
+    signed_authorization_decision_artifact: Any,
+    valid_from: datetime | str,
+    valid_until: datetime | str,
+    *,
+    source_inputs: NativeAuthorizationSourceInputs,
+    governance_inputs: RealBindAuthorizationGovernanceInputs,
+    trust_inputs: BindAuthorizationTrustInputs,
+    authorization_issuer_signer: BindAuthorizationSigner,
+) -> NativeBindAuthorizationArtifact:
+    """Issue and independently verify one native authorization, without effects.
+
+    Requires original signed authority and, where required, human approval.
+    Raises ValueError on any failed source, governance, time or signature check.
+    Injected signer/verifiers must be deployment-controlled non-effecting backends.
+    """
+    signer = authorization_issuer_signer
+    binding = _approved_issuer_binding(
+        signer, trust_inputs, governance_inputs.verification_now
+    )
+    descriptor = SignatureSignerDescriptor(
+        key_id=signer.key_id,
+        algorithm=signer.algorithm,
+        identity=signer.identity,
+        role=signer.role,
+    )
+    raw = _unsigned(
+        runtime_risk_packet,
+        signed_authorization_decision_artifact,
+        valid_from,
+        valid_until,
+        source_inputs=source_inputs,
+        governance_inputs=governance_inputs,
+        trust_inputs=trust_inputs,
+        issuer_signer=descriptor,
+        issuer_binding=binding,
+    )
+    raw["authorization_signature"] = base64.urlsafe_b64encode(
+        signer.sign(native_bind_authorization_signature_payload(raw).encode("utf-8"))
+    ).decode("ascii")
+    return verify_native_bind_authorization(
+        raw,
+        source_inputs=source_inputs,
+        governance_inputs=governance_inputs,
+        trust_inputs=trust_inputs,
+    )
+
+
+def verify_native_bind_authorization(
+    artifact: Any,
+    *,
+    source_inputs: NativeAuthorizationSourceInputs,
+    governance_inputs: RealBindAuthorizationGovernanceInputs,
+    trust_inputs: BindAuthorizationTrustInputs,
+) -> NativeBindAuthorizationArtifact:
+    """Reconstruct the entire signed artifact using external anchors and clock.
+
+    This verifies issuance evidence at governance_inputs.verification_now, not
+    permission to consume. A future v2 consumer must independently recheck all
+    governance and current runtime conditions before atomic consumption.
+    """
+    candidate = NativeBindAuthorizationArtifact.model_validate(_json(artifact))
+    raw = candidate.model_dump(mode="json")
+    result = trust_inputs.authorization_issuer_signature_verifier.verify(raw)
+    binding = _signature_binding(
+        purpose="authorization_issuer",
+        result=result,
+        signer_policy=trust_inputs.authorization_issuer_signer_policy,
+        verifier_policy=trust_inputs.authorization_issuer_verifier_policy,
+        verified_at=governance_inputs.verification_now,
+    )
+    descriptor = SignatureSignerDescriptor(
+        key_id=binding.key_id,
+        algorithm=binding.algorithm,
+        identity=binding.signer_identity,
+        role=binding.signer_role,
+    )
+    expected = _unsigned(
+        candidate.source_runtime_risk_packet,
+        candidate.authorization_decision_artifact,
+        candidate.valid_from,
+        candidate.valid_until,
+        source_inputs=source_inputs,
+        governance_inputs=governance_inputs,
+        trust_inputs=trust_inputs,
+        issuer_signer=descriptor,
+        issuer_binding=binding,
+    )
+    if {k: v for k, v in raw.items() if k != "authorization_signature"} != expected:
+        raise LiveAdapterBindAuthorizationError("NABA_RECONSTRUCTION_MISMATCH")
+    return NativeBindAuthorizationArtifact.model_validate(
+        {
+            **expected,
+            "authorization_signature": candidate.authorization_signature,
+        }
+    )

--- a/veritas_os/tests/test_native_bind_authorization.py
+++ b/veritas_os/tests/test_native_bind_authorization.py
@@ -1,0 +1,343 @@
+"""Native issuance with actual Ed25519 verification and genuine API lineage.
+
+All keys, authority and approval artifacts are explicitly synthetic fixtures.
+Production verifiers are never replaced with accepting mocks.
+"""
+
+from __future__ import annotations
+
+import base64
+from copy import deepcopy
+from dataclasses import replace
+from datetime import timedelta
+
+import pytest
+
+from veritas_os.policy import native_bind_authorization as module
+from veritas_os.policy.live_adapter_bind_authorization_codec import (
+    _digest,
+    native_bind_authorization_signature_payload,
+)
+from veritas_os.policy.live_adapter_bind_authorization_contracts import (
+    RealBindAuthorizationGovernanceInputs,
+)
+from veritas_os.policy.live_adapter_bind_authorization_models import (
+    CanonicalLiveAdapterBindAuthorizationArtifact,
+)
+from veritas_os.policy.promotion_requirement_runtime_risk import (
+    build_promotion_requirement_runtime_risk_packet,
+)
+from veritas_os.tests import test_live_adapter_bind_authorization as crypto
+from veritas_os.tests.test_promotion_requirement_runtime_risk import (
+    api_risk_source as api_fixture,
+    _risk_chain,
+)
+from veritas_os.tests.test_promotion_human_approval_requirement_satisfaction import (
+    _contract,
+)
+
+pytestmark = pytest.mark.slow
+api_risk_source = api_fixture
+
+
+def _setup(source, contract, now):
+    final, risk, anchors = _risk_chain(source, contract, now)
+    source_inputs = module.NativeAuthorizationSourceInputs(
+        final_recheck=final,
+        **{
+            k: v
+            for k, v in anchors.items()
+            if k not in {"expected_source", "expected_contract", "verification_now"}
+        },
+    )
+    # These fixture helpers sign synthetic artifacts. Only their fixture input
+    # globals are adapted; all production source/crypto verifiers run unchanged.
+    placeholder = RealBindAuthorizationGovernanceInputs(
+        contract,
+        {},
+        None,
+        None,
+        None,
+        None,
+        None,
+        anchors["verification_now"],
+        expected_source=source,
+    )
+    _, _, context = module._verified_source(risk, source_inputs, placeholder)
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(crypto, "source_packet", lambda: context)
+        patch.setattr(crypto, "SOURCE_RECORDED_AT", now)
+        patch.setattr(crypto, "AUTHORIZED_AT", anchors["verification_now"])
+        patch.setattr(crypto, "VERIFICATION_NOW", anchors["verification_now"])
+        patch.setattr(crypto, "_bind_context_hash", lambda _: final.bind_context_hash)
+        authority = crypto._authority_bundle(contract)
+        human = (
+            crypto._signed_human_approval(contract)
+            if risk.required_human_approval
+            else (None,) * 4
+        )
+        governance = replace(
+            placeholder,
+            signed_authority_evidence_artifact=authority[0],
+            authority_signature_verifier=authority[1],
+            authority_signer_policy=authority[2],
+            authority_verifier_policy=authority[3],
+            authority_revocation_checker=authority[4],
+            authority_revocation_policy=authority[5],
+            signed_human_approval_artifact=human[0],
+            human_approval_signature_verifier=human[1],
+            human_approval_signer_policy=human[2],
+            human_approval_verifier_policy=human[3],
+        )
+        key, trust, signer = crypto._bind_signature_setup()
+        issuer_verifier = replace(
+            trust.authorization_issuer_signature_verifier,
+            authorization_artifact_version="v2",
+        )
+        approved = trust.authorization_issuer_verifier_policy.approved_verifiers[0]
+        policy = replace(
+            trust.authorization_issuer_verifier_policy,
+            approved_verifiers=[
+                replace(approved, verifier_policy_hash=issuer_verifier.policy_hash())
+            ],
+        )
+        trust = replace(
+            trust,
+            authorization_issuer_signature_verifier=issuer_verifier,
+            authorization_issuer_verifier_policy=policy,
+        )
+        start = anchors["verification_now"]
+        end = now + timedelta(seconds=20)
+        decision = crypto._signed_decision(
+            key, source=context, valid_from=start, valid_until=end
+        )
+    inputs = dict(
+        source_inputs=source_inputs, governance_inputs=governance, trust_inputs=trust
+    )
+    artifact = module.issue_native_bind_authorization(
+        risk,
+        decision,
+        start,
+        end,
+        **inputs,
+        authorization_issuer_signer=signer,
+    )
+    return artifact, inputs, signer, risk, decision, start, end
+
+
+@pytest.fixture(scope="module")
+def issued(api_risk_source):
+    source, now, required, captured = api_risk_source
+    assert captured["pipeline_ok"] is True
+    contract = _contract(source.execution_intent["intended_action"], required)
+    contract.irreversibility["boundary"] = "future-bind-consumption"
+    return _setup(source, contract, now)
+
+
+def _resign(raw, signer):
+    body = {
+        k: v
+        for k, v in raw.items()
+        if k
+        not in {"authorization_id", "authorization_hash", "authorization_signature"}
+    }
+    digest = _digest(module.DOMAIN, body)
+    raw = {
+        **body,
+        "authorization_hash": digest,
+        "authorization_id": "laba:v2:sha256:" + digest,
+    }
+    raw["authorization_signature"] = base64.urlsafe_b64encode(
+        signer.sign(native_bind_authorization_signature_payload(raw).encode())
+    ).decode()
+    return raw
+
+
+def test_real_api_native_issuance_and_reverification(issued):
+    artifact, inputs, _, risk, *_ = issued
+    verified = module.verify_native_bind_authorization(artifact, **inputs)
+    assert verified == artifact and verified is not artifact
+    assert (
+        verified.execution_intent
+        == inputs["source_inputs"].final_recheck.execution_intent
+    )
+    assert verified.source_runtime_risk_packet == risk.model_dump(mode="json")
+    assert verified.human_approval_requirement_status == (
+        "VERIFIED" if risk.required_human_approval else "NOT_REQUIRED"
+    )
+    assert (
+        verified.signed_human_approval_artifact is not None
+    ) == risk.required_human_approval
+    assert verified.authorization_consumption_state == "NOT_CONSUMED"
+    assert verified.authorization_consumption_required
+    assert not verified.duplicate_absence_verified
+    for field in (
+        "execution_authority_created",
+        "human_approval_created",
+        "bind_invoked",
+        "bind_receipt_created",
+        "credential_material_accessed",
+        "network_used",
+        "external_effect_occurred",
+        "authorization_header_constructed",
+    ):
+        assert getattr(verified, field) is False
+
+
+def test_v1_schema_and_verifier_reject_v2(issued):
+    artifact, inputs, *_ = issued
+    with pytest.raises(ValueError):
+        CanonicalLiveAdapterBindAuthorizationArtifact.model_validate(
+            artifact.model_dump()
+        )
+    v2 = inputs["trust_inputs"].authorization_issuer_signature_verifier
+    v1 = replace(v2, authorization_artifact_version="v1")
+    assert not v1.verify(artifact.model_dump(mode="json")).verified
+    assert v1.policy_hash() != v2.policy_hash()
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("source_gate_hash", "0" * 64),
+        ("source_final_recheck_hash", "0" * 64),
+        ("bind_context_hash", "0" * 64),
+        ("action_contract_digest", "0" * 64),
+        ("execution_intent_hash", "0" * 64),
+        ("authority_verification_proof_digest", "0" * 64),
+        ("runtime_authority_result_digest", "0" * 64),
+        ("human_approval_requirement_status", "NOT_REQUIRED"),
+        ("idempotency_key", "laba-idem:v2:sha256:" + "0" * 64),
+    ],
+)
+def test_rehashed_and_resigned_false_claims_rejected(issued, field, value):
+    artifact, inputs, signer, *_ = issued
+    raw = artifact.model_dump(mode="json")
+    if raw[field] == value:
+        value = "VERIFIED"
+    raw[field] = value
+    with pytest.raises(ValueError, match="NABA_RECONSTRUCTION_MISMATCH"):
+        module.verify_native_bind_authorization(_resign(raw, signer), **inputs)
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        "contract_rules",
+        "contract_required",
+        "clock",
+        "endpoint",
+        "credential",
+        "missing_source",
+    ],
+)
+def test_independent_anchors_cannot_be_replaced(issued, change):
+    artifact, original, *_ = issued
+    inputs = dict(original)
+    governance = inputs["governance_inputs"]
+    source = inputs["source_inputs"]
+    if change.startswith("contract"):
+        contract = deepcopy(governance.action_contract)
+        contract.human_approval_rules["minimum_approvals"] = 2
+        if change == "contract_required":
+            contract.human_approval_rules[
+                "required"
+            ] = not contract.human_approval_rules["required"]
+        inputs["governance_inputs"] = replace(governance, action_contract=contract)
+    elif change == "clock":
+        inputs["governance_inputs"] = replace(
+            governance,
+            verification_now=governance.verification_now + timedelta(seconds=30),
+        )
+    elif change == "missing_source":
+        inputs["governance_inputs"] = replace(governance, expected_source=None)
+    else:
+        field = (
+            "current_endpoint"
+            if change == "endpoint"
+            else "current_credential_reference"
+        )
+        inputs["source_inputs"] = replace(source, **{field: {}})
+    with pytest.raises(ValueError):
+        module.verify_native_bind_authorization(artifact, **inputs)
+
+
+@pytest.mark.parametrize("signal", [False, None])
+def test_block_or_indeterminate_cannot_issue_or_call_signer(issued, signal):
+    _, inputs, _, _, decision, start, end = issued
+    src = inputs["source_inputs"]
+    gov = inputs["governance_inputs"]
+    risk_decision = {**src.expected_risk_decision, "runtime_risk_signal": signal}
+    risk = build_promotion_requirement_runtime_risk_packet(
+        src.final_recheck,
+        risk_decision,
+        src.expected_recorded_at,
+        expected_source=gov.expected_source,
+        expected_contract=gov.action_contract,
+        expected_verified_at=src.expected_verified_at,
+        expected_rechecked_at=src.expected_rechecked_at,
+        current_endpoint=src.current_endpoint,
+        current_credential_reference=src.current_credential_reference,
+        required_credential_scope=src.required_credential_scope,
+    )
+    changed = {
+        **inputs,
+        "source_inputs": replace(src, expected_risk_decision=risk_decision),
+    }
+
+    class ForbiddenSigner:
+        key_id = "bind-authorization-issuer-key"
+        algorithm = "Ed25519"
+        identity = "service:bind-authorization-issuer"
+        role = "bind-authorization-issuer"
+
+        def sign(self, payload):
+            pytest.fail("rejected risk must not reach signing")
+
+    with pytest.raises(ValueError, match="PRRR_RISK_NOT_ACCEPTABLE"):
+        module.issue_native_bind_authorization(
+            risk,
+            decision,
+            start,
+            end,
+            **changed,
+            authorization_issuer_signer=ForbiddenSigner(),
+        )
+
+
+def test_missing_or_unexpected_human_receipt_rejected(issued):
+    artifact, inputs, *_ = issued
+    gov = inputs["governance_inputs"]
+    human = (
+        None if gov.signed_human_approval_artifact is not None else {"synthetic": True}
+    )
+    with pytest.raises(ValueError, match="LABA_HUMAN_APPROVAL_(REQUIRED|UNEXPECTED)"):
+        module.verify_native_bind_authorization(
+            artifact,
+            **{
+                **inputs,
+                "governance_inputs": replace(gov, signed_human_approval_artifact=human),
+            },
+        )
+
+
+def test_revoked_authority_rejected(issued):
+    artifact, inputs, *_ = issued
+
+    class Revoked(crypto._FreshRevocationChecker):
+        def check(self, authority_evidence_id, *, now):
+            return replace(super().check(authority_evidence_id, now=now), revoked=True)
+
+    gov = replace(inputs["governance_inputs"], authority_revocation_checker=Revoked())
+    with pytest.raises(ValueError, match="LABA_AUTHORITY_VERIFICATION_FAILED"):
+        module.verify_native_bind_authorization(
+            artifact, **{**inputs, "governance_inputs": gov}
+        )
+
+
+def test_corrupt_issuer_signature_rejected(issued):
+    artifact, inputs, *_ = issued
+    raw = artifact.model_dump(mode="json")
+    raw["authorization_signature"] = "A" * 88
+    with pytest.raises(ValueError, match="LABA_SIGNATURE_INVALID"):
+        module.verify_native_bind_authorization(raw, **inputs)

--- a/veritas_os/tests/test_native_bind_authorization_adversarial.py
+++ b/veritas_os/tests/test_native_bind_authorization_adversarial.py
@@ -1,0 +1,158 @@
+"""Cross-boundary attacks against native v2 issuance, with real verifiers."""
+
+from copy import deepcopy
+from dataclasses import replace
+from datetime import timedelta
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from veritas_os.policy import native_bind_authorization as module
+from veritas_os.tests.test_native_bind_authorization import (
+    issued as issued_fixture,
+    api_risk_source as source_fixture,
+    _setup,
+)
+
+pytestmark = pytest.mark.slow
+issued = issued_fixture
+api_risk_source = source_fixture
+
+
+def test_schema_matches_native_model(issued):
+    artifact, *_ = issued
+    schema = json.loads(
+        (
+            Path(__file__).resolve().parents[2]
+            / "schemas/native-live-adapter-bind-authorization-v2.schema.json"
+        ).read_text()
+    )
+    expected = module.NativeBindAuthorizationArtifact.model_json_schema()
+    assert {k: v for k, v in schema.items() if k != "$schema"} == expected
+    Draft202012Validator(schema).validate(artifact.model_dump(mode="json"))
+
+
+def test_complete_rebuilt_not_required_attack_against_original_contract(issued):
+    _, original_inputs, _, risk, *_ = issued
+    if not risk.required_human_approval:
+        pytest.skip("downgrade requires the REQUIRED baseline")
+    original = original_inputs["governance_inputs"]
+    forged_contract = replace(
+        original.action_contract,
+        human_approval_rules={"required": False, "minimum_approvals": 0},
+    )
+    assert forged_contract.id == original.action_contract.id
+    assert forged_contract.version == original.action_contract.version
+    attacker_artifact, attacker_inputs, *_ = _setup(
+        original.expected_source,
+        forged_contract,
+        original_inputs["source_inputs"].expected_verified_at,
+    )
+    assert attacker_artifact.human_approval_requirement_status == "NOT_REQUIRED"
+    # Even an authenticated issuer cannot turn its embedded, completely rebuilt
+    # HARR/satisfaction/final/risk/authorization into the external policy anchor.
+    with pytest.raises(ValueError):
+        module.verify_native_bind_authorization(
+            attacker_artifact,
+            **{
+                **attacker_inputs,
+                "governance_inputs": replace(
+                    attacker_inputs["governance_inputs"],
+                    action_contract=original.action_contract,
+                    expected_source=original.expected_source,
+                ),
+            },
+        )
+
+
+@pytest.mark.parametrize("target", ["authority", "human", "go"])
+def test_corrupt_upstream_signature_cannot_issue(issued, target):
+    _, inputs, signer, risk, decision, start, end = issued
+    changed = dict(inputs)
+    if target == "go":
+        decision = deepcopy(decision)
+        decision["signature"] = "A" * 88
+    else:
+        gov = inputs["governance_inputs"]
+        field = (
+            "signed_authority_evidence_artifact"
+            if target == "authority"
+            else "signed_human_approval_artifact"
+        )
+        artifact = deepcopy(getattr(gov, field))
+        if artifact is None:
+            artifact = {"signature": "A" * 88}
+        else:
+            artifact["signature"] = "A" * 88
+        changed["governance_inputs"] = replace(gov, **{field: artifact})
+    with pytest.raises(ValueError):
+        module.issue_native_bind_authorization(
+            risk, decision, start, end, **changed, authorization_issuer_signer=signer
+        )
+
+
+def test_expired_authorization_before_risk_deadline_rejected(issued):
+    artifact, inputs, *_ = issued
+    gov = inputs["governance_inputs"]
+    # Risk remains valid until +30; authorization expires at +20.
+    now = inputs["source_inputs"].expected_verified_at + timedelta(seconds=21)
+    with pytest.raises(ValueError, match="NABA_VALIDITY_OUTSIDE_CURRENT_RISK"):
+        module.verify_native_bind_authorization(
+            artifact,
+            **{
+                **inputs,
+                "governance_inputs": replace(gov, verification_now=now),
+            },
+        )
+
+
+def test_absent_issuance_boundary_in_contract_fails_closed(issued):
+    _, inputs, *_ = issued
+    contract = deepcopy(inputs["governance_inputs"].action_contract)
+    del contract.irreversibility["boundary"]
+    with pytest.raises(ValueError, match="LABA_RUNTIME_AUTHORITY_NOT_COMMIT"):
+        _setup(
+            inputs["governance_inputs"].expected_source,
+            contract,
+            inputs["source_inputs"].expected_verified_at,
+        )
+
+
+@pytest.mark.parametrize(
+    "rules",
+    [
+        {"minimum_approvals": 2},
+        {"minimum_approvals": -1},
+        {"minimum_approvals": True},
+        {"minimum_approvals": "1"},
+        {"required": "false"},
+        {"required": 1},
+        {"required": True, "approver_role": "security-officer"},
+    ],
+)
+def test_unimplemented_or_ambiguous_approval_rules_rejected(rules):
+    with pytest.raises(ValueError, match="NABA_UNSUPPORTED_HUMAN_RULES"):
+        module._supported_approval_rules(rules)
+
+
+def test_quorum_contract_cannot_reach_authorization(issued):
+    _, inputs, *_ = issued
+    contract = replace(
+        inputs["governance_inputs"].action_contract,
+        human_approval_rules={"required": True, "minimum_approvals": 2},
+    )
+    # A no-approval source refuses linkage before issuance; a REQUIRED source
+    # reaches the v2 rule guard, which refuses a single receipt for quorum.
+    expected = (
+        "NABA_UNSUPPORTED_HUMAN_RULES"
+        if inputs["governance_inputs"].action_contract.human_approval_rules["required"]
+        else "PLADHAL_HUMAN_APPROVAL_NOT_REQUIRED"
+    )
+    with pytest.raises(ValueError, match=expected):
+        _setup(
+            inputs["governance_inputs"].expected_source,
+            contract,
+            inputs["source_inputs"].expected_verified_at,
+        )


### PR DESCRIPTION
# Summary
Issue and independently reverify native Bind Authorization v2 from the requirement-aware runtime-risk PASS chain. Keep v1/v0.3 artifacts and consumers intact.

## Scope
- New closed native v2 artifact, schema, issuer and reconstruction verifier.
- Mandatory independent full final recheck, trusted Authority Evidence Linkage source / ActionClassContract, expected review, metadata and clocks.
- Reuse existing Authority Evidence / revocation / signed Human Approval / RuntimeAuthority / signed GO / grants / idempotency checks.
- Domain-separated v2 issuer signatures require explicit verifier opt-in and matching deployment policy hash.
- REQUIRED requires an existing signed receipt; NOT_REQUIRED rejects supplied receipts. Quorum and unsupported approval rules fail closed.
- No native packet relabeling, invented handoff/replay evidence, human approval generation, consumption, credential access, network, Bind invocation, BindReceipt or external effect.

## Type of change
- [x] Runtime
- [x] Tests
- [x] Docs
- [x] Governance / security-sensitive

## Why this change matters
The existing v1 issuer requires legacy-only source fields. This adds a separately versioned native issuance boundary without fabricating those fields or weakening v1/v0.3 trust anchors.

## Market / developer / user value
- Market value: no production-readiness or commercial claims added.
- Developer value: a native signed issuance boundary with explicit compatibility rules.
- User/operator value: source/policy substitution, rejected risk, invalid signatures and stale evidence cannot authorize.

## Tests run
- [x] Targeted pytest, Ruff, bilingual docs, responsibility boundaries, diff checks.
- 177 distinct related tests passed across commands; 1 intentional skip (downgrade attack requires a REQUIRED baseline).
  - test_native_bind_authorization.py: 44 passed on final production code.
  - test_native_bind_authorization_adversarial.py: 22 distinct passed, 1 skipped, including focused rerun of both quorum cases after correcting the expected earlier rejection for NOT_REQUIRED sources.
  - Existing authorization / runtime digest / v0.3 issuance trust / HARR integration: 40 passed.
  - Existing requirement runtime risk / real decision authorization boundary: 71 passed.
- New module coverage: 99.30% (142/143 statements; cumulative targeted coverage, 90% gate passed).
- Full GitHub CI: pending, not claimed passed.
- An initial test-environment NumPy import crash was resolved by reinstalling the same numpy==1.26.4 version; no dependency changes committed.
- Local tested tree equals published tree: `3b8ed877a776a4a933ca06b6423ce7114f54d5cd`.

## AI assistance used
- [x] Codex

## Review status
- [ ] CI passed
- [ ] Human maintainer reviewed

## Risk checklist
- [x] Touches bind/admissibility logic
- [x] Touches governance policy behavior

## Human approval required?
- [x] Yes

Reason: new signed authorization format and security-sensitive issuance boundary.

## Notes for reviewer
- **Draft; do not merge automatically.**
- v2 consumption/execution is intentionally NOT implemented. v1 schema/verifier rejects v2.
- Issuance verification reconstructs at the independently supplied issuance verification time; it is not permission to consume. A future consumer must recheck current governance/risk and atomically consume before credentials/effects.
- Idempotency and single-use policy are bound; duplicate absence is not proven and no store is queried/reserved.
- The authorizer must differ from gate and risk reviewers.
- Tests use genuine authenticated /v1/decide lineage and real Ed25519 verifiers, but controlled model/cloud clients, synthetic risk observations and synthetic signed authority/approval fixtures. These are not operational human consent.
- The shared governance extraction does not change v1 policy semantics; native v2 additionally rejects unsupported approval rules.
