### PR TITLE
perf: bound native sandbox verification work

### DIFF
--- a/docs/en/architecture/native-v2-sandbox-event-spec-v1.md
+++ b/docs/en/architecture/native-v2-sandbox-event-spec-v1.md
@@ -270,5 +270,45 @@ only the preparation and a metadata digest, never a token or token hash.
 No Authorization header, Bind, network dispatch, external effect, Human Approval,
 BindReceipt or Outcome is created. A future sender must recheck ownership, expiry
 and current governance at use, then persist dispatch intent. Tests use synthetic
-credentials and deterministic clocks; real-provider authenticity and real-clock
-performance have not been demonstrated by this implementation.
+credentials. Section 13 describes a limited host-clock measurement; real-provider
+authenticity and deployment performance remain unproven.
+
+## 13. Bounded host-clock validation
+
+The timing checkpoint preserves the one-second recheck, two-second conservative
+horizon and five-second provider/descriptor limits. Each public verifier still
+requires its independent source/contract and reconstructs every field. Within that
+same call, HARR returns its reconstructed source to native satisfaction, readiness
+and final rechecks project children of fully rebuilt parents, and native risk
+verification retains the final source it just reconstructed. There is no global or
+cross-call verification cache, no caller-supplied verified flag, and no shortcut for
+current policy, revocation, signatures or either temporal recheck. Exact built-in
+JSON scalar leaves avoid an unnecessary Pydantic model test; boundary-specific
+normalization, timestamp handling and invalid-value rejection are retained.
+
+The opt-in timing test uses actual `datetime.now(timezone.utc)` and `time.monotonic()`
+samples, real native verifiers and signed synthetic artifacts. It builds fresh risk
+evidence inside each measured recheck. Run it separately from coverage/profiling:
+
+```sh
+VERITAS_RUN_SANDBOX_TIMING=1 python -m pytest veritas_os/tests/test_sandbox_real_clock.py -q -s --no-cov -o junit_family=xunit1 --junitxml=/tmp/sandbox-timing.xml
+```
+
+On the 2026-09-07 Python 3.12 development host, three successful runs measured
+0.603–0.770 seconds for each of their nine rechecks and 2.592–2.749 seconds for the
+whole credential continuation (excluding fixture issuance and consumption).
+Descriptor age was 1.287–1.456 seconds against the unchanged five-second limit.
+Injected source delay of 1.05 seconds and provider describe/resolve delays of 5.05
+seconds were rejected with consumption and the attempt retained; no retry occurred.
+These are observations on one host, not throughput or deployment guarantees.
+The opt-in test reports each measurement and fails if the requested phase cannot
+be reached or the normal continuation exceeds the unchanged limits.
+
+Stores are explicitly in-memory, material/provider are synthetic, and clock health
+and zero uncertainty are fixture declarations. No provider service, PostgreSQL
+latency, authenticated time source or external effect is measured. Nonzero clock
+uncertainty exposes a remaining temporal-model limitation: fresh risk stamped at
+`checked.now` is later than the lower uncertainty bound used to verify it. The
+50-millisecond uncertainty case therefore fails closed before provider access.
+This checkpoint preserves that rule; its resolution and actual deployment
+clock/provider validation remain gates before sandbox external execution.

--- a/docs/ja/architecture/native-v2-sandbox-event-spec-v1.md
+++ b/docs/ja/architecture/native-v2-sandbox-event-spec-v1.md
@@ -224,4 +224,37 @@ materialは表示を伏せる`SecretBytes`で保持します。結果は汎用JS
 
 Authorization header・Bind・network dispatch・外部作用・Human Approval・BindReceipt・Outcomeは
 作成しません。将来のsenderは使用時に所有・期限・現在条件を再検証し、送信意図を永続化する必要があります。
-試験は合成credentialと制御した時計を使用します。実providerの真正性と実時計での性能は未実証です。
+試験は合成credentialを使用します。限定的なホスト実時計での測定を13節に示します。
+実providerの真正性と配備環境での性能は未実証です。
+
+## 13. ホスト実時計での限定検証
+
+再検証1秒、保守的な確認上限2秒、providerとdescriptorの5秒制限を維持します。
+各公開verifierは独立したsource/contractを必須とし、全項目を再構築します。同じ呼び出し内では、
+HARRが再構築したsourceをnative satisfactionへ返し、readinessと最終再検証は完全に再構築した
+親packetの子要素を使用し、native risk検証は自身が再構築した最終sourceを保持します。
+グローバル・呼び出し間の検証キャッシュや、callerのverifiedフラグによる省略はありません。
+現在のpolicy・失効・署名・時間区間両端の再検証を維持します。JSONの組み込みscalar値では
+不要なPydanticモデル判定を省きますが、各境界の正規化・時刻処理・不正値拒否は維持します。
+
+明示実行する性能試験は実際の`datetime.now(timezone.utc)`と`time.monotonic()`、
+本物のnative verifier、署名した合成artifactを使用し、測定区間内で新しいrisk証拠を生成します。
+coverageやprofilingと同時に実行せず、次のコマンドで測定します。
+
+```sh
+VERITAS_RUN_SANDBOX_TIMING=1 python -m pytest veritas_os/tests/test_sandbox_real_clock.py -q -s --no-cov -o junit_family=xunit1 --junitxml=/tmp/sandbox-timing.xml
+```
+
+2026-09-07のPython 3.12開発ホストでは、正常3回の計9回の再検証が各0.603〜0.770秒、
+credential継続処理全体が2.592〜2.749秒でした。fixture発行と消費の時間は全体測定に含めません。
+descriptorの経過時間は1.287〜1.456秒で、既存の5秒制限以内でした。
+source取得へ1.05秒、providerのdescribe/resolveへ5.05秒の遅延を入れると拒否され、
+消費と試行を保持し、再試行しません。単一ホストの観測であり、スループットや配備性能の保証ではありません。
+性能試験は各測定値を出力し、対象段階へ到達できない場合や正常処理が既存制限を超えた場合に失敗します。
+
+storeは明示指定のin-memory、material/providerは合成、時計の健全性と誤差ゼロはfixture入力です。
+実provider・PostgreSQL遅延・認証された時刻源・外部作用は測定していません。
+時計誤差が非ゼロの場合には時間モデル上の課題も残ります。`checked.now`で記録する新しいrisk証拠が、
+検証に使う不確実性の下限より未来になるため、誤差50ミリ秒のケースはprovider接続前にfail-closedします。
+このcheckpointではその規則を維持します。この課題の解消と、配備環境の時計/providerの検証が、
+sandbox外部実行前の確認事項として残ります。

