### PR TITLE
feat: resolve pinned sandbox credentials inside owning attempts

### DIFF
--- a/docs/en/architecture/native-v2-sandbox-event-spec-v1.md
+++ b/docs/en/architecture/native-v2-sandbox-event-spec-v1.md
@@ -231,3 +231,44 @@ Human Approval creation or BindReceipt/Outcome generation. A future executor mus
 enforce ownership and repeat current checks after credential work at the actual
 send boundary. The one-second budget is enforced, not a measured performance
 guarantee; deployment throughput and trusted callback configuration remain gates.
+
+## 12. Credential continuation contract
+
+`prepare_and_resolve_sandbox_credential` performs preparation itself. It accepts
+the original authorization and independent deployment/source/governance inputs,
+never a caller's prepared result or consumed flag. An existing attempt cannot be
+resumed through this entry point. PostgreSQL remains the default requirement.
+
+The trusted executor supplies one `SandboxCredentialProvider`. Its `describe`
+operation returns no secret. Its `resolve` operation must authenticate the provider,
+atomically check the expected metadata digest and current revocation/version, and
+return material bound to that exact metadata. No `authenticated=true` packet flag
+substitutes for that integration contract. The local code does not establish a
+provider trust root, select a vendor, read environment tokens or contact a service.
+Provider/hosting configuration and real-provider tests remain deployment gates.
+
+The request pins the credential reference, provider, version, exact scope,
+environment and HTTPS origin audience derived from the verified action binding.
+Metadata must identify a bearer credential, explicitly report non-revocation and
+cover the entire checked time-uncertainty interval. Missing/malformed/stale metadata,
+same-reference version changes, different audience, wider scope, expiry and provider
+errors stop the call. Each provider operation times out after five seconds with no
+retry; descriptor age across the continuation is also bounded to five seconds.
+
+The continuation reads the exact attempt row and repeats the #2200 current checks
+after metadata inspection before secret access, and again after resolution. Failed
+checks never return material or release the attempt/consumption. Current checks
+reuse the existing verifier implementation; embedded snapshots remain untrusted.
+
+Material uses a redacted `SecretBytes` wrapper. The result has no generic JSON,
+dataclass or pickle serialization; explicit trusted code can access bytes through
+`material.get_secret_value()`. `close()` drops the result's reference; it does not
+promise Python memory erasure or control a provider's internal logs. Public failures
+contain a fixed code and do not retain provider exception context. Audit data carries
+only the preparation and a metadata digest, never a token or token hash.
+
+No Authorization header, Bind, network dispatch, external effect, Human Approval,
+BindReceipt or Outcome is created. A future sender must recheck ownership, expiry
+and current governance at use, then persist dispatch intent. Tests use synthetic
+credentials and deterministic clocks; real-provider authenticity and real-clock
+performance have not been demonstrated by this implementation.

--- a/docs/ja/architecture/native-v2-sandbox-event-spec-v1.md
+++ b/docs/ja/architecture/native-v2-sandbox-event-spec-v1.md
@@ -193,3 +193,35 @@ packet内snapshotを信頼源にしません。時刻・健全性callbackは信�
 Human Approval作成・BindReceipt/Outcome生成は行いません。将来のexecutorは実際の送信境界で
 試行所有を強制し、credential処理後に再検証する必要があります。1秒制限は強制条件であり、
 測定済み性能保証ではありません。配備性能と信頼callbackの設定確認は引き続き必須です。
+
+## 12. Credential解決の継続処理
+
+`prepare_and_resolve_sandbox_credential`が試行準備自体を実行します。元の認可と独立した
+deployment/source/governance入力を受け取り、callerのprepared結果やconsumedフラグは受け取りません。
+既存の試行をこの入口から再開できません。標準では引き続きPostgreSQLが必須です。
+
+信頼されたexecutorが一つの`SandboxCredentialProvider`を指定します。`describe`は秘密値を返さず、
+`resolve`はproviderを認証し、期待するmetadata digestと現在の失効・versionを原子的に照合して、
+そのmetadataに結び付いたmaterialを返す契約です。packetの`authenticated=true`は代用になりません。
+ローカル処理はprovider信頼源の確立・vendor選択・環境変数tokenの読取・サービス接続を行いません。
+provider/hosting設定と実providerでの試験は配備前の確認事項です。
+
+検証済み操作のbindingからcredential参照・provider・version・完全一致するscope・environment・
+HTTPS origin audienceを固定します。metadataにはbearer種別と非失効状態の明示が必要で、
+有効期間は確認した時刻の不確実性区間全体を含む必要があります。欠落・形式不正・陳腐化・
+同じ参照のversion変更・宛先違い・過大scope・期限切れ・provider障害は停止します。
+provider呼び出しは各5秒でtimeoutし、再試行しません。継続処理全体でdescriptorの経過時間も5秒以内です。
+
+metadata確認後の秘密値取得直前と、取得後の両方で試行レコード全体を読み直し、#2200の
+現在条件の再検証を行います。検証失敗時はmaterialを返さず、試行・消費も解放しません。
+既存verifierを再利用し、埋め込みsnapshotを信頼源へ戻しません。
+
+materialは表示を伏せる`SecretBytes`で保持します。結果は汎用JSON・dataclass・pickleで
+シリアライズできません。信頼されたコードが明示的に`material.get_secret_value()`を呼ぶとbytesへ
+アクセスできます。`close()`は結果の参照を破棄しますが、Pythonのメモリ消去やprovider内部ログの
+制御は保証しません。公開例外は固定コードのみで、provider例外のcontextを保持しません。
+監査情報は準備結果とmetadata digestだけで、token自体やtokenのhashを含めません。
+
+Authorization header・Bind・network dispatch・外部作用・Human Approval・BindReceipt・Outcomeは
+作成しません。将来のsenderは使用時に所有・期限・現在条件を再検証し、送信意図を永続化する必要があります。
+試験は合成credentialと制御した時計を使用します。実providerの真正性と実時計での性能は未実証です。

