### PR TITLE
feat: add owning native v2 sandbox dispatch intent seam

### DIFF
--- a/docs/en/architecture/native-v2-sandbox-event-spec-v1.md
+++ b/docs/en/architecture/native-v2-sandbox-event-spec-v1.md
@@ -373,3 +373,43 @@ change: the current host also passed a pre-optimization zero-uncertainty control
 (0.622–0.784 second rechecks). These observations demonstrate this host's result,
 not a portable latency guarantee. Deployments still must validate their own time,
 provider and database configuration under expected load.
+
+## 16. Owning dispatch seam (inert validation only)
+
+`execute_sandbox_bind` owns preparation and credential resolution itself; it
+does not accept a returned credential or preparation object as authorization.
+It repeats independent current governance and ownership checks, then uses the
+existing effect-state compare-and-set to persist `EFFECT_UNKNOWN` with reason
+`SANDBOX_DISPATCH_INTENT_PERSISTED_EFFECT_UNCONFIRMED` before entering transport.
+This record links the consumed authorization and its original idempotency key;
+the authorization commits to the action/payload binding. Commit acknowledgement
+loss, failed CAS or mismatched readback prevents transport entry. No state,
+consumption or exclusive attempt is released, reset or retried.
+
+The final ownership read, governance reconstruction, intent persistence/readback
+and transport preparation share a one-second UTC/monotonic budget. The secret
+handoff callback rechecks that budget, clock health, authorization window and
+the original credential descriptor validity/age. It may be called only once.
+Transport entry has a five-second total timeout. Material references are closed
+on return, failure or cancellation; Python memory erasure is not claimed.
+
+`SandboxDispatchTransport` is a trusted executor-injected **interface**, not an
+implemented HTTPS adapter. It must invoke the callback immediately before its
+only send, preserve canonical payload and the original key, verify TLS, and
+disable redirects, proxies and retries. An arbitrary/dishonest implementation
+could retain material or send after its deadline: this interface cannot prove
+otherwise. A reviewed concrete transport and real-clock send tests are mandatory
+before enabling network effects. No default transport or API route is installed.
+
+Transport responses are not parsed as authority or effect evidence. The returned
+`SandboxDispatchObservation` always says `UNKNOWN`; durable state also remains
+`EFFECT_UNKNOWN`, including on apparent transport success. This local result is
+not a BindReceipt, Outcome or acknowledgement. Cancellation raises a sanitized
+cancellation with the same durable uncertainty retained. A recovery process must
+look up the original idempotency key and must not blindly resend.
+
+This checkpoint tests synthetic material and an inert transport using real
+native verifiers. It does not establish real HTTPS delivery, PostgreSQL timing,
+sandbox durability, formal Receipt/Outcome integration or reconciliation. Those
+remain required steps, not guarantees implied by these tests. The deployment
+decisions in section 9 are still required before any external connection.

--- a/docs/ja/architecture/native-v2-sandbox-event-spec-v1.md
+++ b/docs/ja/architecture/native-v2-sandbox-event-spec-v1.md
@@ -307,3 +307,37 @@ source再構築、署名・失効確認は維持します。小さいruntime-ris
 現在のホストでは最適化前の誤差ゼロの対照試験も成功し、再検証は0.622〜0.784秒でした。
 これらはこのホストでの結果であり、全環境の遅延保証ではありません。
 配備先では想定負荷の下で、時計・provider・データベースの設定を検証する必要があります。
