### PR TITLE
feat: add opt-in native sandbox HTTPS transport

### DIFF
--- a/docs/en/architecture/native-v2-sandbox-event-spec-v1.md
+++ b/docs/en/architecture/native-v2-sandbox-event-spec-v1.md
@@ -463,3 +463,33 @@ loss in disposable isolated schemas and are included in the existing PostgreSQL
 CI job. Local mocks are not claimed as durability proof. HTTPS transport, actual
 deployment/provider configuration and native Receipt/Outcome/reconciliation are
 still not connected by this service implementation.
+
+## 18. Opt-in HTTPS transport (synthetic stream validation)
+
+`SandboxHTTPSTransport` can now be explicitly supplied to `execute_sandbox_bind`.
+No default transport, endpoint, provider, listener or deployment is installed.
+The executor independently configures the exact HTTPS event endpoint and reviewed
+CA roots (system roots by default). A fresh verified TLS connection uses that DNS
+name as the peer identity, with TLS 1.2 or later and HTTP/1.1. This is CA/hostname
+verification, not certificate fingerprint pinning or DNS/IP attestation.
+
+The transport checks canonical payload/digest and the original key, completes TLS,
+then invokes the owning one-use material callback immediately before its single
+write, without an intervening await. Connection delay therefore cannot bypass the
+existing final send window. There are no proxies, redirects or retries. The total
+request limit is five seconds. Responses require bounded headers (8 KiB) and a
+Content-Length body (4 KiB); chunking, encoding and duplicate headers fail closed.
+This is a deliberately restricted protocol, not a general HTTP adapter.
+
+Matching 201/200 JSON acknowledgements require the original key, event ID and digest
+plus a valid operation UUID. The returned observation records a fixed classification
+only; raw bodies, headers, remote operation IDs and errors are not retained. 409 and
+503 are distinct observations, never evidence of absence or confirmed success.
+All durable states remain EFFECT_UNKNOWN, including matching acknowledgements.
+Existing transports returning None retain their earlier observation behavior.
+
+Tests use synthetic provider material, real native verifiers and simulated streams;
+they do not establish a real TLS handshake, real HTTPS delivery or receiver commit.
+Real TLS/host-clock and combined PostgreSQL/receiver fault tests are still required
+before enabling external effects. Section 9 prerequisites remain mandatory.
+Reconciliation must use the original key, not infer success from these observations.

--- a/docs/ja/architecture/native-v2-sandbox-event-spec-v1.md
+++ b/docs/ja/architecture/native-v2-sandbox-event-spec-v1.md
@@ -380,3 +380,28 @@ ASGI試験は合成tokenとSQL doubleを使用します。別の実PostgreSQL試
 同一要求・競合要求の同時実行、rollback、commit応答消失を検証し、既存PostgreSQL CIへ追加します。
 ローカルmockを永続性の証明とは扱いません。HTTPS transport、実配備・provider設定、native
 Receipt/Outcome/reconciliationは、このサービス実装ではまだ接続していません。
+
+## 18. 明示設定するHTTPS transport（合成stream試験）
+
+`SandboxHTTPSTransport`を`execute_sandbox_bind`へ明示的に渡せるようにします。
+default transport・宛先・provider・listener・配備は追加しません。
+executorが独立した信頼設定から正確なHTTPS宛先とCA（既定はsystem roots）を指定します。
+毎回新しい接続でDNS名をTLS peer identityとして検証し、TLS 1.2以上・HTTP/1.1を使用します。
+これはCAとhostnameの検証であり、証明書fingerprint pinningやDNS/IPの証明ではありません。
+
+canonical payload・digest・元のkeyを検証し、TLS完了後、唯一のwrite直前に既存の
+一回限りのmaterial callbackを呼びます。その間にawaitは挟みません。
+接続遅延も既存の送信期限検証対象です。proxy・redirect・retryは使いません。
+全体5秒、応答header 8 KiB・Content-Length body 4 KiBに制限し、chunked・encoding・
+重複headerは拒否します。汎用HTTP adapterではなく限定protocolです。
+
+201/200は元のkey・event ID・digest・正しいoperation UUIDが一致した場合のみ
+固定の観測分類を返します。生body・header・remote operation ID・例外は保持しません。
+409と503も区別しますが、作用なしや成功の証明にはしません。
+永続状態は常にEFFECT_UNKNOWNのままです。Noneを返す既存transportの動作は維持します。
+
+試験は合成credential、実native verifier、模擬streamを使用します。
+実TLS handshake・実HTTPS送信・receiver commitの証明ではありません。
+外部作用の有効化前には実TLS・host clock・PostgreSQLとreceiverの結合障害試験、
+および第9節の配備条件の確認が必要です。Reconciliationでは元のkeyを使い、
+HTTP観測から成功を推測しません。