--- a/veritas_os/policy/sandbox_credential_resolution.py
+++ b/veritas_os/policy/sandbox_credential_resolution.py
@@ -1,0 +1,280 @@
+"""Resolve one pinned sandbox bearer credential inside the owning attempt.
+
+The provider is trusted executor configuration, not request data. Its adapter
+must authenticate the provider and bind the returned material to metadata. No
+concrete provider, environment fallback, header, Bind or dispatch is installed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, replace
+from datetime import datetime, timedelta
+import re
+from typing import Any, Callable, Literal, Protocol
+
+from pydantic import BaseModel, ConfigDict, Field, SecretBytes
+
+from veritas_os.policy.bind_effect_reconciliation import (
+    InMemoryAtomicEffectStateStore, PostgresAtomicEffectStateStore,
+)
+from veritas_os.policy.live_adapter_bind_authorization_codec import _timestamp
+from veritas_os.policy.live_adapter_bind_authorization_consumption_store import (
+    InMemoryAtomicAuthorizationConsumptionStore,
+    PostgresAtomicAuthorizationConsumptionStore,
+)
+from veritas_os.policy.live_adapter_bind_authorization_contracts import (
+    BindAuthorizationTrustInputs, RealBindAuthorizationGovernanceInputs,
+)
+from veritas_os.policy.native_bind_authorization import NativeAuthorizationSourceInputs
+from veritas_os.policy.sandbox_action_binding import SandboxDeployment
+from veritas_os.policy.sandbox_pre_effect import (
+    SandboxClockReading, SandboxCurrentInputs, SandboxPreparedAttempt,
+    _clock, _recheck_sandbox_current, _window, prepare_sandbox_attempt,
+)
+from veritas_os.security.hash import sha256_of_canonical_json
+
+PROVIDER_TIMEOUT_SECONDS = 5
+
+
+class SandboxCredentialResolutionError(ValueError):
+    """Sanitized failure; the existing attempt is never released for retry."""
+
+
+@dataclass(frozen=True)
+class SandboxCredentialRequest:
+    """Exact provider lookup derived only from the verified deployment binding."""
+
+    authorization_id: str
+    attempt_id: str
+    credential_reference_id: str
+    credential_provider_type: str
+    credential_version: str
+    credential_scope: str
+    credential_environment: str
+    audience: str
+
+
+class SandboxCredentialMetadata(BaseModel):
+    """Provider-authenticated metadata, never a self-asserted authentication flag.
+
+    Authenticity is the configured provider adapter's responsibility. This model
+    validates shape only; the continuation checks every policy/time binding.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    credential_reference_id: str = Field(min_length=1)
+    credential_provider_type: str = Field(min_length=1)
+    credential_version: str = Field(min_length=1)
+    credential_scope: str = Field(min_length=1)
+    credential_environment: str = Field(min_length=1)
+    audience: str = Field(min_length=1)
+    credential_kind: Literal["bearer"]
+    valid_from: str = Field(min_length=1)
+    valid_until: str = Field(min_length=1)
+    observed_at: str = Field(min_length=1)
+    revoked: bool
+
+
+class SandboxProviderCredential(BaseModel):
+    """Provider response with material redacted by repr and JSON serialization."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+    metadata: SandboxCredentialMetadata
+    material: SecretBytes = Field(repr=False)
+
+
+class SandboxCredentialProvider(Protocol):
+    """Trusted, deployment-injected adapter; no caller-selected provider lookup.
+
+    describe must not return secret material. resolve must atomically enforce
+    expected_metadata_digest and current revocation/version before reading that
+    exact credential. Both operations must authenticate the provider. Client
+    validation cannot prove a dishonest provider's metadata matches its token.
+    """
+
+    async def describe(self, request: SandboxCredentialRequest) -> SandboxCredentialMetadata:
+        ...
+
+    async def resolve(
+        self, request: SandboxCredentialRequest, *, expected_metadata_digest: str,
+    ) -> SandboxProviderCredential:
+        ...
+
+
+class SandboxResolvedCredential:
+    """Ephemeral material plus audit data; never an execution capability.
+
+    Only material.get_secret_value() explicitly exposes bytes to trusted code.
+    Generic repr/JSON/dataclass/pickle paths cannot expose the token. close drops
+    our reference; Python memory erasure or a provider's own logging is not claimed.
+    A future sender must recheck ownership/governance after this function returns.
+    """
+
+    __slots__ = ("preparation", "metadata_digest", "_material")
+
+    def __init__(
+        self, preparation: SandboxPreparedAttempt, metadata_digest: str, material: SecretBytes,
+    ) -> None:
+        self.preparation = preparation
+        self.metadata_digest = metadata_digest
+        self._material: SecretBytes | None = material
+
+    def __repr__(self) -> str:
+        return "SandboxResolvedCredential(material=<redacted>)"
+
+    def __reduce_ex__(self, protocol: int) -> Any:
+        raise TypeError("SandboxResolvedCredential cannot be serialized")
+
+    @property
+    def material(self) -> SecretBytes:
+        """Return a redacted wrapper for explicit, scoped use by trusted code."""
+        if self._material is None:
+            raise SandboxCredentialResolutionError("SCR_CREDENTIAL_CLOSED")
+        return self._material
+
+    def close(self) -> None:
+        """Drop this object's material reference without claiming memory erasure."""
+        self._material = None
+
+
+def _validate_metadata(
+    value: Any, request: SandboxCredentialRequest,
+    started: SandboxClockReading, finished: SandboxClockReading,
+) -> SandboxCredentialMetadata:
+    # Revalidate even a model constructed with model_construct/model_copy.
+    if type(value) is not SandboxCredentialMetadata:
+        raise SandboxCredentialResolutionError("SCR_METADATA_REQUIRED")
+    # Serializer warnings can echo invalid provider values before we reject them.
+    metadata = SandboxCredentialMetadata.model_validate(
+        value.model_dump(mode="python", warnings=False),
+    )
+    for name in (
+        "credential_reference_id", "credential_provider_type", "credential_version",
+        "credential_scope", "credential_environment", "audience",
+    ):
+        if getattr(metadata, name) != getattr(request, name):
+            raise SandboxCredentialResolutionError("SCR_METADATA_BINDING_MISMATCH")
+    start, end = _clock(started), _clock(finished)
+    lower = min(
+        start - timedelta(seconds=started.uncertainty_seconds),
+        end - timedelta(seconds=finished.uncertainty_seconds),
+    )
+    upper = end + timedelta(seconds=finished.uncertainty_seconds)
+    observed = datetime.fromisoformat(_timestamp(metadata.observed_at))
+    if (
+        metadata.revoked
+        or not datetime.fromisoformat(_timestamp(metadata.valid_from)) <= lower
+        or not upper < datetime.fromisoformat(_timestamp(metadata.valid_until))
+        or not lower <= observed <= upper
+        or not 0 <= (end - start).total_seconds() <= PROVIDER_TIMEOUT_SECONDS
+        or not 0 <= finished.monotonic_seconds - started.monotonic_seconds <= PROVIDER_TIMEOUT_SECONDS
+    ):
+        raise SandboxCredentialResolutionError("SCR_METADATA_STALE_REVOKED_OR_EXPIRED")
+    return metadata
+
+
+async def _recheck_owned(
+    prepared: SandboxPreparedAttempt, *, payload_json: str, deployment: SandboxDeployment,
+    effect_store: PostgresAtomicEffectStateStore | InMemoryAtomicEffectStateStore,
+    trusted_clock: Callable[[], SandboxClockReading],
+    load_current_inputs: Callable[[datetime], SandboxCurrentInputs],
+) -> SandboxPreparedAttempt:
+    stored = await effect_store.get(prepared.attempt.operation_id)
+    if stored != prepared.attempt:
+        raise SandboxCredentialResolutionError("SCR_ATTEMPT_OWNERSHIP_LOST")
+    risk_hash, clock = _recheck_sandbox_current(
+        verified=prepared.authorization, binding=prepared.binding,
+        issued_context=prepared.issued_context, payload_json=payload_json,
+        deployment=deployment, started=prepared.clock, trusted_clock=trusted_clock,
+        load_current_inputs=load_current_inputs,
+    )
+    return replace(prepared, runtime_risk_hash=risk_hash, checked_at=_timestamp(clock.now), clock=clock)
+
+
+async def prepare_and_resolve_sandbox_credential(
+    authorization: Any, payload_json: str, *, deployment: SandboxDeployment,
+    issuance_source_inputs: NativeAuthorizationSourceInputs,
+    governance_inputs: RealBindAuthorizationGovernanceInputs,
+    trust_inputs: BindAuthorizationTrustInputs,
+    consumption_store: PostgresAtomicAuthorizationConsumptionStore | InMemoryAtomicAuthorizationConsumptionStore,
+    effect_store: PostgresAtomicEffectStateStore | InMemoryAtomicEffectStateStore,
+    trusted_clock: Callable[[], SandboxClockReading],
+    load_current_inputs: Callable[[datetime], SandboxCurrentInputs],
+    provider: SandboxCredentialProvider,
+    allow_in_memory_for_testing: bool = False,
+) -> SandboxResolvedCredential:
+    """Claim, inspect metadata, recheck, resolve once and recheck before returning.
+
+    No caller-supplied prepared object/consumed flag is accepted. A pre-existing
+    attempt, including an earlier no-effect preparation, cannot enter this path.
+    Provider calls are bounded and never retried. Failures retain consumption and
+    the attempt; acquired material is not returned on failed post-resolution checks.
+    """
+    response = None
+    description = metadata = actual = None
+    cancelled = False
+    try:
+        if provider is None:
+            raise SandboxCredentialResolutionError("SCR_PROVIDER_REQUIRED")
+        prepared = await prepare_sandbox_attempt(
+            authorization, payload_json, deployment=deployment,
+            issuance_source_inputs=issuance_source_inputs, governance_inputs=governance_inputs,
+            trust_inputs=trust_inputs, consumption_store=consumption_store,
+            effect_store=effect_store, trusted_clock=trusted_clock,
+            load_current_inputs=load_current_inputs,
+            allow_in_memory_for_testing=allow_in_memory_for_testing,
+        )
+        request = SandboxCredentialRequest(
+            prepared.binding.authorization_id, prepared.attempt.operation_id,
+            deployment.credential_reference_id, deployment.credential_provider_type,
+            deployment.credential_version, deployment.credential_scope,
+            deployment.credential_environment, deployment.endpoint_url.removesuffix("/v1/events"),
+        )
+        descriptor_started = prepared.clock
+        async with asyncio.timeout(PROVIDER_TIMEOUT_SECONDS):
+            description = await provider.describe(request)
+        observed = trusted_clock()
+        _window(observed, prepared.authorization)
+        metadata = _validate_metadata(description, request, descriptor_started, observed)
+        digest = sha256_of_canonical_json(metadata.model_dump(mode="json"))
+        prepared = await _recheck_owned(
+            prepared, payload_json=payload_json, deployment=deployment, effect_store=effect_store,
+            trusted_clock=trusted_clock, load_current_inputs=load_current_inputs,
+        )
+        # Do not resolve on a descriptor which expired while governance was checked.
+        _validate_metadata(metadata, request, descriptor_started, prepared.clock)
+        async with asyncio.timeout(PROVIDER_TIMEOUT_SECONDS):
+            response = await provider.resolve(request, expected_metadata_digest=digest)
+        if type(response) is not SandboxProviderCredential:
+            raise SandboxCredentialResolutionError("SCR_PROVIDER_RESPONSE_INVALID")
+        finished = trusted_clock()
+        _window(finished, prepared.authorization)
+        actual = _validate_metadata(response.metadata, request, descriptor_started, finished)
+        if actual != metadata or type(response.material) is not SecretBytes:
+            raise SandboxCredentialResolutionError("SCR_PROVIDER_RESPONSE_SUBSTITUTED")
+        # Bearer token grammar only; do not construct a header or hash the secret.
+        if not 1 <= len(response.material.get_secret_value()) <= 4096 or not re.fullmatch(
+            rb"[A-Za-z0-9._~+/-]+=*", response.material.get_secret_value(),
+        ):
+            raise SandboxCredentialResolutionError("SCR_MATERIAL_INVALID")
+        prepared = await _recheck_owned(
+            prepared, payload_json=payload_json, deployment=deployment, effect_store=effect_store,
+            trusted_clock=trusted_clock, load_current_inputs=load_current_inputs,
+        )
+        _validate_metadata(actual, request, descriptor_started, prepared.clock)
+        return SandboxResolvedCredential(prepared, digest, response.material)
+    except asyncio.CancelledError:
+        cancelled = True
+    except Exception:
+        # Raise outside the handler so the public exception does not retain the
+        # provider exception in __context__, even when chaining is suppressed.
+        pass
+    finally:
+        # Also runs on cancellation. Do not log provider objects or their errors.
+        response = None
+        description = metadata = actual = None
+    if cancelled:
+        raise asyncio.CancelledError()
+    raise SandboxCredentialResolutionError("SCR_FAILED_ATTEMPT_NOT_RELEASED")

