### PR TITLE
feat: add isolated sandbox event service with atomic deduplication

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -222,6 +222,10 @@ pnpm --filter frontend e2e   # Playwright E2E
 - [ ] No wildcard CORS origins with credentials
 - [ ] TrustLog entries go through encrypt pipeline
 - [ ] New endpoints have `X-API-Key` authentication
+- Exception approved for the independent sandbox event service only:
+  `create_sandbox_event_service` uses distinct, expiring Bearer writer/reader
+  tokens. It must not be mounted into the main VERITAS API. Missing authentication
+  configuration fails closed; no external deployment is implied.
 - [ ] Governance endpoints have RBAC guard
 - [ ] Web search results pass toxicity filter
 - [ ] Schema/config changes include sample artifact updates and roundtrip drift tests.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -835,6 +835,7 @@ jobs:
             veritas_os/tests/test_storage_postgresql_memory.py \
             veritas_os/tests/test_storage_postgresql_trustlog.py \
             veritas_os/tests/test_pg_trustlog_contention.py \
+            veritas_os/tests/test_pg_sandbox_event_contention.py \
             veritas_os/tests/test_storage_factory.py \
             veritas_os/tests/test_storage_base.py \
             veritas_os/tests/test_storage_db.py \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,14 @@ Do not paste:
 - unpublished internal strategy
 - non-public security details
 
+## Independent Sandbox Authentication Exception
+
+The user-approved independent sandbox event service uses Bearer authentication
+with distinct expiring registration and read-only tokens. This exception applies
+only to `create_sandbox_event_service`; never mount it into the existing VERITAS
+API or change that API's X-API-Key authentication. Missing configuration rejects
+requests. Runtime implementation does not authorize deployment or live credentials.
+
 ## References
 
 - `CLAUDE.md` — project architecture, safety rules, testing, and quality gates

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,6 +199,10 @@ pnpm --filter frontend e2e   # Playwright E2E
 - [ ] No wildcard CORS origins with credentials
 - [ ] TrustLog entries go through encrypt pipeline
 - [ ] New endpoints have `X-API-Key` authentication
+- Exception approved for the independent sandbox event service only:
+  `create_sandbox_event_service` uses distinct, expiring Bearer writer/reader
+  tokens. It must not be mounted into the main VERITAS API. Missing authentication
+  configuration fails closed; no external deployment is implied.
 - [ ] Governance endpoints have RBAC guard
 - [ ] Web search results pass toxicity filter
 

--- a/docs/en/architecture/native-v2-sandbox-event-spec-v1.md
+++ b/docs/en/architecture/native-v2-sandbox-event-spec-v1.md
@@ -413,3 +413,53 @@ native verifiers. It does not establish real HTTPS delivery, PostgreSQL timing,
 sandbox durability, formal Receipt/Outcome integration or reconciliation. Those
 remain required steps, not guarantees implied by these tests. The deployment
 decisions in section 9 are still required before any external connection.
+
+## 17. Independent sandbox event service
+
+`create_sandbox_event_service` constructs a separate ASGI application; it is not
+mounted into the main API and there is no default application/listener. As the
+user-approved narrow exception recorded in the repository instructions, this
+service uses Bearer authentication while existing VERITAS APIs retain X-API-Key.
+An operator supplies two distinct, expiring tokens through trusted configuration:
+writer (registration and lookup) and reader (lookup only). No token is generated,
+resolved from a provider, read from an environment fallback, or recorded in an
+operation. Missing/invalid configuration rejects startup; unauthorized or expired
+requests stop before body processing and database access. Rotation currently
+requires rebuilding the application with new configuration. Live provisioning,
+revocation distribution, TLS termination and network policy remain deployment gates.
+
+The operator must supply a dedicated psycopg async pool and install
+`veritas_os/policy/sandbox_events.sql` in that sandbox database. This is deliberately
+not a main-API migration. A single immutable row represents both event and operation;
+primary/unique constraints cover operation ID, original key and event ID. Runtime
+writer database privileges should be SELECT/INSERT only; independent reconciler
+credentials should permit only read access. Lookup transactions are read-only.
+
+`POST /v1/events` accepts the fixed JSON payload and one `Idempotency-Key` header.
+Duplicate JSON keys, extra fields, invalid UUIDs, invalid UTF-8, NUL, oversized bodies
+or messages are rejected before persistence. Idempotency keys use 1–256 ASCII
+letters, digits, dot, underscore, colon or hyphen. Within one READ COMMITTED
+transaction, registration uses INSERT ON CONFLICT DO NOTHING followed by a fresh
+statement reading the original key. Same key and exact payload returns the original
+operation (200); a new committed row returns 201. Same key/different payload or
+same event ID/different key returns 409, with no second event. Success is returned
+only after commit/context exit; synchronous_commit is enabled for registration.
+Statement duration is bounded to four seconds; timeout or uncertain commit returns
+503 with no automatic retry or success inference. No TTL/delete/reset API exists.
+
+Lookup uses `GET /v1/operations/{operation_id}` or
+`GET /v1/operations?idempotency_key=<original-key>`. Both require authentication
+and return operation ID, original key, event ID, canonical payload digest and
+`PERSISTED`, without the message or credentials. All responses use no-store.
+A missing row returns 404, explicitly not proof of no effect; DB lookup failure
+returns 503. A lost POST response can be investigated by the original key.
+The service's PERSISTED observation is not a VERITAS confirmed Outcome/BindReceipt.
+Independent reconciliation and prevention of replacement authorizations while
+the earlier outcome is unknown remain sender-side work.
+
+ASGI tests use synthetic tokens and a SQL double. Separate real PostgreSQL tests
+exercise concurrent identical/conflicting requests, rollback and commit-response
+loss in disposable isolated schemas and are included in the existing PostgreSQL
+CI job. Local mocks are not claimed as durability proof. HTTPS transport, actual
+deployment/provider configuration and native Receipt/Outcome/reconciliation are
+still not connected by this service implementation.