--- a/veritas_os/policy/sandbox_bind_execution.py
+++ b/veritas_os/policy/sandbox_bind_execution.py
@@ -1,4 +1,4 @@
-"""Owning native v2 dispatch seam; no concrete network adapter is installed.
+"""Owning native v2 dispatch seam; no network adapter is installed by default.
 
 Only executor-configured transports may implement this contract. They must use
 TLS, the exact request, no redirects/retries and call take_material immediately
@@ -38,6 +38,10 @@ from veritas_os.policy.sandbox_pre_effect import (
 from veritas_os.security.hash import sha256_of_canonical_json
 
 REQUEST_TIMEOUT_SECONDS = 5
+SandboxHTTPObservation = Literal[
+    "HTTP_201_MATCHING_ACK", "HTTP_200_MATCHING_ACK", "HTTP_409_CONFLICT",
+    "HTTP_503_UNKNOWN", "HTTP_RESPONSE_UNKNOWN",
+]
 
 
 class SandboxBindExecutionError(ValueError):
@@ -63,13 +67,13 @@ The implementation must authenticate the pinned TLS identity, disable redirects,
 proxies and retries, bound response size, and never log secrets or exceptions.
 It must call take_material once, immediately before sending the exact request,
 and stop on callback failure/cancellation. It must not keep the returned material.
-Its return is deliberately ignored: acknowledgement is NOT confirmed effect.
+Only fixed observation codes may be retained: acknowledgement is NOT confirmed effect.
 A concrete implementation and its timing/TLS tests are a deployment prerequisite.
 """
 
     async def send_once(
         self, request: SandboxDispatchRequest, *, take_material: Callable[[], SecretBytes],
-    ) -> None:
+    ) -> SandboxHTTPObservation | None:
         ...
 
 
@@ -84,7 +88,7 @@ class SandboxDispatchObservation(BaseModel):
     payload_digest: str
     idempotency_key: str
     state: Literal["UNKNOWN"] = "UNKNOWN"
-    reason_code: Literal["TRANSPORT_RETURNED_UNVERIFIED", "TRANSPORT_FAILED_OR_UNKNOWN"]
+    reason_code: Literal["TRANSPORT_RETURNED_UNVERIFIED", "TRANSPORT_FAILED_OR_UNKNOWN"] | SandboxHTTPObservation
 
 
 async def execute_sandbox_bind(
@@ -182,9 +186,14 @@ never upgraded from an HTTP response. Reconciliation/receipts remain separate.
         reason = "TRANSPORT_FAILED_OR_UNKNOWN"
         try:
             async with asyncio.timeout(REQUEST_TIMEOUT_SECONDS):
-                await transport.send_once(request, take_material=take_material)
+                response = await transport.send_once(request, take_material=take_material)
             if taken:
                 reason = "TRANSPORT_RETURNED_UNVERIFIED"
+                if type(response) is str and response in {
+                    "HTTP_201_MATCHING_ACK", "HTTP_200_MATCHING_ACK", "HTTP_409_CONFLICT",
+                    "HTTP_503_UNKNOWN", "HTTP_RESPONSE_UNKNOWN",
+                }:
+                    reason = response
         except asyncio.CancelledError:
             raise
         except Exception:

--- a/veritas_os/policy/sandbox_https_transport.py
+++ b/veritas_os/policy/sandbox_https_transport.py
@@ -1,0 +1,155 @@
+"""Opt-in sandbox HTTPS sender; no listener, deployment or default credentials.
+
+Only the owning executor may configure this transport. Request models are not
+capabilities. TLS authenticates the configured DNS identity through reviewed CA
+roots, not the truth of an operation. Responses never confirm external effect.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import ssl
+from typing import Callable
+
+from pydantic import SecretBytes
+
+from veritas_os.policy.sandbox_action_binding import _unique_object
+from veritas_os.policy.sandbox_bind_execution import (
+    SandboxDispatchRequest, SandboxHTTPObservation,
+)
+from veritas_os.policy.sandbox_event_store import (
+    SandboxOperation, parse_event, validate_key, validate_uuid,
+)
+from veritas_os.security.hash import canonical_json_dumps, sha256_of_canonical_json
+
+REQUEST_TIMEOUT_SECONDS = 5
+
+
+class SandboxHTTPTransportError(ValueError):
+    """Sanitized failure; the caller must retain durable uncertainty."""
+
+
+class SandboxHTTPSTransport:
+    """One fresh TLS connection per call, one POST, no redirects/proxies/retries.
+
+    The endpoint is independently supplied by the executor, never a response or
+    request-selected destination. ca_pem is reviewed CA configuration, not an
+    arbitrary SSLContext that could disable verification. None uses system roots.
+    Production use still requires section 9 deployment approval and TLS tests.
+    """
+
+    def __init__(self, *, endpoint_url: str, ca_pem: str | None = None) -> None:
+        if type(endpoint_url) is not str or not re.fullmatch(
+            r"https://(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+"
+            r"[a-z](?:[a-z0-9-]{0,61}[a-z0-9])?/v1/events", endpoint_url,
+        ):
+            raise SandboxHTTPTransportError("SHT_ENDPOINT_INVALID")
+        self._endpoint = endpoint_url
+        self._host = endpoint_url[len("https://"):-len("/v1/events")]
+        self._tls = ssl.create_default_context(cadata=ca_pem)
+        self._tls.minimum_version = ssl.TLSVersion.TLSv1_2
+        self._tls.set_alpn_protocols(["http/1.1"])
+
+    async def send_once(
+        self, request: SandboxDispatchRequest, *, take_material: Callable[[], SecretBytes],
+    ) -> SandboxHTTPObservation:
+        """Take material after TLS, then write without any intervening await.
+
+        Five seconds includes DNS, TLS, write and bounded response read. Unsupported
+        HTTP framing stays unknown. The response body and exception never escape.
+        Closing drops references; it does not guarantee Python memory erasure.
+        """
+        writer = None
+        token = material = wire = None
+        cancelled = False
+        try:
+            request = SandboxDispatchRequest.model_validate(request.model_dump())
+            if request.endpoint_url != self._endpoint:
+                raise ValueError("endpoint")
+            body = request.payload_json.encode("utf-8")
+            event = parse_event(body)
+            if (request.payload_digest != sha256_of_canonical_json(event.model_dump())
+                    or request.payload_json != canonical_json_dumps(event.model_dump())):
+                raise ValueError("payload")
+            key = validate_key(request.idempotency_key)
+            # All non-secret work is performed before the final one-use callback.
+            prefix = (
+                f"POST /v1/events HTTP/1.1\r\nHost: {self._host}\r\n"
+                f"Idempotency-Key: {key}\r\nContent-Type: application/json\r\n"
+                f"Content-Length: {len(body)}\r\nConnection: close\r\nAuthorization: Bearer "
+            ).encode("ascii")
+            async with asyncio.timeout(REQUEST_TIMEOUT_SECONDS):
+                reader, writer = await asyncio.open_connection(
+                    self._host, 443, ssl=self._tls, server_hostname=self._host,
+                    limit=8192, ssl_handshake_timeout=5,
+                )
+                material = take_material()
+                token = material.get_secret_value()
+                if not 32 <= len(token) <= 4096 or not re.fullmatch(rb"[A-Za-z0-9._~+/-]+=*", token):
+                    raise ValueError("material")
+                wire = prefix + token + b"\r\n\r\n" + body
+                writer.write(wire)
+                token = material = wire = None
+                await writer.drain()
+                return await _read_observation(reader, request, event.event_id)
+        except asyncio.CancelledError:
+            cancelled = True
+        except Exception:
+            pass
+        finally:
+            token = material = wire = None
+            if writer is not None:
+                # Abort without awaiting an untrusted peer's TLS close-notify.
+                try:
+                    writer.transport.abort()
+                except Exception:
+                    pass
+        if cancelled:
+            raise asyncio.CancelledError()
+        raise SandboxHTTPTransportError("SHT_FAILED_OR_UNKNOWN")
+
+
+async def _read_observation(
+    reader: asyncio.StreamReader, request: SandboxDispatchRequest, event_id: str,
+) -> SandboxHTTPObservation:
+    """Accept only bounded Content-Length HTTP/1.1 JSON from the fixed service.
+
+    Chunked, encoded, duplicate-header, interim and malformed responses remain
+    unknown. This deliberately narrow client does not follow response locations.
+    """
+    head = await reader.readuntil(b"\r\n\r\n")
+    if len(head) > 8192:
+        raise ValueError("headers")
+    lines = head[:-4].split(b"\r\n")
+    if not re.fullmatch(rb"HTTP/1\.1 [0-9]{3} [\x20-\x7e]*", lines[0]):
+        raise ValueError("status")
+    status = int(lines[0].split(b" ")[1])
+    headers = {}
+    for line in lines[1:]:
+        name, value = line.split(b":", 1)
+        if not re.fullmatch(rb"[A-Za-z0-9-]+", name) or name.lower() in headers:
+            raise ValueError("header")
+        headers[name.lower()] = value.strip()
+    length = headers.get(b"content-length", b"")
+    if (not re.fullmatch(rb"[0-9]{1,4}", length) or int(length) > 4096
+            or b"transfer-encoding" in headers or b"content-encoding" in headers):
+        raise ValueError("framing")
+    raw = await reader.readexactly(int(length))
+    if status == 409:
+        return "HTTP_409_CONFLICT"
+    if status == 503:
+        return "HTTP_503_UNKNOWN"
+    if status not in {200, 201}:
+        return "HTTP_RESPONSE_UNKNOWN"
+    if headers.get(b"content-type", b"").split(b";")[0].lower() != b"application/json":
+        raise ValueError("type")
+    operation = SandboxOperation.model_validate(
+        json.loads(raw.decode("utf-8"), object_pairs_hook=_unique_object),
+    )
+    validate_uuid(operation.operation_id)
+    if (operation.idempotency_key != request.idempotency_key
+            or operation.event_id != event_id or operation.payload_digest != request.payload_digest):
+        raise ValueError("binding")
+    return "HTTP_201_MATCHING_ACK" if status == 201 else "HTTP_200_MATCHING_ACK"

--- a/veritas_os/tests/fixtures/sandbox_dispatch_observation.json
+++ b/veritas_os/tests/fixtures/sandbox_dispatch_observation.json
@@ -6,5 +6,5 @@
   "payload_digest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
   "idempotency_key": "synthetic-original-key",
   "state": "UNKNOWN",
-  "reason_code": "TRANSPORT_RETURNED_UNVERIFIED"
+  "reason_code": "HTTP_201_MATCHING_ACK"
 }