+
+## 16. 所有呼出し内のdispatch接続点（非通信試験のみ）
+
+`execute_sandbox_bind`は準備とcredential解決を自身で実行し、呼出し側が渡した
+解決済みcredentialや準備結果を認可として受け取りません。独立した現在のgovernanceと
+所有権を再検証し、既存effect-stateのcompare-and-setで`EFFECT_UNKNOWN`とreason
+`SANDBOX_DISPATCH_INTENT_PERSISTED_EFFECT_UNCONFIRMED`を永続化してからtransportへ
+進みます。記録は消費済みauthorizationと元のidempotency keyに結び付き、authorizationが
+action/payload bindingへ結び付きます。commit応答消失、CAS失敗、読戻し不一致では
+transportを呼びません。状態・消費・専有attemptを解放、リセット、再試行しません。
+
+最後の所有権読出し、governance再構築、intent書込み・読戻し、transport準備に共通の
+UTC/monotonic 1秒上限を適用します。material受渡しcallbackでその上限、時計の健全性、
+authorizationの有効区間、元のcredential descriptorの有効期限・経過時間を再検証します。
+callbackは1回限りです。transport呼出し全体のtimeoutは5秒です。成功・失敗・キャンセルで
+material参照をcloseしますが、Pythonメモリの消去は保証しません。
+
+`SandboxDispatchTransport`は信頼されたexecutor設定から注入するインターフェースであり、
+実HTTPS adapterではありません。唯一の送信の直前にcallbackを呼び、canonical payloadと
+元のkeyを保持し、TLS検証とredirect・proxy・retry無効化を実装する必要があります。
+不正な実装がmaterialを保持したり期限後に送信することを、このインターフェースだけで
+防いだとは主張しません。外部作用を有効にする前に、具体的transportのレビューと実時計の
+送信試験が必須です。デフォルトtransportやAPI routeは追加していません。
+
+transport応答を権限や外部作用の証拠として解釈しません。返却する
+`SandboxDispatchObservation`は常に`UNKNOWN`で、見かけ上のtransport成功でも永続状態は
+`EFFECT_UNKNOWN`のままです。このローカル結果はBindReceipt・Outcome・外部acknowledgement
+ではありません。キャンセルでは秘匿済み例外を返し、永続的な不確実状態を保持します。
+復旧処理は元のidempotency keyで照合し、盲目的に再送してはいけません。
+
+この工程は合成materialと非通信transportを実native verifierで試験するものです。
+実HTTPS送信、PostgreSQLの遅延、sandbox側の永続性、正式Receipt/Outcome連携、reconciliationは
+未検証・未完了です。これらは後続の必須工程であり、この試験で保証されたものではありません。
+外部へ接続するには引き続き第9節の配備条件の確定が必要です。