--- a/docs/ja/architecture/native-v2-sandbox-event-spec-v1.md
+++ b/docs/ja/architecture/native-v2-sandbox-event-spec-v1.md
@@ -341,3 +341,42 @@ transport応答を権限や外部作用の証拠として解釈しません。�
 実HTTPS送信、PostgreSQLの遅延、sandbox側の永続性、正式Receipt/Outcome連携、reconciliationは
 未検証・未完了です。これらは後続の必須工程であり、この試験で保証されたものではありません。
 外部へ接続するには引き続き第9節の配備条件の確定が必要です。
+
+## 17. 独立したsandbox eventサービス
+
+`create_sandbox_event_service`は独立ASGIアプリを作成します。main APIへの組込みや
+デフォルトapp・listenerはありません。ユーザーが承認し規約に明記した限定例外として、
+このサービスはBearer認証、既存VERITAS APIは引き続きX-API-Key認証を使用します。
+operatorが信頼された設定から、有効期限付きの別々のwriter（登録・参照）とreader
+（参照のみ）tokenを渡します。tokenの生成、providerからの解決、環境変数へのfallback、
+operationへの記録は行いません。設定欠落・不正は起動時に拒否し、未認証・期限切れの
+リクエストはbody処理・DBアクセス前に拒否します。現在のrotationは新設定でappを再作成する
+方式です。実credentialの配布・失効反映、TLS終端、ネットワーク制御は配備前の必須条件です。
+
+operatorは専用psycopg async poolを渡し、sandbox専用DBに
+`veritas_os/policy/sandbox_events.sql`を適用します。main API用migrationには追加しません。
+同じ不変行がeventとoperationを表し、operation ID・元のkey・event IDに一意制約を設けます。
+実行用DB principalはSELECT/INSERTのみ、独立reconcilerは読取りのみとしてください。
+lookupのtransactionはread-onlyです。
+
+`POST /v1/events`は固定JSON payloadと単一`Idempotency-Key`ヘッダーを受け取ります。
+JSONキー重複、余分なfield、不正UUID・UTF-8、NUL、body・messageの上限超過は保存前に拒否します。
+keyはASCII英数字・ピリオド・アンダースコア・コロン・ハイフンの1〜256文字です。
+READ COMMITTED transaction内でINSERT ON CONFLICT DO NOTHINGを実行後、別のSQL文で
+元のkeyを読みます。同じkey・同じpayloadは元のoperationを200で返し、新規commitは201です。
+同じkey・異なるpayload、または同じevent ID・異なるkeyは409となり、2件目を保存しません。
+commitと接続contextの終了後にだけ成功を返し、登録ではsynchronous_commitを有効にします。
+SQL実行は4秒に制限し、timeoutやcommit不明は503です。自動再試行・成功推測は行いません。
+TTL・削除・リセットAPIもありません。
+
+参照は`GET /v1/operations/{operation_id}`または
+`GET /v1/operations?idempotency_key=<元のkey>`です。認証を必須とし、operation ID・元のkey・
+event ID・canonical payload digest・`PERSISTED`を返します。message・credentialは返しません。
+全応答をno-storeとします。未発見の404は「作用なしの証拠」ではなく、DB障害は503です。
+POST応答が失われても元のkeyで調査できます。サービスのPERSISTED観測はVERITASの確定Outcomeや
+BindReceiptではありません。独立照合と、結果不明中の代替authorization抑止は送信側の後続課題です。
+
+ASGI試験は合成tokenとSQL doubleを使用します。別の実PostgreSQL試験では、隔離した一時schemaで
+同一要求・競合要求の同時実行、rollback、commit応答消失を検証し、既存PostgreSQL CIへ追加します。
+ローカルmockを永続性の証明とは扱いません。HTTPS transport、実配備・provider設定、native
+Receipt/Outcome/reconciliationは、このサービス実装ではまだ接続していません。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,7 @@ veritas_os = [
   "prompts/*.txt",
   "sample_data/memory/*.jsonl",
   "storage/migrations/sql/*.sql",
+  "policy/sandbox_events.sql",
   "templates/**/*.txt",
 ]
 

