### PR TITLE
fix: propagate optional approval through downstream schemas

### DIFF
--- a/schemas/adapter-dry-run-fixture-result-v1.schema.json
+++ b/schemas/adapter-dry-run-fixture-result-v1.schema.json
@@ -2163,7 +2163,6 @@
         },
         "evidence_refs": {
           "type": "array",
-          "minItems": 5,
           "items": {
             "type": "string",
             "minLength": 1
@@ -2185,22 +2184,47 @@
           "minLength": 1
         },
         "approval_context": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "human_approval_receipt_ref",
-            "human_approval_receipt_hash"
-          ],
-          "properties": {
-            "human_approval_receipt_ref": {
-              "type": "string",
-              "minLength": 1
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "human_approval_receipt_ref",
+                "human_approval_receipt_hash"
+              ],
+              "properties": {
+                "human_approval_receipt_ref": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "human_approval_receipt_hash": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
             },
-            "human_approval_receipt_hash": {
-              "type": "string",
-              "minLength": 1
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "required_human_approval",
+                "requirement_state",
+                "requirement_policy_ref"
+              ],
+              "properties": {
+                "required_human_approval": {
+                  "const": false
+                },
+                "requirement_state": {
+                  "const": "NOT_REQUIRED_BY_CANONICAL_HANDOFF"
+                },
+                "requirement_policy_ref": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
             }
-          }
+          ]
         },
         "policy_lineage": {
           "type": "object",
@@ -2223,6 +2247,34 @@
               "type": "string",
               "minLength": 1
             }