--- a/veritas_os/policy/sandbox_bind_execution.py
+++ b/veritas_os/policy/sandbox_bind_execution.py
@@ -1,0 +1,208 @@
+"""Owning native v2 dispatch seam; no concrete network adapter is installed.
+
+Only executor-configured transports may implement this contract. They must use
+TLS, the exact request, no redirects/retries and call take_material immediately
+before their sole send. Tests are inert; this module does not certify a transport
+or enable a deployment. Durable uncertainty precedes possible external effect.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from typing import Any, Callable, Literal, Protocol
+
+from pydantic import BaseModel, ConfigDict, SecretBytes
+
+from veritas_os.policy.bind_effect_reconciliation import (
+    EffectExecutionState, EffectStateRecord, InMemoryAtomicEffectStateStore,
+    PostgresAtomicEffectStateStore,
+)
+from veritas_os.policy.live_adapter_bind_authorization_codec import _timestamp
+from veritas_os.policy.live_adapter_bind_authorization_consumption_store import (
+    InMemoryAtomicAuthorizationConsumptionStore,
+    PostgresAtomicAuthorizationConsumptionStore,
+)
+from veritas_os.policy.live_adapter_bind_authorization_contracts import (
+    BindAuthorizationTrustInputs, RealBindAuthorizationGovernanceInputs,
+)
+from veritas_os.policy.native_bind_authorization import NativeAuthorizationSourceInputs
+from veritas_os.policy.sandbox_action_binding import SandboxDeployment
+from veritas_os.policy.sandbox_credential_resolution import (
+    SandboxCredentialProvider, _recheck_owned, _validate_metadata,
+    prepare_and_resolve_sandbox_credential,
+)
+from veritas_os.policy.sandbox_pre_effect import (
+    SandboxClockReading, SandboxCurrentInputs, _clock, _window,
+)
+from veritas_os.security.hash import sha256_of_canonical_json
+
+REQUEST_TIMEOUT_SECONDS = 5
+
+
+class SandboxBindExecutionError(ValueError):
+    """Sanitized failure; consumption and attempt are never released."""
+
+
+class SandboxDispatchRequest(BaseModel):
+    """Exact non-secret request, reconstructed inside the owning call."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+    method: Literal["POST"] = "POST"
+    endpoint_url: str
+    payload_json: str
+    payload_digest: str
+    idempotency_key: str
+    attempt_id: str
+
+
+class SandboxDispatchTransport(Protocol):
+    """Trusted executor seam, not a caller-selectable generic adapter.
+
+The implementation must authenticate the pinned TLS identity, disable redirects,
+proxies and retries, bound response size, and never log secrets or exceptions.
+It must call take_material once, immediately before sending the exact request,
+and stop on callback failure/cancellation. It must not keep the returned material.
+Its return is deliberately ignored: acknowledgement is NOT confirmed effect.
+A concrete implementation and its timing/TLS tests are a deployment prerequisite.
+"""
+
+    async def send_once(
+        self, request: SandboxDispatchRequest, *, take_material: Callable[[], SecretBytes],
+    ) -> None:
+        ...
+
+
+class SandboxDispatchObservation(BaseModel):
+    """Non-secret local observation, not a BindReceipt or consequence proof."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+    attempt_id: str
+    authorization_id: str
+    consumption_id: str
+    dispatch_intent_hash: str
+    payload_digest: str
+    idempotency_key: str
+    state: Literal["UNKNOWN"] = "UNKNOWN"
+    reason_code: Literal["TRANSPORT_RETURNED_UNVERIFIED", "TRANSPORT_FAILED_OR_UNKNOWN"]
+
+
+async def execute_sandbox_bind(
+    authorization: Any, payload_json: str, *, deployment: SandboxDeployment,
+    issuance_source_inputs: NativeAuthorizationSourceInputs,
+    governance_inputs: RealBindAuthorizationGovernanceInputs,
+    trust_inputs: BindAuthorizationTrustInputs,
+    consumption_store: PostgresAtomicAuthorizationConsumptionStore | InMemoryAtomicAuthorizationConsumptionStore,
+    effect_store: PostgresAtomicEffectStateStore | InMemoryAtomicEffectStateStore,
+    trusted_clock: Callable[[], SandboxClockReading],
+    load_current_inputs: Callable[[datetime], SandboxCurrentInputs],
+    provider: SandboxCredentialProvider,
+    transport: SandboxDispatchTransport,
+    allow_in_memory_for_testing: bool = False,
+) -> SandboxDispatchObservation:
+    """Own preparation/resolution, persist possible dispatch, then send at most once.
+
+Never accept a caller's resolved credential, prepared result or verified flag.
+The existing permanent claim rejects all repeat calls, including after crashes.
+CAS acknowledgement loss prevents transport entry; durable EFFECT_UNKNOWN is
+never upgraded from an HTTP response. Reconciliation/receipts remain separate.
+"""
+    resolved = None
+    cancelled = False
+    try:
+        if transport is None:
+            raise SandboxBindExecutionError("SBE_TRANSPORT_REQUIRED")
+        resolved = await prepare_and_resolve_sandbox_credential(
+            authorization, payload_json, deployment=deployment,
+            issuance_source_inputs=issuance_source_inputs,
+            governance_inputs=governance_inputs, trust_inputs=trust_inputs,
+            consumption_store=consumption_store, effect_store=effect_store,
+            trusted_clock=trusted_clock, load_current_inputs=load_current_inputs,
+            provider=provider, allow_in_memory_for_testing=allow_in_memory_for_testing,
+        )
+        # Capture before the ownership read and final reconstruction. Storage,
+        # reconstruction, CAS and transport setup all share this one-second cap.
+        started = trusted_clock()
+        _clock(started)
+        prepared = await _recheck_owned(
+            resolved.preparation, payload_json=payload_json, deployment=deployment,
+            effect_store=effect_store, trusted_clock=trusted_clock,
+            load_current_inputs=load_current_inputs,
+        )
+        request = SandboxDispatchRequest(
+            endpoint_url=deployment.endpoint_url,
+            payload_json=prepared.binding.binding.payload_json,
+            payload_digest=prepared.binding.binding.payload_digest,
+            idempotency_key=prepared.binding.idempotency_key,
+            attempt_id=prepared.attempt.operation_id,
+        )
+
+        def check_send_window() -> None:
+            now = trusted_clock()
+            _window(now, prepared.authorization)
+            if not (
+                0 <= (now.now - started.now).total_seconds() <= 1
+                and 0 <= now.monotonic_seconds - started.monotonic_seconds <= 1
+                and now.now >= prepared.clock.now
+                and now.monotonic_seconds >= prepared.clock.monotonic_seconds
+            ):
+                raise SandboxBindExecutionError("SBE_SEND_WINDOW_EXCEEDED")
+            _validate_metadata(
+                resolved._metadata, resolved._request, resolved._descriptor_started, now,
+            )
+
+        check_send_window()
+        values = prepared.attempt.model_dump(mode="json")
+        values.update(
+            state=EffectExecutionState.EFFECT_UNKNOWN.value,
+            revision=prepared.attempt.revision + 1,
+            updated_at=_timestamp(prepared.clock.now),
+            reason_code="SANDBOX_DISPATCH_INTENT_PERSISTED_EFFECT_UNCONFIRMED",
+        )
+        values.pop("record_hash")
+        intent = EffectStateRecord(**values, record_hash=sha256_of_canonical_json(values))
+        committed = await effect_store.transition(
+            operation_id=intent.operation_id,
+            expected_state=EffectExecutionState.IN_FLIGHT, record=intent,
+        )
+        if committed is not True or await effect_store.get(intent.operation_id) != intent:
+            raise SandboxBindExecutionError("SBE_DISPATCH_INTENT_NOT_CONFIRMED")
+        check_send_window()
+        taken = False
+
+        def take_material() -> SecretBytes:
+            nonlocal taken
+            if taken:
+                raise SandboxBindExecutionError("SBE_MATERIAL_ALREADY_TAKEN")
+            # A failing first callback cannot be retried after time/state changes.
+            taken = True
+            check_send_window()
+            return resolved.material
+
+        reason = "TRANSPORT_FAILED_OR_UNKNOWN"
+        try:
+            async with asyncio.timeout(REQUEST_TIMEOUT_SECONDS):
+                await transport.send_once(request, take_material=take_material)
+            if taken:
+                reason = "TRANSPORT_RETURNED_UNVERIFIED"
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            # No remote body, header or exception is returned or persisted.
+            pass
+        return SandboxDispatchObservation(
+            attempt_id=intent.operation_id, authorization_id=intent.authorization_id,
+            consumption_id=intent.consumption_id, dispatch_intent_hash=intent.record_hash,
+            payload_digest=request.payload_digest, idempotency_key=intent.idempotency_key,
+            reason_code=reason,
+        )
+    except asyncio.CancelledError:
+        cancelled = True
+    except Exception:
+        pass
+    finally:
+        if resolved is not None:
+            resolved.close()
+    if cancelled:
+        raise asyncio.CancelledError()
+    raise SandboxBindExecutionError("SBE_FAILED_ATTEMPT_NOT_RELEASED")

--- a/veritas_os/policy/sandbox_credential_resolution.py
+++ b/veritas_os/policy/sandbox_credential_resolution.py
@@ -112,14 +112,20 @@ class SandboxResolvedCredential:
     A future sender must recheck ownership/governance after this function returns.
     """
 
