### PR TITLE
test: restore shadowed tests and record consolidation checkpoint

### DIFF
--- a/docs/en/development/consolidation-checkpoint-1.md
+++ b/docs/en/development/consolidation-checkpoint-1.md
@@ -1,0 +1,122 @@
+# Lightweight Consolidation Checkpoint 1
+
+Baseline: `236a468cc426f57e70f9aad84eee1c09e9f2b5f9` (PR #2195 merged).
+Date: 2026-09-07. This is a bounded static inventory, not a whole-repository
+dead-code proof, security audit, or production certification.
+
+## Classification and disposition
+
+| Label | Meaning and action |
+| --- | --- |
+| KEEP | Used behavior or an independent trust boundary; retain. |
+| PUBLIC_COMPAT | Public import/version compatibility; retain pending consumer migration. |
+| TEST_ONLY | Test infrastructure; changes require collection and assertion checks. |
+| REMOVE_NEXT_MAJOR | Proposed future removal after compatibility review, not permission to delete now. |
+| DEAD | Requires reference, dynamic import, public API, operational and recovery-path review. No runtime item is assigned this label here. |
+
+## Safe fixes in this checkpoint
+
+Three direct module-level test names were defined twice. Python replaced the
+earlier definitions before pytest collection. The tests are not equivalent.
+
+| File under `veritas_os/tests/` | Earlier definition now collected |
+| --- | --- |
+| `unit/test_kernel_decide_ext.py` | `test_decide_simple_qa_time_response_contract` |
+| `integration/test_decide_e2e_ext.py` | `test_run_decide_pipeline_happy_path_with_trust_receipt` |
+| `integration/test_decide_e2e_ext.py` | `test_run_decide_pipeline_explicit_options_preserve_ids_without_ml_gate` |
+
+All original assertions remain. The newly restored explicit-options test now
+uses `monkeypatch.setitem` for its kernel module stub, so teardown restores the
+previous module. Existing later definitions retain their original names.
+These changes are TEST_ONLY; no production authorization or verifier changes.
+
+`tests/test_unique_test_names.py` prevents direct module/class test-definition
+overwrites in tracked pytest files. It parses ASTs without importing the tests.
+It does not detect conditional definitions, dynamic assignments, imported-name
+collisions, or every possible pytest customization.
+
+Validation: the two affected files pass 194 tests; with the detector tests,
+197 tests pass. Full CI is a separate gate and is not claimed by these counts.
+
+## Similar tests and helpers: inventory, not deletion
+
+The baseline has 566 tracked Python files under `tests` directories. Comparing
+module-level test ASTs (including names, decorators and docstrings, excluding
+source positions) identifies 15 identical groups / 38 definitions across files.
+For example, schema-existence tests in `tests/demo/test_*_schema.py` have identical
+bodies but refer to different module-level schema paths. Keep those guarantees;
+textual equality is not evidence that their coverage is redundant.
+
+Module-level helper definitions in tracked non-test Python files:
+
+| Name | Definitions | Disposition |
+| --- | ---: | --- |
+| `_digest` | 50 | KEEP; five exact AST groups contain 18, 5, 12, 2 and 4 definitions, but global bindings still differ. |
+| `_timestamp` | 18 | KEEP; compare parsing and error contracts before sharing. |
+| `_json` | 20 | KEEP; accepted values and normalization can differ. |
+| `_fail` | 16 | KEEP; domain-specific failure types/codes must remain explicit. |
+
+For example, `policy/live_adapter_bind_authorization_codec.py` accepts a digest
+domain argument, while `policy/human_approval_requirement_resolution.py` uses its
+own DOMAIN. Their JSON value acceptance and timestamp error contracts differ.
+No verifier or helper is merged merely because its name or AST looks alike.
+
+## Legacy shim inventory
+
+39 non-test files match the narrow `_TARGET_MODULE` plus `import_module`/`sys`
+alias pattern. Paths below are relative to `veritas_os/core/`. All are
+PUBLIC_COMPAT today; other compatibility mechanisms are outside this heuristic.
+
+| Group | Module stems |
+| --- | --- |
+| FUJI (6) | `fuji_codes`, `fuji_helpers`, `fuji_injection`, `fuji_policy`, `fuji_policy_rollout`, `fuji_safety_head` |
+| Memory (14) | `memory_compliance`, `memory_distillation`, `memory_evidence`, `memory_helpers`, `memory_lifecycle`, `memory_search_helpers`, `memory_security`, `memory_storage`, `memory_store`, `memory_store_compat`, `memory_store_helpers`, `memory_summary_helpers`, `memory_vector`, `models/memory_model` |
+| Pipeline (19) | `pipeline_compat`, `pipeline_contracts`, `pipeline_critique`, `pipeline_decide_stages`, `pipeline_evidence`, `pipeline_execute`, `pipeline_gate`, `pipeline_helpers`, `pipeline_inputs`, `pipeline_memory_adapter`, `pipeline_persist`, `pipeline_persistence`, `pipeline_policy`, `pipeline_replay`, `pipeline_response`, `pipeline_retrieval`, `pipeline_signature_adapter`, `pipeline_types`, `pipeline_web_adapter` |
+
+`core/_shim_deprecation.py` mentions v2.2.0 and a not-before date of 2026-08-01.
+That date passing does not prove migration. `test_memory_vector_core.py` and
+`test_legacy_core_shim_deprecations.py` still exercise old imports and alias
+behavior. A REMOVE_NEXT_MAJOR proposal needs an explicit release decision and
+external-consumer review; nothing is deleted here.
+
+## Builder candidates
+
+An AST name/attribute/import scan finds 61 `build_*` definitions whose references
+outside their defining file occur only in tests. This is not a TEST_ONLY or DEAD
+classification: same-file callers, CLI entrypoints and public consumers matter.
+Examples rejected as deletion candidates:
+
+| Builder | Evidence | Label |
+| --- | --- | --- |
+| `audit/anchor_backends.py:build_timestamp_request` | Same-file timestamp request caller | KEEP |
+| `audit/trustlog_signed.py:build_trustlog_summary` | Same-file signed audit caller | KEEP |
+| `sdk/python/examples/aml_kyc_webhook_bind.py:build_review_payload` | Same-file example flow callers | KEEP |
+
+The remaining candidates need manual reference review. Token searches alone did
+not establish a runtime builder with no uses. Dynamic/external uses are not
+resolved by either heuristic.
+
+## Largest schema candidates
+
+Top five tracked `*schema.json` files by physical lines; size is a review signal,
+not evidence that fields or embedded definitions are unnecessary.
+
+| File under `schemas/` | Lines | UTF-8 bytes |
+| --- | ---: | ---: |
+| `adapter-dry-run-fixture-result-v1.schema.json` | 6582 | 185226 |
+| `adapter-dry-run-plan-v1.schema.json` | 4475 | 122180 |
+| `bind-adapter-contract-selection-v1.schema.json` | 3995 | 106900 |
+| `canonical-bind-preflight-adjudication-v1.schema.json` | 3087 | 81710 |
+| `live-adapter-dry-run-request-v1.schema.json` | 2878 | 85831 |
+
+KEEP until schema generation, reference resolution, version compatibility and
+hash/signature effects have been reviewed. No schema changes in this checkpoint.
+
+## Next boundary
+
+Complete this test-only correction and review the inventory before native v2
+execution. For one selected integration, define trust anchors, clock behavior,
+material-change rules and ambiguous-outcome handling before external effects.
+Freeze after the first complete path passes both normal and failure/recovery
+scenarios; then perform the larger consolidation audit. One unused E2E path is
+not proof of dead code. No obsolete PRs or branches are closed/deleted here.

--- a/docs/ja/development/consolidation-checkpoint-1.md
+++ b/docs/ja/development/consolidation-checkpoint-1.md
@@ -1,0 +1,117 @@
+# 軽量Consolidation Checkpoint 1
+
+基準: `236a468cc426f57e70f9aad84eee1c09e9f2b5f9`（PR #2195マージ後）。
+確認日: 2026-09-07。範囲を限定した静的棚卸しであり、リポジトリ全体の
+未使用コード証明・セキュリティ監査・本番認証ではありません。
+
+## 分類と扱い
+
+| 分類 | 意味・対応 |
+| --- | --- |
+| KEEP | 利用される処理や独立した信頼境界。維持する。 |
+| PUBLIC_COMPAT | 公開import・バージョン互換。利用側の移行確認まで維持する。 |
+| TEST_ONLY | テスト基盤。変更時は収集件数とassertionを確認する。 |
+| REMOVE_NEXT_MAJOR | 互換性レビュー後の将来削除案。今の削除許可ではない。 |
+| DEAD | 参照・動的import・公開API・運用・復旧経路の確認が必要。今回は本体コードをこの分類に確定しない。 |
+
+## 今回の安全な修正
+
+同じモジュールで3つのテスト名が二重定義され、pytest収集前に前の定義が
+上書きされていました。それぞれ異なる検証を含むため、削除せず改名します。
+
+| `veritas_os/tests/`配下のファイル | 復活する前の定義の新しい名前 |
+| --- | --- |
+| `unit/test_kernel_decide_ext.py` | `test_decide_simple_qa_time_response_contract` |
+| `integration/test_decide_e2e_ext.py` | `test_run_decide_pipeline_happy_path_with_trust_receipt` |
+| `integration/test_decide_e2e_ext.py` | `test_run_decide_pipeline_explicit_options_preserve_ids_without_ml_gate` |
+
+元のassertionはすべて維持します。復活するexplicit-optionsテストのkernel
+モジュール差し替えは`monkeypatch.setitem`へ変更し、終了後に元の状態へ戻します。
+後に定義されていた既存テストの名前は維持します。分類はTEST_ONLYです。
+本体の認可処理・verifierは変更しません。
+
+`tests/test_unique_test_names.py`で追跡対象pytestファイルの直接定義による
+上書きを検出します。importせずASTを解析します。条件分岐内の定義、動的代入、
+import名の衝突、すべてのpytest拡張を検出できるわけではありません。
+
+対象2ファイルは194件成功。検出器のテストを含め197件成功しました。
+full CIは別の確認事項であり、この件数をもって全CI成功とはしません。
+
+## 類似テスト・ヘルパーの棚卸し
+
+基準commitの`tests`ディレクトリ配下には追跡対象Pythonファイルが566個あります。
+モジュール直下のテストをAST比較すると、位置情報を除き名前・decorator・docstring
+を含めて一致するものが15グループ・38定義ありました。
+例として`tests/demo/test_*_schema.py`のschema存在確認は本文が同じでも、
+各モジュールの対象パスが違います。見た目の一致だけで検証を削除しません。
+
+追跡対象の非テストPythonファイルにある、モジュール直下のヘルパー定義数:
+
+| 名前 | 定義数 | 扱い |
+| --- | ---: | --- |
+| `_digest` | 50 | KEEP。AST一致は5グループ（18・5・12・2・4定義）だが参照先のglobalは異なり得る。 |
+| `_timestamp` | 18 | KEEP。解析仕様とエラー契約を比較してから共通化を検討する。 |
+| `_json` | 20 | KEEP。許容値・正規化の差異を確認する。 |
+| `_fail` | 16 | KEEP。各領域の例外型・コードを維持する。 |
+
+例として`policy/live_adapter_bind_authorization_codec.py`のdigestはdomainを
+引数で受け取り、`policy/human_approval_requirement_resolution.py`は固有DOMAINを
+使います。JSONの許容値や時刻エラー契約も異なります。名前やASTだけで
+verifier・ヘルパーを統合しません。
+
+## Legacy shim一覧
+
+`_TARGET_MODULE`と`import_module`/`sys`による別名化のパターンに一致する
+非テストファイルは39個です。以下は`veritas_os/core/`からのモジュール名で、
+現時点の分類はすべてPUBLIC_COMPATです。他方式の互換層はこの抽出範囲外です。
+
+| 区分 | モジュール名 |
+| --- | --- |
+| FUJI（6） | `fuji_codes`, `fuji_helpers`, `fuji_injection`, `fuji_policy`, `fuji_policy_rollout`, `fuji_safety_head` |
+| Memory（14） | `memory_compliance`, `memory_distillation`, `memory_evidence`, `memory_helpers`, `memory_lifecycle`, `memory_search_helpers`, `memory_security`, `memory_storage`, `memory_store`, `memory_store_compat`, `memory_store_helpers`, `memory_summary_helpers`, `memory_vector`, `models/memory_model` |
+| Pipeline（19） | `pipeline_compat`, `pipeline_contracts`, `pipeline_critique`, `pipeline_decide_stages`, `pipeline_evidence`, `pipeline_execute`, `pipeline_gate`, `pipeline_helpers`, `pipeline_inputs`, `pipeline_memory_adapter`, `pipeline_persist`, `pipeline_persistence`, `pipeline_policy`, `pipeline_replay`, `pipeline_response`, `pipeline_retrieval`, `pipeline_signature_adapter`, `pipeline_types`, `pipeline_web_adapter` |
+
+`core/_shim_deprecation.py`にはv2.2.0・2026-08-01以降という予定がありますが、
+日付の経過は移行完了の証明ではありません。`test_memory_vector_core.py`と
+`test_legacy_core_shim_deprecations.py`は旧importと別名動作を検証しています。
+REMOVE_NEXT_MAJORの提案には明示的なリリース判断と外部利用側の確認が必要です。
+
+## Builder候補
+
+ASTの名前・属性・import参照を調べると、定義ファイル外の参照がテストだけの
+`build_*`が61定義あります。ただしTEST_ONLYやDEADとは判定できません。
+同一ファイル内の利用、CLI、外部の公開API利用を確認する必要があります。
+削除候補としなかった例:
+
+| Builder | 根拠 | 分類 |
+| --- | --- | --- |
+| `audit/anchor_backends.py:build_timestamp_request` | 同一ファイル内のtimestamp要求処理から利用 | KEEP |
+| `audit/trustlog_signed.py:build_trustlog_summary` | 同一ファイル内の署名監査処理から利用 | KEEP |
+| `sdk/python/examples/aml_kyc_webhook_bind.py:build_review_payload` | 同一ファイル内のサンプル処理から利用 | KEEP |
+
+残りは個別参照レビューが必要です。単語検索でも使用がない本体builderは確定
+できませんでした。どちらの方法でも動的参照・外部利用までは解決できません。
+
+## 大きいschema候補
+
+追跡対象`*schema.json`を物理行数で並べた上位5件です。大きさはレビューの
+目安であり、フィールドや埋め込み定義が不要である証拠ではありません。
+
+| `schemas/`配下 | 行数 | UTF-8バイト数 |
+| --- | ---: | ---: |
+| `adapter-dry-run-fixture-result-v1.schema.json` | 6582 | 185226 |
+| `adapter-dry-run-plan-v1.schema.json` | 4475 | 122180 |
+| `bind-adapter-contract-selection-v1.schema.json` | 3995 | 106900 |
+| `canonical-bind-preflight-adjudication-v1.schema.json` | 3087 | 81710 |
+| `live-adapter-dry-run-request-v1.schema.json` | 2878 | 85831 |
+
+分類はKEEP。生成方法・参照解決・互換性・hashや署名への影響を確認してから
+整理を検討します。今回はschemaを変更しません。
+
+## 次の境界
+
+このテスト修正と棚卸しのレビュー後、native v2実行へ進みます。
+最初の外部連携について、信頼源・時刻・変更条件・結果不明時の処理を
+外部作用の接続前に固定します。正常系と障害・復旧シナリオを通した後に
+freezeし、大規模Consolidation Auditを行います。1本のE2Eで未使用であることは
+DEADの証明にはなりません。今回は古いPRやブランチも削除・closeしません。

--- a/tests/test_unique_test_names.py
+++ b/tests/test_unique_test_names.py
@@ -1,0 +1,61 @@
+"""Prevent direct test definitions from silently overwriting earlier tests."""
+
+import ast
+from pathlib import Path
+import subprocess
+
+
+def _duplicates(body: list[ast.stmt], scope: str = "module") -> list[str]:
+    """Find repeated direct test declarations in module and class namespaces."""
+    seen: dict[str, int] = {}
+    errors = []
+    for node in body:
+        if isinstance(node, ast.ClassDef):
+            errors.extend(_duplicates(node.body, f"{scope}.{node.name}"))
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            continue
+        if not node.name.startswith(("test_", "Test")):
+            continue
+        if node.name in seen:
+            errors.append(f"{scope}.{node.name}: {seen[node.name]}, {node.lineno}")
+        seen[node.name] = node.lineno
+    return errors
+
+
+def test_detector_catches_sync_async_and_class_overwrites() -> None:
+    source = (
+        "def test_same(): pass\n"
+        "async def test_same(): pass\n"
+        "class TestA:\n"
+        " def test_method(self): pass\n"
+        " def test_method(self): pass\n"
+        "class TestA: pass\n"
+    )
+    assert _duplicates(ast.parse(source).body) == [
+        "module.test_same: 1, 2",
+        "module.TestA.test_method: 4, 5",
+        "module.TestA: 3, 6",
+    ]
+
+
+def test_detector_keeps_separate_class_namespaces() -> None:
+    source = "class TestA:\n def test_x(self): pass\nclass TestB:\n def test_x(self): pass"
+    assert _duplicates(ast.parse(source).body) == []
+
+
+def test_tracked_test_definitions_have_unique_names() -> None:
+    """Parse tracked pytest files without importing them or running fixtures."""
+    root = Path(__file__).resolve().parents[1]
+    paths = subprocess.check_output(
+        ["git", "ls-files", "-z", "*.py"], cwd=root, text=True
+    ).split("\0")
+    errors = []
+    for name in paths:
+        path = Path(name)
+        if "tests" not in path.parts:
+            continue
+        if not (path.name.startswith("test_") or path.name.endswith("_test.py")):
+            continue
+        tree = ast.parse((root / path).read_text(encoding="utf-8"), filename=name)
+        errors.extend(f"{name}: {error}" for error in _duplicates(tree.body))
+    assert not errors, "Overwritten test definitions:\n" + "\n".join(errors)

--- a/veritas_os/tests/integration/test_decide_e2e_ext.py
+++ b/veritas_os/tests/integration/test_decide_e2e_ext.py
@@ -548,7 +548,7 @@ def patched_pipeline(monkeypatch, tmp_path):
 
 
 @pytest.mark.anyio
-async def test_run_decide_pipeline_happy_path(patched_pipeline):
+async def test_run_decide_pipeline_happy_path_with_trust_receipt(patched_pipeline):
     pipeline = patched_pipeline
 
     body = {"query": "Test veritas agi research", "context": {"user_id": "u1"}, "options": []}
@@ -736,7 +736,7 @@ async def test_run_decide_pipeline_fast_mode_flags(patched_pipeline):
 
 
 @pytest.mark.anyio
-async def test_run_decide_pipeline_with_explicit_options_and_no_ml_gate(monkeypatch, patched_pipeline):
+async def test_run_decide_pipeline_explicit_options_preserve_ids_without_ml_gate(monkeypatch, patched_pipeline):
     """
     explicit options を渡したとき alternatives の id が維持される（opt1/opt2）か、
     もしくは core_alt が残ることを担保する回帰テスト。
@@ -760,7 +760,7 @@ async def test_run_decide_pipeline_with_explicit_options_and_no_ml_gate(monkeypa
         return pipeline.veritas_core.decide(*args, **kwargs)
 
     m_kernel.decide = kernel_decide
-    sys.modules["veritas_os.core.kernel"] = m_kernel
+    monkeypatch.setitem(sys.modules, "veritas_os.core.kernel", m_kernel)
 
     # --- 明示 options ---
     body = {

--- a/veritas_os/tests/unit/test_kernel_decide_ext.py
+++ b/veritas_os/tests/unit/test_kernel_decide_ext.py
@@ -475,7 +475,7 @@ def test_score_alternatives_with_value_core_and_persona(monkeypatch):
 # ============================================================
 
 @pytest.mark.anyio
-async def test_decide_simple_qa_time():
+async def test_decide_simple_qa_time_response_contract():
     ctx = {"user_id": "test-user"}
     res = await kernel.decide(ctx, "今何時？", alternatives=None)
 


### PR DESCRIPTION
## Summary
Three earlier test definitions were silently overwritten by later definitions in the same modules. Restore collection using distinct names and add an AST guard for direct module/class test-name collisions.

This is the agreed lightweight consolidation checkpoint after #2195, based on main `236a468cc426f57e70f9aad84eee1c09e9f2b5f9`.

## Changes
- Restore simple-QA response assertions, canonical trust-receipt linkage assertions, and explicit-options/no-ML-gate assertions. Preserve every assertion and later test name.
- Use monkeypatch.setitem for the restored options test's kernel module stub so teardown restores the prior module.
- Add a tracked-pytest-file AST guard plus positive/negative detector tests. No test imports required by the guard.
- Record a bilingual bounded inventory: 39 PUBLIC_COMPAT alias shims; helper-definition counts and semantic differences; test similarity candidates; builder reference-search limitations; largest schema candidates.
- No production authorization, verifier, credential, schema, compatibility or external-effect changes. No deletions of PRs/branches/runtime code.

## Validation
- Affected test files + name-collision guard: **197 passed** (194 affected-file tests + 3 guard tests).
- Legacy shim and memory-vector compatibility tests: **41 passed**.
- **238 distinct local tests passed**, plus overlapping guard rerun after staging passed.
- Repository Ruff, explicit guard Ruff, bilingual-doc checks and diff checks passed.
- Published tree equals tested local tree: `a03375cd92b6ae1f1c6fec5a6ae35c65b24e5365`.
- Full GitHub CI pending; do not treat local checks as all-CI success.

## Inventory limitations
Classification precedes deletion. Identical ASTs may reference different globals or fixtures. External-test-only references do not exclude same-file/CLI/public use. No runtime item is proven DEAD.
The test guard covers direct module/class declarations, not conditional/dynamic definitions or imported-name collisions.
Full verifier consolidation, schema normalization and compatibility removal remain deferred.

## Review
- [x] Codex assistance
- [ ] Full CI passed
- [ ] Human maintainer reviewed
- Draft; do not merge automatically.
