### PR TITLE
feat: bind sandbox event requests to native v2 authorization

### DIFF
--- a/docs/en/architecture/native-v2-sandbox-event-spec-v1.md
+++ b/docs/en/architecture/native-v2-sandbox-event-spec-v1.md
@@ -176,3 +176,26 @@ database durability/retention and read-only lookup access. Confirm synthetic pay
 and failure-injection scope. These are mandatory deployment inputs. Until provided
 and reviewed, implementation may use inert tests, but must not access credentials,
 deploy infrastructure or send external requests.
+
+## 10. Initial metadata binding implementation
+
+`veritas_os/policy/sandbox_action_binding.py` supplies the opt-in local binding
+boundary. `build_sandbox_action_binding` validates the two-string payload and
+explicit deployment pins and returns a `sandbox-action:v1:sha256:` reference.
+Include exactly one such reference in the decision candidate's `evidence_refs`
+before decision capture, promotion and authorization issuance. It commits to POST,
+the exact endpoint, payload digest, full contract digest and credential metadata
+pins without introducing a circular dependency on a later authorization digest.
+
+`verify_sandbox_action_binding` calls the native authorization verifier with
+independent source/governance/trust inputs, then reconstructs the reference and
+checks the verified intent, endpoint and credential metadata. It preserves the
+authorization's original idempotency key. The returned immutable association is
+not executable permission and is not accepted in place of native verification.
+No existing native entry point is rerouted: a future sandbox executor must require
+this boundary as well as consumption and final pre-effect checks.
+
+The provider credential version is a deployment pin committed before issuance;
+authenticating that version and its expiry/revocation remains a resolver task.
+This module does not authenticate TLS, time health, provider data or payload truth,
+and does not implement an execution claim, credential access or external effect.

--- a/docs/ja/architecture/native-v2-sandbox-event-spec-v1.md
+++ b/docs/ja/architecture/native-v2-sandbox-event-spec-v1.md
@@ -152,3 +152,20 @@ sandbox origin/TLS identityと管理者、credential provider/ref/scope、信頼
 時刻健全性の取得元と実測上限、DB永続性・保持条件・読取専用照合権限を記録します。
 合成payloadと障害注入の範囲も確定します。これらは必須の配備入力です。
 供給・レビューが済むまでは、作用のないテストによる実装準備に限定し、秘密取得・インフラ配備・外部要求を行いません。
+
+## 10. 最初のmetadata binding実装
+
+`veritas_os/policy/sandbox_action_binding.py`に、明示的に呼び出すローカル検証境界を設けます。
+`build_sandbox_action_binding`は2文字列のpayloadと明示的な配備設定を検証し、
+`sandbox-action:v1:sha256:`参照を返します。この参照をdecision記録・promotion・認可発行より前に、
+候補の `evidence_refs` に正確に1つ含めます。POST・正確なendpoint・payload digest・契約全体のdigest・
+credential metadataの固定値を含み、後から生成される認可digestとの循環依存は作りません。
+
+`verify_sandbox_action_binding`は独立したsource/governance/trust入力でnative認可verifierを呼び、
+参照を再構築して検証済みintent・endpoint・credential metadataに照合します。
+元の認可のidempotency keyを維持します。不変の関連付け結果は実行許可ではなく、native検証の代用にもなりません。
+既存のnative入口の経路は変更しません。将来のsandbox executorは、この境界に加えて消費・実行直前再確認を必須にします。
+
+credential versionは発行前に結び付ける配備固定値です。providerに対するversion・expiry・revocationの
+真正性確認はresolverの作業として残ります。本モジュールはTLS・時刻健全性・provider情報・payloadの真実性を
+認証せず、実行担当取得・秘密情報取得・外部作用も実装しません。