--- a/veritas_os/policy/sandbox_event_service.py
+++ b/veritas_os/policy/sandbox_event_service.py
@@ -1,0 +1,139 @@
+"""Separate sandbox ASGI factory; no default app, credentials or deployment.
+
+Bearer-only exception applies solely to this service. The existing VERITAS API
+keeps X-API-Key authentication. Operator-provisioned writer and reader tokens
+are distinct, expiring and scoped here; no token is issued or resolved here.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import hmac
+import re
+from typing import Callable
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, ConfigDict, Field, SecretStr
+
+from veritas_os.policy.sandbox_event_store import (
+    PostgresSandboxEventStore, SandboxEventConflict, SandboxEventStoreError,
+    parse_event, validate_key, validate_uuid,
+)
+
+
+class SandboxServiceTokens(BaseModel):
+    """Trusted service configuration; never populate this from request input."""
+
+    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
+    writer: SecretStr = Field(repr=False)
+    reader: SecretStr = Field(repr=False)
+    valid_until: datetime
+
+
+def create_sandbox_event_service(
+    *, store: PostgresSandboxEventStore, tokens: SandboxServiceTokens,
+    clock: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
+) -> FastAPI:
+    """Create an isolated, authenticated service; mounting into main is forbidden.
+
+An operator must provide dedicated storage and tokens from reviewed secret
+configuration. No environment fallback, token generator or public listener is
+installed. Writer may register and lookup; reader may only lookup. Authentication
+is checked before reading a body or touching the database. HTTP success is an
+external observation for VERITAS, never independent consequence proof.
+"""
+    if type(store) is not PostgresSandboxEventStore or type(tokens) is not SandboxServiceTokens:
+        raise ValueError("SSE_CONFIG_REQUIRED")
+    tokens = SandboxServiceTokens.model_validate(tokens.model_dump())
+    values = (tokens.writer.get_secret_value(), tokens.reader.get_secret_value())
+    if (
+        any(len(x) > 4096 or not re.fullmatch(r"[A-Za-z0-9._~+/-]{32,4096}=*", x) for x in values)
+        or values[0] == values[1]
+        or tokens.valid_until.tzinfo is None
+        or tokens.valid_until.utcoffset() is None
+    ):
+        raise ValueError("SSE_CONFIG_INVALID")
+    app = FastAPI(docs_url=None, redoc_url=None, openapi_url=None)
+
+    def authenticate(request: Request, *, write: bool = False) -> None:
+        headers = request.headers.getlist("authorization")
+        allowed = False
+        try:
+            now = clock()
+            if len(headers) == 1 and headers[0].startswith("Bearer "):
+                token = headers[0][7:].encode("ascii")
+                writer = hmac.compare_digest(token, tokens.writer.get_secret_value().encode("ascii"))
+                reader = hmac.compare_digest(token, tokens.reader.get_secret_value().encode("ascii"))
+                allowed = now < tokens.valid_until and (writer or (reader and not write))
+        except Exception:
+            pass
+        if not allowed:
+            raise HTTPException(401, "SSE_UNAUTHORIZED", headers={"WWW-Authenticate": "Bearer"})
+
+    @app.middleware("http")
+    async def no_cache(request: Request, call_next: Callable) -> JSONResponse:
+        response = await call_next(request)
+        response.headers["Cache-Control"] = "no-store"
+        return response
+
+    @app.post("/v1/events")
+    async def register(request: Request) -> JSONResponse:
+        authenticate(request, write=True)
+        if request.headers.get("content-type", "").split(";")[0].lower() != "application/json":
+            raise HTTPException(415, "SSE_JSON_REQUIRED")
+        if request.headers.get("content-encoding", "identity") != "identity":
+            raise HTTPException(415, "SSE_ENCODING_UNSUPPORTED")
+        keys = request.headers.getlist("idempotency-key")
+        body = bytearray()
+        try:
+            if len(keys) != 1:
+                raise ValueError("key")
+            key = validate_key(keys[0])
+            async for chunk in request.stream():
+                if len(body) + len(chunk) > 4096:
+                    raise HTTPException(413, "SSE_BODY_TOO_LARGE")
+                body.extend(chunk)
+            parse_event(bytes(body))
+        except HTTPException:
+            raise
+        except (ValueError, TypeError, UnicodeError, RecursionError):
+            raise HTTPException(400, "SSE_INVALID_REQUEST") from None
+        try:
+            operation, created = await store.register(bytes(body), key)
+        except SandboxEventConflict:
+            raise HTTPException(409, "SSE_CONFLICT") from None
+        except SandboxEventStoreError:
+            raise HTTPException(503, "SSE_DATABASE_OUTCOME_UNKNOWN") from None
+        return JSONResponse(operation.model_dump(), status_code=201 if created else 200)
+
+    async def lookup(request: Request, operation_id: str | None) -> JSONResponse:
+        authenticate(request)
+        try:
+            if operation_id is not None:
+                validate_uuid(operation_id)
+                if request.query_params:
+                    raise ValueError("query")
+                result = await store.lookup(operation_id=operation_id)
+            else:
+                pairs = list(request.query_params.multi_items())
+                if len(pairs) != 1 or pairs[0][0] != "idempotency_key":
+                    raise ValueError("key")
+                result = await store.lookup(key=validate_key(pairs[0][1]))
+        except (ValueError, TypeError):
+            raise HTTPException(400, "SSE_INVALID_LOOKUP") from None
+        except SandboxEventStoreError:
+            raise HTTPException(503, "SSE_LOOKUP_UNAVAILABLE") from None
+        if result is None:
+            raise HTTPException(404, "SSE_NOT_FOUND_NOT_PROOF_OF_NO_EFFECT")
+        return JSONResponse(result.model_dump())
+
+    @app.get("/v1/operations")
+    async def lookup_by_key(request: Request) -> JSONResponse:
+        return await lookup(request, None)
+
+    @app.get("/v1/operations/{operation_id}")
+    async def lookup_by_id(request: Request, operation_id: str) -> JSONResponse:
+        return await lookup(request, operation_id)
+
+    return app

--- a/veritas_os/policy/sandbox_event_store.py
+++ b/veritas_os/policy/sandbox_event_store.py
@@ -125,18 +125,23 @@ The DDL is installed separately, never by serving a request.
         if (operation_id is None) == (key is None):
             raise ValueError("SSE_ONE_LOOKUP_REQUIRED")
         if operation_id is not None:
-            value, column = validate_uuid(operation_id), "operation_id"
+            value = validate_uuid(operation_id)
+            query = (
+                "SELECT operation_id, idempotency_key, event_id, payload_digest "
+                "FROM sandbox_events WHERE operation_id=%s"
+            )
         else:
-            value, column = validate_key(key), "idempotency_key"
+            value = validate_key(key)
+            query = (
+                "SELECT operation_id, idempotency_key, event_id, payload_digest "
+                "FROM sandbox_events WHERE idempotency_key=%s"
+            )
         try:
             async with self._pool.connection() as conn:
                 async with conn.transaction():
                     await conn.execute("SET TRANSACTION READ ONLY")
                     await conn.execute("SET LOCAL statement_timeout = '4000ms'")
-                    cur = await conn.execute(
-                        "SELECT operation_id, idempotency_key, event_id, payload_digest "
-                        f"FROM sandbox_events WHERE {column}=%s", (value,),
-                    )
+                    cur = await conn.execute(query, (value,))
                     row = await cur.fetchone()
                     result = None if row is None else _operation(row)
             return result

--- a/veritas_os/policy/sandbox_event_store.py
+++ b/veritas_os/policy/sandbox_event_store.py
@@ -1,0 +1,152 @@
+"""Dedicated sandbox event persistence; never use the VERITAS governance DB.
+
+One immutable row is both the synthetic event and its operation record. Unique
+constraints arbitrate races. Success is returned only after transaction commit.
+No delete, retry, upsert mutation or deduplication expiry is provided.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Literal
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from veritas_os.policy.sandbox_action_binding import _unique_object
+from veritas_os.security.hash import sha256_of_canonical_json
+
+
+class SandboxEventConflict(ValueError):
+    """The key or event ID already belongs to a different request."""
+
+
+class SandboxEventStoreError(RuntimeError):
+    """Database outcome is unknown; no automatic retry is authorized."""
+
+
+class SandboxEvent(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
+    event_id: str
+    message: str
+
+
+class SandboxOperation(BaseModel):
+    """Service observation only, not a VERITAS Receipt or confirmation."""
+
+    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
+    operation_id: str
+    idempotency_key: str
+    event_id: str
+    payload_digest: str = Field(pattern=r"^[0-9a-f]{64}$")
+    state: Literal["PERSISTED"] = "PERSISTED"
+
+
+def validate_key(key: str) -> str:
+    if type(key) is not str or not re.fullmatch(r"[A-Za-z0-9._:-]{1,256}", key):
+        raise ValueError("SSE_INVALID_KEY")
+    return key
+
+
+def validate_uuid(value: str) -> str:
+    if type(value) is not str or str(UUID(value)) != value:
+        raise ValueError("SSE_INVALID_ID")
+    return value
+
+
+def parse_event(raw: bytes) -> SandboxEvent:
+    """Reject extra/duplicate fields, non-UTF8 JSON and oversized messages."""
+    if type(raw) is not bytes or len(raw) > 4096:
+        raise ValueError("SSE_INVALID_BODY")
+    body = json.loads(raw.decode("utf-8"), object_pairs_hook=_unique_object)
+    event = SandboxEvent.model_validate(body)
+    validate_uuid(event.event_id)
+    if "\x00" in event.message or not 1 <= len(event.message.encode("utf-8")) <= 256:
+        raise ValueError("SSE_INVALID_MESSAGE")
+    return event
+
+
+class PostgresSandboxEventStore:
+    """Use an operator-supplied dedicated psycopg async pool and installed schema.
+
+The pool must hand out idle connections. Each registration explicitly uses
+READ COMMITTED, so a conflict loser can read the winner in its next statement.
+The DDL is installed separately, never by serving a request.
+"""
+
+    def __init__(self, pool: Any) -> None:
+        if pool is None:
+            raise ValueError("SSE_DEDICATED_POOL_REQUIRED")
+        self._pool = pool
+
+    async def register(self, raw: bytes, key: str) -> tuple[SandboxOperation, bool]:
+        event, key = parse_event(raw), validate_key(key)
+        digest = sha256_of_canonical_json(event.model_dump())
+        operation_id = str(uuid4())
+        conflict = False
+        try:
+            async with self._pool.connection() as conn:
+                async with conn.transaction():
+                    await conn.execute("SET TRANSACTION ISOLATION LEVEL READ COMMITTED")
+                    await conn.execute("SET LOCAL synchronous_commit = on")
+                    await conn.execute("SET LOCAL statement_timeout = '4000ms'")
+                    cur = await conn.execute(
+                        "INSERT INTO sandbox_events "
+                        "(operation_id, idempotency_key, event_id, message, payload_digest) "
+                        "VALUES (%s, %s, %s, %s, %s) ON CONFLICT DO NOTHING "
+                        "RETURNING operation_id",
+                        (operation_id, key, event.event_id, event.message, digest),
+                    )
+                    created = await cur.fetchone() is not None
+                    cur = await conn.execute(
+                        "SELECT operation_id, idempotency_key, event_id, payload_digest, message "
+                        "FROM sandbox_events WHERE idempotency_key=%s", (key,),
+                    )
+                    row = await cur.fetchone()
+                    if row is None or (str(row[2]), row[3], row[4]) != (
+                        event.event_id, digest, event.message,
+                    ):
+                        conflict = True
+                    else:
+                        operation = _operation(row)
+            if not conflict:
+                return operation, created
+        except Exception:
+            # Raise outside the handler; do not retain SQL/connection exceptions.
+            pass
+        else:
+            raise SandboxEventConflict("SSE_CONFLICT")
+        raise SandboxEventStoreError("SSE_DATABASE_OUTCOME_UNKNOWN")
+
+    async def lookup(
+        self, *, operation_id: str | None = None, key: str | None = None,
+    ) -> SandboxOperation | None:
+        if (operation_id is None) == (key is None):
+            raise ValueError("SSE_ONE_LOOKUP_REQUIRED")
+        if operation_id is not None:
+            value, column = validate_uuid(operation_id), "operation_id"
+        else:
+            value, column = validate_key(key), "idempotency_key"
+        try:
+            async with self._pool.connection() as conn:
+                async with conn.transaction():
+                    await conn.execute("SET TRANSACTION READ ONLY")
+                    await conn.execute("SET LOCAL statement_timeout = '4000ms'")
+                    cur = await conn.execute(
+                        "SELECT operation_id, idempotency_key, event_id, payload_digest "
+                        f"FROM sandbox_events WHERE {column}=%s", (value,),
+                    )
+                    row = await cur.fetchone()
+                    result = None if row is None else _operation(row)
+            return result
+        except Exception:
+            pass
+        raise SandboxEventStoreError("SSE_DATABASE_LOOKUP_FAILED")
+
+
+def _operation(row: Any) -> SandboxOperation:
+    return SandboxOperation(
+        operation_id=validate_uuid(str(row[0])), idempotency_key=validate_key(row[1]),
+        event_id=validate_uuid(str(row[2])), payload_digest=row[3],
+    )

--- a/veritas_os/policy/sandbox_events.sql
+++ b/veritas_os/policy/sandbox_events.sql
@@ -1,0 +1,13 @@
+-- Install only in a dedicated sandbox database. Not a main-API migration.
+-- A row is both the event effect and its immutable operation record.
+CREATE TABLE sandbox_events (
+    operation_id UUID PRIMARY KEY,
+    idempotency_key TEXT NOT NULL UNIQUE
+        CHECK (length(idempotency_key) BETWEEN 1 AND 256
+               AND idempotency_key ~ '^[A-Za-z0-9._:-]+$'),
+    event_id UUID NOT NULL UNIQUE,
+    message TEXT NOT NULL CHECK (octet_length(message) BETWEEN 1 AND 256),
+    payload_digest TEXT NOT NULL CHECK (payload_digest ~ '^[0-9a-f]{64}$')
+);
+-- Runtime writer: SELECT, INSERT only. Reconciler DB role: SELECT only.
+-- No TTL/deletion while any operation may remain unknown.

--- a/veritas_os/tests/fixtures/sandbox_event_service.json
+++ b/veritas_os/tests/fixtures/sandbox_event_service.json
@@ -1,0 +1,13 @@
+{
+  "request": {
+    "event_id": "9d914b43-0cb6-4c48-84fa-d4f7a05231ca",
+    "message": "synthetic"
+  },
+  "operation": {
+    "operation_id": "0e5328ae-7004-4c91-a002-e3f528ec09ae",
+    "idempotency_key": "synthetic-original-key",
+    "event_id": "9d914b43-0cb6-4c48-84fa-d4f7a05231ca",
+    "payload_digest": "6055bbb39389f08acd180c8e7adafc65363ffa476005ec5b74208e3b6a1598de",
+    "state": "PERSISTED"
+  }
+}

--- a/veritas_os/tests/test_pg_sandbox_event_contention.py
+++ b/veritas_os/tests/test_pg_sandbox_event_contention.py
@@ -1,0 +1,126 @@
+"""Real PostgreSQL arbitration, rollback and lost-ack recovery in an isolated schema."""
+
+import asyncio
+from contextlib import asynccontextmanager
+import json
+import os
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from veritas_os.policy.sandbox_event_store import (
+    PostgresSandboxEventStore, SandboxEventConflict, SandboxEventStoreError,
+)
+
+pytestmark = [pytest.mark.postgresql, pytest.mark.contention]
+
+
+@asynccontextmanager
+async def database():
+    dsn = os.getenv("VERITAS_DATABASE_URL", "")
+    if not dsn.startswith("postgresql"):
+        pytest.skip("real PostgreSQL test service required")
+    import psycopg
+    from psycopg_pool import AsyncConnectionPool
+
+    dsn = dsn.replace("postgresql+psycopg://", "postgresql://", 1)
+    schema = "sandbox_test_" + uuid4().hex
+    admin = await psycopg.AsyncConnection.connect(dsn, autocommit=True)
+    await admin.execute(f"CREATE SCHEMA {schema}")
+    pool = AsyncConnectionPool(
+        dsn, kwargs={"options": f"-c search_path={schema}"},
+        min_size=0, max_size=16, open=False,
+    )
+    try:
+        await pool.open()
+        async with pool.connection() as conn:
+            ddl = Path(__file__).parents[1] / "policy" / "sandbox_events.sql"
+            await conn.execute(ddl.read_text())
+        yield pool
+    finally:
+        await pool.close()
+        # Only this randomly named test schema; never an application schema.
+        await admin.execute(f"DROP SCHEMA {schema} CASCADE")
+        await admin.close()
+
+
+def payload(event=None, message="synthetic"):
+    return json.dumps({"event_id": event or str(uuid4()), "message": message}).encode()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_same_key_and_payload_commits_one_event():
+    async with database() as pool:
+        raw = payload()
+        results = await asyncio.gather(*(
+            PostgresSandboxEventStore(pool).register(raw, "original-key") for _ in range(32)
+        ))
+        assert sum(created for _, created in results) == 1
+        assert all(operation == results[0][0] for operation, _ in results)
+        async with pool.connection() as conn:
+            assert (await (await conn.execute("SELECT count(*) FROM sandbox_events")).fetchone())[0] == 1
+        operation = results[0][0]
+        # A fresh store/connection observes the committed operation, not local memory.
+        assert await PostgresSandboxEventStore(pool).lookup(operation_id=operation.operation_id) == operation
+        assert await PostgresSandboxEventStore(pool).lookup(key="original-key") == operation
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("same_key", [True, False])
+async def test_conflicting_requests_never_create_a_second_row(same_key):
+    async with database() as pool:
+        event = str(uuid4())
+        results = await asyncio.gather(*(
+            PostgresSandboxEventStore(pool).register(
+                payload(event, message=f"synthetic-{i}"), "key" if same_key else f"key-{i}",
+            ) for i in range(16)
+        ), return_exceptions=True)
+        assert sum(isinstance(r, tuple) for r in results) == 1
+        assert sum(isinstance(r, SandboxEventConflict) for r in results) == 15
+        async with pool.connection() as conn:
+            assert (await (await conn.execute("SELECT count(*) FROM sandbox_events")).fetchone())[0] == 1
+
+
+class InterruptingPool:
+    def __init__(self, pool, *, lost_ack):
+        self.pool, self.lost_ack = pool, lost_ack
+
+    @asynccontextmanager
+    async def connection(self):
+        async with self.pool.connection() as conn:
+            if self.lost_ack:
+                yield conn
+            else:
+                yield FailingConnection(conn)
+        if self.lost_ack:
+            raise RuntimeError("synthetic lost commit response")
+
+
+class FailingConnection:
+    def __init__(self, conn):
+        self.conn = conn
+
+    def transaction(self):
+        return self.conn.transaction()
+
+    async def execute(self, sql, args=None):
+        if sql.startswith("SELECT"):
+            raise RuntimeError("synthetic crash before commit")
+        return await self.conn.execute(sql, args)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("lost_ack", [True, False])
+async def test_rollback_or_committed_but_ack_lost_is_never_false_success(lost_ack):
+    async with database() as pool:
+        store = PostgresSandboxEventStore(InterruptingPool(pool, lost_ack=lost_ack))
+        raw = payload()
+        with pytest.raises(SandboxEventStoreError):
+            await store.register(raw, "original-key")
+        restarted = PostgresSandboxEventStore(pool)
+        found = await restarted.lookup(key="original-key")
+        assert (found is not None) == lost_ack
+        async with pool.connection() as conn:
+            count = (await (await conn.execute("SELECT count(*) FROM sandbox_events")).fetchone())[0]
+        assert count == int(lost_ack)

--- a/veritas_os/tests/test_sandbox_event_service.py
+++ b/veritas_os/tests/test_sandbox_event_service.py
@@ -1,0 +1,216 @@
+"""ASGI-only tests with synthetic tokens; no listener or real credential access."""
+
+from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
+import json
+from pathlib import Path
+from uuid import uuid4
+
+import httpx
+import pytest
+from pydantic import SecretStr
+
+from veritas_os.policy.sandbox_event_service import (
+    SandboxServiceTokens, create_sandbox_event_service,
+)
+from veritas_os.policy.sandbox_event_store import (
+    PostgresSandboxEventStore, SandboxEventStoreError, SandboxOperation, parse_event,
+)
+from veritas_os.security.hash import sha256_of_canonical_json
+
+NOW = datetime(2026, 9, 8, tzinfo=timezone.utc)
+WRITER = "synthetic-writer-" + "w" * 32
+READER = "synthetic-reader-" + "r" * 32
+EVENT = {"event_id": "9d914b43-0cb6-4c48-84fa-d4f7a05231ca", "message": "synthetic"}
+
+
+class Pool:
+    """SQL-shape double only; concurrency proof belongs to real PostgreSQL tests."""
+
+    def __init__(self):
+        self.rows = {}
+        self.result = None
+        self.fail_commit = False
+        self.fail_read = False
+        self.calls = []
+
+    @asynccontextmanager
+    async def connection(self):
+        yield self
+
+    @asynccontextmanager
+    async def transaction(self):
+        yield self
+        if self.fail_commit:
+            raise RuntimeError(WRITER)
+
+    async def execute(self, sql, args=None):
+        self.calls.append(sql)
+        if sql.startswith("INSERT"):
+            op, key, event, message, digest = args
+            duplicate = key in self.rows or any(row[2] == event for row in self.rows.values())
+            self.result = None if duplicate else (op,)
+            if not duplicate:
+                self.rows[key] = (op, key, event, digest, message)
+        elif sql.startswith("SELECT"):
+            if self.fail_read:
+                raise RuntimeError(WRITER)
+            if "WHERE operation_id=" in sql:
+                self.result = next((row for row in self.rows.values() if row[0] == args[0]), None)
+            else:
+                self.result = self.rows.get(args[0])
+        return self
+
+    async def fetchone(self):
+        return self.result
+
+
+def tokens(**changes):
+    return SandboxServiceTokens(**{
+        "writer": SecretStr(WRITER), "reader": SecretStr(READER),
+        "valid_until": NOW + timedelta(hours=1), **changes,
+    })
+
+
+def client(pool=None, config=None, clock=lambda: NOW):
+    store = PostgresSandboxEventStore(pool or Pool())
+    app = create_sandbox_event_service(store=store, tokens=config or tokens(), clock=clock)
+    return httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="https://test.invalid")
+
+
+def headers(token=WRITER, key="original-key"):
+    return {"Authorization": f"Bearer {token}", "Idempotency-Key": key, "Content-Type": "application/json"}
+
+
+@pytest.mark.asyncio
+async def test_registration_duplicates_conflicts_and_lookup():
+    pool = Pool()
+    async with client(pool) as c:
+        a = await c.post("/v1/events", json=EVENT, headers=headers())
+        assert a.status_code == 201
+        b = await c.post("/v1/events", json=EVENT, headers=headers())
+        assert b.status_code == 200 and a.json() == b.json()
+        for body, key in [({**EVENT, "message": "changed"}, "original-key"), (EVENT, "another-key")]:
+            assert (await c.post("/v1/events", json=body, headers=headers(key=key))).status_code == 409
+        op = a.json()
+        for path in [f'/v1/operations/{op["operation_id"]}', "/v1/operations?idempotency_key=original-key"]:
+            r = await c.get(path, headers=headers(READER))
+            assert r.status_code == 200 and r.json() == op
+            assert r.headers["cache-control"] == "no-store"
+        assert (await c.post("/v1/events", json=EVENT, headers=headers(READER))).status_code == 401
+    assert len(pool.rows) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("auth", [None, "Bearer wrong", "Basic wrong", "Bearer 日本語"])
+async def test_unauthorized_never_touches_db(auth):
+    pool = Pool()
+    h = {} if auth is None else {"authorization": auth}
+    if auth and "日本語" in auth:
+        h = [(b"authorization", auth.encode("utf-8"))]
+    async with client(pool) as c:
+        assert (await c.post("/v1/events", content=b"bad", headers=h)).status_code == 401
+        assert (await c.get("/v1/operations?idempotency_key=key", headers=h)).status_code == 401
+    assert not pool.calls
+
+
+@pytest.mark.asyncio
+async def test_duplicate_auth_and_expired_or_broken_clock_fail_closed():
+    async with client() as c:
+        h = [("authorization", f"Bearer {WRITER}")] * 2
+        assert (await c.get("/v1/operations?idempotency_key=key", headers=h)).status_code == 401
+    def broken():
+        raise RuntimeError(WRITER)
+    for clock in [lambda: NOW + timedelta(hours=1), broken, lambda: NOW.replace(tzinfo=None)]:
+        async with client(clock=clock) as c:
+            assert (await c.get("/v1/operations?idempotency_key=key", headers=headers())).status_code == 401
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("raw", [
+    b"{}", b"[]", b"null", b'{"event_id":"x","message":"a"}',
+    json.dumps({**EVENT, "message": ""}).encode(),
+    json.dumps({**EVENT, "message": "x" * 257}).encode(),
+    json.dumps({**EVENT, "message": "\x00"}).encode(),
+    json.dumps({**EVENT, "extra": 1}).encode(),
+    json.dumps({**EVENT, "message": 1}).encode(),
+    b'{"message":"a","message":"b"}', b"\xff", b"[" * 1200,
+])
+async def test_invalid_payloads_are_sanitized_before_store(raw):
+    pool = Pool()
+    async with client(pool) as c:
+        r = await c.post("/v1/events", content=raw, headers=headers())
+        assert r.status_code == 400
+        assert r.json() == {"detail": "SSE_INVALID_REQUEST"}
+    assert not pool.calls
+
+
+@pytest.mark.asyncio
+async def test_body_size_media_type_and_duplicate_key_headers():
+    async with client() as c:
+        assert (await c.post("/v1/events", content=b"x" * 4097, headers=headers())).status_code == 413
+        assert (await c.post("/v1/events", content=b"x", headers={**headers(), "Content-Type": "text/plain"})).status_code == 415
+        assert (await c.post("/v1/events", content=b"x", headers={**headers(), "Content-Encoding": "gzip"})).status_code == 415
+        h = list(headers().items()) + [("Idempotency-Key", "second")]
+        assert (await c.post("/v1/events", json=EVENT, headers=h)).status_code == 400
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path,status", [
+    ("/v1/operations?bad=key", 400), ("/v1/operations", 400),
+    ("/v1/operations?idempotency_key=a&idempotency_key=b", 400),
+    ("/v1/operations/not-uuid", 400), (f"/v1/operations/{uuid4()}?x=y", 400),
+    (f"/v1/operations/{uuid4()}", 404), ("/v1/operations?idempotency_key=missing", 404),
+])
+async def test_lookup_invalid_and_absent_is_never_success(path, status):
+    async with client() as c:
+        assert (await c.get(path, headers=headers(READER))).status_code == status
+
+
+@pytest.mark.asyncio
+async def test_lost_commit_response_is_unknown_then_original_key_recovers():
+    pool = Pool()
+    pool.fail_commit = True
+    async with client(pool) as c:
+        response = await c.post("/v1/events", json=EVENT, headers=headers())
+        assert response.status_code == 503 and WRITER not in response.text
+        pool.fail_commit = False
+        found = await c.get("/v1/operations?idempotency_key=original-key", headers=headers(READER))
+        assert found.status_code == 200
+        pool.fail_read = True
+        assert (await c.get("/v1/operations?idempotency_key=original-key", headers=headers())).status_code == 503
+    assert len(pool.rows) == 1
+
+
+@pytest.mark.parametrize("changes", [
+    {"writer": SecretStr("short")}, {"reader": SecretStr(WRITER)},
+    {"valid_until": NOW.replace(tzinfo=None)},
+])
+def test_invalid_service_configuration_rejects(changes):
+    with pytest.raises(ValueError):
+        create_sandbox_event_service(store=PostgresSandboxEventStore(Pool()), tokens=tokens(**changes))
+
+
+@pytest.mark.asyncio
+async def test_store_validates_direct_inputs_and_sanitizes_exceptions():
+    with pytest.raises(ValueError):
+        PostgresSandboxEventStore(None)
+    with pytest.raises(ValueError):
+        parse_event(b"x" * 4097)
+    store = PostgresSandboxEventStore(Pool())
+    for args in [{}, {"key": "bad key"}, {"key": "x", "operation_id": str(uuid4())}]:
+        with pytest.raises(ValueError):
+            await store.lookup(**args)
+    store._pool.fail_read = True
+    with pytest.raises(SandboxEventStoreError) as caught:
+        await store.register(json.dumps(EVENT).encode(), "key")
+    assert caught.value.__context__ is None and WRITER not in str(caught.value)
+    with pytest.raises(ValueError):
+        create_sandbox_event_service(store=store, tokens=None)
+
+
+def test_committed_synthetic_sample_roundtrip():
+    body = json.loads((Path(__file__).parent / "fixtures" / "sandbox_event_service.json").read_text())
+    assert parse_event(json.dumps(body["request"]).encode()).model_dump() == body["request"]
+    assert SandboxOperation.model_validate(body["operation"]).model_dump() == body["operation"]
+    assert body["operation"]["payload_digest"] == sha256_of_canonical_json(body["request"])