--- a/veritas_os/policy/canonical_promotion_adapter_dry_run_fixture_result.py
+++ b/veritas_os/policy/canonical_promotion_adapter_dry_run_fixture_result.py
@@ -179,6 +179,9 @@ class CanonicalPromotionAdapterDryRunFixtureResultPacket(BaseModel):
 
 
 def _json_value(value: Any) -> Any:
+    # Exact JSON scalars cannot be models; avoid Pydantic's metaclass per leaf.
+    if value is None or type(value) in (str, bool, int):
+        return value
     if isinstance(value, BaseModel):
         value = value.model_dump(mode="json")
     if value is None or isinstance(value, (str, bool, int)):

--- a/veritas_os/policy/canonical_promotion_live_adapter_dry_run_authority_evidence_linkage.py
+++ b/veritas_os/policy/canonical_promotion_live_adapter_dry_run_authority_evidence_linkage.py
@@ -504,6 +504,9 @@ def _aware(value: Any, code: str) -> datetime:
 
 
 def _json(value: Any) -> Any:
+    # Exact JSON scalars cannot be models; avoid Pydantic's metaclass per leaf.
+    if value is None or type(value) in (str, bool, int):
+        return value
     if isinstance(value, BaseModel):
         value = value.model_dump(mode="python")
     if value is None or isinstance(value, (str, bool, int)):

--- a/veritas_os/policy/canonical_promotion_live_adapter_dry_run_bind_pre_dispatch_review.py
+++ b/veritas_os/policy/canonical_promotion_live_adapter_dry_run_bind_pre_dispatch_review.py
@@ -432,6 +432,9 @@ def _aware(value: Any, code: str) -> datetime:
 
 
 def _json(value: Any) -> Any:
+    # Exact JSON scalars cannot be models; avoid Pydantic's metaclass per leaf.
+    if value is None or type(value) in (str, bool, int):
+        return value
     if isinstance(value, BaseModel):
         value = value.model_dump(mode="python")
     if value is None or isinstance(value, (str, bool, int)):

--- a/veritas_os/policy/canonical_promotion_live_adapter_dry_run_credential_authorization.py
+++ b/veritas_os/policy/canonical_promotion_live_adapter_dry_run_credential_authorization.py
@@ -411,6 +411,9 @@ def _aware(value: Any, code: str) -> datetime:
 
 
 def _json_value(value: Any) -> Any:
+    # Exact JSON scalars cannot be models; avoid Pydantic's metaclass per leaf.
+    if value is None or type(value) in (str, bool, int):
+        return value
     if isinstance(value, BaseModel):
         value = value.model_dump(mode="python")
     if value is None or isinstance(value, (str, bool, int)):

--- a/veritas_os/policy/canonical_promotion_live_adapter_dry_run_dispatch_readiness.py
+++ b/veritas_os/policy/canonical_promotion_live_adapter_dry_run_dispatch_readiness.py
@@ -256,6 +256,9 @@ class CanonicalPromotionLiveAdapterDryRunDispatchReadinessPacket(BaseModel):
 
 
 def _json_value(value: Any) -> Any:
+    # Exact JSON scalars cannot be models; avoid Pydantic's metaclass per leaf.
+    if value is None or type(value) in (str, bool, int):
+        return value
     if isinstance(value, BaseModel):
         value = value.model_dump(mode="python")
     if value is None or isinstance(value, (str, bool, int)):

--- a/veritas_os/policy/canonical_promotion_live_adapter_dry_run_endpoint_allowlist.py
+++ b/veritas_os/policy/canonical_promotion_live_adapter_dry_run_endpoint_allowlist.py
@@ -293,6 +293,9 @@ def _aware(value: Any, code: str) -> datetime:
     return parsed
 
 def _json_value(value: Any) -> Any:
+    # Exact JSON scalars cannot be models; avoid Pydantic's metaclass per leaf.
+    if value is None or type(value) in (str, bool, int):
+        return value
     if isinstance(value, BaseModel):
         value = value.model_dump(mode="python")
     if value is None or isinstance(value, (str, bool, int)):

--- a/veritas_os/policy/canonical_promotion_live_adapter_dry_run_operator_dispatch_review.py
+++ b/veritas_os/policy/canonical_promotion_live_adapter_dry_run_operator_dispatch_review.py
@@ -381,6 +381,9 @@ def _aware(value: Any, code: str) -> datetime:
 
 
 def _json(value: Any) -> Any:
+    # Exact JSON scalars cannot be models; avoid Pydantic's metaclass per leaf.
+    if value is None or type(value) in (str, bool, int):
+        return value
     if isinstance(value, BaseModel):
         value = value.model_dump(mode="python")
     if value is None or isinstance(value, (str, bool, int)):

--- a/veritas_os/policy/canonical_promotion_live_adapter_dry_run_readiness.py
+++ b/veritas_os/policy/canonical_promotion_live_adapter_dry_run_readiness.py
@@ -284,6 +284,9 @@ class CanonicalPromotionLiveAdapterDryRunRequestReadinessPacket(BaseModel):
 
 
 def _json(value: Any) -> Any:
+    # Exact JSON scalars cannot be models; avoid Pydantic's metaclass per leaf.
+    if value is None or type(value) in (str, bool, int):
+        return value
     if isinstance(value, BaseModel):
         value = value.model_dump(mode="json")
     if value is None or isinstance(value, (str, bool, int)):

--- a/veritas_os/policy/canonical_promotion_live_adapter_dry_run_request.py
+++ b/veritas_os/policy/canonical_promotion_live_adapter_dry_run_request.py
@@ -369,6 +369,9 @@ class CanonicalPromotionLiveAdapterDryRunRequestPacket(BaseModel):
 
 
 def _json_value(value: Any) -> Any:
+    # Exact JSON scalars cannot be models; avoid Pydantic's metaclass per leaf.
+    if value is None or type(value) in (str, bool, int):
+        return value
     if isinstance(value, BaseModel):
         value = value.model_dump(mode="python")
     if value is None or isinstance(value, (str, bool, int)):

--- a/veritas_os/policy/canonical_promotion_reference_adapter_rehearsal.py
+++ b/veritas_os/policy/canonical_promotion_reference_adapter_rehearsal.py
@@ -246,6 +246,9 @@ class CanonicalPromotionReferenceAdapterInMemoryRehearsalPacket(BaseModel):
 
 
 def _json(value: Any) -> Any:
+    # Exact JSON scalars cannot be models; avoid Pydantic's metaclass per leaf.
+    if value is None or type(value) in (str, bool, int):
+        return value
     if isinstance(value, BaseModel):
         value = value.model_dump(mode="json")
     if value is None or isinstance(value, (str, bool, int)):

--- a/veritas_os/policy/human_approval_requirement_resolution.py
+++ b/veritas_os/policy/human_approval_requirement_resolution.py
@@ -125,6 +125,9 @@ def _timestamp(value: Any) -> str:
 
 
 def _json(value: Any) -> Any:
+    # Exact JSON scalars cannot be models; avoid Pydantic's metaclass per leaf.
+    if value is None or type(value) in (str, bool, int):
+        return value
     if isinstance(value, BaseModel):
         value = value.model_dump(mode="python")
     if value is None or isinstance(value, (str, bool, int)):
@@ -235,6 +238,18 @@ def build_human_approval_requirement_resolution_packet(
     resolved_at: datetime,
 ) -> CanonicalHumanApprovalRequirementResolutionPacket:
     """Build a fail-closed, non-authorizing requirement-resolution packet."""