--- a/veritas_os/policy/sandbox_action_binding.py
+++ b/veritas_os/policy/sandbox_action_binding.py
@@ -1,0 +1,188 @@
+"""Bind one synthetic sandbox request to an independently verified native grant.
+
+The pre-issuance reference must enter the decision candidate's evidence_refs.
+This module neither modifies/creates authorization nor consumes, resolves secrets,
+claims an execution attempt or dispatches. Deployment inputs are trusted caller
+configuration, not fields extracted from an authorization packet.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import json
+import re
+from typing import Any
+from uuid import UUID
+
+from veritas_os.governance.action_contracts import ActionClassContract
+from veritas_os.policy.native_bind_authorization import (
+    NativeAuthorizationSourceInputs,
+    verify_native_bind_authorization,
+)
+from veritas_os.policy.live_adapter_bind_authorization_contracts import (
+    BindAuthorizationTrustInputs,
+    RealBindAuthorizationGovernanceInputs,
+)
+from veritas_os.security.hash import canonical_json_dumps, sha256_of_canonical_json
+
+ACTION = "sandbox.event.register.v1"
+REFERENCE_PREFIX = "sandbox-action:v1:sha256:"
+
+
+class SandboxActionBindingError(ValueError):
+    """Sanitized failure of local action binding, never an execution decision."""
+
+
+@dataclass(frozen=True)
+class SandboxDeployment:
+    """Reviewed deployment pins; no defaults, secret material or packet fallback.
+
+    credential_version pins the provider version to be checked by a future
+    resolver; this metadata-only verifier cannot authenticate the provider.
+    """
+
+    endpoint_url: str
+    target_system: str
+    action_contract_digest: str
+    credential_reference_id: str
+    credential_version: str
+    credential_provider_type: str
+    credential_scope: str
+    credential_environment: str
+
+
+@dataclass(frozen=True)
+class SandboxActionBinding:
+    """Immutable local request description; not an authorization/capability."""
+
+    reference: str
+    payload_json: str
+    payload_digest: str
+
+
+@dataclass(frozen=True)
+class VerifiedSandboxActionBinding:
+    """Audit association only; consumption and pre-effect checks remain required."""
+
+    binding: SandboxActionBinding
+    authorization_id: str
+    authorization_hash: str
+    idempotency_key: str
+
+
+def _unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise SandboxActionBindingError("SAB_DUPLICATE_JSON_KEY")
+        result[key] = value
+    return result
+
+
+def build_sandbox_action_binding(
+    payload_json: str,
+    *,
+    deployment: SandboxDeployment,
+    expected_contract: ActionClassContract,
+) -> SandboxActionBinding:
+    """Build a reference before issuance, over exact payload and deployment pins.
+
+    Only the existing two-string event protocol is accepted. No URL normalization,
+    network lookup, runtime configuration mutation or new policy is performed.
+    """
+    if type(deployment) is not SandboxDeployment or any(
+        type(value) is not str or not value or value != value.strip()
+        for value in asdict(deployment).values()
+    ):
+        raise SandboxActionBindingError("SAB_DEPLOYMENT_REQUIRED")
+    # Deliberately narrow: lower-case ASCII DNS, default TLS port, exact path.
+    if not re.fullmatch(
+        r"https://(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+"
+        r"[a-z](?:[a-z0-9-]{0,61}[a-z0-9])?/v1/events",
+        deployment.endpoint_url,
+    ):
+        raise SandboxActionBindingError("SAB_ENDPOINT_INVALID")
+    if (
+        type(expected_contract) is not ActionClassContract
+        or expected_contract.id != ACTION
+        or expected_contract.action_class != ACTION
+        or deployment.action_contract_digest != expected_contract.deterministic_digest()
+    ):
+        raise SandboxActionBindingError("SAB_CONTRACT_MISMATCH")
+    try:
+        if type(payload_json) is not str or len(payload_json.encode("utf-8")) > 4096:
+            raise SandboxActionBindingError("SAB_PAYLOAD_INVALID")
+        payload = json.loads(payload_json, object_pairs_hook=_unique_object)
+        if (
+            type(payload) is not dict
+            or set(payload) != {"event_id", "message"}
+            or type(payload["event_id"]) is not str
+            or str(UUID(payload["event_id"])) != payload["event_id"]
+            or type(payload["message"]) is not str
+            or not 1 <= len(payload["message"].encode("utf-8")) <= 256
+        ):
+            raise SandboxActionBindingError("SAB_PAYLOAD_INVALID")
+    except (ValueError, TypeError, UnicodeError, RecursionError):
+        raise SandboxActionBindingError("SAB_PAYLOAD_INVALID") from None
+    digest = sha256_of_canonical_json(payload)
+    reference = REFERENCE_PREFIX + sha256_of_canonical_json({
+        "domain": "veritas.sandbox-action-binding/v1",
+        "action": ACTION,
+        "method": "POST",
+        "payload_digest": digest,
+        "deployment": asdict(deployment),
+    })
+    return SandboxActionBinding(reference, canonical_json_dumps(payload), digest)
+
+
+def verify_sandbox_action_binding(
+    authorization: Any,
+    payload_json: str,
+    *,
+    deployment: SandboxDeployment,
+    source_inputs: NativeAuthorizationSourceInputs,
+    governance_inputs: RealBindAuthorizationGovernanceInputs,
+    trust_inputs: BindAuthorizationTrustInputs,
+) -> VerifiedSandboxActionBinding:
+    """Verify native signatures/lineage, then reconstruct the pre-issuance binding.
+
+    Returned canonical bytes are for later checked use, not permission to send.
+    Provider authenticity, credential expiry and TLS-peer identity are not claimed.
+    No consumed flag or caller-asserted 'verified' result is accepted as a shortcut.
+    """
+    verified = verify_native_bind_authorization(
+        authorization, source_inputs=source_inputs,
+        governance_inputs=governance_inputs, trust_inputs=trust_inputs,
+    )
+    binding = build_sandbox_action_binding(
+        payload_json, deployment=deployment,
+        expected_contract=governance_inputs.action_contract,
+    )
+    intent = verified.execution_intent
+    refs = intent.get("evidence_refs", [])
+    if (
+        intent.get("intended_action") != ACTION
+        or intent.get("target_system") != deployment.target_system
+        or intent.get("target_resource") != deployment.endpoint_url
+        or verified.action_contract_digest != deployment.action_contract_digest
+        or [ref for ref in refs if isinstance(ref, str) and ref.startswith(REFERENCE_PREFIX)]
+        != [binding.reference]
+    ):
+        raise SandboxActionBindingError("SAB_AUTHORIZATION_BINDING_MISMATCH")
+    endpoint = source_inputs.current_endpoint
+    credential = source_inputs.current_credential_reference
+    if not isinstance(endpoint, dict) or not isinstance(credential, dict):
+        raise SandboxActionBindingError("SAB_CURRENT_METADATA_REQUIRED")
+    host = deployment.endpoint_url[len("https://"):-len("/v1/events")]
+    if any(endpoint.get(k) != v for k, v in {
+        "endpoint_scheme": "https", "endpoint_host": host,
+        "endpoint_port": 443, "endpoint_path_prefix": "/v1/events",
+    }.items()) or any(credential.get(k) != getattr(deployment, k) for k in (
+        "credential_reference_id", "credential_provider_type",
+        "credential_scope", "credential_environment",
+    )) or source_inputs.required_credential_scope != deployment.credential_scope:
+        raise SandboxActionBindingError("SAB_CURRENT_METADATA_MISMATCH")
+    return VerifiedSandboxActionBinding(
+        binding, verified.authorization_id, verified.authorization_hash,
+        verified.idempotency_key,
+    )

--- a/veritas_os/tests/helpers/live_decision_capture.py
+++ b/veritas_os/tests/helpers/live_decision_capture.py
@@ -19,7 +19,10 @@ from unittest.mock import patch
 from scripts import run_decision_to_external_bind_poc as poc
 
 
-def capture(output: Path, *, required_human_approval: bool = False) -> None:
+def capture(
+    output: Path, *, required_human_approval: bool = False,
+    candidate_overrides: dict | None = None,
+) -> None:
     """Write only the synthetic decision and infrastructure observations."""
     runtime = output.parent / "runtime"
     runtime.mkdir()
@@ -39,6 +42,8 @@ def capture(output: Path, *, required_human_approval: bool = False) -> None:
         evidence_refs=["synthetic:local-review-input"],
         required_human_approval=required_human_approval,
     )
+    if candidate_overrides:
+        candidate = replace(candidate, **candidate_overrides)
     with (
         patch.object(poc, "_candidate", return_value=candidate),
         patch.object(pipeline, "REPLAY_SOURCE_DIR", runtime / "replay-sources"),

--- a/veritas_os/tests/test_sandbox_action_binding.py
+++ b/veritas_os/tests/test_sandbox_action_binding.py
@@ -1,0 +1,103 @@
+"""Exact request binding tests; all deployment metadata is synthetic."""
+
+from dataclasses import replace
+import json
+
+import pytest
+
+from veritas_os.policy import sandbox_action_binding as binding
+from veritas_os.tests.test_promotion_human_approval_requirement_satisfaction import _contract
+
+
+def contract():
+    return replace(
+        _contract(action=binding.ACTION, required=False),
+        irreversibility={"level": "low", "boundary": "future-bind-consumption"},
+    )
+
+
+def deployment():
+    return binding.SandboxDeployment(
+        endpoint_url="https://sandbox.example.invalid/v1/events",
+        target_system="synthetic-sandbox",
+        action_contract_digest=contract().deterministic_digest(),
+        credential_reference_id="credential-ref:promotion:billing:v1",
+        credential_version="1",
+        credential_provider_type="LOCAL_SECRET_STORE_REFERENCE",
+        credential_scope="sandbox:events:register sandbox:operations:read",
+        credential_environment="sandbox",
+    )
+
+
+PAYLOAD = {"event_id": "12345678-1234-4234-8234-123456789abc", "message": "synthetic"}
+
+
+def build(value=None, config=None, policy=None):
+    return binding.build_sandbox_action_binding(
+        json.dumps(PAYLOAD) if value is None else value,
+        deployment=deployment() if config is None else config,
+        expected_contract=contract() if policy is None else policy,
+    )
+
+
+def test_stable_reference_canonicalizes_only_json_whitespace_and_key_order():
+    first = build()
+    second = build(json.dumps(dict(reversed(list(PAYLOAD.items()))), indent=2))
+    assert first == second
+    assert json.loads(first.payload_json) == PAYLOAD
+
+
+@pytest.mark.parametrize("value", [
+    "[]", "null", "true", "{}", "{", '{"event_id":"x","message":"x"}',
+    json.dumps({**PAYLOAD, "message": ""}),
+    json.dumps({**PAYLOAD, "message": "あ" * 86}),
+    json.dumps({**PAYLOAD, "message": 1}),
+    json.dumps({**PAYLOAD, "extra": True}),
+    json.dumps({**PAYLOAD, "message": "\ud800"}),
+    '{"event_id":"12345678-1234-4234-8234-123456789abc","message":"a","message":"b"}',
+    " " * 4097, "[" * 1500,
+])
+def test_invalid_payload_fails_closed(value):
+    with pytest.raises(binding.SandboxActionBindingError, match="SAB_PAYLOAD_INVALID"):
+        build(value)
+
+
+@pytest.mark.parametrize("url", [
+    "http://sandbox.example.invalid/v1/events", "https://user@host.test/v1/events",
+    "https://host.test/v1/events?x=1", "https://host.test/v1/events#x",
+    "https://host.test/v1/events/", "https://host.test:443/v1/events",
+    "https://HOST.test/v1/events", "https://host.test/v1/../events",
+])
+def test_non_exact_destination_rejected(url):
+    with pytest.raises(binding.SandboxActionBindingError):
+        build(config=replace(deployment(), endpoint_url=url))
+
+
+@pytest.mark.parametrize("field", binding.SandboxDeployment.__dataclass_fields__)
+def test_missing_deployment_field_rejected(field):
+    with pytest.raises(binding.SandboxActionBindingError):
+        build(config=replace(deployment(), **{field: ""}))
+
+
+@pytest.mark.parametrize("field", [
+    "credential_version", "credential_reference_id", "credential_scope",
+    "credential_provider_type", "credential_environment", "target_system",
+])
+def test_changed_deployment_requires_different_preissuance_reference(field):
+    assert build(config=replace(deployment(), **{field: "changed"})).reference != build().reference
+
+
+def test_same_id_version_contract_downgrade_rejected():
+    original = contract()
+    changed = replace(original, human_approval_rules={"required": True})
+    assert changed.id == original.id and changed.version == original.version
+    with pytest.raises(binding.SandboxActionBindingError, match="CONTRACT_MISMATCH"):
+        build(policy=changed)
+
+
+@pytest.mark.parametrize("field,value", [
+    ("message", "another synthetic event"),
+    ("event_id", "12345678-1234-4234-8234-123456789abd"),
+])
+def test_payload_change_changes_preissuance_reference(field, value):
+    assert build(json.dumps({**PAYLOAD, field: value})).reference != build().reference

--- a/veritas_os/tests/test_sandbox_action_binding_integration.py
+++ b/veritas_os/tests/test_sandbox_action_binding_integration.py
@@ -1,0 +1,139 @@
+"""Signed native authorization must contain the action reference before issuance."""
+
+from dataclasses import replace
+from datetime import datetime
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+from veritas_os.policy import sandbox_action_binding as binding
+from veritas_os.policy.canonical_verified_decision_promotion import (
+    build_canonical_verified_decision_promotion_packet,
+)
+from veritas_os.tests.helpers.native_approval_source import build_native_authority_source
+from veritas_os.tests import test_canonical_promotion_live_adapter_dry_run_endpoint_allowlist as endpoints
+from veritas_os.tests import test_canonical_promotion_live_adapter_dry_run_credential_authorization as credentials
+from veritas_os.tests.test_native_bind_authorization import _setup
+from veritas_os.tests.test_sandbox_action_binding import PAYLOAD, build, contract, deployment
+
+pytestmark = pytest.mark.slow
+
+
+@pytest.fixture(scope="module")
+def issued(tmp_path_factory):
+    """Capture the real API and sign synthetic fixtures; never mock verifiers."""
+    output = tmp_path_factory.mktemp("sandbox-native") / "capture.json"
+    config = deployment()
+    overrides = {
+        "intended_action": binding.ACTION,
+        "target_system": config.target_system,
+        "target_resource": config.endpoint_url,
+        "evidence_refs": [build().reference],
+    }
+    code = (
+        "import json,sys; from pathlib import Path; "
+        "from veritas_os.tests.helpers.live_decision_capture import capture; "
+        "capture(Path(sys.argv[1]), candidate_overrides=json.loads(sys.argv[2]))"
+    )
+    subprocess.run(
+        [sys.executable, "-c", code, str(output), json.dumps(overrides)],
+        cwd=Path(__file__).resolve().parents[2], check=True, timeout=180,
+        capture_output=True, text=True,
+    )
+    captured = json.loads(output.read_text())
+    assert captured["pipeline_ok"]
+    now = datetime.fromisoformat(captured["observed_at"])
+    promotion = build_canonical_verified_decision_promotion_packet(
+        captured["canonical_decision_artifact"], captured["candidate"],
+        promoted_at=now, ttl_seconds=300,
+        expected_state_fingerprint="synthetic:sandbox:empty",
+    )
+    original = endpoints._candidate
+    original_reference = credentials._reference
+    with pytest.MonkeyPatch.context() as patch:
+        # Change only fixture metadata; all source builders/verifiers are real.
+        patch.setattr(endpoints, "_candidate", lambda **kw: original(
+            **kw, endpoint_host="sandbox.example.invalid", endpoint_path_prefix="/v1/events",
+        ))
+        patch.setattr(credentials, "_reference", lambda **kw: original_reference(
+            **kw, credential_scope=config.credential_scope,
+            credential_environment=config.credential_environment,
+        ))
+        source = build_native_authority_source(promotion, now)
+    artifact, inputs, *_ = _setup(source, contract(), now)
+    return artifact, inputs
+
+
+def verify(issued, payload=None, config=None):
+    artifact, inputs = issued
+    return binding.verify_sandbox_action_binding(
+        artifact, json.dumps(PAYLOAD if payload is None else payload),
+        deployment=deployment() if config is None else config, **inputs,
+    )
+
+
+def test_real_native_signature_and_source_accept_original_request(issued):
+    artifact, _ = issued
+    verified = verify(issued)
+    assert verified.binding == build()
+    assert verified.idempotency_key == artifact.idempotency_key
+    assert verified.authorization_hash == artifact.authorization_hash
+    assert not artifact.credential_material_accessed and not artifact.bind_invoked
+
+
+@pytest.mark.parametrize("field,value", [
+    ("message", "changed"),
+    ("event_id", "12345678-1234-4234-8234-123456789abd"),
+])
+def test_recomputed_payload_reference_cannot_rebind_signed_authorization(issued, field, value):
+    with pytest.raises(binding.SandboxActionBindingError, match="AUTHORIZATION_BINDING"):
+        verify(issued, {**PAYLOAD, field: value})
+
+
+@pytest.mark.parametrize("field,value", [
+    ("endpoint_url", "https://another.example.invalid/v1/events"),
+    ("credential_version", "2"),
+    ("credential_reference_id", "credential:attacker"),
+    ("credential_scope", "admin"),
+    ("target_system", "another-system"),
+])
+def test_deployment_changes_cannot_rebind_existing_authorization(issued, field, value):
+    with pytest.raises(binding.SandboxActionBindingError):
+        verify(issued, config=replace(deployment(), **{field: value}))
+
+
+def test_adding_reference_after_issuance_is_rejected(issued):
+    artifact, inputs = issued
+    raw = artifact.model_dump(mode="json")
+    raw["execution_intent"]["evidence_refs"].append(build().reference)
+    with pytest.raises(ValueError):
+        verify((raw, inputs))
+
+
+def test_corrupted_native_signature_is_rejected(issued):
+    artifact, inputs = issued
+    raw = artifact.model_dump(mode="json")
+    raw["authorization_signature"] = "A" * 88
+    with pytest.raises(ValueError):
+        verify((raw, inputs))
+
+
+def test_current_metadata_cannot_be_replaced_from_embedded_snapshot(issued):
+    artifact, inputs = issued
+    original = inputs["source_inputs"]
+    changed = replace(original, current_credential_reference={
+        **original.current_credential_reference, "credential_scope": "admin",
+    })
+    with pytest.raises(ValueError):
+        verify((artifact, {**inputs, "source_inputs": changed}))
+
+
+def test_same_id_version_contract_change_rejected(issued):
+    artifact, inputs = issued
+    gov = inputs["governance_inputs"]
+    changed = replace(gov.action_contract, human_approval_rules={"required": True})
+    with pytest.raises(ValueError):
+        verify((artifact, {**inputs, "governance_inputs": replace(gov, action_contract=changed)}))


### PR DESCRIPTION
## Purpose

Implement the initial local request binding from #2198 before credential access or execution. Existing ExecutionIntent has no dedicated payload field; the new domain-separated reference must be included in candidate evidence_refs before decision/promotion/issuance.

## Changes

- Add an opt-in builder binding the exact two-field synthetic event payload, POST endpoint, full ActionClassContract digest and independent deployment credential pins.
- Reject duplicate JSON keys, malformed UUIDs, oversized/invalid UTF-8 messages, extra fields, non-exact URLs, missing deployment fields and contract mismatch.
- Verify using the existing native v2 verifier with independent source/governance/trust inputs, then reconstruct and compare the signed intent reference and current metadata. Preserve the original authorization idempotency key.
- Return an immutable audit association, not permission to execute. No existing native entry point is rerouted or loosened.
- Add local and real native-signature/API-lineage tests. Only synthetic model/infrastructure and fixture metadata are controlled; no accepting verifier mocks.
- Document the implementation boundary in English and Japanese.

## Claim boundary

This does not authenticate provider version/expiry/revocation, clock health, TLS peer or payload truth. Credential version is an independent deployment pin committed before issuance; provider verification remains a resolver task. A future sandbox executor must require this check plus consumption, durable attempt ownership and final pre-effect rechecks. No credential material access, consumption, execution claim, Human Approval creation, Bind, BindReceipt, dispatch or external effect is added.

## Validation

- Initial new-test run: 52 passed; new module statement coverage 97% (72/74). Sandbox-specific fixture scope was subsequently refined.
- Final new tests plus existing native issuance/consumption and test-name guard: **139 passed**, 4 existing jsonschema deprecation warnings in 631.04s on the published tree.
- Ruff, bilingual documentation and diff checks passed.
- Published tree equals local tree: `22e0eeb2a908d8514a84e6d8deb7a5c88b229cea`.
- Head: `5a184f4dd3ac6e6fc84159e98f524662b0fb8c99`.
- Full GitHub CI pending.

## Review

- [x] AI-assisted implementation
- [ ] Full CI passed on final head
- [ ] Human maintainer reviewed governance-sensitive changes
- Draft; do not merge automatically.