--- a/veritas_os/policy/sandbox_pre_effect.py
+++ b/veritas_os/policy/sandbox_pre_effect.py
@@ -7,7 +7,7 @@ Failures after claim leave the row intact; recovery cannot acquire it again.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timedelta
 import math
 from typing import Any, Callable
@@ -29,7 +29,8 @@ from veritas_os.policy.live_adapter_bind_authorization_governance import (
     _validate_governance_for_verified_context,
 )
 from veritas_os.policy.native_bind_authorization import (
-    NativeAuthorizationSourceInputs, _supported_approval_rules, _verified_source,
+    NativeAuthorizationSourceInputs, NativeBindAuthorizationArtifact,
+    _VerifiedContext, _supported_approval_rules, _verified_source,
     verify_native_bind_authorization,
 )
 from veritas_os.policy.sandbox_action_binding import (
@@ -74,6 +75,9 @@ class SandboxPreparedAttempt:
     runtime_risk_hash: str
     checked_at: str
     durable_store_used: bool
+    authorization: NativeBindAuthorizationArtifact = field(repr=False)
+    issued_context: _VerifiedContext = field(repr=False)
+    clock: SandboxClockReading = field(repr=False)
 
 
 def _clock(reading: SandboxClockReading) -> datetime:
@@ -184,6 +188,33 @@ async def prepare_sandbox_attempt(
         raise SandboxPreEffectError("SPE_CLAIM_FAILED_OR_UNKNOWN") from None
     if claimed is not True:
         raise SandboxPreEffectError("SPE_ATTEMPT_ALREADY_EXISTS")
+    risk_hash, finished = _recheck_sandbox_current(
+        verified=verified, binding=binding, issued_context=issued_context,
+        payload_json=payload_json, deployment=deployment, started=started,
+        trusted_clock=trusted_clock, load_current_inputs=load_current_inputs,
+    )
+    return SandboxPreparedAttempt(
+        binding, attempt, risk_hash, _timestamp(finished.now), durable,
+        verified, issued_context, finished,
+    )
+
+
+def _recheck_sandbox_current(
+    *,
+    verified: NativeBindAuthorizationArtifact,
+    binding: VerifiedSandboxActionBinding,
+    issued_context: _VerifiedContext,
+    payload_json: str,
+    deployment: SandboxDeployment,
+    started: SandboxClockReading,
+    trusted_clock: Callable[[], SandboxClockReading],
+    load_current_inputs: Callable[[datetime], SandboxCurrentInputs],
+) -> tuple[str, SandboxClockReading]:
+    """Repeat the same checks inside an owning call, never from request claims.
+
+    Shared by preparation and its credential continuation. This private helper
+    grants no ownership; the continuation must itself create the unique attempt.
+    """
     try:
         checked = trusted_clock()
         lower, _ = _window(checked, verified)
@@ -240,6 +271,4 @@ async def prepare_sandbox_attempt(
     except Exception:
         # Provider errors can contain private registry/connection details.
         raise SandboxPreEffectError("SPE_RECHECK_FAILED_ATTEMPT_RETAINED") from None
-    return SandboxPreparedAttempt(
-        binding, attempt, risk.packet_hash, _timestamp(finished.now), durable,
-    )
+    return risk.packet_hash, finished

--- a/veritas_os/tests/test_sandbox_credential_resolution.py
+++ b/veritas_os/tests/test_sandbox_credential_resolution.py
@@ -1,0 +1,116 @@
+"""Metadata policy, token redaction and exact provider-request binding."""
+
+from dataclasses import asdict, replace
+from datetime import datetime, timedelta, timezone
+import json
+
+import pytest
+from pydantic import SecretBytes, ValidationError
+
+from veritas_os.policy import sandbox_credential_resolution as module
+
+NOW = datetime(2026, 9, 7, 12, tzinfo=timezone.utc)
+TOKEN = b"synthetic.only.test.token"
+
+
+def request():
+    return module.SandboxCredentialRequest(
+        "authorization", "attempt", "sandbox:token", "TEST_PROVIDER", "1",
+        "sandbox:events:register", "sandbox", "https://sandbox.example.invalid",
+    )
+
+
+def metadata(now=NOW, **changes):
+    body = asdict(request())
+    body.pop("authorization_id")
+    body.pop("attempt_id")
+    return module.SandboxCredentialMetadata(**{
+        **body, "credential_kind": "bearer", "revoked": False,
+        "valid_from": (now - timedelta(seconds=60)).isoformat(),
+        "valid_until": (now + timedelta(seconds=60)).isoformat(),
+        "observed_at": now.isoformat(), **changes,
+    })
+
+
+def clock(now=NOW, **changes):
+    return replace(module.SandboxClockReading(now, 100.0, now, 0.0), **changes)
+
+
+@pytest.mark.parametrize("field", [
+    "credential_reference_id", "credential_provider_type", "credential_version",
+    "credential_scope", "credential_environment", "audience",
+])
+def test_each_provider_pin_must_match_independent_request(field):
+    with pytest.raises(ValueError, match="METADATA_BINDING_MISMATCH"):
+        module._validate_metadata(metadata(**{field: "substituted"}), request(), clock(), clock())
+
+
+@pytest.mark.parametrize("changes", [
+    {"revoked": True}, {"valid_until": NOW.isoformat()},
+    {"valid_from": (NOW + timedelta(microseconds=1)).isoformat()},
+    {"observed_at": (NOW - timedelta(seconds=1)).isoformat()},
+    {"observed_at": (NOW + timedelta(seconds=1)).isoformat()},
+    {"valid_until": "not-a-time"}, {"valid_from": "2026-09-07T12:00:00"},
+])
+def test_revoked_expired_stale_or_invalid_metadata_rejects(changes):
+    with pytest.raises(ValueError):
+        module._validate_metadata(metadata(**changes), request(), clock(), clock())
+
+
+@pytest.mark.parametrize("field,value", [
+    ("revoked", "false"), ("revoked", 0), ("credential_kind", "other"),
+    ("credential_reference_id", None), ("observed_at", 0),
+])
+def test_forged_pydantic_instances_are_revalidated(field, value):
+    forged = metadata().model_copy(update={field: value})
+    with pytest.raises(ValidationError):
+        module._validate_metadata(forged, request(), clock(), clock())
+
+
+def test_missing_metadata_is_not_treated_as_verified():
+    with pytest.raises(ValueError):
+        module._validate_metadata(None, request(), clock(), clock())
+    body = metadata().model_dump()
+    body.pop("revoked")
+    with pytest.raises(ValidationError):
+        module.SandboxCredentialMetadata(**body)
+
+
+@pytest.mark.parametrize("changes", [
+    {"monotonic_seconds": 106.0}, {"monotonic_seconds": 99.0},
+    {"now": NOW + timedelta(seconds=6)},
+    {"now": NOW - timedelta(seconds=1), "health_checked_at": NOW - timedelta(seconds=1)},
+    {"uncertainty_seconds": 1.1},
+])
+def test_provider_elapsed_time_and_clock_health_are_enforced(changes):
+    with pytest.raises(ValueError):
+        module._validate_metadata(metadata(), request(), clock(), clock(**changes))
+
+
+def test_descriptor_can_precede_response_but_not_its_request():
+    later = clock(NOW + timedelta(seconds=1), monotonic_seconds=101.0)
+    assert module._validate_metadata(metadata(), request(), clock(), later) == metadata()
+
+
+def test_uncertainty_interval_cannot_extend_past_credential_expiry():
+    with pytest.raises(ValueError):
+        module._validate_metadata(
+            metadata(valid_until=(NOW + timedelta(seconds=1)).isoformat()),
+            request(), clock(), clock(uncertainty_seconds=1.0),
+        )
+
+
+def test_secret_wrappers_are_redacted_and_result_cannot_be_serialized():
+    response = module.SandboxProviderCredential(metadata=metadata(), material=SecretBytes(TOKEN))
+    result = module.SandboxResolvedCredential(None, "a" * 64, response.material)
+    assert TOKEN.decode() not in repr(response) + response.model_dump_json() + repr(result)
+    assert result.material.get_secret_value() == TOKEN
+    with pytest.raises(TypeError):
+        json.dumps(result)
+    with pytest.raises(TypeError):
+        asdict(result)
+    with pytest.raises(TypeError):
+        result.__reduce_ex__(4)
+    result.close()
+    with pytest.raises(ValueError, match="CREDENTIAL_CLOSED"):
+        _ = result.material

--- a/veritas_os/tests/test_sandbox_credential_resolution_integration.py
+++ b/veritas_os/tests/test_sandbox_credential_resolution_integration.py
@@ -1,0 +1,218 @@
+"""Owning native call is mandatory; no accepting verifier mocks or real secrets."""
+
+import asyncio
+from dataclasses import replace
+import json
+import traceback
+
+import pytest
+from pydantic import SecretBytes
+
+from veritas_os.policy import sandbox_credential_resolution as module
+from veritas_os.security.hash import sha256_of_canonical_json
+from veritas_os.tests.test_sandbox_action_binding import PAYLOAD
+from veritas_os.tests.test_sandbox_pre_effect import (
+    issued as issued_fixture, prepared_inputs as prepared_inputs_fixture, _args,
+)
+from veritas_os.tests.test_native_bind_authorization_consumption import _Revocation
+from veritas_os.tests.test_sandbox_credential_resolution import TOKEN, metadata
+
+pytestmark = pytest.mark.slow
+issued = issued_fixture
+prepared_inputs = prepared_inputs_fixture
+
+
+class Provider:
+    """Synthetic trusted adapter with controlled failures, no network or env reads."""
+
+    def __init__(self, fixture, args, mode="valid"):
+        self.clock = fixture[4]
+        self.args = args
+        config = args["deployment"]
+        self.metadata = metadata(self.clock.now, **{
+            name: getattr(config, name) for name in (
+                "credential_reference_id", "credential_provider_type", "credential_version",
+                "credential_scope", "credential_environment",
+            )
+        })
+        self.calls = []
+        self.mode = mode
+
+    async def describe(self, request):
+        self.calls.append(("describe", request))
+        assert await self.args["effect_store"].get(request.attempt_id) is not None
+        if self.mode == "bad_metadata":
+            return self.metadata.model_copy(update={"credential_scope": "admin"})
+        if self.mode == "missing_metadata":
+            return None
+        if self.mode == "invalid_metadata_shape":
+            return self.metadata.model_copy(update={"revoked": TOKEN.decode()})
+        if self.mode == "read_error":
+            raise RuntimeError(TOKEN.decode())
+        if self.mode == "lost_owner_before_resolve":
+            self.args["effect_store"]._records.clear()
+        return self.metadata
+
+    async def resolve(self, request, *, expected_metadata_digest):
+        self.calls.append(("resolve", request))
+        assert expected_metadata_digest == sha256_of_canonical_json(self.metadata.model_dump(mode="json"))
+        if self.mode == "resolve_error":
+            raise RuntimeError(TOKEN.decode())
+        if self.mode == "cancel":
+            raise asyncio.CancelledError(TOKEN.decode())
+        if self.mode == "lost_owner_after_resolve":
+            self.args["effect_store"]._records.clear()
+        actual = self.metadata
+        if self.mode == "substitution":
+            actual = actual.model_copy(update={"credential_version": "2"})
+        if self.mode == "revoked_during_resolve":
+            actual = actual.model_copy(update={"revoked": True})
+        if self.mode == "expired_during_resolve":
+            actual = actual.model_copy(update={"valid_until": self.clock.now.isoformat()})
+        token = TOKEN
+        if self.mode == "bad_material":
+            token = b"header\r\ninjection"
+        if self.mode == "empty_material":
+            token = b""
+        if self.mode == "oversize_material":
+            token = b"x" + b"=" * 4096
+        return module.SandboxProviderCredential(metadata=actual, material=SecretBytes(token))
+
+
+async def resolve(artifact, args, provider):
+    return await module.prepare_and_resolve_sandbox_credential(
+        artifact, json.dumps(PAYLOAD), provider=provider, **args,
+    )
+
+
+@pytest.mark.asyncio
+async def test_only_owning_call_resolves_once_without_receipts_or_dispatch(prepared_inputs):
+    artifact, args = await _args(prepared_inputs)
+    provider = Provider(prepared_inputs, args)
+    result = await resolve(artifact, args, provider)
+    assert [x[0] for x in provider.calls] == ["describe", "resolve"]
+    request = provider.calls[0][1]
+    assert request == provider.calls[1][1]
+    assert request.authorization_id == artifact.authorization_id
+    assert request.credential_reference_id == args["deployment"].credential_reference_id
+    assert result.material.get_secret_value() == TOKEN
+    assert result.preparation.binding.idempotency_key == artifact.idempotency_key
+    assert result.preparation.attempt == await args["effect_store"].get(request.attempt_id)
+    with pytest.raises(ValueError):
+        await resolve(artifact, args, provider)
+    assert len(provider.calls) == 2
+    result.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode,expected_calls", [
+    ("bad_metadata", 1), ("missing_metadata", 1), ("invalid_metadata_shape", 1), ("read_error", 1),
+    ("resolve_error", 2), ("substitution", 2), ("revoked_during_resolve", 2),
+    ("expired_during_resolve", 2), ("bad_material", 2),
+    ("empty_material", 2), ("oversize_material", 2),
+])
+async def test_failures_never_return_material_or_release_attempt(prepared_inputs, mode, expected_calls, caplog, recwarn):
+    artifact, args = await _args(prepared_inputs)
+    provider = Provider(prepared_inputs, args, mode)
+    with pytest.raises(module.SandboxCredentialResolutionError) as caught:
+        await resolve(artifact, args, provider)
+    assert len(provider.calls) == expected_calls
+    assert caught.value.__context__ is None
+    assert TOKEN.decode() not in "".join(traceback.format_exception(caught.value)) + caplog.text
+    assert TOKEN.decode() not in "".join(str(w.message) for w in recwarn)
+    assert await args["effect_store"].get(prepared_inputs[2].consumption_id) is not None
+    assert await args["consumption_store"].get(artifact.authorization_id) == prepared_inputs[2]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode,expected_calls", [
+    ("lost_owner_before_resolve", 1), ("lost_owner_after_resolve", 2),
+])
+async def test_ownership_is_read_before_and_after_material_resolution(prepared_inputs, mode, expected_calls):
+    artifact, args = await _args(prepared_inputs)
+    provider = Provider(prepared_inputs, args, mode)
+    with pytest.raises(ValueError):
+        await resolve(artifact, args, provider)
+    assert len(provider.calls) == expected_calls
+
+
+@pytest.mark.asyncio
+async def test_cancelled_provider_leaves_attempt_and_does_not_leak_message(prepared_inputs):
+    artifact, args = await _args(prepared_inputs)
+    provider = Provider(prepared_inputs, args, "cancel")
+    with pytest.raises(asyncio.CancelledError) as caught:
+        await resolve(artifact, args, provider)
+    assert not caught.value.args and caught.value.__context__ is None
+    assert await args["effect_store"].get(prepared_inputs[2].consumption_id) is not None
+
+
+@pytest.mark.asyncio
+async def test_preexisting_audit_preparation_does_not_allow_secret_access(prepared_inputs):
+    artifact, args = await _args(prepared_inputs)
+    await module.prepare_sandbox_attempt(artifact, json.dumps(PAYLOAD), **args)
+    provider = Provider(prepared_inputs, args)
+    with pytest.raises(ValueError):
+        await resolve(artifact, args, provider)
+    assert provider.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("after", ["describe", "resolve"])
+async def test_current_revocation_is_rechecked_around_material_access(prepared_inputs, after):
+    artifact, args = await _args(prepared_inputs)
+    provider = Provider(prepared_inputs, args)
+    original = args["load_current_inputs"]
+
+    def load(now):
+        current = original(now)
+        if after in [call[0] for call in provider.calls]:
+            current = replace(current, governance=replace(current.governance,
+                authority_revocation_checker=_Revocation(current.governance, "revoked")))
+        return current
+
+    args["load_current_inputs"] = load
+    with pytest.raises(ValueError):
+        await resolve(artifact, args, provider)
+    assert len(provider.calls) == (1 if after == "describe" else 2)
+
+
+@pytest.mark.asyncio
+async def test_missing_provider_fails_before_claim(prepared_inputs):
+    artifact, args = await _args(prepared_inputs)
+    with pytest.raises(ValueError):
+        await resolve(artifact, args, None)
+    assert not args["effect_store"]._records
+
+
+@pytest.mark.asyncio
+async def test_provider_timeout_never_retries(prepared_inputs, monkeypatch):
+    artifact, args = await _args(prepared_inputs)
+    provider = Provider(prepared_inputs, args)
+    describe = provider.describe
+
+    async def stalled(request):
+        await describe(request)
+        await asyncio.Event().wait()
+
+    provider.describe = stalled
+    monkeypatch.setattr(module, "PROVIDER_TIMEOUT_SECONDS", 0.01)
+    with pytest.raises(ValueError):
+        await resolve(artifact, args, provider)
+    assert len(provider.calls) == 1
+    assert args["effect_store"]._records
+
+
+@pytest.mark.asyncio
+async def test_competing_resolvers_read_material_only_once(prepared_inputs):
+    artifact, args = await _args(prepared_inputs)
+    provider = Provider(prepared_inputs, args)
+    results = await asyncio.gather(
+        resolve(artifact, args, provider), resolve(artifact, args, provider),
+        return_exceptions=True,
+    )
+    assert sum(isinstance(x, module.SandboxResolvedCredential) for x in results) == 1
+    assert sum(isinstance(x, module.SandboxCredentialResolutionError) for x in results) == 1
+    assert [x[0] for x in provider.calls] == ["describe", "resolve"]
+    for result in results:
+        if isinstance(result, module.SandboxResolvedCredential):
+            result.close()