-    __slots__ = ("preparation", "metadata_digest", "_material")
+    __slots__ = ("preparation", "metadata_digest", "_material", "_metadata", "_descriptor_started", "_request")
 
     def __init__(
         self, preparation: SandboxPreparedAttempt, metadata_digest: str, material: SecretBytes,
+        *, metadata: SandboxCredentialMetadata | None = None,
+        descriptor_started: SandboxClockReading | None = None,
+        request: SandboxCredentialRequest | None = None,
     ) -> None:
         self.preparation = preparation
         self.metadata_digest = metadata_digest
         self._material: SecretBytes | None = material
+        self._metadata = metadata
+        self._descriptor_started = descriptor_started
+        self._request = request
 
     def __repr__(self) -> str:
         return "SandboxResolvedCredential(material=<redacted>)"
@@ -137,6 +143,7 @@ class SandboxResolvedCredential:
     def close(self) -> None:
         """Drop this object's material reference without claiming memory erasure."""
         self._material = None
+        self._metadata = self._descriptor_started = self._request = None
 
 
 def _validate_metadata(
@@ -264,7 +271,10 @@ async def prepare_and_resolve_sandbox_credential(
             trusted_clock=trusted_clock, load_current_inputs=load_current_inputs,
         )
         _validate_metadata(actual, request, descriptor_started, prepared.clock)
-        return SandboxResolvedCredential(prepared, digest, response.material)
+        return SandboxResolvedCredential(
+            prepared, digest, response.material, metadata=actual,
+            descriptor_started=descriptor_started, request=request,
+        )
     except asyncio.CancelledError:
         cancelled = True
     except Exception:

--- a/veritas_os/tests/fixtures/sandbox_dispatch_observation.json
+++ b/veritas_os/tests/fixtures/sandbox_dispatch_observation.json
@@ -1,0 +1,10 @@
+{
+  "attempt_id": "synthetic-attempt",
+  "authorization_id": "synthetic-authorization",
+  "consumption_id": "synthetic-consumption",
+  "dispatch_intent_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "payload_digest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "idempotency_key": "synthetic-original-key",
+  "state": "UNKNOWN",
+  "reason_code": "TRANSPORT_RETURNED_UNVERIFIED"
+}

--- a/veritas_os/tests/test_sandbox_bind_execution.py
+++ b/veritas_os/tests/test_sandbox_bind_execution.py
@@ -1,0 +1,205 @@
+"""Inert dispatch seam with real native verification; never accesses a network."""
+
+import asyncio
+from dataclasses import replace
+import json
+import traceback
+
+import pytest
+
+from veritas_os.policy import sandbox_bind_execution as module
+from veritas_os.tests.test_sandbox_action_binding import PAYLOAD
+from veritas_os.tests.test_sandbox_pre_effect import (
+    issued as issued_fixture, prepared_inputs as prepared_inputs_fixture, _args,
+)
+from veritas_os.tests.test_sandbox_credential_resolution_integration import Provider
+from veritas_os.tests.test_sandbox_credential_resolution import TOKEN
+from veritas_os.tests.test_native_bind_authorization_consumption import _Revocation
+
+pytestmark = pytest.mark.slow
+issued = issued_fixture
+prepared_inputs = prepared_inputs_fixture
+
+
+class Transport:
+    """Records only a synthetic send, after asserting durable intent."""
+
+    def __init__(self, args, mode="valid"):
+        self.args = args
+        self.mode = mode
+        self.calls = []
+        self.sent = []
+
+    async def send_once(self, request, *, take_material):
+        self.calls.append(request)
+        self.take_material = take_material
+        row = await self.args["effect_store"].get(request.attempt_id)
+        assert row.state == module.EffectExecutionState.EFFECT_UNKNOWN
+        assert row.reason_code == "SANDBOX_DISPATCH_INTENT_PERSISTED_EFFECT_UNCONFIRMED"
+        if self.mode == "no_take":
+            return
+        if self.mode == "late":
+            clock = self.args["trusted_clock"]()
+            self.args["clock_cell"][0] = replace(clock, monotonic_seconds=clock.monotonic_seconds + 1.01)
+        assert take_material().get_secret_value() == TOKEN
+        self.sent.append(request)
+        if self.mode == "twice":
+            take_material()
+        if self.mode == "error":
+            raise RuntimeError(TOKEN.decode())
+        if self.mode == "cancel":
+            raise asyncio.CancelledError(TOKEN.decode())
+        if self.mode == "timeout":
+            await asyncio.Event().wait()
+
+
+async def run(artifact, args, provider, transport):
+    return await module.execute_sandbox_bind(
+        artifact, json.dumps(PAYLOAD), provider=provider, transport=transport,
+        **{key: value for key, value in args.items() if key != "clock_cell"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_exact_request_is_sent_once_but_never_claims_success(prepared_inputs):
+    artifact, args = await _args(prepared_inputs)
+    provider, transport = Provider(prepared_inputs, args), Transport(args)
+    result = await run(artifact, args, provider, transport)
+    assert result.state == "UNKNOWN"
+    assert result.reason_code == "TRANSPORT_RETURNED_UNVERIFIED"
+    assert len(transport.sent) == 1
+    request = transport.sent[0]
+    assert request.idempotency_key == artifact.idempotency_key
+    assert request.endpoint_url == args["deployment"].endpoint_url
+    assert json.loads(request.payload_json) == PAYLOAD
+    assert module.SandboxDispatchRequest.model_validate_json(request.model_dump_json()) == request
+    assert module.SandboxDispatchObservation.model_validate_json(result.model_dump_json()) == result
+    assert TOKEN.decode() not in repr(result) + result.model_dump_json() + request.model_dump_json()
+    with pytest.raises(module.SandboxBindExecutionError):
+        transport.take_material()
+    with pytest.raises(module.SandboxBindExecutionError):
+        await run(artifact, args, provider, transport)
+    assert len(transport.sent) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["error", "twice", "no_take", "timeout", "late"])
+async def test_transport_ambiguity_remains_unknown_without_resend(prepared_inputs, mode, monkeypatch, caplog):
+    artifact, args = await _args(prepared_inputs)
+    cell = [prepared_inputs[4]]
+    args.update(trusted_clock=lambda: cell[0], clock_cell=cell)
+    provider, transport = Provider(prepared_inputs, args), Transport(args, mode)
+    if mode == "timeout":
+        monkeypatch.setattr(module, "REQUEST_TIMEOUT_SECONDS", 0.01)
+    result = await run(artifact, args, provider, transport)
+    assert result.reason_code == "TRANSPORT_FAILED_OR_UNKNOWN"
+    assert result.state == "UNKNOWN"
+    assert len(transport.calls) == 1
+    assert len(transport.sent) == (0 if mode in {"no_take", "late"} else 1)
+    assert TOKEN.decode() not in result.model_dump_json() + caplog.text
+    row = await args["effect_store"].get(result.attempt_id)
+    assert row.state == module.EffectExecutionState.EFFECT_UNKNOWN
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["lost_ack", "cas_false", "readback_changed", "slow_commit", "clock_rollback"])
+async def test_intent_persistence_failure_never_enters_transport(prepared_inputs, mode, monkeypatch):
+    artifact, args = await _args(prepared_inputs)
+    cell = [prepared_inputs[4]]
+    args["trusted_clock"] = lambda: cell[0]
+    provider, transport = Provider(prepared_inputs, args), Transport(args)
+    store = args["effect_store"]
+    transition = store.transition
+
+    async def commit(**kwargs):
+        if mode == "cas_false":
+            return False
+        result = await transition(**kwargs)
+        if mode == "lost_ack":
+            raise RuntimeError(TOKEN.decode())
+        if mode == "readback_changed":
+            row = kwargs["record"]
+            store._records[row.operation_id] = row.model_copy(update={"reason_code": "changed"})
+        if mode in {"slow_commit", "clock_rollback"}:
+            delta = 1.01 if mode == "slow_commit" else -0.01
+            cell[0] = replace(cell[0], monotonic_seconds=cell[0].monotonic_seconds + delta)
+        return result
+
+    monkeypatch.setattr(store, "transition", commit)
+    with pytest.raises(module.SandboxBindExecutionError) as caught:
+        await run(artifact, args, provider, transport)
+    assert caught.value.__context__ is None
+    assert TOKEN.decode() not in "".join(traceback.format_exception(caught.value))
+    assert not transport.calls
+    assert await args["consumption_store"].get(artifact.authorization_id) == prepared_inputs[2]
+    assert await store.get(prepared_inputs[2].consumption_id) is not None
+
+
+@pytest.mark.asyncio
+async def test_cancel_after_possible_send_retains_unknown_and_sanitizes(prepared_inputs):
+    artifact, args = await _args(prepared_inputs)
+    transport = Transport(args, "cancel")
+    with pytest.raises(asyncio.CancelledError) as caught:
+        await run(artifact, args, Provider(prepared_inputs, args), transport)
+    assert not caught.value.args and caught.value.__context__ is None
+    row = await args["effect_store"].get(prepared_inputs[2].consumption_id)
+    assert row.state == module.EffectExecutionState.EFFECT_UNKNOWN
+    with pytest.raises(ValueError):
+        transport.take_material()
+
+
+@pytest.mark.asyncio
+async def test_competing_executors_only_one_can_dispatch(prepared_inputs):
+    artifact, args = await _args(prepared_inputs)
+    provider, transport = Provider(prepared_inputs, args), Transport(args)
+    results = await asyncio.gather(
+        run(artifact, args, provider, transport), run(artifact, args, provider, transport),
+        return_exceptions=True,
+    )
+    assert sum(isinstance(x, module.SandboxDispatchObservation) for x in results) == 1
+    assert sum(isinstance(x, module.SandboxBindExecutionError) for x in results) == 1
+    assert len(transport.sent) == 1
+    assert len(provider.calls) == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["revoked", "contract", "endpoint", "scope"])
+async def test_final_recheck_drift_stops_before_intent(prepared_inputs, mode):
+    artifact, args = await _args(prepared_inputs)
+    original = args["load_current_inputs"]
+    count = 0
+
+    def load(now):
+        nonlocal count
+        count += 1
+        current = original(now)
+        if count == 4:
+            if mode == "revoked":
+                current = replace(current, governance=replace(current.governance,
+                    authority_revocation_checker=_Revocation(current.governance, "revoked")))
+            elif mode == "contract":
+                contract = replace(current.governance.action_contract, human_approval_rules={"required": True})
+                current = replace(current, governance=replace(current.governance, action_contract=contract))
+            elif mode == "endpoint":
+                current = replace(current, source=replace(current.source, current_endpoint={}))
+            else:
+                current = replace(current, source=replace(current.source, required_credential_scope="admin"))
+        return current
+
+    args["load_current_inputs"] = load
+    provider, transport = Provider(prepared_inputs, args), Transport(args)
+    with pytest.raises(module.SandboxBindExecutionError):
+        await run(artifact, args, provider, transport)
+    assert len(provider.calls) == 2 and count == 4
+    assert not transport.calls
+    row = await args["effect_store"].get(prepared_inputs[2].consumption_id)
+    assert row.state == module.EffectExecutionState.IN_FLIGHT
+
+
+@pytest.mark.asyncio
+async def test_missing_transport_stops_before_claim_or_provider(prepared_inputs):
+    artifact, args = await _args(prepared_inputs)
+    provider = Provider(prepared_inputs, args)
+    with pytest.raises(module.SandboxBindExecutionError):
+        await run(artifact, args, provider, None)
+    assert not provider.calls and not args["effect_store"]._records

