### PR TITLE
feat: consume native v2 authorization after current governance rechecks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -887,11 +887,11 @@ jobs:
     runs-on: ubuntu-latest
     # test-slow installs the full requirements.txt which includes heavy optional
     # ML wheels (e.g. torch, torchvision). On a cold runner cache these can take
-    # 8-12 minutes to install before pytest even starts. The 20-minute ceiling
-    # provides headroom without masking genuine test hangs; do not reduce below
-    # 15 minutes without first verifying that the full wheel install completes
-    # within the new limit on a cache-miss run.
-    timeout-minutes: 20
+    # 8-12 minutes to install before pytest even starts. On PR #2195 the expanded
+    # slow suite reached only 63% before the previous 20-minute job limit.
+    # Allow 60 minutes for installation and the full suite, retaining a bounded
+    # timeout and normal failure propagation. Revisit using completed durations.
+    timeout-minutes: 60
 
     env:
       PYTHONUNBUFFERED: "1"

--- a/docs/en/development/approval-requirement-source-verification.md
+++ b/docs/en/development/approval-requirement-source-verification.md
@@ -219,7 +219,8 @@ approval states with controlled model/cloud clients and explicit test metadata.
 The older native and legacy APIs remain unchanged. The requirement-aware
 runtime-risk boundary below consumes the final packet. Authorization issuance,
 real-decision single-use execution and outcome validation are separate boundaries;
-native v2 issuance is described below, while consumption remains incomplete.
+native v2 issuance and consume-only boundaries are described below. Integration
+with action execution and outcome validation remains incomplete.
 
 ## Runtime-risk review from verified final rechecks
 
@@ -283,13 +284,45 @@ reject v2; existing v1/v0.3 paths are retained.
 
 `verify_native_bind_authorization` re-verifies signatures and reconstructs every
 field at the independently supplied issuance verification time. This is not a
-consumer or a current execution permission. The v2 consumer is not implemented.
+consumer or a current execution permission. The consume-only API below performs
+the independent current-time checks.
 Idempotency commits the signed decision/context, risk hash, contract and window;
 single-use policy is signed, but unused-key status is **not** proven. Atomic
-consumption and fresh Bind-time governance/risk checks remain mandatory future
-work. No credential resolution, header construction, network, Bind invocation,
+consumption is implemented separately below; fresh Bind-time governance/risk checks
+remain mandatory for future execution. No credential resolution, header construction, network, Bind invocation,
 BindReceipt or external effect is performed by this issuance boundary.
 
 Test keys and signed authority/approval artifacts are synthetic; they do not
 represent operational human consent. Caller risk evidence remains unauthenticated
 sensor input, and the injected cryptographic backends must be non-effecting.
+
+## Native v2 consume-only boundary
+
+`consume_native_bind_authorization` verifies the unchanged signed issuance
+artifact with independent issuance inputs, rejects backdated/expired clocks,
+then reconstructs the current source from separately supplied source/risk inputs.
+The fresh review and record times must equal the trusted consumption time.
+BLOCK, INDETERMINATE, drift, missing inputs and reused issuance reviews fail
+before storage. Exact intent, Bind context, gate and contract must match the
+signed authorization. Original authority and required human receipt signatures,
+revocation status and RuntimeAuthority are reverified at consumption time.
+Historical signed proof hashes remain unchanged; current proofs are returned
+separately. Caller-supplied observations are still not authenticated sensors.
+
+The existing PostgreSQL store atomically records one consumption using unique
+authorization-ID and idempotency-key constraints. The existing record schema
+can carry native `laba:v2` IDs without fabricating legacy source data. PostgreSQL
+is required by default; in-memory storage requires explicit test-only opt-in and
+is reported as non-durable. Unknown stores cannot self-assert production safety.
+Duplicate attempts and failed/ambiguous store acknowledgements return no success.
+No consumption is released after failure, including commit followed by lost ACK.
+
+The only intended write is the configured consumption database. No action
+credential, authorization header, adapter, Bind invocation, BindReceipt or
+external-action dispatch is involved. The consumption result is audit lineage,
+not a reusable execution capability. The supplied clock establishes validation
+time, not database commit time; future action execution must recheck current
+policy/risk and durable consumed lineage rather than trusting a saved result.
+Both approval states have real-verifier tests and PostgreSQL contention tests
+in the existing database CI job; this does not claim production deployment or
+completed decision-to-external-effect integration.

--- a/docs/ja/development/approval-requirement-source-verification.md
+++ b/docs/ja/development/approval-requirement-source-verification.md
@@ -224,12 +224,35 @@ deployment policy hashが必要です。既定v1 verifierとv1 artifact schema�
 既存v1／v0.3経路は維持します。
 
 `verify_native_bind_authorization`は独立入力の発行検証時刻で署名・全項目を再検証・再構築します。
-これはconsumerでも現在の実行許可でもなく、v2 consumerは未実装です。idempotencyは署名済み
+これはconsumerでも現在の実行許可でもありません。下記の消費専用APIが現在時刻の独立検証を行います。idempotencyは署名済み
 判断／context・risk hash・契約・有効期間を固定しますが、未使用keyであることは証明しません。
-単回消費ポリシーを署名しても、atomic consumptionとBind直前の最新governance／risk再検査は
-今後の必須作業です。この発行境界でcredential取得・header構築・network・Bind実行・
+atomic consumptionは下記の別境界で実装し、Bind直前の最新governance／risk再検査は
+今後の実行境界でも必須です。この発行境界でcredential取得・header構築・network・Bind実行・
 BindReceipt・外部効果は行いません。
 
 テスト用鍵・署名済みAuthority／Approval artifactは合成fixtureであり、実運用の人間同意を
 意味しません。呼び出し元のrisk evidenceは認証済みセンサー入力ではありません。
 注入する暗号処理backendには、外部効果を起こさない実装が必要です。