### PR DESCRIPTION
## Purpose

A prepared audit result must not become permission to read a secret. Add an opt-in sandbox credential continuation which creates the unique attempt itself, verifies exact provider metadata, and repeats current governance before and after material access.

## Behavior

- Accept the original authorization and independent source, contract, deployment and trust inputs. Call #2200 preparation internally; reject pre-existing attempts, including serialized/replayed preparation results.
- Describe metadata before requesting material. Bind reference, provider, version, scope, environment and HTTPS origin audience; require bearer kind, explicit non-revocation, freshness and validity across clock uncertainty.
- Require the trusted provider adapter to authenticate its service and atomically resolve against the expected metadata digest/current revocation. Revalidate the returned metadata and reject substitutions.
- Re-read the exact attempt and reuse #2200 current verification around material access. Failures/cancellation retain consumption and the attempt; no automatic provider retry.
- Bound provider operations and descriptor age to five seconds. Preserve the existing one-second recheck budget.
- Redact material in repr/JSON, block generic result serialization, provide explicit close, and sanitize errors without retaining provider exception context. Suppress serializer warnings that could echo rejected provider values.
- Document the adapter contract and remaining deployment gates in EN/JA.

## Scope and remaining gates

No concrete provider/vendor configuration or live secret is introduced. The provider is trusted executor configuration, not request data; this code does not prove provider authenticity or token/metadata truth by itself. Production needs an authenticated adapter implementing the atomic metadata contract and deployment-specific tests. Tests use synthetic material and deterministic clocks; real-clock performance is not demonstrated.