+    packet, _ = _build_resolution_and_source(
+        source_authority_evidence_linkage_review_packet, action_contract, resolved_at,
+    )
+    return packet
+
+
+def _build_resolution_and_source(
+    source_authority_evidence_linkage_review_packet: Any,
+    action_contract: ActionClassContract,
+    resolved_at: datetime,
+) -> tuple[CanonicalHumanApprovalRequirementResolutionPacket, AuthorityLinkageSource]:
+    """Reconstruct the complete source and retain it with the derived resolution."""
     source = _verified_source(source_authority_evidence_linkage_review_packet)
     source_id, source_hash = _source_identity(source)
     if isinstance(
@@ -297,11 +312,12 @@ def build_human_approval_requirement_resolution_packet(
         "scope_limitations": SCOPE_LIMITATIONS,
     }
     packet_hash = _digest(payload)
-    return CanonicalHumanApprovalRequirementResolutionPacket(
+    packet = CanonicalHumanApprovalRequirementResolutionPacket(
         human_approval_requirement_resolution_id=(f"harr:v1:sha256:{packet_hash}"),
         human_approval_requirement_resolution_hash=packet_hash,
         **payload,
     )
+    return packet, source
 
 
 def verify_human_approval_requirement_resolution_packet(
@@ -313,6 +329,22 @@ def verify_human_approval_requirement_resolution_packet(
 
     Hash integrity alone does not authenticate authority or policy. Callers
     must obtain the expected source and contract independently of this packet.
+    """
+    rebuilt, _ = _verify_resolution_and_source(
+        value, source_authority_evidence_linkage_review_packet, action_contract,
+    )
+    return rebuilt
+
+
+def _verify_resolution_and_source(
+    value: Any,
+    source_authority_evidence_linkage_review_packet: Any,
+    action_contract: ActionClassContract,
+) -> tuple[CanonicalHumanApprovalRequirementResolutionPacket, AuthorityLinkageSource]:
+    """Verify every field and return the source reconstructed in this call.
+
+    Independent source and contract remain mandatory. This is not a cache or a
+    path accepting preverified caller objects; every invocation rebuilds both.
     """
     try:
         packet = CanonicalHumanApprovalRequirementResolutionPacket.model_validate(
@@ -350,7 +382,7 @@ def verify_human_approval_requirement_resolution_packet(
     expected = _digest(raw)
     if packet_hash != expected or packet_id != f"harr:v1:sha256:{expected}":
         raise HumanApprovalRequirementResolutionError("HARR_HASH_MISMATCH")
-    rebuilt = build_human_approval_requirement_resolution_packet(
+    rebuilt, source = _build_resolution_and_source(
         source_authority_evidence_linkage_review_packet,
         action_contract,
         datetime.fromisoformat(_timestamp(packet.resolved_at)),
@@ -359,4 +391,4 @@ def verify_human_approval_requirement_resolution_packet(
         raise HumanApprovalRequirementResolutionError(
             "HARR_SOURCE_RECONSTRUCTION_MISMATCH"
         )
-    return rebuilt
+    return rebuilt, source

--- a/veritas_os/policy/native_bind_authorization.py
+++ b/veritas_os/policy/native_bind_authorization.py
@@ -48,11 +48,8 @@ from veritas_os.policy.live_adapter_bind_authorization_governance import (
 from veritas_os.policy.live_adapter_bind_authorization_requirements import (
     _approved_issuer_binding,
 )
-from veritas_os.policy.promotion_requirement_final_rechecks import (
-    verify_promotion_requirement_final_recheck_packet,
-)
 from veritas_os.policy.promotion_requirement_runtime_risk import (
-    require_promotion_requirement_runtime_risk_pass,
+    _require_runtime_risk_pass_and_source,
 )
 
 DOMAIN = "veritas.native-live-adapter-bind-authorization/v2"
@@ -178,16 +175,12 @@ def _verified_source(
         current_credential_reference=source_inputs.current_credential_reference,
         required_credential_scope=source_inputs.required_credential_scope,
     )
-    verified_risk = require_promotion_requirement_runtime_risk_pass(
+    verified_risk, final = _require_runtime_risk_pass_and_source(
         risk,
         source_inputs.final_recheck,
         expected_risk_decision=source_inputs.expected_risk_decision,
         expected_recorded_at=source_inputs.expected_recorded_at,
         verification_now=governance_inputs.verification_now,
-        **anchors,
-    )
-    final = verify_promotion_requirement_final_recheck_packet(
-        source_inputs.final_recheck,
         **anchors,
     )
     # Traverse only the freshly reconstructed chain, not the input objects.

--- a/veritas_os/policy/promotion_human_approval_requirement_satisfaction.py
+++ b/veritas_os/policy/promotion_human_approval_requirement_satisfaction.py
@@ -19,10 +19,10 @@ from veritas_os.governance.action_contracts import (
 from veritas_os.policy.human_approval_requirement_resolution import (
     _json,
     _timestamp,
-    verify_human_approval_requirement_resolution_packet,
+    _verify_resolution_and_source,
 )
 from veritas_os.policy.canonical_promotion_live_adapter_dry_run_authority_evidence_linkage import (
-    verify_canonical_promotion_live_adapter_dry_run_authority_evidence_linkage_review_packet as verify_source,
+    CanonicalPromotionLiveAdapterDryRunAuthorityEvidenceLinkageReviewPacket,
 )
 from veritas_os.policy.canonical_promotion_live_adapter_dry_run_human_approval_linkage import (
     verify_canonical_promotion_live_adapter_dry_run_human_approval_linkage_review_packet as verify_linkage,
@@ -100,10 +100,11 @@ def build_promotion_human_approval_requirement_satisfaction_packet(
             "PHARS_CONTRACT_REQUIRED"
         )
     contract = validate_action_class_contract(contract.to_dict())
-    source = verify_source(source)
-    resolution = verify_human_approval_requirement_resolution_packet(
+    resolution, source = _verify_resolution_and_source(
         resolution, source, contract
     )
+    if not isinstance(source, CanonicalPromotionLiveAdapterDryRunAuthorityEvidenceLinkageReviewPacket):
+        raise PromotionHumanApprovalRequirementSatisfactionError("PHARS_NATIVE_SOURCE_REQUIRED")
     recorded = _timestamp(recorded_at)
     if datetime.fromisoformat(recorded) < datetime.fromisoformat(
         resolution.resolved_at

--- a/veritas_os/policy/promotion_requirement_bind_readiness.py
+++ b/veritas_os/policy/promotion_requirement_bind_readiness.py
@@ -202,9 +202,10 @@ def build_promotion_requirement_bind_gate_packet(
     )
     if verified.fail_closed or not verified.ready_for_bind_authorization_gate_review:
         raise PromotionRequirementBindReviewError("PRBR_READINESS_REJECTED")
-    satisfaction = verify_satisfaction(
+    # The readiness verifier returned a full reconstruction against the external
+    # anchors above. Project its reconstructed child, never readiness.source_packet.
+    satisfaction = PromotionHumanApprovalRequirementSatisfactionPacket.model_validate(
         verified.source_packet,
-        expected_source=expected_source, expected_contract=expected_contract,
     )
     return PromotionRequirementBindGatePacket.model_validate(
         _assemble(verified, satisfaction, decision, recorded_at, gate=True)

--- a/veritas_os/policy/promotion_requirement_final_rechecks.py
+++ b/veritas_os/policy/promotion_requirement_final_rechecks.py
@@ -19,7 +19,7 @@ from veritas_os.policy.promotion_requirement_bind_readiness import (
     verify_promotion_requirement_bind_gate_packet as verify_gate,
 )
 from veritas_os.policy.canonical_promotion_live_adapter_dry_run_authority_evidence_linkage import (
-    verify_canonical_promotion_live_adapter_dry_run_authority_evidence_linkage_review_packet as verify_authority_source,
+    CanonicalPromotionLiveAdapterDryRunAuthorityEvidenceLinkageReviewPacket,
 )
 from veritas_os.policy.canonical_promotion_live_adapter_dry_run_final_endpoint_identity_recheck import (
     _candidate as validate_endpoint,
@@ -192,6 +192,21 @@ def _common(source: Any, context: ExactRequirementBindContext) -> dict[str, Any]
     }
 
 
+def _authority_from_rebuilt_gate(
+    gate: dict[str, Any],
+) -> CanonicalPromotionLiveAdapterDryRunAuthorityEvidenceLinkageReviewPacket:
+    """Project a child only after the parent verifier fully reconstructs it.
+
+    This helper performs no admission. Both callers first run the complete gate
+    chain against their mandatory external source and contract. An input packet,
+    matching hash, model type, or embedded snapshot never substitutes for that.
+    """
+    satisfaction = gate["source_packet"]["source_packet"]
+    return CanonicalPromotionLiveAdapterDryRunAuthorityEvidenceLinkageReviewPacket.model_validate(
+        satisfaction["source_authority_evidence_linkage_review_packet"],
+    )
+
+
 def build_promotion_requirement_fresh_source_packet(
     gate: Any,
     fresh_verified_at: datetime,
@@ -205,7 +220,7 @@ def build_promotion_requirement_fresh_source_packet(
     )
     if verified.fail_closed or not verified.ready_for_fresh_verified_source_gate:
         raise PromotionRequirementRecheckError("PRRC_GATE_REJECTED")
-    source = verify_authority_source(expected_source)
+    source = _authority_from_rebuilt_gate(verified.model_dump(mode="json"))
     _ordered(verified.recorded_at, fresh_verified_at)
     context = ExactRequirementBindContext(
         gate_packet_hash=verified.packet_hash,
@@ -275,7 +290,7 @@ def build_promotion_requirement_final_recheck_packet(
         expected_contract=expected_contract,
         expected_verified_at=expected_verified_at,
     )
-    source = verify_authority_source(expected_source)
+    source = _authority_from_rebuilt_gate(verified.source_packet)
     endpoint = validate_endpoint(current_endpoint)
     reference = validate_reference(current_credential_reference)
     scope = validate_scope(required_credential_scope)

--- a/veritas_os/policy/promotion_requirement_runtime_risk.py
+++ b/veritas_os/policy/promotion_requirement_runtime_risk.py
@@ -15,6 +15,7 @@ from veritas_os.governance.action_contracts import ActionClassContract
 from veritas_os.policy.human_approval_requirement_resolution import _json, _timestamp
 from veritas_os.policy.promotion_requirement_final_rechecks import (
     ABSENT_FIELDS,
+    PromotionRequirementFinalRecheckPacket,
     verify_promotion_requirement_final_recheck_packet as verify_rechecks,
 )
 from veritas_os.policy.canonical_promotion_live_adapter_dry_run_runtime_risk_review import (
@@ -202,19 +203,34 @@ def verify_promotion_requirement_runtime_risk_packet(
     required_credential_scope: str,
 ) -> PromotionRequirementRuntimeRiskPacket:
     """Rebuild against independent review/source and reject expired consumption."""
-    candidate = PromotionRequirementRuntimeRiskPacket.model_validate(_json(packet))
-    rebuilt = build_promotion_requirement_runtime_risk_packet(
-        final_recheck,
-        expected_risk_decision,
-        expected_recorded_at,
-        expected_source=expected_source,
-        expected_contract=expected_contract,
+    rebuilt, _ = _verify_runtime_risk_and_source(
+        packet, final_recheck,
+        expected_risk_decision=expected_risk_decision,
+        expected_recorded_at=expected_recorded_at, verification_now=verification_now,
+        expected_source=expected_source, expected_contract=expected_contract,
         expected_verified_at=expected_verified_at,
         expected_rechecked_at=expected_rechecked_at,
         current_endpoint=current_endpoint,
         current_credential_reference=current_credential_reference,
         required_credential_scope=required_credential_scope,
     )
+    return rebuilt
+
+
+def _verify_runtime_risk_and_source(
+    packet: Any, final_recheck: Any, *, expected_risk_decision: Any,
+    expected_recorded_at: datetime, verification_now: datetime,
+    **source_inputs: Any,
+) -> tuple[PromotionRequirementRuntimeRiskPacket, PromotionRequirementFinalRecheckPacket]:
+    """Return both reconstructions from this call, with no reusable trust cache.
+
+    The final recheck is verified against every mandatory external anchor before
+    deriving risk. Native callers project only this reconstructed source; no
+    caller-provided 'already verified' result or embedded trust anchor is accepted.
+    """
+    candidate = PromotionRequirementRuntimeRiskPacket.model_validate(_json(packet))
+    source = verify_rechecks(final_recheck, **source_inputs)
+    rebuilt = _assemble(source, expected_risk_decision, expected_recorded_at)
     if _json(candidate) != _json(rebuilt):
         raise PromotionRequirementRuntimeRiskError("PRRR_RECONSTRUCTION_MISMATCH")
     now = datetime.fromisoformat(_timestamp(verification_now))
@@ -224,7 +240,7 @@ def verify_promotion_requirement_runtime_risk_packet(
         < datetime.fromisoformat(rebuilt.risk_decision.valid_until)
     ):
         raise PromotionRequirementRuntimeRiskError("PRRR_REVIEW_NOT_CURRENT")
-    return rebuilt
+    return rebuilt, source
 
 
 def require_promotion_requirement_runtime_risk_pass(
@@ -237,12 +253,22 @@ def require_promotion_requirement_runtime_risk_pass(
     The verifier enforces all mandatory keyword inputs. This guard grants no
     execution authority and does not replace the independent Bind-time check.
     """
-    verified = verify_promotion_requirement_runtime_risk_packet(
+    verified, _ = _require_runtime_risk_pass_and_source(
         packet, final_recheck, **verification_inputs
+    )
+    return verified
+
+
+def _require_runtime_risk_pass_and_source(
+    packet: Any, final_recheck: Any, **verification_inputs: Any,
+) -> tuple[PromotionRequirementRuntimeRiskPacket, PromotionRequirementFinalRecheckPacket]:
+    """Apply the identical PASS guard while retaining its verified source."""
+    verified, source = _verify_runtime_risk_and_source(
+        packet, final_recheck, **verification_inputs,
     )
     if (
         verified.fail_closed
         or not verified.ready_for_remaining_authorization_requirements
     ):
         raise PromotionRequirementRuntimeRiskError("PRRR_RISK_NOT_ACCEPTABLE")
-    return verified
+    return verified, source

--- a/veritas_os/tests/test_native_json_scalar_paths.py
+++ b/veritas_os/tests/test_native_json_scalar_paths.py
@@ -1,0 +1,81 @@
+"""Scalar dispatch preserves each boundary's JSON and rejection semantics."""
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from importlib import import_module
+
+import pytest
+from pydantic import BaseModel
+
+NORMALIZERS = [
+    ("human_approval_requirement_resolution", "_json"),
+    ("canonical_promotion_reference_adapter_rehearsal", "_json"),
+    ("canonical_promotion_adapter_dry_run_fixture_result", "_json_value"),
+    ("canonical_promotion_live_adapter_dry_run_authority_evidence_linkage", "_json"),
+    ("canonical_promotion_live_adapter_dry_run_bind_pre_dispatch_review", "_json"),
+    (
+        "canonical_promotion_live_adapter_dry_run_credential_authorization",
+        "_json_value",
+    ),
+    ("canonical_promotion_live_adapter_dry_run_operator_dispatch_review", "_json"),
+    ("canonical_promotion_live_adapter_dry_run_endpoint_allowlist", "_json_value"),
+    ("canonical_promotion_live_adapter_dry_run_dispatch_readiness", "_json_value"),
+    ("canonical_promotion_live_adapter_dry_run_request", "_json_value"),
+    ("canonical_promotion_live_adapter_dry_run_readiness", "_json"),
+]
+
+
+@pytest.fixture(params=NORMALIZERS, ids=[item[0] for item in NORMALIZERS])
+def normalize(request):
+    module, name = request.param
+    return getattr(import_module("veritas_os.policy." + module), name)
+
+
+def test_nested_scalars_and_models_preserve_values_without_container_aliases(normalize):
+    class Envelope(BaseModel):
+        content: dict
+
+    payload = {
+        "text": "é日本語\n",
+        "none": None,
+        "yes": True,
+        "no": False,
+        "large": 2**90,
+        "nested": ({"finite": -0.25}, 0, -2, ""),
+    }
+    expected = {**payload, "nested": [{"finite": -0.25}, 0, -2, ""]}
+    actual = normalize(payload)
+    assert actual == expected
+    assert actual is not payload and actual["nested"][0] is not payload["nested"][0]
+    assert normalize(Envelope(content=payload)) == {"content": expected}
+    now = datetime(2026, 9, 7, tzinfo=timezone.utc)
+    assert normalize({"time": now}) == {"time": now.isoformat()}
+
+
+def test_scalar_subclasses_keep_the_existing_path(normalize):
+    class Text(str):
+        pass
+
+    class Integer(int):
+        pass
+
+    text, number = Text("custom"), Integer(42)
+    assert normalize(text) is text and normalize(number) is number
+
+
+@pytest.mark.parametrize(
+    "invalid",
+    [
+        float("nan"),
+        float("inf"),
+        float("-inf"),
+        Decimal("1"),
+        b"bytes",
+        object(),
+        {1: "non-string-key"},
+        datetime(2026, 9, 7),
+    ],
+)
+def test_invalid_nested_values_still_fail_closed(normalize, invalid):
+    with pytest.raises(ValueError):
+        normalize({"nested": [invalid]})

--- a/veritas_os/tests/test_native_reconstruction_reuse.py
+++ b/veritas_os/tests/test_native_reconstruction_reuse.py
@@ -1,0 +1,101 @@
+"""Reconstructed children are local results, never caller trust shortcuts."""
+
+from copy import deepcopy
+from dataclasses import replace
+from datetime import datetime, timedelta
+
+import pytest
+
+from veritas_os.policy import native_bind_authorization as native
+from veritas_os.policy import promotion_requirement_runtime_risk as risk
+from veritas_os.tests.test_native_bind_authorization import (
+    issued as issued_fixture,
+    api_risk_source as source_fixture,
+)
+from veritas_os.tests.test_human_approval_requirement_resolution_integration import (
+    chain as legacy_fixture,
+)
+
+pytestmark = pytest.mark.slow
+issued = issued_fixture
+api_risk_source = source_fixture
+legacy_chain = legacy_fixture
+
+
+def test_valid_legacy_source_cannot_enter_native_satisfaction(legacy_chain):
+    from veritas_os.policy.promotion_human_approval_requirement_satisfaction import (
+        build_promotion_human_approval_requirement_satisfaction_packet,
+    )
+
+    source, contract, resolution = legacy_chain
+    with pytest.raises(ValueError, match="PHARS_NATIVE_SOURCE_REQUIRED"):
+        build_promotion_human_approval_requirement_satisfaction_packet(
+            source,
+            resolution,
+            contract,
+            None,
+            datetime.fromisoformat(resolution.resolved_at),
+        )
+
+
+def test_native_projects_one_fresh_reconstruction_per_call(issued, monkeypatch):
+    artifact, inputs, *_ = issued
+    source, governance = inputs["source_inputs"], inputs["governance_inputs"]
+    before = source.final_recheck.model_dump(mode="json")
+    original = risk.verify_rechecks
+    calls = []
+
+    def observe(*args, **kwargs):
+        result = original(*args, **kwargs)
+        calls.append(result)
+        return result
+
+    monkeypatch.setattr(risk, "verify_rechecks", observe)
+    _, final, context = native._verified_source(
+        artifact.source_runtime_risk_packet,
+        source,
+        governance,
+    )
+    assert calls == [final] and calls[0] is final
+    assert final is not source.final_recheck
+    assert context.execution_intent == before["execution_intent"]
+    final.execution_intent["target_resource"] = "attacker"
+    assert source.final_recheck.model_dump(mode="json") == before
+    _, second, _ = native._verified_source(
+        artifact.source_runtime_risk_packet,
+        source,
+        governance,
+    )
+    assert len(calls) == 2 and second is not final
+    assert second.model_dump(mode="json") == before
+
+
+@pytest.mark.parametrize(
+    "change", ["contract", "source", "endpoint", "credential", "clock"]
+)
+def test_previous_success_never_skips_changed_external_inputs(issued, change):
+    artifact, inputs, *_ = issued
+    source, governance = inputs["source_inputs"], inputs["governance_inputs"]
+    native._verified_source(artifact.source_runtime_risk_packet, source, governance)
+    if change == "contract":
+        contract = deepcopy(governance.action_contract)
+        contract.human_approval_rules["required"] = not contract.human_approval_rules[
+            "required"
+        ]
+        governance = replace(governance, action_contract=contract)
+    elif change == "source":
+        governance = replace(governance, expected_source=None)
+    elif change == "clock":
+        governance = replace(
+            governance,
+            verification_now=governance.verification_now + timedelta(minutes=1),
+        )
+    else:
+        field = (
+            "current_endpoint"
+            if change == "endpoint"
+            else "current_credential_reference"
+        )
+        source = replace(source, **{field: {}})
+    with pytest.raises(ValueError):
+        native._verified_source(artifact.source_runtime_risk_packet, source, governance)

--- a/veritas_os/tests/test_sandbox_real_clock.py
+++ b/veritas_os/tests/test_sandbox_real_clock.py
@@ -1,0 +1,255 @@
+"""Opt-in host timing gate with real UTC/monotonic samples and real verifiers.
+
+Run without coverage/profiling: VERITAS_RUN_SANDBOX_TIMING=1 python -m pytest
+veritas_os/tests/test_sandbox_real_clock.py -q -s --no-cov
+Synthetic provider/health declarations and in-memory stores do not establish
+deployment clock authenticity, provider truth, or PostgreSQL latency.
+"""
+
+import asyncio
+from datetime import datetime, timezone
+import json
+import os
+import time
+
+import pytest
+from pydantic import SecretBytes
+
+from veritas_os.policy import sandbox_credential_resolution as credential
+from veritas_os.policy import sandbox_pre_effect as preparation
+from veritas_os.policy.native_bind_authorization_consumption import (
+    consume_native_bind_authorization,
+)
+from veritas_os.security.hash import sha256_of_canonical_json
+from veritas_os.tests.test_native_bind_authorization import _setup
+from veritas_os.tests.test_native_bind_authorization_consumption import _fresh
+from veritas_os.tests.test_sandbox_action_binding import PAYLOAD, deployment
+from veritas_os.tests.test_sandbox_action_binding_integration import (
+    issued as issued_fixture,
+)
+
+pytestmark = [
+    pytest.mark.slow,
+    pytest.mark.skipif(
+        os.environ.get("VERITAS_RUN_SANDBOX_TIMING") != "1",
+        reason="Host performance gate: explicitly opt in without coverage/profiling",
+    ),
+]
+TOKEN = b"synthetic.real.clock.test.only"
+issued = issued_fixture
+
+
+class _Clock:
+    """Sample the actual host clocks; health/zero uncertainty are fixture inputs."""
+
+    def __init__(self, uncertainty=0.0):
+        self.readings = []
+        self.uncertainty = uncertainty
+
+    def __call__(self):
+        now = datetime.now(timezone.utc)
+        reading = preparation.SandboxClockReading(
+            now, time.monotonic(), now, self.uncertainty
+        )
+        self.readings.append(reading)
+        return reading
+
+
+class _Provider:
+    """Synthetic material only; no network or credential backend is involved."""
+
+    def __init__(self, artifact, mode):
+        self.artifact = artifact
+        self.mode = mode
+        self.calls = []
+
+    async def describe(self, request):
+        self.calls.append("describe")
+        if self.mode == "slow_describe":
+            await asyncio.sleep(5.05)
+        self.metadata = credential.SandboxCredentialMetadata(
+            **{
+                name: getattr(request, name)
+                for name in (
+                    "credential_reference_id",
+                    "credential_provider_type",
+                    "credential_version",
+                    "credential_scope",
+                    "credential_environment",
+                    "audience",
+                )
+            },
+            credential_kind="bearer",
+            valid_from=self.artifact.valid_from,
+            valid_until=self.artifact.valid_until,
+            observed_at=datetime.now(timezone.utc).isoformat(),
+            revoked=False,
+        )
+        return self.metadata
+
+    async def resolve(self, request, *, expected_metadata_digest):
+        self.calls.append("resolve")
+        assert expected_metadata_digest == sha256_of_canonical_json(
+            self.metadata.model_dump(mode="json"),
+        )
+        if self.mode == "slow_resolve":
+            await asyncio.sleep(5.05)
+        return credential.SandboxProviderCredential(
+            metadata=self.metadata,
+            material=SecretBytes(TOKEN),
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "mode",
+    [
+        pytest.param("valid", id="valid-1"),
+        pytest.param("valid", id="valid-2"),
+        pytest.param("valid", id="valid-3"),
+        "slow_source",
+        "slow_describe",
+        "slow_resolve",
+        "uncertain_clock",
+    ],
+)
+async def test_real_clock_budget_and_fail_closed(
+    issued, mode, monkeypatch, record_property
+):
+    """Measure the complete owning continuation, including fresh risk creation."""
+    _, seed = issued
+    # Fresh signed fixtures for each run; do not edit timestamps inside artifacts.
+    now = datetime.now(timezone.utc)
+    artifact, inputs, *_ = _setup(
+        seed["governance_inputs"].expected_source,
+        seed["governance_inputs"].action_contract,
+        now,
+    )
+    # Existing synthetic issuance places its declared start three seconds ahead.
+    # Wait for real UTC to reach it; the verification clock is never frozen/shifted.
+    delay = (
+        datetime.fromisoformat(artifact.valid_from) - datetime.now(timezone.utc)
+    ).total_seconds()
+    if delay > 0:
+        await asyncio.sleep(delay + 0.01)
+    consumed_at = datetime.now(timezone.utc)
+    risk, source = _fresh(inputs, consumed_at)
+    consumption = preparation.InMemoryAtomicAuthorizationConsumptionStore()
+    result = await consume_native_bind_authorization(
+        artifact,
+        issuance_source_inputs=inputs["source_inputs"],
+        governance_inputs=inputs["governance_inputs"],
+        trust_inputs=inputs["trust_inputs"],
+        current_source_inputs=source,
+        current_runtime_risk_packet=risk,
+        now=consumed_at,
+        consumption_store=consumption,
+        allow_in_memory_for_testing=True,
+    )
+    clock = _Clock(0.05 if mode == "uncertain_clock" else 0.0)
+    effects = preparation.InMemoryAtomicEffectStateStore()
+    provider = _Provider(artifact, mode)
+    recheck_seconds = []
+    load_seconds = []
+    completed_clocks = []
+    uncertain_risk_rejected = []
+    original = preparation._recheck_sandbox_current
+
+    def measured(**kwargs):
+        start = time.perf_counter()
+        try:
+            result = original(**kwargs)
+            completed_clocks.append(result[1])
+            return result
+        except preparation.SandboxPreEffectError as exc:
+            if mode == "uncertain_clock":
+                uncertain_risk_rejected.append(
+                    str(exc.__context__) == "PRRR_REVIEW_NOT_CURRENT"
+                )
+            raise
+        finally:
+            recheck_seconds.append(time.perf_counter() - start)
+
+    def load(checked_at):
+        start = time.perf_counter()
+        if mode == "slow_source":
+            time.sleep(1.05)
+        risk, source = _fresh(inputs, checked_at)
+        load_seconds.append(time.perf_counter() - start)
+        return preparation.SandboxCurrentInputs(
+            source, inputs["governance_inputs"], risk
+        )
+
+    # Observation wrappers always call the real verifier; no accepting mock.
+    monkeypatch.setattr(preparation, "_recheck_sandbox_current", measured)
+    monkeypatch.setattr(credential, "_recheck_sandbox_current", measured)
+    start = time.perf_counter()
+    resolved = None
+    error = None
+    try:
+        resolved = await credential.prepare_and_resolve_sandbox_credential(
+            artifact,
+            json.dumps(PAYLOAD),
+            deployment=deployment(),
+            issuance_source_inputs=inputs["source_inputs"],
+            governance_inputs=inputs["governance_inputs"],
+            trust_inputs=inputs["trust_inputs"],
+            consumption_store=consumption,
+            effect_store=effects,
+            trusted_clock=clock,
+            load_current_inputs=load,
+            provider=provider,
+            allow_in_memory_for_testing=True,
+        )
+    except credential.SandboxCredentialResolutionError as exc:
+        error = exc
+    elapsed = time.perf_counter() - start
+    measurement = {
+        "case": mode,
+        "outcome": "resolved" if resolved else "rejected",
+        "continuation_seconds": round(elapsed, 6),
+        "recheck_seconds": [round(x, 6) for x in recheck_seconds],
+        "source_load_seconds": [round(x, 6) for x in load_seconds],
+        "provider_calls": provider.calls,
+        "declared_uncertainty_seconds": clock.uncertainty,
+    }
+    if resolved is not None:
+        descriptor_age = (
+            completed_clocks[-1].monotonic_seconds
+            - completed_clocks[0].monotonic_seconds
+        )
+        measurement["descriptor_age_seconds"] = round(descriptor_age, 6)
+    record_property("sandbox_timing", json.dumps(measurement))
+    try:
+        assert (
+            await consumption.get(artifact.authorization_id)
+            == result.consumption_record
+        )
+        assert await effects.get(result.consumption_record.consumption_id) is not None
+        assert all(
+            b.now > a.now and b.monotonic_seconds > a.monotonic_seconds
+            for a, b in zip(clock.readings, clock.readings[1:], strict=False)
+        )
+        if mode == "valid":
+            assert error is None and resolved is not None, measurement
+            assert resolved.material.get_secret_value() == TOKEN
+            assert len(recheck_seconds) == 3 and max(recheck_seconds) <= 1
+            assert 0 < descriptor_age <= 5
+            assert provider.calls == ["describe", "resolve"]
+        else:
+            assert resolved is None and error is not None, measurement
+            assert error.__context__ is None
+            expected = {
+                "slow_source": [],
+                "slow_describe": ["describe"],
+                "slow_resolve": ["describe", "resolve"],
+                "uncertain_clock": [],
+            }
+            assert provider.calls == expected[mode]
+            if mode == "uncertain_clock":
+                assert uncertain_risk_rejected == [True]
+            else:
+                assert elapsed >= (1 if mode == "slow_source" else 5)
+    finally:
+        if resolved is not None:
+            resolved.close()


### PR DESCRIPTION
Real-clock sandbox rechecks exceeded their one-second budget. Remove repeated pure reconstruction inside a single verification call while retaining complete source/contract validation, current governance checks and all existing time limits.

Changes:

- Retain the source reconstructed by HARR for native satisfaction, and the final source reconstructed by runtime-risk verification for native authorization.
- Derive readiness/final-recheck children only from parent verifiers' fully rebuilt results. Independent external source/contract inputs remain mandatory; no embedded input snapshot becomes a trust anchor.
- Add an exact built-in JSON scalar fast path in 11 existing normalizers. Boundary-specific normalization, timestamp handling, rejection rules and canonical hashes are preserved.
- Keep both temporal rechecks, current policy/revocation/signature verification and ownership checks. No global/cross-call cache or caller-provided “already verified” capability is introduced.
- Add reconstruction-isolation, changed-anchor-after-success, legacy/native separation, scalar rejection and opt-in real-clock tests. Update EN/JA specifications.

Validation:

- Related suite: **561 passed**, 5 existing NumPy/jsonschema warnings, 766.51 seconds.
- Coverage of the six reconstruction modules: **98.04% (701/715)**; the 90% gate passed. Native satisfaction, bind readiness and final rechecks each reached 100%.
- Final opt-in host-clock suite: **7 passed**, 4 existing jsonschema warnings, 57.12 seconds. Three normal runs, three injected delay cases, and one nonzero-uncertainty rejection case.
- Normal real-clock runs: rechecks **0.603–0.770 seconds** (nine samples, including fresh risk construction), descriptor age **1.287–1.456 seconds**, continuation **2.592–2.749 seconds**, excluding fixture issuance/consumption.
- Source delay of 1.05 seconds and describe/resolve delays of 5.05 seconds reject without retry or releasing consumption/attempt ownership.
- Ruff, bilingual-document checks and diff checks passed.
- Published tree matches the local tree: `98fb819d7a4bc9bb18b3bdb82f94b395151a9513`.
- Head: `c2babd8e8c0042cd769962d4c996c1b17d01452c`. Latest GitHub check snapshot: **6 succeeded, 15 in progress**. Full CI is not complete.

Reproduce the host timing gate separately from coverage/profiling:
```sh
VERITAS_RUN_SANDBOX_TIMING=1 python -m pytest veritas_os/tests/test_sandbox_real_clock.py -q --no-cov -o junit_family=xunit1 --junitxml=/tmp/sandbox-timing.xml
```

Remaining deployment gates:
The measured normal runs use real host UTC/monotonic clocks with synthetic health and zero declared uncertainty, synthetic credentials and explicitly opted-in in-memory stores. They do not prove provider authenticity, PostgreSQL latency, authenticated time, throughput or production readiness.

**Nonzero clock uncertainty remains an execution blocker.** Fresh risk is stamped at checked.now, but checked against the lower uncertainty bound; with 50 ms uncertainty it is rejected as not current before any provider call. The new test documents this existing limitation. Resolving its temporal semantics and validating the actual clock/provider deployment must precede sandbox external execution.

No concrete provider, live secret access, header, Bind invocation, dispatch intent, network effect, Human Approval issuance, BindReceipt or Outcome is added. Existing acceptance rules and deadlines are not relaxed.

Review:

- [x] AI-assisted implementation
- [x] Related tests and explicit host-clock tests passed
- [ ] Full CI passed on final head
- [ ] Human maintainer reviewed the source reconstruction changes and remaining clock limitation

Draft; do not merge automatically.