--- a/veritas_os/tests/test_sandbox_bind_execution.py
+++ b/veritas_os/tests/test_sandbox_bind_execution.py
@@ -203,3 +203,52 @@ async def test_missing_transport_stops_before_claim_or_provider(prepared_inputs)
     with pytest.raises(module.SandboxBindExecutionError):
         await run(artifact, args, provider, None)
     assert not provider.calls and not args["effect_store"]._records
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [201, 200, 409, 503])
+async def test_concrete_transport_preserves_owning_unknown_state(prepared_inputs, monkeypatch, status):
+    from pydantic import SecretBytes
+    from veritas_os.policy import sandbox_https_transport as https
+    from veritas_os.tests.test_sandbox_https_transport import Writer, TOKEN as HTTP_TOKEN
+
+    artifact, args = await _args(prepared_inputs)
+    provider = Provider(prepared_inputs, args)
+    original_resolve = provider.resolve
+
+    async def resolve(request, **kwargs):
+        credential = await original_resolve(request, **kwargs)
+        return credential.model_copy(update={"material": SecretBytes(HTTP_TOKEN)})
+
+    provider.resolve = resolve
+    writer = Writer()
+    connections = []
+
+    async def connect(*positional, **kwargs):
+        connections.append(True)
+        row = await args["effect_store"].get(prepared_inputs[2].consumption_id)
+        assert row.state == module.EffectExecutionState.EFFECT_UNKNOWN
+        body = json.dumps(dict(
+            operation_id="22222222-2222-4222-8222-222222222222",
+            event_id=PAYLOAD["event_id"], payload_digest=module.sha256_of_canonical_json(PAYLOAD),
+            idempotency_key=artifact.idempotency_key, state="PERSISTED",
+        )).encode()
+        reader = asyncio.StreamReader()
+        reader.feed_data((f"HTTP/1.1 {status} Test\r\nContent-Type: application/json\r\n"
+                          f"Content-Length: {len(body)}\r\n\r\n").encode() + body)
+        reader.feed_eof()
+        return reader, writer
+
+    monkeypatch.setattr(https.asyncio, "open_connection", connect)
+    transport = https.SandboxHTTPSTransport(endpoint_url=args["deployment"].endpoint_url)
+    result = await run(artifact, args, provider, transport)
+    assert result.state == "UNKNOWN"
+    assert result.reason_code == {201: "HTTP_201_MATCHING_ACK", 200: "HTTP_200_MATCHING_ACK",
+                                  409: "HTTP_409_CONFLICT", 503: "HTTP_503_UNKNOWN"}[status]
+    assert len(writer.writes) == len(connections) == 1
+    assert HTTP_TOKEN.decode() not in result.model_dump_json()
+    row = await args["effect_store"].get(result.attempt_id)
+    assert row.state == module.EffectExecutionState.EFFECT_UNKNOWN
+    with pytest.raises(module.SandboxBindExecutionError):
+        await run(artifact, args, provider, transport)
+    assert len(writer.writes) == 1