### PR DESCRIPTION
## Purpose

Add the dedicated sandbox receiver needed to test a single native v2 external event. This PR does not connect the executor to a real service or complete native Bind/Receipt/Outcome/reconciliation.

## Changes

- Separate ASGI factory; no default app/listener and no mounting into the main VERITAS API.
- Record the user-approved Bearer-only exception for this independent service in AGENTS/CLAUDE/Copilot instructions. Existing API X-API-Key authentication stays unchanged.
- Distinct operator-provisioned, expiring writer and reader tokens. Reader cannot register; missing/invalid configuration fails closed. No live credential lookup, generation or environment fallback.
- POST /v1/events with bounded, strict JSON and the original Idempotency-Key.
- Dedicated PostgreSQL table: one immutable row is both event and operation; operation ID, event ID and key are unique.
- READ COMMITTED INSERT ON CONFLICT DO NOTHING plus next-statement lookup; identical request returns original operation (200), new committed event returns 201, conflicting key/payload or event/key returns 409.
- Return success only after transaction/context exit; synchronous_commit enabled, four-second SQL statement cap.
- Authenticated lookup by operation ID or original key. Missing row is not proof of no effect. Ambiguous write returns 503 without retry.
- Separate DDL packaged with the module; no main database migration. EN/JA specification and sample roundtrip tests included.
- Add five real PostgreSQL tests to the existing PostgreSQL CI job for 32-way identical contention, conflicting requests, rollback and lost commit acknowledgement.