--- a/veritas_os/tests/test_sandbox_dispatch_contract.py
+++ b/veritas_os/tests/test_sandbox_dispatch_contract.py
@@ -1,0 +1,29 @@
+"""Committed synthetic observation sample cannot assert confirmed success."""
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from veritas_os.policy.sandbox_bind_execution import SandboxDispatchObservation
+
+
+def sample():
+    return json.loads(
+        (Path(__file__).parent / "fixtures" / "sandbox_dispatch_observation.json").read_text(),
+    )
+
+
+def test_committed_dispatch_observation_roundtrips_without_field_loss():
+    body = sample()
+    assert SandboxDispatchObservation.model_validate(body).model_dump(mode="json") == body
+
+
+@pytest.mark.parametrize("field,value", [
+    ("state", "CONFIRMED_EFFECT"), ("state", "SUCCESS"),
+    ("reason_code", "HTTP_200_PROVES_EFFECT"), ("token", "synthetic-secret"),
+])
+def test_observation_rejects_success_claims_and_secret_fields(field, value):
+    with pytest.raises(ValidationError):
+        SandboxDispatchObservation.model_validate({**sample(), field: value})


### PR DESCRIPTION
## Purpose

Add an owning native v2 sandbox dispatch **seam**, following merged #2203. This is not completed native HTTPS Bind execution and does not enable a deployment.