--- a/veritas_os/tests/test_sandbox_https_transport.py
+++ b/veritas_os/tests/test_sandbox_https_transport.py
@@ -1,0 +1,170 @@
+"""Synthetic stream tests only: no DNS, TLS handshake or external effect."""
+
+import asyncio
+import json
+import ssl
+
+import pytest
+from pydantic import SecretBytes
+
+from veritas_os.policy import sandbox_https_transport as module
+from veritas_os.policy.sandbox_bind_execution import SandboxDispatchRequest
+from veritas_os.security.hash import canonical_json_dumps, sha256_of_canonical_json
+
+ENDPOINT = "https://sandbox.example.test/v1/events"
+EVENT = {"event_id": "11111111-1111-4111-8111-111111111111", "message": "synthetic"}
+TOKEN = b"synthetic-test-token-never-a-live-credential"
+
+
+def request():
+    return SandboxDispatchRequest(
+        endpoint_url=ENDPOINT, payload_json=canonical_json_dumps(EVENT),
+        payload_digest=sha256_of_canonical_json(EVENT), idempotency_key="original-key",
+        attempt_id="attempt",
+    )
+
+
+def response(status=201, **changes):
+    operation = dict(operation_id="22222222-2222-4222-8222-222222222222",
+                     event_id=EVENT["event_id"], payload_digest=request().payload_digest,
+                     idempotency_key="original-key", state="PERSISTED")
+    operation.update(changes)
+    body = json.dumps(operation).encode()
+    return (f"HTTP/1.1 {status} Test\r\nContent-Type: application/json\r\n"
+            f"Content-Length: {len(body)}\r\n\r\n").encode() + body
+
+
+class Writer:
+    def __init__(self):
+        self.writes = []
+        self.transport = self
+        self.aborted = False
+
+    def write(self, wire):
+        self.writes.append(wire)
+
+    async def drain(self):
+        pass
+
+    def abort(self):
+        self.aborted = True
+
+
+def setup(monkeypatch, raw):
+    writer, calls, taken = Writer(), [], []
+
+    async def connect(host, port, **kwargs):
+        calls.append((host, port, kwargs))
+        reader = asyncio.StreamReader(limit=8192)
+        reader.feed_data(raw)
+        reader.feed_eof()
+        return reader, writer
+
+    def take():
+        assert len(calls) == 1 and not writer.writes
+        taken.append(True)
+        return SecretBytes(TOKEN)
+
+    monkeypatch.setattr(module.asyncio, "open_connection", connect)
+    return writer, calls, taken, take
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status,expected", [
+    (201, "HTTP_201_MATCHING_ACK"), (200, "HTTP_200_MATCHING_ACK"),
+    (409, "HTTP_409_CONFLICT"), (503, "HTTP_503_UNKNOWN"),
+    (302, "HTTP_RESPONSE_UNKNOWN"), (401, "HTTP_RESPONSE_UNKNOWN"),
+    (500, "HTTP_RESPONSE_UNKNOWN"),
+])
+async def test_single_exact_post_and_observations(monkeypatch, status, expected):
+    writer, calls, taken, take = setup(monkeypatch, response(status))
+    result = await module.SandboxHTTPSTransport(endpoint_url=ENDPOINT).send_once(request(), take_material=take)
+    assert result == expected
+    assert len(writer.writes) == len(calls) == len(taken) == 1
+    wire = writer.writes[0]
+    assert wire.endswith(request().payload_json.encode())
+    assert b"Authorization: Bearer " + TOKEN + b"\r\n" in wire
+    assert b"Idempotency-Key: original-key\r\n" in wire
+    assert calls[0][:2] == ("sandbox.example.test", 443)
+    tls = calls[0][2]["ssl"]
+    assert tls.check_hostname and tls.verify_mode == ssl.CERT_REQUIRED
+    assert calls[0][2]["server_hostname"] == "sandbox.example.test"
+    assert writer.aborted
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("field,value", [
+    ("event_id", "other"), ("operation_id", "invalid"), ("payload_digest", "0" * 64),
+    ("idempotency_key", "substituted"), ("state", "SUCCESS"), ("secret", "untrusted"),
+])
+async def test_mismatched_response_is_unknown(monkeypatch, field, value):
+    writer, calls, taken, take = setup(monkeypatch, response(**{field: value}))
+    with pytest.raises(module.SandboxHTTPTransportError) as caught:
+        await module.SandboxHTTPSTransport(endpoint_url=ENDPOINT).send_once(request(), take_material=take)
+    assert caught.value.__context__ is None
+    assert len(calls) == len(writer.writes) == 1 and writer.aborted
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("raw", [
+    b"garbage\r\n\r\n", b"HTTP/1.1 201 OK\r\nContent-Length: 9999\r\n\r\n",
+    response().replace(b"Content-Type:", b"Content-Length: 0\r\nContent-Type:"),
+    response().replace(b"Content-Type:", b"Transfer-Encoding: chunked\r\nContent-Type:"),
+    response().replace(b"application/json", b"text/plain"), response()[:-5],
+    b"x" * 9000 + b"\r\n\r\n",
+])
+async def test_malformed_bounded_response_no_retry(monkeypatch, raw):
+    writer, calls, taken, take = setup(monkeypatch, raw)
+    with pytest.raises(module.SandboxHTTPTransportError):
+        await module.SandboxHTTPSTransport(endpoint_url=ENDPOINT).send_once(request(), take_material=take)
+    assert len(calls) == 1 and writer.aborted
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["tls", "late", "cancel", "token", "endpoint", "digest", "key"])
+async def test_failure_prevents_write(monkeypatch, mode):
+    writer, calls, taken, take = setup(monkeypatch, response())
+    req = request()
+    if mode in {"tls", "cancel"}:
+        async def fail(*args, **kwargs):
+            if mode == "cancel":
+                raise asyncio.CancelledError(TOKEN.decode())
+            raise ssl.SSLError(TOKEN.decode())
+        monkeypatch.setattr(module.asyncio, "open_connection", fail)
+    elif mode == "late":
+        def take():
+            raise ValueError("send window exceeded")
+    elif mode == "token":
+        def take():
+            return SecretBytes(TOKEN + b"\r\nInjected: true")
+    else:
+        updates = {"endpoint": {"endpoint_url": "https://other.test/v1/events"},
+                   "digest": {"payload_digest": "0" * 64},
+                   "key": {"idempotency_key": "bad\r\nkey"}}
+        req = req.model_copy(update=updates[mode])
+    error = asyncio.CancelledError if mode == "cancel" else module.SandboxHTTPTransportError
+    with pytest.raises(error) as caught:
+        await module.SandboxHTTPSTransport(endpoint_url=ENDPOINT).send_once(req, take_material=take)
+    assert not writer.writes
+    assert TOKEN.decode() not in str(caught.value) and caught.value.__context__ is None
+
+
+@pytest.mark.parametrize("url", ["http://sandbox.test/v1/events", "https://sandbox.test/other",
+                                      "https://user@sandbox.test/v1/events", "https://127.0.0.1/v1/events"])
+def test_invalid_configuration(url):
+    with pytest.raises(module.SandboxHTTPTransportError):
+        module.SandboxHTTPSTransport(endpoint_url=url)
+
+
+@pytest.mark.asyncio
+async def test_timeout_after_write_does_not_retry(monkeypatch):
+    writer, calls, taken, take = setup(monkeypatch, response())
+
+    async def stall():
+        await asyncio.Event().wait()
+
+    writer.drain = stall
+    monkeypatch.setattr(module, "REQUEST_TIMEOUT_SECONDS", 0.01)
+    with pytest.raises(module.SandboxHTTPTransportError):
+        await module.SandboxHTTPSTransport(endpoint_url=ENDPOINT).send_once(request(), take_material=take)
+    assert len(writer.writes) == len(calls) == 1 and writer.aborted