## Validation

- Local related suite: **80 passed, 5 skipped**, one existing NumPy warning.
- The five skips are real PostgreSQL tests: this local runtime has no PostgreSQL service, and package installation was blocked by OS permissions. No mock result is presented as a durability proof.
- New module statement coverage: **99.45% (182/183)**; service 100%, store 99%; 90% gate passed.
- Ruff, bilingual docs, responsibility boundaries and diff checks passed.
- Initial CI failed in Bandit B608 because a lookup column selected from two internal constants was interpolated into SQL. The query now uses two complete fixed statements; local Bandit 1.9.4 reports no medium/high issues. Updated-head GitHub CI completed with **38/38 checks successful**. The real PostgreSQL job passed, including all five new sandbox contention/rollback/commit-acknowledgement-loss tests.
- Published head: `8333f753fea9f8849e999bfff6016fcb43d0f56c`.
- Exact tested/published tree: `fc0ef89ad72f25c5c278f347570823f0134a989b`.
- Local head `cc1bfcbb5d77fa6e07ecfb9b2ca4cdfdd9098455` differs from the Git Data API publication head; tree equality was verified.

## Security and limits

Only synthetic payloads/tokens were used, with no external HTTP request, provider access or deployment. Dedicated DB provisioning, TLS termination, secret provisioning/rotation/revocation and network policies remain operator responsibilities. The initial token configuration rotates by rebuilding the service; it does not implement a provider trust root or live revocation distribution.

The service's PERSISTED response is an observation, not a VERITAS confirmed Outcome or BindReceipt. Independent reconciliation, unknown-outcome replacement-authorization blocking and concrete HTTPS transport remain incomplete. No Human Approval or execution authorization is issued. No TTL, delete, reset or automatic retry API is added.

Draft for human maintainer review; no automatic merge.