+
+## Native v2の消費専用境界
+
+`consume_native_bind_authorization`は独立した発行時入力で署名済みartifactを再検証し、
+過去へ戻した時計・期限切れを拒否します。続いて別途渡す現在のsource／risk入力から再構築します。
+新しいreview時刻と記録時刻はtrusted消費時刻と一致する必要があります。BLOCK・判定不能・
+状態変化・入力欠落・発行時レビューの再利用はDB記録前に拒否します。intent・Bind context・gate・
+契約は署名済みauthorizationと一致させます。元のAuthority Evidenceと必須のHuman Approval Receiptの
+署名、失効状態、RuntimeAuthorityを消費時刻で再検証します。発行時の署名済みproof hashは変更せず、
+現在のproofを別に返します。呼び出し元の観測値が認証済みセンサー値になるわけではありません。
+
+既存PostgreSQL storeのauthorization ID／idempotency key一意制約で一回だけ原子的に記録します。
+既存record schemaはnative `laba:v2` IDを保持でき、legacy sourceの捏造は不要です。
+既定ではPostgreSQL必須で、メモリstoreは明示的なテスト用opt-inが必要です。結果にも非永続と表示します。
+未知のstoreによるproduction-safe自己申告は認めません。重複やDB応答の失敗・不確定状態では成功を返さず、
+commit後の応答喪失を含め、失敗しても消費を解除しません。
+
+意図する書き込みは設定済みの消費DBだけです。アクション用credential取得、header、adapter、Bind実行、
+BindReceipt、外部アクション送信は行いません。返す消費結果は監査用の系譜であり、再利用可能な実行権限ではありません。
+指定時計は検証時刻を表し、DB commit時刻の証明ではありません。今後の実行境界では保存済み結果だけを信用せず、
+最新policy／riskと永続化された消費の系譜を再検証する必要があります。
+承認必須／不要の両方に実verifierテストと、既存DB CI jobでのPostgreSQL競合テストを追加します。
+本番配備やdecisionから外部効果までの統合完了を意味しません。

--- a/tests/ci/test_slow_test_workflow.py
+++ b/tests/ci/test_slow_test_workflow.py
@@ -1,0 +1,37 @@
+"""Guard the slow-suite time budget without weakening test coverage or failures."""
+
+from pathlib import Path
+
+import yaml
+
+
+def _slow_job() -> dict:
+    """Read the authoritative GitHub Actions slow-test job."""
+    root = Path(__file__).resolve().parents[2]
+    workflow = yaml.safe_load(
+        (root / ".github/workflows/main.yml").read_text(encoding="utf-8")
+    )
+    return workflow["jobs"]["test-slow"]
+
+
+def test_slow_suite_has_bounded_completion_budget() -> None:
+    """Installation plus the expanded suite must have a bounded one-hour budget."""
+    assert _slow_job()["timeout-minutes"] == 60
+
+
+def test_slow_suite_preserves_selection_and_failure_propagation() -> None:
+    """The timeout fix must not skip tests or tolerate failing pytest results."""
+    job = _slow_job()
+    assert not job.get("continue-on-error", False)
+    step = next(s for s in job["steps"] if s["name"] == "Run slow tests (if any)")
+    assert not step.get("continue-on-error", False)
+    assert step["run"].strip() == '\n'.join([
+        "set -euxo pipefail",
+        "status=0",
+        "pytest -q veritas_os/tests -m slow --durations=20 --tb=short || status=$?",
+        'if [ "$status" -eq 5 ]; then',
+        '  echo "No slow tests were selected."',
+        "  exit 0",
+        "fi",
+        'exit "$status"',
+    ])