## Changes

- Own preparation and credential resolution in the same call; never accept a caller's prepared result, credential or verified flag as execution permission.
- Repeat independent governance and attempt ownership checks before dispatch intent.
- Persist EFFECT_UNKNOWN with SANDBOX_DISPATCH_INTENT_PERSISTED_EFFECT_UNCONFIRMED through the existing effect-state CAS; require successful commit acknowledgement and exact readback before transport entry.
- Preserve the exact canonical payload, destination and original authorization idempotency key.
- Share a one-second UTC/monotonic budget across final ownership read, recheck, persistence/readback and transport preparation. Revalidate clock, authorization and credential metadata at one-use material handoff.
- Bound the transport call to five seconds. Never release consumption/attempt or retry after failure, timeout, cancellation or ambiguity.
- Return only an UNKNOWN local observation; apparent transport success is not confirmed effect.
- Add inert transport adversarial tests, sample roundtrip checks and EN/JA specification notes.

## Validation

On the tested local tree:
- Related suite: **182 passed**, five existing NumPy/jsonschema warnings, 357.68 seconds.
- Contract/sample suite: **5 passed**.
- New dispatch module: **100% statement coverage (88/88)**.
- Changed dispatch + credential modules: **99.07% (213/215)**; 90% gate passed.
- Ruff, bilingual docs, responsibility boundaries, core complexity, HTTP upload/subprocess checks and diff checks passed.
- GitHub full CI has not yet been verified for this head.