+          }
+        }
+      },
+      "if": {
+        "properties": {
+          "approval_context": {
+            "required": [
+              "required_human_approval"
+            ],
+            "properties": {
+              "required_human_approval": {
+                "const": false
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "evidence_refs": {
+            "minItems": 4
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "evidence_refs": {
+            "minItems": 5
           }
         }
       }
@@ -2277,7 +2329,6 @@
         },
         "evidence_refs": {
           "type": "array",
-          "minItems": 5,
           "items": {
             "type": "string",
             "minLength": 1
@@ -2299,22 +2350,47 @@
           "minLength": 1
         },
         "approval_context": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "human_approval_receipt_ref",
-            "human_approval_receipt_hash"
-          ],
-          "properties": {
-            "human_approval_receipt_ref": {
-              "type": "string",
-              "minLength": 1
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "human_approval_receipt_ref",
+                "human_approval_receipt_hash"
+              ],
+              "properties": {
+                "human_approval_receipt_ref": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "human_approval_receipt_hash": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
             },
-            "human_approval_receipt_hash": {
-              "type": "string",
-              "minLength": 1
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "required_human_approval",
+                "requirement_state",
+                "requirement_policy_ref"
+              ],
+              "properties": {
+                "required_human_approval": {
+                  "const": false
+                },
+                "requirement_state": {
+                  "const": "NOT_REQUIRED_BY_CANONICAL_HANDOFF"
+                },
+                "requirement_policy_ref": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
             }
-          }
+          ]
         },
         "policy_lineage": {
           "type": "object",
@@ -2337,6 +2413,34 @@
               "type": "string",
               "minLength": 1
             }
+          }
+        }
+      },
+      "if": {
+        "properties": {
+          "approval_context": {
+            "required": [
+              "required_human_approval"
+            ],
+            "properties": {
+              "required_human_approval": {
+                "const": false
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "evidence_refs": {
+            "minItems": 4
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "evidence_refs": {
+            "minItems": 5
           }
         }
       }
@@ -2655,12 +2759,26 @@
               "minLength": 1
             },
             "human_approval_receipt_ref": {
-              "type": "string",
-              "minLength": 1
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "human_approval_receipt_hash": {
-              "type": "string",
-              "minLength": 1
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "policy_snapshot_id": {
               "type": "string",
@@ -3021,7 +3139,6 @@
             },
             "evidence_refs": {
               "type": "array",
-              "minItems": 5,
               "items": {
                 "type": "string",
                 "minLength": 1
@@ -3043,22 +3160,47 @@
               "minLength": 1
             },
             "approval_context": {
-              "type": "object",
-              "additionalProperties": false,
-              "required": [
-                "human_approval_receipt_ref",
-                "human_approval_receipt_hash"
-              ],
-              "properties": {
-                "human_approval_receipt_ref": {
-                  "type": "string",
-                  "minLength": 1
+              "oneOf": [
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "human_approval_receipt_ref",
+                    "human_approval_receipt_hash"
+                  ],
+                  "properties": {
+                    "human_approval_receipt_ref": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "human_approval_receipt_hash": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
                 },
-                "human_approval_receipt_hash": {
-                  "type": "string",
-                  "minLength": 1
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "required_human_approval",
+                    "requirement_state",
+                    "requirement_policy_ref"
+                  ],
+                  "properties": {
+                    "required_human_approval": {
+                      "const": false
+                    },
+                    "requirement_state": {
+                      "const": "NOT_REQUIRED_BY_CANONICAL_HANDOFF"
+                    },
+                    "requirement_policy_ref": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
                 }
-              }
+              ]
             },
             "policy_lineage": {
               "type": "object",
@@ -3081,6 +3223,34 @@
                   "type": "string",
                   "minLength": 1
                 }
+              }
+            }
+          },
+          "if": {
+            "properties": {
+              "approval_context": {
+                "required": [
+                  "required_human_approval"
+                ],
+                "properties": {
+                  "required_human_approval": {
+                    "const": false
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "evidence_refs": {
+                "minItems": 4
+              }
+            }
+          },
+          "else": {
+            "properties": {
+              "evidence_refs": {
+                "minItems": 5
               }
             }
           }
@@ -3272,12 +3442,26 @@
               "minLength": 1
             },
             "human_approval_receipt_ref": {
-              "type": "string",
-              "minLength": 1
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "human_approval_receipt_hash": {
-              "type": "string",
-              "minLength": 1
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "policy_snapshot_id": {
               "type": "string",
@@ -3696,10 +3880,24 @@
               "type": "string"
             },
             "human_approval_receipt_ref": {
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "human_approval_receipt_hash": {
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "policy_snapshot_id": {
               "type": "string"
@@ -4351,12 +4549,26 @@
               "minLength": 1
             },
             "human_approval_receipt_ref": {
-              "type": "string",
-              "minLength": 1
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "human_approval_receipt_hash": {
-              "type": "string",
-              "minLength": 1
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "policy_snapshot_id": {
               "type": "string",
@@ -4901,12 +5113,26 @@
               "minLength": 1
             },
             "human_approval_receipt_ref": {
-              "type": "string",
-              "minLength": 1
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "human_approval_receipt_hash": {
-              "type": "string",
-              "minLength": 1
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "policy_snapshot_id": {
               "type": "string",
@@ -5934,12 +6160,26 @@
               "minLength": 1
             },
             "human_approval_receipt_ref": {
-              "type": "string",
-              "minLength": 1
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "human_approval_receipt_hash": {
-              "type": "string",
-              "minLength": 1
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "policy_snapshot_id": {
               "type": "string",

--- a/schemas/adapter-dry-run-plan-v1.schema.json
+++ b/schemas/adapter-dry-run-plan-v1.schema.json
@@ -536,7 +536,6 @@
         },
         "evidence_refs": {
           "type": "array",
-          "minItems": 5,
           "items": {
             "type": "string",
             "minLength": 1
@@ -558,22 +557,47 @@
           "minLength": 1
         },
         "approval_context": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "human_approval_receipt_ref",
-            "human_approval_receipt_hash"
-          ],
-          "properties": {
-            "human_approval_receipt_ref": {
-              "type": "string",
-              "minLength": 1
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "human_approval_receipt_ref",
+                "human_approval_receipt_hash"
+              ],
+              "properties": {
+                "human_approval_receipt_ref": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "human_approval_receipt_hash": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
             },
-            "human_approval_receipt_hash": {
-              "type": "string",
-              "minLength": 1
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "required_human_approval",
+                "requirement_state",
+                "requirement_policy_ref"
+              ],
+              "properties": {
+                "required_human_approval": {
+                  "const": false
+                },
+                "requirement_state": {
+                  "const": "NOT_REQUIRED_BY_CANONICAL_HANDOFF"
+                },
+                "requirement_policy_ref": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
             }
-          }
+          ]
         },
         "policy_lineage": {
           "type": "object",
@@ -596,6 +620,34 @@
               "type": "string",
               "minLength": 1
             }
+          }
+        }
+      },
+      "if": {
+        "properties": {
+          "approval_context": {
+            "required": [
+              "required_human_approval"
+            ],
+            "properties": {
+              "required_human_approval": {
+                "const": false
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "evidence_refs": {
+            "minItems": 4
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "evidence_refs": {
+            "minItems": 5
           }
         }
       }
@@ -650,7 +702,6 @@
         },
         "evidence_refs": {
           "type": "array",
-          "minItems": 5,
           "items": {
             "type": "string",
             "minLength": 1
@@ -672,22 +723,47 @@
           "minLength": 1
         },
         "approval_context": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "human_approval_receipt_ref",
-            "human_approval_receipt_hash"
-          ],
-          "properties": {
-            "human_approval_receipt_ref": {
-              "type": "string",
-              "minLength": 1
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "human_approval_receipt_ref",
+                "human_approval_receipt_hash"
+              ],
+              "properties": {
+                "human_approval_receipt_ref": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "human_approval_receipt_hash": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
             },
-            "human_approval_receipt_hash": {
-              "type": "string",
-              "minLength": 1
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "required_human_approval",
+                "requirement_state",
+                "requirement_policy_ref"
+              ],
+              "properties": {
+                "required_human_approval": {
+                  "const": false
+                },
+                "requirement_state": {
+                  "const": "NOT_REQUIRED_BY_CANONICAL_HANDOFF"
+                },
+                "requirement_policy_ref": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
             }
-          }
+          ]
         },
         "policy_lineage": {
           "type": "object",
@@ -710,6 +786,34 @@
               "type": "string",
               "minLength": 1
             }
+          }
+        }
+      },
+      "if": {
+        "properties": {
+          "approval_context": {
+            "required": [
+              "required_human_approval"
+            ],
+            "properties": {
+              "required_human_approval": {
+                "const": false
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "evidence_refs": {
+            "minItems": 4
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "evidence_refs": {
+            "minItems": 5
           }
         }
       }
@@ -1028,12 +1132,26 @@
               "minLength": 1
             },
             "human_approval_receipt_ref": {
-              "type": "string",
-              "minLength": 1
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "human_approval_receipt_hash": {
-              "type": "string",
-              "minLength": 1
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "policy_snapshot_id": {
               "type": "string",
@@ -1394,7 +1512,6 @@
             },
             "evidence_refs": {
               "type": "array",
-              "minItems": 5,
               "items": {
                 "type": "string",
                 "minLength": 1
@@ -1416,22 +1533,47 @@
               "minLength": 1
             },
             "approval_context": {
-              "type": "object",
-              "additionalProperties": false,
-              "required": [
-                "human_approval_receipt_ref",
-                "human_approval_receipt_hash"
-              ],
-              "properties": {
-                "human_approval_receipt_ref": {
-                  "type": "string",
-                  "minLength": 1
+              "oneOf": [
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "human_approval_receipt_ref",
+                    "human_approval_receipt_hash"
+                  ],
+                  "properties": {
+                    "human_approval_receipt_ref": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "human_approval_receipt_hash": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
                 },
-                "human_approval_receipt_hash": {
-                  "type": "string",
-                  "minLength": 1
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "required_human_approval",
+                    "requirement_state",
+                    "requirement_policy_ref"
+                  ],
+                  "properties": {
+                    "required_human_approval": {
+                      "const": false
+                    },
+                    "requirement_state": {
+                      "const": "NOT_REQUIRED_BY_CANONICAL_HANDOFF"
+                    },
+                    "requirement_policy_ref": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
                 }
-              }
+              ]
             },
             "policy_lineage": {
               "type": "object",
@@ -1454,6 +1596,34 @@
                   "type": "string",
                   "minLength": 1
                 }
+              }
+            }
+          },
+          "if": {
+            "properties": {
+              "approval_context": {
+                "required": [
+                  "required_human_approval"
+                ],
+                "properties": {
+                  "required_human_approval": {
+                    "const": false
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "evidence_refs": {
+                "minItems": 4
+              }
+            }
+          },
+          "else": {
+            "properties": {
+              "evidence_refs": {
+                "minItems": 5
               }
             }
           }
@@ -1645,12 +1815,26 @@
               "minLength": 1
             },
             "human_approval_receipt_ref": {
-              "type": "string",
-              "minLength": 1
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "human_approval_receipt_hash": {
-              "type": "string",
-              "minLength": 1
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "policy_snapshot_id": {
               "type": "string",
@@ -2069,10 +2253,24 @@
               "type": "string"
             },
             "human_approval_receipt_ref": {
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "human_approval_receipt_hash": {
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "policy_snapshot_id": {
               "type": "string"
@@ -2724,12 +2922,26 @@
               "minLength": 1
             },
             "human_approval_receipt_ref": {
-              "type": "string",
-              "minLength": 1
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "human_approval_receipt_hash": {
-              "type": "string",
-              "minLength": 1
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "policy_snapshot_id": {
               "type": "string",
@@ -3274,12 +3486,26 @@
               "minLength": 1
             },
             "human_approval_receipt_ref": {
-              "type": "string",
-              "minLength": 1
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "human_approval_receipt_hash": {
-              "type": "string",
-              "minLength": 1
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "policy_snapshot_id": {
               "type": "string",
@@ -4307,12 +4533,26 @@
               "minLength": 1
             },
             "human_approval_receipt_ref": {
-              "type": "string",
-              "minLength": 1
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "human_approval_receipt_hash": {
-              "type": "string",
-              "minLength": 1
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "policy_snapshot_id": {
               "type": "string",

--- a/schemas/bind-adapter-contract-selection-v1.schema.json
+++ b/schemas/bind-adapter-contract-selection-v1.schema.json
@@ -476,12 +476,26 @@
           "minLength": 1
         },
         "human_approval_receipt_ref": {
-          "type": "string",
-          "minLength": 1
+          "anyOf": [
+            {
+              "type": "string",
+              "minLength": 1
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "human_approval_receipt_hash": {
-          "type": "string",
-          "minLength": 1
+          "anyOf": [
+            {
+              "type": "string",
+              "minLength": 1
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "policy_snapshot_id": {
           "type": "string",
@@ -695,7 +709,6 @@
         },
         "evidence_refs": {
           "type": "array",
-          "minItems": 5,
           "items": {
             "type": "string",
             "minLength": 1
@@ -717,22 +730,47 @@
           "minLength": 1
         },
         "approval_context": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "human_approval_receipt_ref",
-            "human_approval_receipt_hash"
-          ],
-          "properties": {
-            "human_approval_receipt_ref": {
-              "type": "string",
-              "minLength": 1
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "human_approval_receipt_ref",
+                "human_approval_receipt_hash"
+              ],
+              "properties": {
+                "human_approval_receipt_ref": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "human_approval_receipt_hash": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
             },
-            "human_approval_receipt_hash": {
-              "type": "string",
-              "minLength": 1
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "required_human_approval",
+                "requirement_state",
+                "requirement_policy_ref"
+              ],
+              "properties": {
+                "required_human_approval": {
+                  "const": false
+                },
+                "requirement_state": {
+                  "const": "NOT_REQUIRED_BY_CANONICAL_HANDOFF"
+                },
+                "requirement_policy_ref": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
             }
-          }
+          ]
         },
         "policy_lineage": {
           "type": "object",
@@ -755,6 +793,34 @@
               "type": "string",
               "minLength": 1
             }
+          }
+        }
+      },
+      "if": {
+        "properties": {
+          "approval_context": {
+            "required": [
+              "required_human_approval"
+            ],
+            "properties": {
+              "required_human_approval": {
+                "const": false
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "evidence_refs": {
+            "minItems": 4
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "evidence_refs": {
+            "minItems": 5
           }
         }
       }
@@ -809,7 +875,6 @@
         },
         "evidence_refs": {
           "type": "array",
-          "minItems": 5,
           "items": {
             "type": "string",
             "minLength": 1
@@ -831,22 +896,47 @@
           "minLength": 1
         },
         "approval_context": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "human_approval_receipt_ref",
-            "human_approval_receipt_hash"
-          ],
-          "properties": {
-            "human_approval_receipt_ref": {
-              "type": "string",
-              "minLength": 1
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "human_approval_receipt_ref",
+                "human_approval_receipt_hash"
+              ],
+              "properties": {
+                "human_approval_receipt_ref": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "human_approval_receipt_hash": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
             },
-            "human_approval_receipt_hash": {
-              "type": "string",
-              "minLength": 1
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "required_human_approval",
+                "requirement_state",
+                "requirement_policy_ref"
+              ],
+              "properties": {
+                "required_human_approval": {
+                  "const": false
+                },
+                "requirement_state": {
+                  "const": "NOT_REQUIRED_BY_CANONICAL_HANDOFF"
+                },
+                "requirement_policy_ref": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
             }
-          }
+          ]
         },
         "policy_lineage": {
           "type": "object",
@@ -869,6 +959,34 @@
               "type": "string",
               "minLength": 1
             }
+          }
+        }
+      },
+      "if": {
+        "properties": {
+          "approval_context": {
+            "required": [
+              "required_human_approval"
+            ],
+            "properties": {
+              "required_human_approval": {
+                "const": false
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "evidence_refs": {
+            "minItems": 4
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "evidence_refs": {
+            "minItems": 5
           }
         }
       }
@@ -1187,12 +1305,26 @@
               "minLength": 1
             },
             "human_approval_receipt_ref": {
-              "type": "string",
-              "minLength": 1
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "human_approval_receipt_hash": {
-              "type": "string",
-              "minLength": 1
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "policy_snapshot_id": {
               "type": "string",
@@ -1553,7 +1685,6 @@
             },
             "evidence_refs": {
               "type": "array",
-              "minItems": 5,
               "items": {
                 "type": "string",
                 "minLength": 1
@@ -1575,22 +1706,47 @@
               "minLength": 1
             },
             "approval_context": {
-              "type": "object",
-              "additionalProperties": false,
-              "required": [
-                "human_approval_receipt_ref",
-                "human_approval_receipt_hash"
-              ],
-              "properties": {
-                "human_approval_receipt_ref": {
-                  "type": "string",
-                  "minLength": 1
+              "oneOf": [
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "human_approval_receipt_ref",
+                    "human_approval_receipt_hash"
+                  ],
+                  "properties": {
+                    "human_approval_receipt_ref": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "human_approval_receipt_hash": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
                 },
-                "human_approval_receipt_hash": {
-                  "type": "string",
-                  "minLength": 1
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "required_human_approval",
+                    "requirement_state",
+                    "requirement_policy_ref"
+                  ],
+                  "properties": {
+                    "required_human_approval": {
+                      "const": false
+                    },
+                    "requirement_state": {
+                      "const": "NOT_REQUIRED_BY_CANONICAL_HANDOFF"
+                    },
+                    "requirement_policy_ref": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
                 }
-              }
+              ]
             },
             "policy_lineage": {
               "type": "object",
@@ -1613,6 +1769,34 @@
                   "type": "string",
                   "minLength": 1
                 }
+              }
+            }
+          },
+          "if": {
+            "properties": {
+              "approval_context": {
+                "required": [
+                  "required_human_approval"
+                ],
+                "properties": {
+                  "required_human_approval": {
+                    "const": false
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "evidence_refs": {
+                "minItems": 4
+              }
+            }
+          },
+          "else": {
+            "properties": {
+              "evidence_refs": {
+                "minItems": 5
               }
             }
           }
@@ -1804,12 +1988,26 @@
               "minLength": 1
             },
             "human_approval_receipt_ref": {
-              "type": "string",
-              "minLength": 1
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "human_approval_receipt_hash": {
-              "type": "string",
-              "minLength": 1
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "policy_snapshot_id": {
               "type": "string",
@@ -2228,10 +2426,24 @@
               "type": "string"
             },
             "human_approval_receipt_ref": {
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "human_approval_receipt_hash": {
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "policy_snapshot_id": {
               "type": "string"
@@ -2883,12 +3095,26 @@
               "minLength": 1
             },
             "human_approval_receipt_ref": {
-              "type": "string",
-              "minLength": 1
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "human_approval_receipt_hash": {
-              "type": "string",
-              "minLength": 1
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "policy_snapshot_id": {
               "type": "string",
@@ -3433,12 +3659,26 @@
               "minLength": 1
             },
             "human_approval_receipt_ref": {
-              "type": "string",
-              "minLength": 1
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "human_approval_receipt_hash": {
-              "type": "string",
-              "minLength": 1
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "policy_snapshot_id": {
               "type": "string",

--- a/schemas/canonical-bind-preflight-adjudication-v1.schema.json
+++ b/schemas/canonical-bind-preflight-adjudication-v1.schema.json
@@ -344,12 +344,26 @@
           "minLength": 1
         },
         "human_approval_receipt_ref": {
-          "type": "string",
-          "minLength": 1
+          "anyOf": [
+            {
+              "type": "string",
+              "minLength": 1
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "human_approval_receipt_hash": {
-          "type": "string",
-          "minLength": 1
+          "anyOf": [
+            {
+              "type": "string",
+              "minLength": 1
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "policy_snapshot_id": {
           "type": "string",
@@ -689,7 +703,6 @@
         },
         "evidence_refs": {
           "type": "array",
-          "minItems": 5,
           "items": {
             "type": "string",
             "minLength": 1
@@ -711,22 +724,47 @@
           "minLength": 1
         },
         "approval_context": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "human_approval_receipt_ref",
-            "human_approval_receipt_hash"
-          ],
-          "properties": {
-            "human_approval_receipt_ref": {
-              "type": "string",
-              "minLength": 1
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "human_approval_receipt_ref",
+                "human_approval_receipt_hash"
+              ],
+              "properties": {
+                "human_approval_receipt_ref": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "human_approval_receipt_hash": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
             },
-            "human_approval_receipt_hash": {
-              "type": "string",
-              "minLength": 1
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "required_human_approval",
+                "requirement_state",
+                "requirement_policy_ref"
+              ],
+              "properties": {
+                "required_human_approval": {
+                  "const": false
+                },
+                "requirement_state": {
+                  "const": "NOT_REQUIRED_BY_CANONICAL_HANDOFF"
+                },
+                "requirement_policy_ref": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
             }
-          }
+          ]
         },
         "policy_lineage": {
           "type": "object",
@@ -749,6 +787,34 @@
               "type": "string",
               "minLength": 1
             }
+          }
+        }
+      },
+      "if": {
+        "properties": {
+          "approval_context": {
+            "required": [
+              "required_human_approval"
+            ],
+            "properties": {
+              "required_human_approval": {
+                "const": false
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "evidence_refs": {
+            "minItems": 4
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "evidence_refs": {
+            "minItems": 5
           }
         }
       }
@@ -803,7 +869,6 @@
         },
         "evidence_refs": {
           "type": "array",
-          "minItems": 5,
           "items": {
             "type": "string",
             "minLength": 1
@@ -825,22 +890,47 @@
           "minLength": 1
         },
         "approval_context": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "human_approval_receipt_ref",
-            "human_approval_receipt_hash"
-          ],
-          "properties": {
-            "human_approval_receipt_ref": {
-              "type": "string",
-              "minLength": 1
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "human_approval_receipt_ref",
+                "human_approval_receipt_hash"
+              ],
+              "properties": {
+                "human_approval_receipt_ref": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "human_approval_receipt_hash": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
             },
-            "human_approval_receipt_hash": {
-              "type": "string",
-              "minLength": 1
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "required_human_approval",
+                "requirement_state",
+                "requirement_policy_ref"
+              ],
+              "properties": {
+                "required_human_approval": {
+                  "const": false
+                },
+                "requirement_state": {
+                  "const": "NOT_REQUIRED_BY_CANONICAL_HANDOFF"
+                },
+                "requirement_policy_ref": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
             }
-          }
+          ]
         },
         "policy_lineage": {
           "type": "object",
@@ -863,6 +953,34 @@
               "type": "string",
               "minLength": 1
             }
+          }
+        }
+      },
+      "if": {
+        "properties": {
+          "approval_context": {
+            "required": [
+              "required_human_approval"
+            ],
+            "properties": {
+              "required_human_approval": {
+                "const": false
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "evidence_refs": {
+            "minItems": 4
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "evidence_refs": {
+            "minItems": 5
           }
         }
       }
@@ -1181,12 +1299,26 @@
               "minLength": 1
             },
             "human_approval_receipt_ref": {
-              "type": "string",
-              "minLength": 1
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "human_approval_receipt_hash": {
-              "type": "string",
-              "minLength": 1
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "policy_snapshot_id": {
               "type": "string",
@@ -1547,7 +1679,6 @@
             },
             "evidence_refs": {
               "type": "array",
-              "minItems": 5,
               "items": {
                 "type": "string",
                 "minLength": 1
@@ -1569,22 +1700,47 @@
               "minLength": 1
             },
             "approval_context": {
-              "type": "object",
-              "additionalProperties": false,
-              "required": [
-                "human_approval_receipt_ref",
-                "human_approval_receipt_hash"
-              ],
-              "properties": {
-                "human_approval_receipt_ref": {
-                  "type": "string",
-                  "minLength": 1
+              "oneOf": [
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "human_approval_receipt_ref",
+                    "human_approval_receipt_hash"
+                  ],
+                  "properties": {
+                    "human_approval_receipt_ref": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "human_approval_receipt_hash": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
                 },
-                "human_approval_receipt_hash": {
-                  "type": "string",
-                  "minLength": 1
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "required_human_approval",
+                    "requirement_state",
+                    "requirement_policy_ref"
+                  ],
+                  "properties": {
+                    "required_human_approval": {
+                      "const": false
+                    },
+                    "requirement_state": {
+                      "const": "NOT_REQUIRED_BY_CANONICAL_HANDOFF"
+                    },
+                    "requirement_policy_ref": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
                 }
-              }
+              ]
             },
             "policy_lineage": {
               "type": "object",
@@ -1607,6 +1763,34 @@
                   "type": "string",
                   "minLength": 1
                 }
+              }
+            }
+          },
+          "if": {
+            "properties": {
+              "approval_context": {
+                "required": [
+                  "required_human_approval"
+                ],
+                "properties": {
+                  "required_human_approval": {
+                    "const": false
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "evidence_refs": {
+                "minItems": 4
+              }
+            }
+          },
+          "else": {
+            "properties": {
+              "evidence_refs": {
+                "minItems": 5
               }
             }
           }
@@ -1798,12 +1982,26 @@
               "minLength": 1
             },
             "human_approval_receipt_ref": {
-              "type": "string",
-              "minLength": 1
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "human_approval_receipt_hash": {
-              "type": "string",
-              "minLength": 1
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "policy_snapshot_id": {
               "type": "string",
@@ -2222,10 +2420,24 @@
               "type": "string"
             },
             "human_approval_receipt_ref": {
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "human_approval_receipt_hash": {
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "policy_snapshot_id": {
               "type": "string"
@@ -2877,12 +3089,26 @@
               "minLength": 1
             },
             "human_approval_receipt_ref": {
-              "type": "string",
-              "minLength": 1
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "human_approval_receipt_hash": {
-              "type": "string",
-              "minLength": 1
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "policy_snapshot_id": {
               "type": "string",

--- a/schemas/canonical-execution-intent-formation-v1.schema.json
+++ b/schemas/canonical-execution-intent-formation-v1.schema.json
@@ -315,12 +315,26 @@
           "minLength": 1
         },
         "human_approval_receipt_ref": {
-          "type": "string",
-          "minLength": 1
+          "anyOf": [
+            {
+              "type": "string",
+              "minLength": 1
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "human_approval_receipt_hash": {
-          "type": "string",
-          "minLength": 1
+          "anyOf": [
+            {
+              "type": "string",
+              "minLength": 1
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "policy_snapshot_id": {
           "type": "string",
@@ -684,7 +698,6 @@
             },
             "evidence_refs": {
               "type": "array",
-              "minItems": 5,
               "items": {
                 "type": "string",
                 "minLength": 1
@@ -706,22 +719,47 @@
               "minLength": 1
             },
             "approval_context": {
-              "type": "object",
-              "additionalProperties": false,
-              "required": [
-                "human_approval_receipt_ref",
-                "human_approval_receipt_hash"
-              ],
-              "properties": {
-                "human_approval_receipt_ref": {
-                  "type": "string",
-                  "minLength": 1
+              "oneOf": [
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "human_approval_receipt_ref",
+                    "human_approval_receipt_hash"
+                  ],
+                  "properties": {
+                    "human_approval_receipt_ref": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "human_approval_receipt_hash": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
                 },
-                "human_approval_receipt_hash": {
-                  "type": "string",
-                  "minLength": 1
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "required_human_approval",
+                    "requirement_state",
+                    "requirement_policy_ref"
+                  ],
+                  "properties": {
+                    "required_human_approval": {
+                      "const": false
+                    },
+                    "requirement_state": {
+                      "const": "NOT_REQUIRED_BY_CANONICAL_HANDOFF"
+                    },
+                    "requirement_policy_ref": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
                 }
-              }
+              ]
             },
             "policy_lineage": {
               "type": "object",
@@ -744,6 +782,34 @@
                   "type": "string",
                   "minLength": 1
                 }
+              }
+            }
+          },
+          "if": {
+            "properties": {
+              "approval_context": {
+                "required": [
+                  "required_human_approval"
+                ],
+                "properties": {
+                  "required_human_approval": {
+                    "const": false
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "evidence_refs": {
+                "minItems": 4
+              }
+            }
+          },
+          "else": {
+            "properties": {
+              "evidence_refs": {
+                "minItems": 5
               }
             }
           }
@@ -935,12 +1001,26 @@
               "minLength": 1
             },
             "human_approval_receipt_ref": {
-              "type": "string",
-              "minLength": 1
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "human_approval_receipt_hash": {
-              "type": "string",
-              "minLength": 1
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "policy_snapshot_id": {
               "type": "string",
@@ -1362,10 +1442,24 @@
                   "type": "string"
                 },
                 "human_approval_receipt_ref": {
-                  "type": "string"
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 },
                 "human_approval_receipt_hash": {
-                  "type": "string"
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 },
                 "policy_snapshot_id": {
                   "type": "string"
@@ -1742,7 +1836,6 @@
         },
         "evidence_refs": {
           "type": "array",
-          "minItems": 5,
           "items": {
             "type": "string",
             "minLength": 1
@@ -1764,22 +1857,47 @@
           "minLength": 1
         },
         "approval_context": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "human_approval_receipt_ref",
-            "human_approval_receipt_hash"
-          ],
-          "properties": {
-            "human_approval_receipt_ref": {
-              "type": "string",
-              "minLength": 1
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "human_approval_receipt_ref",
+                "human_approval_receipt_hash"
+              ],
+              "properties": {
+                "human_approval_receipt_ref": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "human_approval_receipt_hash": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
             },
-            "human_approval_receipt_hash": {
-              "type": "string",
-              "minLength": 1
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "required_human_approval",
+                "requirement_state",
+                "requirement_policy_ref"
+              ],
+              "properties": {
+                "required_human_approval": {
+                  "const": false
+                },
+                "requirement_state": {
+                  "const": "NOT_REQUIRED_BY_CANONICAL_HANDOFF"
+                },
+                "requirement_policy_ref": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
             }
-          }
+          ]
         },
         "policy_lineage": {
           "type": "object",
@@ -1802,6 +1920,34 @@
               "type": "string",
               "minLength": 1
             }
+          }
+        }
+      },
+      "if": {
+        "properties": {
+          "approval_context": {
+            "required": [
+              "required_human_approval"
+            ],
+            "properties": {
+              "required_human_approval": {
+                "const": false
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "evidence_refs": {
+            "minItems": 4
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "evidence_refs": {
+            "minItems": 5
           }
         }
       }
@@ -1861,7 +2007,6 @@
         },
         "evidence_refs": {
           "type": "array",
-          "minItems": 5,
           "items": {
             "type": "string",
             "minLength": 1
@@ -1883,22 +2028,47 @@
           "minLength": 1
         },
         "approval_context": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "human_approval_receipt_ref",
-            "human_approval_receipt_hash"
-          ],
-          "properties": {
-            "human_approval_receipt_ref": {
-              "type": "string",
-              "minLength": 1
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "human_approval_receipt_ref",
+                "human_approval_receipt_hash"
+              ],
+              "properties": {
+                "human_approval_receipt_ref": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "human_approval_receipt_hash": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
             },
-            "human_approval_receipt_hash": {
-              "type": "string",
-              "minLength": 1
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "required_human_approval",
+                "requirement_state",
+                "requirement_policy_ref"
+              ],
+              "properties": {
+                "required_human_approval": {
+                  "const": false
+                },
+                "requirement_state": {
+                  "const": "NOT_REQUIRED_BY_CANONICAL_HANDOFF"
+                },
+                "requirement_policy_ref": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
             }
-          }
+          ]
         },
         "policy_lineage": {
           "type": "object",
@@ -1921,6 +2091,34 @@
               "type": "string",
               "minLength": 1
             }
+          }
+        }
+      },
+      "if": {
+        "properties": {
+          "approval_context": {
+            "required": [
+              "required_human_approval"
+            ],
+            "properties": {
+              "required_human_approval": {
+                "const": false
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "evidence_refs": {
+            "minItems": 4
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "evidence_refs": {
+            "minItems": 5
           }
         }
       }

--- a/schemas/execution-intent-pre-bind-validation-v1.schema.json
+++ b/schemas/execution-intent-pre-bind-validation-v1.schema.json
@@ -330,12 +330,26 @@
           "minLength": 1
         },
         "human_approval_receipt_ref": {
-          "type": "string",
-          "minLength": 1
+          "anyOf": [
+            {
+              "type": "string",
+              "minLength": 1
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "human_approval_receipt_hash": {
-          "type": "string",
-          "minLength": 1
+          "anyOf": [
+            {
+              "type": "string",
+              "minLength": 1
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "policy_snapshot_id": {
           "type": "string",
@@ -591,7 +605,6 @@
         },
         "evidence_refs": {
           "type": "array",
-          "minItems": 5,
           "items": {
             "type": "string",
             "minLength": 1
@@ -613,22 +626,47 @@
           "minLength": 1
         },
         "approval_context": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "human_approval_receipt_ref",
-            "human_approval_receipt_hash"
-          ],
-          "properties": {
-            "human_approval_receipt_ref": {
-              "type": "string",
-              "minLength": 1
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "human_approval_receipt_ref",
+                "human_approval_receipt_hash"
+              ],
+              "properties": {
+                "human_approval_receipt_ref": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "human_approval_receipt_hash": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
             },
-            "human_approval_receipt_hash": {
-              "type": "string",
-              "minLength": 1
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "required_human_approval",
+                "requirement_state",
+                "requirement_policy_ref"
+              ],
+              "properties": {
+                "required_human_approval": {
+                  "const": false
+                },
+                "requirement_state": {
+                  "const": "NOT_REQUIRED_BY_CANONICAL_HANDOFF"
+                },
+                "requirement_policy_ref": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
             }
-          }
+          ]
         },
         "policy_lineage": {
           "type": "object",
@@ -651,6 +689,34 @@
               "type": "string",
               "minLength": 1
             }
+          }
+        }
+      },
+      "if": {
+        "properties": {
+          "approval_context": {
+            "required": [
+              "required_human_approval"
+            ],
+            "properties": {
+              "required_human_approval": {
+                "const": false
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "evidence_refs": {
+            "minItems": 4
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "evidence_refs": {
+            "minItems": 5
           }
         }
       }
@@ -705,7 +771,6 @@
         },
         "evidence_refs": {
           "type": "array",
-          "minItems": 5,
           "items": {
             "type": "string",
             "minLength": 1
@@ -727,22 +792,47 @@
           "minLength": 1
         },
         "approval_context": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "human_approval_receipt_ref",
-            "human_approval_receipt_hash"
-          ],
-          "properties": {
-            "human_approval_receipt_ref": {
-              "type": "string",
-              "minLength": 1
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "human_approval_receipt_ref",
+                "human_approval_receipt_hash"
+              ],
+              "properties": {
+                "human_approval_receipt_ref": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "human_approval_receipt_hash": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
             },
-            "human_approval_receipt_hash": {
-              "type": "string",
-              "minLength": 1
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "required_human_approval",
+                "requirement_state",
+                "requirement_policy_ref"
+              ],
+              "properties": {
+                "required_human_approval": {
+                  "const": false
+                },
+                "requirement_state": {
+                  "const": "NOT_REQUIRED_BY_CANONICAL_HANDOFF"
+                },
+                "requirement_policy_ref": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
             }
-          }
+          ]
         },
         "policy_lineage": {
           "type": "object",
@@ -765,6 +855,34 @@
               "type": "string",
               "minLength": 1
             }
+          }
+        }
+      },
+      "if": {
+        "properties": {
+          "approval_context": {
+            "required": [
+              "required_human_approval"
+            ],
+            "properties": {
+              "required_human_approval": {
+                "const": false
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "evidence_refs": {
+            "minItems": 4
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "evidence_refs": {
+            "minItems": 5
           }
         }
       }
@@ -1083,12 +1201,26 @@
               "minLength": 1
             },
             "human_approval_receipt_ref": {
-              "type": "string",
-              "minLength": 1
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "human_approval_receipt_hash": {
-              "type": "string",
-              "minLength": 1
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "policy_snapshot_id": {
               "type": "string",
@@ -1449,7 +1581,6 @@
             },
             "evidence_refs": {
               "type": "array",
-              "minItems": 5,
               "items": {
                 "type": "string",
                 "minLength": 1
@@ -1471,22 +1602,47 @@
               "minLength": 1
             },
             "approval_context": {
-              "type": "object",
-              "additionalProperties": false,
-              "required": [
-                "human_approval_receipt_ref",
-                "human_approval_receipt_hash"
-              ],
-              "properties": {
-                "human_approval_receipt_ref": {
-                  "type": "string",
-                  "minLength": 1
+              "oneOf": [
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "human_approval_receipt_ref",
+                    "human_approval_receipt_hash"
+                  ],
+                  "properties": {
+                    "human_approval_receipt_ref": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "human_approval_receipt_hash": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
                 },
-                "human_approval_receipt_hash": {
-                  "type": "string",
-                  "minLength": 1
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "required_human_approval",
+                    "requirement_state",
+                    "requirement_policy_ref"
+                  ],
+                  "properties": {
+                    "required_human_approval": {
+                      "const": false
+                    },
+                    "requirement_state": {
+                      "const": "NOT_REQUIRED_BY_CANONICAL_HANDOFF"
+                    },
+                    "requirement_policy_ref": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
                 }
-              }
+              ]
             },
             "policy_lineage": {
               "type": "object",
@@ -1509,6 +1665,34 @@
                   "type": "string",
                   "minLength": 1
                 }
+              }
+            }
+          },
+          "if": {
+            "properties": {
+              "approval_context": {
+                "required": [
+                  "required_human_approval"
+                ],
+                "properties": {
+                  "required_human_approval": {
+                    "const": false
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "evidence_refs": {
+                "minItems": 4
+              }
+            }
+          },
+          "else": {
+            "properties": {
+              "evidence_refs": {
+                "minItems": 5
               }
             }
           }
@@ -1700,12 +1884,26 @@
               "minLength": 1
             },
             "human_approval_receipt_ref": {
-              "type": "string",
-              "minLength": 1
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "human_approval_receipt_hash": {
-              "type": "string",
-              "minLength": 1
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "policy_snapshot_id": {
               "type": "string",
@@ -2124,10 +2322,24 @@
               "type": "string"
             },
             "human_approval_receipt_ref": {
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "human_approval_receipt_hash": {
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "policy_snapshot_id": {
               "type": "string"

--- a/veritas_os/tests/test_approval_optional_downstream_schemas.py
+++ b/veritas_os/tests/test_approval_optional_downstream_schemas.py
@@ -1,0 +1,89 @@
+"""Optional approval metadata remains schema-valid through inert dry-run stages."""
+
+from copy import deepcopy
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator, FormatChecker
+
+from veritas_os.policy.canonical_execution_intent_formation import (
+    build_canonical_execution_intent_formation_packet as form,
+)
+from veritas_os.policy.execution_intent_formation_readiness import (
+    build_execution_intent_formation_readiness_packet as ready,
+)
+from veritas_os.policy.execution_intent_pre_bind_validation import (
+    build_execution_intent_pre_bind_validation_packet as pre_bind,
+)
+from veritas_os.policy.canonical_bind_preflight_adjudication import (
+    build_canonical_bind_preflight_adjudication_packet as preflight,
+)
+from veritas_os.policy.bind_adapter_contract_selection import (
+    build_bind_adapter_contract_selection_packet as select,
+)
+from veritas_os.policy.adapter_dry_run_plan import build_adapter_dry_run_plan_packet as plan
+from veritas_os.policy.adapter_dry_run_result import (
+    build_adapter_dry_run_fixture_result_packet as result,
+)
+from veritas_os.tests.test_execution_intent_formation_readiness import (
+    NOW, _eligibility, _eligibility_without_approval,
+)
+from veritas_os.tests.test_canonical_execution_intent_formation import FORMED_AT
+from veritas_os.tests.test_execution_intent_pre_bind_validation import CHECKED_AT
+from veritas_os.tests.test_canonical_bind_preflight_adjudication import ADJUDICATED_AT
+from veritas_os.tests.test_bind_adapter_contract_selection import SELECTED_AT, _descriptor
+from veritas_os.tests.test_adapter_dry_run_plan import PLANNED_AT
+from veritas_os.tests.test_adapter_dry_run_fixture_result import RESULTED_AT, _fixtures
+
+
+SCHEMAS = (
+    "canonical-execution-intent-formation-v1",
+    "execution-intent-pre-bind-validation-v1",
+    "canonical-bind-preflight-adjudication-v1",
+    "bind-adapter-contract-selection-v1",
+    "adapter-dry-run-plan-v1",
+    "adapter-dry-run-fixture-result-v1",
+)
+
+
+@pytest.fixture(scope="module", params=[True, False], ids=["required", "not-required"])
+def chain(request):
+    """Use real builders/verifiers with local fixture metadata and no dispatch."""
+    required = request.param
+    eligibility = _eligibility() if required else _eligibility_without_approval()
+    formed = form(ready(eligibility, NOW), FORMED_AT)
+    checked = pre_bind(formed, CHECKED_AT)
+    adjudicated = preflight(checked, ADJUDICATED_AT)
+    selected = select(adjudicated, _descriptor(), SELECTED_AT)
+    planned = plan(selected, PLANNED_AT)
+    resulted = result(planned, _fixtures(planned), RESULTED_AT)
+    return required, (formed, checked, adjudicated, selected, planned, resulted)
+
+
+@pytest.mark.parametrize("stage", range(len(SCHEMAS)), ids=SCHEMAS)
+def test_real_downstream_packet_matches_schema_without_fake_receipt(chain, stage):
+    required, packets = chain
+    raw = packets[stage].model_dump(mode="json")
+    schema = json.loads(Path(f"schemas/{SCHEMAS[stage]}.schema.json").read_text())
+    validator = Draft202012Validator(schema, format_checker=FormatChecker())
+    validator.validate(raw)
+    intent = raw["execution_intent"]
+    assert len(intent["evidence_refs"]) == (5 if required else 4)
+    assert all(isinstance(ref, str) and ref for ref in intent["evidence_refs"])
+    if not required:
+        assert intent["approval_context"] == {
+            "required_human_approval": False,
+            "requirement_state": "NOT_REQUIRED_BY_CANONICAL_HANDOFF",
+            "requirement_policy_ref": "fixture-policy",
+        }
+        assert raw["evidence_lineage"]["human_approval_receipt_ref"] is None
+        assert raw["evidence_lineage"]["human_approval_receipt_hash"] is None
+
+    # Both branches retain their evidence minimum; no blanket relaxation to four.
+    missing = deepcopy(raw)
+    missing["execution_intent"]["evidence_refs"].pop()
+    assert not validator.is_valid(missing)
+    malformed = deepcopy(raw)
+    malformed["execution_intent"]["approval_context"] = {"required_human_approval": False}
+    assert not validator.is_valid(malformed)


### PR DESCRIPTION
## Problem

#2184 makes approval-not-required metadata valid through ExecutionIntent Formation Readiness. Six downstream JSON schemas still embed the old mandatory-receipt definitions, rejecting legitimate packets produced by the real builders/verifiers.

## Dependency and review scope

#2184 is merged. This branch now includes latest main `c431923874bf4836c6df713ea833d0ce0ea6e3c2`; the main comparison is limited to six downstream schemas and one regression test file.

## Changes

- Propagate the explicit NOT_REQUIRED_BY_CANONICAL_HANDOFF approval context and nullable absent receipt lineage through Formation, Pre-Bind Validation, Preflight Adjudication, Adapter Contract Selection, Dry-Run Plan and Fixture Result schemas.
- Preserve the five-reference minimum for the receipt branch; allow four only for the explicit no-approval branch. Keep string constraints and reject incomplete approval contexts.
- Validate actual packets through all six stages using production builders/verifiers and inert fixture metadata, for both required and not-required approval.
- No new runtime changes beyond the prerequisite #2184. No verifier consolidation, receipt fabrication, credential resolution, Bind execution, network dispatch or external effect.

## Validation

- Before the follow-up: six required cases passed; six not-required cases failed schema validation.
- After: all 12 new cases pass, including evidence-minimum and malformed-context negative assertions.
- Related stage and trusted-source/contract binding tests: **489 passed** in 51.85s.
- Tracked test-name guard: **3 passed**. Total **492 distinct local tests passed**.
- Ruff and diff checks passed.
- Published tree equals tested local tree: `deef4dee15b9dec3809f7fb28dcc7d67f703146f`.
- Latest-main validation: **492 passed** in 53.93s; Ruff and diff checks passed. Full CI pending on head `72fa5edaa3ae214bcceaa6dd4c25463840970324`.

## Claim boundary

Schema compatibility through inert Fixture Result is not a complete external-effect E2E proof and does not establish authority or input truth. Independent trusted ActionClassContract/source verification remains required downstream.

- [x] AI-assisted changes
- [ ] Full CI passed on final head
- [ ] Human maintainer review
- Draft; do not merge automatically.