--- a/veritas_os/policy/native_bind_authorization.py
+++ b/veritas_os/policy/native_bind_authorization.py
@@ -413,7 +413,7 @@ def verify_native_bind_authorization(
     """Reconstruct the entire signed artifact using external anchors and clock.
 
     This verifies issuance evidence at governance_inputs.verification_now, not
-    permission to consume. A future v2 consumer must independently recheck all
+    permission to consume. The v2 consume-only API must independently recheck all
     governance and current runtime conditions before atomic consumption.
     """
     candidate = NativeBindAuthorizationArtifact.model_validate(_json(artifact))

--- a/veritas_os/policy/native_bind_authorization_consumption.py
+++ b/veritas_os/policy/native_bind_authorization_consumption.py
@@ -1,0 +1,181 @@
+"""Consume native v2 once after fresh governance, without executing an action.
+
+Only the configured consumption database may be written. No credentials,
+headers, adapter, BindReceipt, or external-action dispatch enter this API.
+The returned record is audit evidence, not a reusable execution capability.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from datetime import datetime
+from typing import Any, Literal
+
+from veritas_os.policy.native_bind_authorization import (
+    NativeAuthorizationSourceInputs,
+    NativeBindAuthorizationArtifact,
+    verify_native_bind_authorization,
+    _verified_source,
+    _supported_approval_rules,
+)
+from veritas_os.policy.live_adapter_bind_authorization_contracts import (
+    BindAuthorizationTrustInputs,
+    RealBindAuthorizationGovernanceInputs,
+)
+from veritas_os.policy.live_adapter_bind_authorization_codec import _timestamp
+from veritas_os.policy.live_adapter_bind_authorization_governance import (
+    _validate_governance_for_verified_context,
+)
+from veritas_os.policy.live_adapter_bind_authorization_consumption_store import (
+    AuthorizationConsumptionRecord,
+    InMemoryAtomicAuthorizationConsumptionStore,
+    PostgresAtomicAuthorizationConsumptionStore,
+    build_authorization_consumption_record,
+)
+
+
+class NativeAuthorizationConsumptionError(ValueError):
+    """Fail-closed native consumption error; never includes backend secrets."""
+
+
+@dataclass(frozen=True)
+class NativeAuthorizationConsumptionResult:
+    """Consumed audit lineage, not permission to execute or retry an action."""
+
+    authorization: NativeBindAuthorizationArtifact
+    consumption_record: AuthorizationConsumptionRecord
+    current_runtime_risk_hash: str
+    current_authority_proof_digest: str
+    current_human_approval_proof_digest: str | None
+    current_runtime_authority_digest: str
+    durable_store_used: bool
+    authorization_consumed: Literal[True] = True
+    execution_authority_created: Literal[False] = False
+    credential_material_accessed: Literal[False] = False
+    bind_invoked: Literal[False] = False
+    bind_receipt_created: Literal[False] = False
+    external_action_executed: Literal[False] = False
+
+
+async def consume_native_bind_authorization(
+    artifact: Any,
+    *,
+    issuance_source_inputs: NativeAuthorizationSourceInputs,
+    governance_inputs: RealBindAuthorizationGovernanceInputs,
+    trust_inputs: BindAuthorizationTrustInputs,
+    current_source_inputs: NativeAuthorizationSourceInputs,
+    current_runtime_risk_packet: Any,
+    now: datetime,
+    consumption_store: PostgresAtomicAuthorizationConsumptionStore
+    | InMemoryAtomicAuthorizationConsumptionStore,
+    allow_in_memory_for_testing: bool = False,
+) -> NativeAuthorizationConsumptionResult:
+    """Reverify historical and current evidence, then atomically consume once.
+
+    Callers supply the trusted consumption clock and fresh risk evidence:
+    both risk reviewed_at and recorded_at must equal now. Source/contract trust
+    anchors are deployment inputs, never extracted from candidate snapshots.
+    Historical signed proof hashes are not rewritten with current proof hashes.
+
+    PostgreSQL is required by default. Explicit process-local testing is not
+    durable and cannot establish cross-process replay protection. Unrecognized
+    store implementations, even with production_safe=True, are rejected.
+
+    Failure after an attempted write never releases or reuses an authorization.
+    A database commit with a lost acknowledgement must be treated as consumed
+    or unknown, not automatically retried as an executable action. A future
+    execution boundary still needs fresh policy/risk checks and durable lineage.
+    """
+    durable = type(consumption_store) is PostgresAtomicAuthorizationConsumptionStore
+    if not durable and not (
+        allow_in_memory_for_testing is True
+        and type(consumption_store) is InMemoryAtomicAuthorizationConsumptionStore
+    ):
+        raise NativeAuthorizationConsumptionError("NABC_DURABLE_STORE_REQUIRED")
+    if not isinstance(governance_inputs, RealBindAuthorizationGovernanceInputs):
+        raise NativeAuthorizationConsumptionError("NABC_GOVERNANCE_INPUTS_REQUIRED")
+    current = datetime.fromisoformat(_timestamp(now))
+    issued_at = datetime.fromisoformat(_timestamp(governance_inputs.verification_now))
+    if current < issued_at:
+        raise NativeAuthorizationConsumptionError("NABC_CLOCK_BEFORE_ISSUANCE")
+
+    authorization = verify_native_bind_authorization(
+        artifact,
+        source_inputs=issuance_source_inputs,
+        governance_inputs=governance_inputs,
+        trust_inputs=trust_inputs,
+    )
+    if not (
+        datetime.fromisoformat(authorization.valid_from)
+        <= current
+        < datetime.fromisoformat(authorization.valid_until)
+    ):
+        raise NativeAuthorizationConsumptionError("NABC_AUTHORIZATION_EXPIRED")
+    current_governance = replace(governance_inputs, verification_now=current)
+    risk, final, context = _verified_source(
+        current_runtime_risk_packet,
+        current_source_inputs,
+        current_governance,
+    )
+    if (
+        datetime.fromisoformat(risk.risk_decision.reviewed_at) != current
+        or datetime.fromisoformat(risk.recorded_at) != current
+    ):
+        raise NativeAuthorizationConsumptionError("NABC_FRESH_RISK_REVIEW_REQUIRED")
+    if (
+        final.bind_context_hash != authorization.bind_context_hash
+        or final.exact_bind_context.action_contract_digest
+        != authorization.action_contract_digest
+        or context.execution_intent != authorization.execution_intent
+        or context.execution_intent_id != authorization.execution_intent_id
+        or context.execution_intent_hash != authorization.execution_intent_hash
+        or final.exact_bind_context.gate_packet_hash != authorization.source_gate_hash
+    ):
+        raise NativeAuthorizationConsumptionError("NABC_CURRENT_CONTEXT_MISMATCH")
+    _supported_approval_rules(current_governance.action_contract.human_approval_rules)
+    governance = _validate_governance_for_verified_context(
+        context,
+        current_governance,
+        bind_context_hash=final.bind_context_hash,
+    )
+    if (
+        governance.human_approval_status
+        != authorization.human_approval_requirement_status
+        or (governance.human_approval_status == "VERIFIED")
+        != risk.required_human_approval
+    ):
+        raise NativeAuthorizationConsumptionError("NABC_CURRENT_APPROVAL_MISMATCH")
+    record = build_authorization_consumption_record(
+        live_adapter_bind_authorization_id=authorization.authorization_id,
+        live_adapter_bind_authorization_hash=authorization.authorization_hash,
+        idempotency_key=authorization.idempotency_key,
+        bind_context_hash=authorization.bind_context_hash,
+        execution_intent_id=authorization.execution_intent_id,
+        execution_intent_hash=authorization.execution_intent_hash,
+        endpoint_identity_binding_digest=context.endpoint_identity_binding_digest,
+        credential_reference_digest=context.credential_reference_digest,
+        credential_scope_binding_digest=context.credential_scope_binding_digest,
+        consumed_at=current.isoformat(),
+    )
+    try:
+        claimed = await consumption_store.consume_once(record)
+    except Exception:
+        # Storage exceptions can include connection strings. Never expose them.
+        raise NativeAuthorizationConsumptionError(
+            "NABC_STORE_FAILED_OR_UNKNOWN"
+        ) from None
+    if claimed is not True:
+        raise NativeAuthorizationConsumptionError("NABC_ALREADY_CONSUMED")
+    return NativeAuthorizationConsumptionResult(
+        authorization=authorization,
+        consumption_record=record,
+        current_runtime_risk_hash=risk.packet_hash,
+        current_authority_proof_digest=governance.authority_proof.verification_proof_hash,
+        current_human_approval_proof_digest=(
+            governance.human_approval_proof.verification_proof_hash
+            if governance.human_approval_proof
+            else None
+        ),
+        current_runtime_authority_digest=governance.runtime_result_digest,
+        durable_store_used=durable,
+    )

--- a/veritas_os/tests/test_memory_branches.py
+++ b/veritas_os/tests/test_memory_branches.py
@@ -19,6 +19,7 @@ memory.py 分岐カバレッジ強化テスト
 from __future__ import annotations
 
 import json
+from copy import copy
 import logging
 import threading
 import time
@@ -162,10 +163,21 @@ class FakeVecOldSig:
 class TestVectorMemoryLoadModel:
     """_load_model: ImportError fallback / config mismatch / success."""
 
-    def test_importerror_fallback_when_not_explicitly_enabled(self, monkeypatch):
+    @pytest.fixture(params=["current", "replaced"])
+    def capability_config(self, request, monkeypatch):
+        """Patch the call-time config, including a simulated reload generation."""
+        from veritas_os.core import config
+
+        if request.param == "replaced":
+            monkeypatch.setattr(config, "capability_cfg", copy(config.capability_cfg))
+        return config.capability_cfg
+
+    def test_importerror_fallback_when_not_explicitly_enabled(
+        self, monkeypatch, capability_config
+    ):
         """sentence-transformers unavailable + default config → warning + model=None."""
         monkeypatch.setattr(
-            mem_mod.capability_cfg,
+            capability_config,
             "enable_memory_sentence_transformers",
             True,
         )
@@ -189,10 +201,12 @@ class TestVectorMemoryLoadModel:
         vm._load_model()
         assert vm.model is None
 
-    def test_importerror_raises_when_explicitly_enabled(self, monkeypatch):
+    def test_importerror_raises_when_explicitly_enabled(
+        self, monkeypatch, capability_config
+    ):
         """sentence-transformers unavailable + explicit enable → RuntimeError."""
         monkeypatch.setattr(
-            mem_mod.capability_cfg,
+            capability_config,
             "enable_memory_sentence_transformers",
             True,
         )
@@ -215,10 +229,12 @@ class TestVectorMemoryLoadModel:
         with pytest.raises(RuntimeError, match="sentence-transformers is required"):
             vm._load_model()
 
-    def test_capability_disabled_skips_load(self, monkeypatch):
+    def test_capability_disabled_skips_load(
+        self, monkeypatch, capability_config
+    ):
         """enable_memory_sentence_transformers=False → model stays None."""
         monkeypatch.setattr(
-            mem_mod.capability_cfg,
+            capability_config,
             "enable_memory_sentence_transformers",
             False,
         )
@@ -230,10 +246,12 @@ class TestVectorMemoryLoadModel:
         vm._load_model()
         assert vm.model is None
 
-    def test_model_load_success_with_fake(self, monkeypatch):
+    def test_model_load_success_with_fake(
+        self, monkeypatch, capability_config
+    ):
         """Model loads successfully with a fake SentenceTransformer."""
         monkeypatch.setattr(
-            mem_mod.capability_cfg,
+            capability_config,
             "enable_memory_sentence_transformers",
             True,
         )
@@ -258,10 +276,12 @@ class TestVectorMemoryLoadModel:
         vm._load_model()
         assert vm.model is fake_model
 
-    def test_oserror_during_load_sets_model_none(self, monkeypatch):
+    def test_oserror_during_load_sets_model_none(
+        self, monkeypatch, capability_config
+    ):
         """OSError during SentenceTransformer() → model=None (no raise)."""
         monkeypatch.setattr(
-            mem_mod.capability_cfg,
+            capability_config,
             "enable_memory_sentence_transformers",
             True,
         )

--- a/veritas_os/tests/test_native_bind_authorization_consumption.py
+++ b/veritas_os/tests/test_native_bind_authorization_consumption.py
@@ -1,0 +1,338 @@
+"""Native consume-only tests with real source and Ed25519 verifiers."""
+
+import asyncio
+from copy import deepcopy
+from dataclasses import replace
+from datetime import timedelta
+
+import pytest
+
+from veritas_os.policy import native_bind_authorization_consumption as module
+from veritas_os.policy.promotion_requirement_runtime_risk import (
+    build_promotion_requirement_runtime_risk_packet,
+)
+from veritas_os.tests.test_native_bind_authorization import (
+    issued as issued_fixture,
+    api_risk_source as source_fixture,
+)
+
+pytestmark = pytest.mark.slow
+issued = issued_fixture
+api_risk_source = source_fixture
+
+
+def _fresh(inputs, now, **changes):
+    src = inputs["source_inputs"]
+    gov = inputs["governance_inputs"]
+    decision = {**src.expected_risk_decision, "reviewed_at": now.isoformat(), **changes}
+    risk = build_promotion_requirement_runtime_risk_packet(
+        src.final_recheck,
+        decision,
+        now,
+        expected_source=gov.expected_source,
+        expected_contract=gov.action_contract,
+        expected_verified_at=src.expected_verified_at,
+        expected_rechecked_at=src.expected_rechecked_at,
+        current_endpoint=src.current_endpoint,
+        current_credential_reference=src.current_credential_reference,
+        required_credential_scope=src.required_credential_scope,
+    )
+    return risk, replace(src, expected_risk_decision=decision, expected_recorded_at=now)
+
+
+@pytest.fixture(scope="module")
+def consumable(issued):
+    artifact, inputs, *_ = issued
+    now = inputs["governance_inputs"].verification_now + timedelta(seconds=1)
+    risk, source = _fresh(inputs, now)
+    return (
+        artifact,
+        dict(
+            issuance_source_inputs=inputs["source_inputs"],
+            governance_inputs=inputs["governance_inputs"],
+            trust_inputs=inputs["trust_inputs"],
+            current_source_inputs=source,
+            current_runtime_risk_packet=risk,
+            now=now,
+        ),
+        inputs,
+    )
+
+
+def _store_inputs(inputs):
+    store = module.InMemoryAtomicAuthorizationConsumptionStore()
+    return store, {
+        **inputs,
+        "consumption_store": store,
+        "allow_in_memory_for_testing": True,
+    }
+
+
+class _Revocation:
+    def __init__(self, gov, mode="valid"):
+        self.original = gov.authority_revocation_checker
+        self.issued_at = gov.verification_now
+        self.mode = mode
+        self.times = []
+
+    def check(self, evidence_id, *, now):
+        self.times.append(now)
+        result = self.original.check(evidence_id, now=now)
+        if now <= self.issued_at:
+            return result
+        if self.mode == "revoked":
+            return replace(result, revoked=True)
+        if self.mode == "stale":
+            return replace(result, checked_at=(now - timedelta(seconds=61)).isoformat())
+        if self.mode == "unavailable":
+            raise ValueError("fixture: revocation unavailable")
+        return result
+
+
+@pytest.mark.asyncio
+async def test_consume_once_preserves_signed_proofs_and_rechecks_current_governance(
+    consumable,
+):
+    artifact, original, _ = consumable
+    before = artifact.model_dump(mode="json")
+    checker = _Revocation(original["governance_inputs"])
+    store, inputs = _store_inputs(original)
+    inputs["governance_inputs"] = replace(
+        inputs["governance_inputs"], authority_revocation_checker=checker
+    )
+    result = await module.consume_native_bind_authorization(artifact, **inputs)
+    assert checker.times == [
+        inputs["governance_inputs"].verification_now,
+        inputs["now"],
+    ]
+    assert (
+        result.authorization.model_dump(mode="json")
+        == before
+        == artifact.model_dump(mode="json")
+    )
+    assert (
+        result.current_authority_proof_digest
+        != artifact.authority_verification_proof_digest
+    )
+    assert result.consumption_record == await store.get(artifact.authorization_id)
+    assert result.consumption_record.idempotency_key == artifact.idempotency_key
+    assert result.authorization_consumed and not result.durable_store_used
+    assert (
+        result.current_runtime_risk_hash
+        == original["current_runtime_risk_packet"].packet_hash
+    )
+    for name in (
+        "execution_authority_created",
+        "credential_material_accessed",
+        "bind_invoked",
+        "bind_receipt_created",
+        "external_action_executed",
+    ):
+        assert getattr(result, name) is False
+    with pytest.raises(ValueError, match="NABC_ALREADY_CONSUMED"):
+        await module.consume_native_bind_authorization(artifact, **inputs)
+
+
+@pytest.mark.asyncio
+async def test_four_parallel_consumers_have_one_winner(consumable):
+    artifact, original, _ = consumable
+    _, inputs = _store_inputs(original)
+    outcomes = await asyncio.gather(
+        *(
+            module.consume_native_bind_authorization(artifact, **inputs)
+            for _ in range(4)
+        ),
+        return_exceptions=True,
+    )
+    assert (
+        sum(
+            isinstance(x, module.NativeAuthorizationConsumptionResult) for x in outcomes
+        )
+        == 1
+    )
+    assert (
+        sum(isinstance(x, module.NativeAuthorizationConsumptionError) for x in outcomes)
+        == 3
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["revoked", "stale", "unavailable"])
+async def test_changed_revocation_rejects_before_store(consumable, mode):
+    artifact, original, _ = consumable
+    store, inputs = _store_inputs(original)
+    checker = _Revocation(inputs["governance_inputs"], mode)
+    inputs["governance_inputs"] = replace(
+        inputs["governance_inputs"], authority_revocation_checker=checker
+    )
+    with pytest.raises(ValueError):
+        await module.consume_native_bind_authorization(artifact, **inputs)
+    assert inputs["now"] in checker.times
+    assert await store.get(artifact.authorization_id) is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["negative", "missing", "drift", "issuance_review"])
+async def test_current_risk_is_independent_and_fresh(consumable, mode):
+    artifact, original, issuance = consumable
+    store, inputs = _store_inputs(original)
+    if mode == "issuance_review":
+        inputs["current_source_inputs"] = issuance["source_inputs"]
+        inputs["current_runtime_risk_packet"] = artifact.source_runtime_risk_packet
+    else:
+        changes = (
+            {"observed_state_fingerprint": "different"}
+            if mode == "drift"
+            else {"runtime_risk_signal": False if mode == "negative" else None}
+        )
+        risk, source = _fresh(issuance, inputs["now"], **changes)
+        inputs.update(current_runtime_risk_packet=risk, current_source_inputs=source)
+    with pytest.raises(ValueError):
+        await module.consume_native_bind_authorization(artifact, **inputs)
+    assert await store.get(artifact.authorization_id) is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "mode", ["backdated", "naive", "expired", "contract", "endpoint", "tampered"]
+)
+async def test_invalid_clock_or_context_never_consumes(consumable, mode):
+    artifact, original, _ = consumable
+    store, inputs = _store_inputs(original)
+    if mode == "backdated":
+        inputs["now"] = inputs["governance_inputs"].verification_now - timedelta(
+            seconds=1
+        )
+    elif mode == "naive":
+        inputs["now"] = inputs["now"].replace(tzinfo=None)
+    elif mode == "expired":
+        inputs["now"] = artifact.valid_until
+    elif mode == "contract":
+        contract = deepcopy(inputs["governance_inputs"].action_contract)
+        contract.human_approval_rules["required"] = not contract.human_approval_rules[
+            "required"
+        ]
+        inputs["governance_inputs"] = replace(
+            inputs["governance_inputs"], action_contract=contract
+        )
+    elif mode == "endpoint":
+        inputs["current_source_inputs"] = replace(
+            inputs["current_source_inputs"], current_endpoint={}
+        )
+    else:
+        artifact = artifact.model_copy(update={"bind_context_hash": "0" * 64})
+    with pytest.raises(ValueError):
+        await module.consume_native_bind_authorization(artifact, **inputs)
+    assert await store.get(artifact.authorization_id) is None
+
+
+@pytest.mark.asyncio
+async def test_memory_store_is_not_production_default(consumable):
+    artifact, original, _ = consumable
+    store, inputs = _store_inputs(original)
+    inputs["allow_in_memory_for_testing"] = False
+    with pytest.raises(ValueError, match="NABC_DURABLE_STORE_REQUIRED"):
+        await module.consume_native_bind_authorization(artifact, **inputs)
+    assert await store.get(artifact.authorization_id) is None
+
+
+@pytest.mark.asyncio
+async def test_lost_store_acknowledgement_never_releases_consumption(
+    consumable, monkeypatch
+):
+    artifact, original, _ = consumable
+    store, inputs = _store_inputs(original)
+    real_consume = store.consume_once
+
+    async def lost_ack(record):
+        await real_consume(record)
+        raise RuntimeError("sensitive-backend-detail")
+
+    monkeypatch.setattr(store, "consume_once", lost_ack)
+    with pytest.raises(ValueError, match="^NABC_STORE_FAILED_OR_UNKNOWN$"):
+        await module.consume_native_bind_authorization(artifact, **inputs)
+    assert await store.get(artifact.authorization_id) is not None
+    monkeypatch.setattr(store, "consume_once", real_consume)
+    with pytest.raises(ValueError, match="NABC_ALREADY_CONSUMED"):
+        await module.consume_native_bind_authorization(artifact, **inputs)
+
+
+@pytest.mark.asyncio
+async def test_human_signature_trust_is_rechecked_at_consumption(consumable):
+    artifact, original, _ = consumable
+    store, inputs = _store_inputs(original)
+    gov = inputs["governance_inputs"]
+    checker = _Revocation(gov)
+    calls = []
+
+    class WithdrawnVerifier:
+        def verify(self, envelope):
+            calls.append(checker.times[-1])
+            result = gov.human_approval_signature_verifier.verify(envelope)
+            if checker.times[-1] == inputs["now"]:
+                return replace(result, verified=False)
+            return result
+
+    inputs["governance_inputs"] = replace(
+        gov,
+        authority_revocation_checker=checker,
+        human_approval_signature_verifier=WithdrawnVerifier(),
+    )
+    if gov.signed_human_approval_artifact is None:
+        await module.consume_native_bind_authorization(artifact, **inputs)
+        assert calls == []
+    else:
+        with pytest.raises(ValueError, match="HUMAN_APPROVAL_VERIFICATION_FAILED"):
+            await module.consume_native_bind_authorization(artifact, **inputs)
+        assert calls == [gov.verification_now, inputs["now"]]
+        assert await store.get(artifact.authorization_id) is None
+
+
+@pytest.mark.asyncio
+async def test_store_cannot_self_assert_production_safety(consumable):
+    artifact, inputs, _ = consumable
+
+    class FakeStore:
+        production_safe = True
+
+        async def consume_once(self, record):
+            pytest.fail("unrecognized store must not be called")
+
+    with pytest.raises(ValueError, match="NABC_DURABLE_STORE_REQUIRED"):
+        await module.consume_native_bind_authorization(
+            artifact, **inputs, consumption_store=FakeStore()
+        )
+
+
+@pytest.mark.asyncio
+async def test_valid_new_gate_cannot_replace_authorized_context(consumable):
+    """A fully rebuilt PASS for another gate is not this authorization."""
+    from veritas_os.tests.test_promotion_requirement_final_rechecks import _complete
+
+    artifact, original, issuance = consumable
+    gov = original["governance_inputs"]
+    changed_time = issuance["source_inputs"].expected_verified_at + timedelta(seconds=1)
+    _, _, final, _ = _complete(gov.expected_source, gov.action_contract, changed_time)
+    assert final.bind_context_hash != artifact.bind_context_hash
+    source = replace(
+        issuance["source_inputs"],
+        final_recheck=final,
+        expected_verified_at=changed_time,
+        expected_rechecked_at=changed_time,
+        expected_risk_decision={
+            **issuance["source_inputs"].expected_risk_decision,
+            "source_final_recheck_id": final.packet_id,
+            "source_final_recheck_hash": final.packet_hash,
+            "bind_context_hash": final.bind_context_hash,
+        },
+    )
+    risk, current_source = _fresh(
+        {**issuance, "source_inputs": source}, original["now"]
+    )
+    store, inputs = _store_inputs(original)
+    inputs.update(
+        current_source_inputs=current_source, current_runtime_risk_packet=risk
+    )
+    with pytest.raises(ValueError, match="NABC_CURRENT_CONTEXT_MISMATCH"):
+        await module.consume_native_bind_authorization(artifact, **inputs)
+    assert await store.get(artifact.authorization_id) is None

--- a/veritas_os/tests/test_pg_bind_authorization_consumption_contention.py
+++ b/veritas_os/tests/test_pg_bind_authorization_consumption_contention.py
@@ -13,7 +13,7 @@ from veritas_os.policy.live_adapter_bind_authorization_consumption_store import 
     PostgresAtomicAuthorizationConsumptionStore,
     build_authorization_consumption_record,
 )
-from veritas_os.storage.db import get_pool
+from veritas_os.storage.db import close_pool, get_pool
 from veritas_os.policy.native_bind_authorization_consumption import (
     consume_native_bind_authorization,
     NativeAuthorizationConsumptionResult,
@@ -98,14 +98,20 @@ async def test_real_postgres_allows_exactly_one_concurrent_consumer() -> None:
     record = _record(token)
     store = PostgresAtomicAuthorizationConsumptionStore()
 
-    outcomes = await asyncio.gather(*(store.consume_once(record) for _ in range(32)))
+    try:
+        # Create and close pool workers on this test's event loop. Opening once
+        # also keeps the race focused on consumption, not lazy pool creation.
+        await get_pool()
+        outcomes = await asyncio.gather(*(store.consume_once(record) for _ in range(32)))
 
-    assert outcomes.count(True) == 1
-    assert outcomes.count(False) == 31
-    assert (
-        await _count_rows(authorization_id=record.live_adapter_bind_authorization_id)
-        == 1
-    )
+        assert outcomes.count(True) == 1
+        assert outcomes.count(False) == 31
+        assert (
+            await _count_rows(authorization_id=record.live_adapter_bind_authorization_id)
+            == 1
+        )
+    finally:
+        await close_pool()
 
 
 @pytest.mark.asyncio
@@ -128,13 +134,17 @@ async def test_real_postgres_idempotency_key_is_unique_across_authorizations() -
     )
 
     store = PostgresAtomicAuthorizationConsumptionStore()
-    outcomes = await asyncio.gather(
-        store.consume_once(first),
-        store.consume_once(second),
-    )
+    try:
+        await get_pool()
+        outcomes = await asyncio.gather(
+            store.consume_once(first),
+            store.consume_once(second),
+        )
 
-    assert sorted(outcomes) == [False, True]
-    assert await _count_rows(idempotency_key=shared_idempotency_key) == 1
+        assert sorted(outcomes) == [False, True]
+        assert await _count_rows(idempotency_key=shared_idempotency_key) == 1
+    finally:
+        await close_pool()
 
 
 @pytest.mark.skipif(
@@ -144,11 +154,9 @@ async def test_real_postgres_idempotency_key_is_unique_across_authorizations() -
 @pytest.mark.asyncio
 async def test_native_v2_real_verification_and_postgres_race(consumable) -> None:
     """Genuine API lineage, real signatures and four full consumers: one row."""
-    from veritas_os.storage.db import close_pool
-
     authorization, inputs, _ = consumable
-    await close_pool()
     try:
+        await get_pool()
         store = PostgresAtomicAuthorizationConsumptionStore()
         outcomes = await asyncio.gather(
             *(

--- a/veritas_os/tests/test_pg_bind_authorization_consumption_contention.py
+++ b/veritas_os/tests/test_pg_bind_authorization_consumption_contention.py
@@ -14,6 +14,20 @@ from veritas_os.policy.live_adapter_bind_authorization_consumption_store import 
     build_authorization_consumption_record,
 )
 from veritas_os.storage.db import get_pool
+from veritas_os.policy.native_bind_authorization_consumption import (
+    consume_native_bind_authorization,
+    NativeAuthorizationConsumptionResult,
+    NativeAuthorizationConsumptionError,
+)
+from veritas_os.tests.test_native_bind_authorization_consumption import (
+    consumable as native_consumable_fixture,
+    issued as native_issued_fixture,
+    api_risk_source as native_source_fixture,
+)
+
+consumable = native_consumable_fixture
+issued = native_issued_fixture
+api_risk_source = native_source_fixture
 
 pytestmark = [pytest.mark.postgresql, pytest.mark.contention]
 
@@ -28,7 +42,12 @@ def _require_real_postgresql() -> None:
         pytest.skip("real PostgreSQL service container is required")
 
 
-def _record(token: str, *, authorization_id: str | None = None, idempotency_key: str | None = None):
+def _record(
+    token: str,
+    *,
+    authorization_id: str | None = None,
+    idempotency_key: str | None = None,
+):
     auth_hash = _digest("authorization:" + token)
     return build_authorization_consumption_record(
         live_adapter_bind_authorization_id=(
@@ -48,7 +67,9 @@ def _record(token: str, *, authorization_id: str | None = None, idempotency_key:
     )
 
 
-async def _count_rows(*, authorization_id: str | None = None, idempotency_key: str | None = None) -> int:
+async def _count_rows(
+    *, authorization_id: str | None = None, idempotency_key: str | None = None
+) -> int:
     pool = await get_pool()
     async with pool.connection() as conn:
         if authorization_id is not None:
@@ -82,9 +103,7 @@ async def test_real_postgres_allows_exactly_one_concurrent_consumer() -> None:
     assert outcomes.count(True) == 1
     assert outcomes.count(False) == 31
     assert (
-        await _count_rows(
-            authorization_id=record.live_adapter_bind_authorization_id
-        )
+        await _count_rows(authorization_id=record.live_adapter_bind_authorization_id)
         == 1
     )
 
@@ -103,7 +122,10 @@ async def test_real_postgres_idempotency_key_is_unique_across_authorizations() -
         token + ":b",
         idempotency_key=shared_idempotency_key,
     )
-    assert first.live_adapter_bind_authorization_id != second.live_adapter_bind_authorization_id
+    assert (
+        first.live_adapter_bind_authorization_id
+        != second.live_adapter_bind_authorization_id
+    )
 
     store = PostgresAtomicAuthorizationConsumptionStore()
     outcomes = await asyncio.gather(
@@ -113,3 +135,46 @@ async def test_real_postgres_idempotency_key_is_unique_across_authorizations() -
 
     assert sorted(outcomes) == [False, True]
     assert await _count_rows(idempotency_key=shared_idempotency_key) == 1
+
+
+@pytest.mark.skipif(
+    not os.getenv("VERITAS_DATABASE_URL", "").startswith("postgresql"),
+    reason="real PostgreSQL service container is required",
+)
+@pytest.mark.asyncio
+async def test_native_v2_real_verification_and_postgres_race(consumable) -> None:
+    """Genuine API lineage, real signatures and four full consumers: one row."""
+    from veritas_os.storage.db import close_pool
+
+    authorization, inputs, _ = consumable
+    await close_pool()
+    try:
+        store = PostgresAtomicAuthorizationConsumptionStore()
+        outcomes = await asyncio.gather(
+            *(
+                consume_native_bind_authorization(
+                    authorization,
+                    **inputs,
+                    consumption_store=store,
+                )
+                for _ in range(4)
+            ),
+            return_exceptions=True,
+        )
+        winners = [
+            x for x in outcomes if isinstance(x, NativeAuthorizationConsumptionResult)
+        ]
+        assert len(winners) == 1, outcomes
+        assert winners[0].durable_store_used
+        losers = [
+            x for x in outcomes if isinstance(x, NativeAuthorizationConsumptionError)
+        ]
+        assert len(losers) == 3
+        assert all(str(x) == "NABC_ALREADY_CONSUMED" for x in losers)
+        assert await _count_rows(authorization_id=authorization.authorization_id) == 1
+        assert await _count_rows(idempotency_key=authorization.idempotency_key) == 1
+        assert not winners[0].credential_material_accessed
+        assert not winners[0].bind_invoked
+        assert not winners[0].external_action_executed
+    finally:
+        await close_pool()


### PR DESCRIPTION
# Summary
Add a native v2 **consume-only** boundary. No credential resolution, adapter construction, Bind invocation, BindReceipt or external-action dispatch.

## Scope
- Independently reconstruct signed issuance evidence, then verify current source/context, original signed authority and required Human Approval, revocation and RuntimeAuthority at the consumption clock.
- Require separately supplied current runtime-risk packet/source inputs, with review and record time equal to the consumption time.
- Reject backdating, expiry, risk BLOCK/INDETERMINATE/drift, reused issuance review, changed contract/endpoint and another fully rebuilt gate/context before storage.
- Preserve historical signed proof hashes; return fresh proof digests separately.
- Reuse existing PostgreSQL atomic consumption store and record schema. No migration or workflow change.
- PostgreSQL required by default; only explicit in-memory test opt-in is accepted. Unknown stores cannot self-assert production safety.
- Duplicate, failed or ambiguous storage writes cannot return success or release an already consumed authorization.
- Add full native real-verifier/PostgreSQL contention cases to the existing dedicated PostgreSQL CI test file for both approval states.

## Type of change
- [x] Runtime
- [x] Tests
- [x] Docs
- [x] Governance / security-sensitive

## Why this change matters
Connect the merged native v2 issuer to durable consume-once storage while keeping action execution separate and preserving v1/v0.3 behavior.

## Market / developer / user value
- Market value: no production-readiness or commercial claims.
- Developer value: explicit issuance-time versus consumption-time verification.
- User/operator value: failed current checks cannot consume; retries after a lost commit acknowledgement cannot reuse a consumed authorization.

## CI failure fixes
- Follow-up changes touch only two test files; authorization/governance runtime behavior is unchanged.
- PostgreSQL: each test initializes its pool before racing consumption and closes it in `finally` on the owning event loop. Previously v1 tests leaked their pool across test loops and the new native test hit `CancelledError` closing cancelled workers.
- Memory: patch the current call-time config instead of the potentially stale memory-module alias. All five model-loading branches now run with both current and replacement config objects; no real model/network access.
- No weakened assertions, skipped failing cases, swallowed cancellation or changed CI gates.

## Tests run
Head: `b17cab4a6ba82b404c34a82183ea5d68afb3c48c`
- Local: **272 distinct passed**:
  - Native consumption, native issuance and existing v1/governance consumption: **112 passed** (429.78s).
  - Capability flags + memory branches, including config replacement regression: **101 passed**.
  - Memory vector/core/decomposition: **59 passed**.
- Local PostgreSQL: 4 skipped (no local service); not counted as passes.
- **Real PostgreSQL CI: 4 passed** (104.23s), including both native approval states and existing v1 races: https://github.com/veritasfuji-japan/veritas_os/actions/runs/34065305455/job/101572903005
- Repository Ruff, responsibility-boundary, bare-except and diff checks passed.
- Native consumption targeted cumulative coverage was 94.64% (53/56 statements) on the previous head; production module unchanged in this test-only follow-up. Coverage was not remeasured locally.
- Previous-head CI finished with 37 successful checks and the slow job cancelled at its 20-minute ceiling; the slow suite had reported progress through 63%. This was not an all-CI-pass result.
- Published tree matches the tested local tree: `aec2ed6633b2d94ca7cde9fdc91a9705f75d97eb`.

## Slow-suite timeout follow-up
- Current head: `b831d167ff12fc20ee0885b6dffd3b525f54e7f7`.
- Only `test-slow` job timeout changes from 20 to 60 minutes, plus explanatory comments and regression tests. Runtime implementation, test selection, exit status handling and failure gates are unchanged.
- CI configuration tests: **17 passed** locally (including 2 new slow-workflow guards); targeted Ruff and diff checks passed.
- Local/published tree: `69f490bfb1584aa3db9a46aff2525572d2b50f60`.
- Earlier 272 local passes and 4 real PostgreSQL CI passes above belong to the previous head. They were not rerun locally for this workflow-only update.
- Full CI on the current head has been triggered and is pending: https://github.com/veritasfuji-japan/veritas_os/actions/runs/34068120577
- Keep Draft and do not merge until the current-head slow suite and other checks complete successfully and human review is finished.

## AI assistance used
- [x] Codex

## Review status
- [ ] CI passed
- [ ] Human maintainer reviewed

## Risk checklist
- [x] Touches bind/admissibility logic
- [x] Touches governance policy behavior

## Human approval required?
- [x] Yes

Reason: governance-sensitive native authorization consumption boundary.

## Notes for reviewer
- **Draft: do not merge automatically.**
- Only the configured consumption database is intentionally written. No operational credentials or external-action network dispatch.
- The result is audit lineage, not a reusable execution capability. v2 Bind execution and BindReceipt/Outcome integration remain unimplemented.
- The caller's trusted clock denotes verification time, not database commit time. Future execution must independently recheck current policy/risk and durable consumed lineage.
- Current proof digests are returned separately; historical signed authorization remains unchanged.
- Tests use genuine authenticated API lineage and real Ed25519 verification with synthetic authority/approval/risk fixtures and controlled model/cloud clients. No operational human consent is created or inferred.
- Production source/signature verifiers are not replaced with accepting mocks.