The returned secret wrapper is not execution authority. No header, Bind, dispatch intent, outbound effect request, Human Approval, BindReceipt or Outcome is generated. A future sender must recheck ownership/expiry/governance at use and persist dispatch intent. close drops our reference, not guaranteed Python memory erasure. Existing v1/native consumption entry points are unchanged.

## Validation

- Initial unit plus real native happy-path tests: 28 passed.
- After suppressing potentially value-bearing serializer warnings: 27 unit tests passed.
- Final published-tree suite: **125 passed** in 897.92s (5 existing NumPy reload/jsonschema warnings).
- New credential module coverage: **98.37% (121/123)**. Preparation module: **91.82% (101/110)**. Combined: **95.28%**; 90% gate passed.
- Ruff, bilingual documentation and diff checks passed.
- Published tree equals local tree: `119628ea9ec81ea1da85b715562fbfb42b3ddf3e`.
- Head: `bb10308741b902378f692c045074efbe9b621857`.
- GitHub CI at final local validation: **28 succeeded**, **7 in progress**. Full CI is not yet complete.

## Review

- [x] AI-assisted implementation
- [x] Final local suite passed
- [ ] Full CI passed on final head
- [ ] Human maintainer reviewed credential/governance-sensitive changes

Draft; do not merge automatically.