### PR DESCRIPTION
## Purpose

Connect the native v2 owning dispatch seam to an opt-in, narrowly scoped sandbox HTTPS sender. No default transport, provider, deployment or live external request is enabled.

## Changes

- Independently configure the exact HTTPS endpoint and CA roots; verify TLS hostname and certificates, TLS 1.2+ and HTTP/1.1.
- Complete TLS before invoking the existing one-use credential callback, then write once without an intervening await. The original final send window remains enforced.
- Preserve canonical payload, digest and original Idempotency-Key; no redirects, proxies or automatic retries.
- Bound total request time to five seconds, headers to 8 KiB and Content-Length response bodies to 4 KiB. Unsupported framing/encoding or duplicate headers fail closed.
- Classify matching 201/200 acknowledgements, 409 conflict and 503 uncertainty using fixed non-secret codes. Validate acknowledgement key/event/digest/operation UUID.
- Keep durable EFFECT_UNKNOWN and observation UNKNOWN even after matching acknowledgements; do not issue BindReceipt, Outcome or replacement authority.
- Preserve existing None-returning transport behavior; update sample roundtrip artifact and EN/JA specification.

## Validation

- Related local tests: **158 passed**, four existing jsonschema deprecation warnings.
- New transport suite: **32 passed**; statement coverage **96.70%** (90% gate passed).
- Real native-verifier integration tests cover HTTP 201/200/409/503, durable uncertainty, original key and repeat-call rejection.
- Ruff, responsibility-boundary, bilingual-doc and git diff checks passed.
- Bandit: zero medium/high findings (four low-severity findings).
- Published head: `c21ce5b1c872461d49aaa956b337f546ec33b5d5`.
- Exact local/published tree: `452bbf4d0b2c0c92cc583973148261f4bab2a581`.
- Local commit `1fabb5888b66e28b147b22784723b56006a1fb8d` differs from Git Data API publication; tree equality was verified.
- Full GitHub CI is pending on this new PR.

## Security boundaries and remaining gates

Tests use synthetic credentials, real native verifiers and simulated streams. **Real TLS handshake, actual HTTPS delivery and combined PostgreSQL/receiver fault E2E are not verified here.** CA/hostname validation is not certificate fingerprint pinning or DNS/IP attestation. This restricted HTTP parser and credential-send boundary require human security review.

No live credential/provider access, external dispatch, deployment, main API authentication change, Human Approval creation, confirmed Outcome or reconciliation is performed. Python memory erasure is not claimed. Deployment prerequisites in specification section 9 remain mandatory before enabling real effects.

Draft for human maintainer review. Do not merge automatically.