Published head: `e3a72152671a1e0e6444d1b9da0f8615554b549f`.
Exact tested/published tree: `80a3b9450d2e85cdfc60fb65966c4f4a90e4d496`.
Publication via the connected GitHub Git Data API produces a different commit SHA from local `8e19c3a8b8440f98c20684faf969042c5cbdb1ad`; complete tree equality was verified.

## Security and explicit limitations

- SandboxDispatchTransport is a trusted executor-injected interface, **not a concrete HTTPS adapter**. Tests send no network requests and use synthetic credentials and explicit in-memory stores.
- A concrete adapter must enforce TLS identity, exact request binding, no redirects/proxies/retries, response bounds and callback immediately before its sole send. A dishonest implementation could retain credentials or send after its deadline; this seam alone cannot prevent or certify that.
- No default transport, API route, infrastructure deployment or real credential provider is installed.
- No new Human Approval Receipt or authorization is created.
- Real HTTPS delivery, real PostgreSQL dispatch timing, sandbox-side durability/deduplication, formal BindReceipt/Outcome, reconciliation and crash recovery remain incomplete.
- The new observation is not a Receipt or independent external acknowledgement.
- Deployment trust inputs and real-clock send validation remain mandatory before external connection.

Draft for human maintainer review. **Do not merge automatically.**
