### PR TITLE
feat: add sandbox read-only reconciliation

### DIFF
--- a/docs/en/architecture/native-v2-sandbox-event-spec-v1.md
+++ b/docs/en/architecture/native-v2-sandbox-event-spec-v1.md
@@ -493,3 +493,53 @@ they do not establish a real TLS handshake, real HTTPS delivery or receiver comm
 Real TLS/host-clock and combined PostgreSQL/receiver fault tests are still required
 before enabling external effects. Section 9 prerequisites remain mandatory.
 Reconciliation must use the original key, not infer success from these observations.
+
+## 19. Owning read-only sandbox reconciliation
+
+`reconcile_sandbox_effect` receives the original authorization/payload and independent
+archived source/governance/trust inputs. It re-verifies native issuance and rebuilds
+the exact action and complete consumption row. Only the matching revision-2 sandbox
+dispatch-intent EFFECT_UNKNOWN record is eligible. Missing, substituted, terminal or
+non-sandbox records fail closed. No execution attempt or consumption is created.
+
+Current operator configuration supplies a separate reader credential reference,
+version, provider, environment and CA roots. Its fixed scope is
+`sandbox.operation.lookup.v1`; the writer reference is rejected. The exact reader,
+CA and original deployment/action configuration must be approved through an independent
+`ReconciliationVerifierPolicy`. Provider metadata is revalidated before and after
+resolution and after TLS, including audience, scope, version, non-revocation,
+expiry and trusted clock health. Separate references do not themselves prove separate
+principals: the configured provider/service must enforce this deployment property.
+
+The only network operation is GET at the original origin's `/v1/operations`, using
+the original key as its single query parameter. There is no POST, redirect, proxy,
+retry or response-selected destination. Provider plus lookup work has a five-second
+budget. The existing bounded HTTP framing parser is reused, but interpretation and
+binding are independently performed here. A matching 200 PERSISTED operation must
+contain the original key, event ID and payload digest and a valid remote operation UUID.
+The UUID is learned from the independent lookup, never from the dispatch response.
+All five operation fields, including explicit PERSISTED state, are mandatory;
+neither dispatch nor lookup may infer that state from a model default.
+
+The canonical retrieved operation digest, all observation lineage/time fields,
+approved policy hash, original record hash and reader metadata digest form the
+returned verified evidence. Only then does an existing effect-store CAS advance to
+CONFIRMED_EFFECT, with commit readback required before returning confirmation.
+404/401/503/redirects and other non-200 statuses preserve the original UNKNOWN row;
+malformed replies, mismatches, timeouts and persistence uncertainty raise sanitized
+errors without returning success. A lost CAS acknowledgement can leave a committed
+terminal record; callers must inspect trusted storage, never reset or resend.
+
+Archived issuance verification and current reader authorization are distinct: the
+original grant can expire without preventing investigation of its earlier effect.
+No current execution authority is restored. Terminal calls are rejected rather than
+rewritten. Independent means independent of dispatch, not of the sandbox operator.
+
+The effect store retains the verified-evidence digest; full returned evidence still
+needs durable archival in the later Receipt/Outcome pipeline. Crash-safe atomic
+evidence/receipt publication, replacement-authorization blocking and automatic
+terminal recovery remain separate work. This is not the complete E2E proof.
+Tests use real native verifiers with synthetic provider/streams and in-memory stores
+under explicit test opt-in. Real TLS and PostgreSQL composition and all section 9
+deployment prerequisites remain required. No live credentials or external requests
+are authorized by these tests.

--- a/docs/ja/architecture/native-v2-sandbox-event-spec-v1.md
+++ b/docs/ja/architecture/native-v2-sandbox-event-spec-v1.md
@@ -405,3 +405,42 @@ canonical payload・digest・元のkeyを検証し、TLS完了後、唯一のwri
 外部作用の有効化前には実TLS・host clock・PostgreSQLとreceiverの結合障害試験、
 および第9節の配備条件の確認が必要です。Reconciliationでは元のkeyを使い、
 HTTP観測から成功を推測しません。
+
+## 19. 独立したread-only sandbox reconciliation
+
+`reconcile_sandbox_effect`は元のauthorization・payloadと独立した過去時点の
+source/governance/trust入力でnative issuance、action binding、消費行全体を再構築します。
+対象は一致するrevision 2のsandbox dispatch-intent EFFECT_UNKNOWN行のみです。
+欠落・差替え・terminal・別経路の行は拒否し、新たな消費や実行attemptは作りません。
+
+現在のoperator設定から、送信用とは別のreader reference・version・provider・environment・
+CAを渡します。scopeは`sandbox.operation.lookup.v1`固定で、writer referenceは拒否します。
+reader・CA・元のdeployment/action設定全体への独立したReconciliationVerifierPolicy承認を
+必須とします。providerのaudience・scope・version・失効・有効期限・clock healthは
+解決前後とTLS後に再検証します。referenceの違いだけではprincipal分離の証明にならず、
+provider/serviceでread-only権限と別principalを強制する配備が必要です。
+
+元のoriginの`/v1/operations`へ、元のkeyだけをqueryに指定したGETを行います。
+POST・redirect・proxy・retry・応答指定の宛先は使いません。providerと照会全体を5秒に制限します。
+bounded HTTP framingのみ既存parserを再利用し、内容解釈とbindingは独立に検証します。
+200 PERSISTEDのkey・event ID・digestの一致とremote operation UUIDの形式を確認します。
+remote UUIDは独立lookupから取得し、dispatch応答には依存しません。
+明示的なPERSISTED stateを含む全5項目を必須とし、送信側・照合側ともに
+モデルの既定値からstateを補って成功を推測しません。
+
+取得operationのcanonical digest、全観測lineage・時刻、承認policy hash、元の行hash、
+reader metadata digestを検証済み証拠へ結び付けた後、CASでCONFIRMED_EFFECTへ進めます。
+commit readbackが確認できた場合だけ確認済みを返します。404・401・503・redirectなど
+200以外は元のUNKNOWNを保持します。不正応答・不一致・timeout・保存不明は成功を返しません。
+CAS応答喪失時にはterminal行だけcommit済みの可能性があり、resetや再送ではなく
+trusted storageの調査が必要です。
+
+過去のissuance検証と現在のreader認可は分離し、元の認可が失効していても過去の作用を
+調査できます。実行権限は復元しません。terminal行は書換えず拒否します。
+独立とはdispatch応答からの独立であり、sandbox operatorからの独立ではありません。
+
+effect storeに保持するのは証拠digestで、返した証拠全文の永続保管は後続Receipt/Outcome
+工程に残ります。証拠・receiptのatomic保存、代替認可抑止、terminal自動復旧も未完です。
+完全なE2E証明ではありません。試験は実native verifier、合成provider/stream、明示許可した
+in-memory storeを使用します。実TLS・PostgreSQL結合試験と第9節の配備条件は引き続き必須です。
+実credential・外部送信は、この試験では許可しません。

--- a/veritas_os/policy/sandbox_https_transport.py
+++ b/veritas_os/policy/sandbox_https_transport.py
@@ -119,6 +119,22 @@ async def _read_observation(
     Chunked, encoded, duplicate-header, interim and malformed responses remain
     unknown. This deliberately narrow client does not follow response locations.
     """
+    status, headers, raw = await _read_bounded_response(reader)
+    if status == 409:
+        return "HTTP_409_CONFLICT"
+    if status == 503:
+        return "HTTP_503_UNKNOWN"
+    if status not in {200, 201}:
+        return "HTTP_RESPONSE_UNKNOWN"
+    operation = _parse_operation(headers, raw)
+    if (operation.idempotency_key != request.idempotency_key
+            or operation.event_id != event_id or operation.payload_digest != request.payload_digest):
+        raise ValueError("binding")
+    return "HTTP_201_MATCHING_ACK" if status == 201 else "HTTP_200_MATCHING_ACK"
+
+
+async def _read_bounded_response(reader: asyncio.StreamReader) -> tuple[int, dict[bytes, bytes], bytes]:
+    """Bound HTTP framing only; callers independently interpret and bind content."""
     head = await reader.readuntil(b"\r\n\r\n")
     if len(head) > 8192:
         raise ValueError("headers")
@@ -137,19 +153,18 @@ async def _read_observation(
             or b"transfer-encoding" in headers or b"content-encoding" in headers):
         raise ValueError("framing")
     raw = await reader.readexactly(int(length))
-    if status == 409:
-        return "HTTP_409_CONFLICT"
-    if status == 503:
-        return "HTTP_503_UNKNOWN"
-    if status not in {200, 201}:
-        return "HTTP_RESPONSE_UNKNOWN"
+    return status, headers, raw
+
+
+def _parse_operation(headers: dict[bytes, bytes], raw: bytes) -> SandboxOperation:
+    """Parse service shape only, never authority or independent effect evidence."""
     if headers.get(b"content-type", b"").split(b";")[0].lower() != b"application/json":
         raise ValueError("type")
-    operation = SandboxOperation.model_validate(
-        json.loads(raw.decode("utf-8"), object_pairs_hook=_unique_object),
-    )
+    payload = json.loads(raw.decode("utf-8"), object_pairs_hook=_unique_object)
+    if type(payload) is not dict or set(payload) != {
+        "operation_id", "idempotency_key", "event_id", "payload_digest", "state",
+    }:
+        raise ValueError("operation fields")
+    operation = SandboxOperation.model_validate(payload)
     validate_uuid(operation.operation_id)
-    if (operation.idempotency_key != request.idempotency_key
-            or operation.event_id != event_id or operation.payload_digest != request.payload_digest):
-        raise ValueError("binding")
-    return "HTTP_201_MATCHING_ACK" if status == 201 else "HTTP_200_MATCHING_ACK"
+    return operation

--- a/veritas_os/policy/sandbox_reconciliation.py
+++ b/veritas_os/policy/sandbox_reconciliation.py
@@ -1,0 +1,266 @@
+"""Independent read-only sandbox lookup and fail-closed effect confirmation.
+
+No POST, consumption, execution claim, receipt or authorization is created.
+Historical authorization inputs and current read-only credential policy are
+separate trust inputs. A dispatch acknowledgement is never accepted as input.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import asdict, dataclass
+from datetime import datetime
+import re
+import ssl
+from typing import Any, Callable
+
+from pydantic import SecretBytes
+
+from veritas_os.policy.bind_effect_reconciliation import (
+    EffectExecutionState, EffectStateRecord, InMemoryAtomicEffectStateStore,
+    PostgresAtomicEffectStateStore, ReconciliationClaim, ReconciliationEvidence,
+    VerifiedReconciliationEvidence, _build_record,
+)
+from veritas_os.policy.live_adapter_bind_authorization_codec import _timestamp
+from veritas_os.policy.live_adapter_bind_authorization_consumption_store import (
+    InMemoryAtomicAuthorizationConsumptionStore, PostgresAtomicAuthorizationConsumptionStore,
+    build_authorization_consumption_record,
+)
+from veritas_os.policy.live_adapter_bind_authorization_contracts import (
+    BindAuthorizationTrustInputs, RealBindAuthorizationGovernanceInputs,
+)
+from veritas_os.policy.native_bind_authorization import (
+    NativeAuthorizationSourceInputs, _verified_source, verify_native_bind_authorization,
+)
+from veritas_os.policy.sandbox_action_binding import SandboxDeployment, verify_sandbox_action_binding
+from veritas_os.policy.sandbox_credential_resolution import (
+    SandboxCredentialProvider, SandboxCredentialRequest, SandboxProviderCredential, _validate_metadata,
+)
+from veritas_os.policy.sandbox_event_store import parse_event, validate_key
+from veritas_os.policy.sandbox_https_transport import _parse_operation, _read_bounded_response
+from veritas_os.policy.sandbox_pre_effect import SandboxClockReading, _clock
+from veritas_os.policy.trusted_https_reconciliation import (
+    ReconciliationVerifierPolicy, reconciliation_observation_digest,
+)
+from veritas_os.security.hash import sha256_of_canonical_json
+
+VERIFIER_ID = "sandbox-readonly-reconciliation/v1"
+LOOKUP_SCOPE = "sandbox.operation.lookup.v1"
+
+
+class SandboxReconciliationError(ValueError):
+    """No inferred outcome; original consumption and execution attempt remain."""
+
+
+@dataclass(frozen=True)
+class SandboxReaderPolicy:
+    """Current operator configuration, independent of the execution credential.
+
+    The provider must enforce read-only scope and a distinct principal/material.
+    Different references alone cannot prove separation inside a dishonest provider.
+    """
+
+    credential_reference_id: str
+    credential_version: str
+    credential_provider_type: str
+    credential_environment: str
+    ca_pem: str | None = None
+
+
+def sandbox_reconciliation_policy_hash(deployment: SandboxDeployment, reader: SandboxReaderPolicy) -> str:
+    """Approval digest for exact endpoint, action pins, reader and CA configuration."""
+    return sha256_of_canonical_json({
+        "verifier": VERIFIER_ID, "deployment": asdict(deployment), "reader": asdict(reader),
+        "scope": LOOKUP_SCOPE, "method": "GET", "path": "/v1/operations",
+        "timeout_seconds": 5, "header_limit": 8192, "body_limit": 4096,
+        "interpretation": "matching-persisted-event-only/v1",
+    })
+
+
+@dataclass(frozen=True)
+class SandboxReconciliationResult:
+    """Local record and independently retrieved evidence, not a Receipt/Outcome.
+
+    Existing effect storage persists the evidence digest. Callers must retain the
+    full returned evidence in their audit pipeline; durable evidence archival and
+    atomic Receipt/Outcome publication are not implemented by this result.
+    """
+
+    record: EffectStateRecord
+    evidence: VerifiedReconciliationEvidence | None
+
+
+async def reconcile_sandbox_effect(
+    authorization: Any, payload_json: str, *, deployment: SandboxDeployment,
+    issuance_source_inputs: NativeAuthorizationSourceInputs,
+    historical_governance_inputs: RealBindAuthorizationGovernanceInputs,
+    trust_inputs: BindAuthorizationTrustInputs,
+    consumption_store: PostgresAtomicAuthorizationConsumptionStore | InMemoryAtomicAuthorizationConsumptionStore,
+    effect_store: PostgresAtomicEffectStateStore | InMemoryAtomicEffectStateStore,
+    reader_policy: SandboxReaderPolicy, verifier_policy: ReconciliationVerifierPolicy,
+    provider: SandboxCredentialProvider, trusted_clock: Callable[[], SandboxClockReading],
+    allow_in_memory_for_testing: bool = False,
+) -> SandboxReconciliationResult:
+    """Rebuild original lineage, independently GET by key, then CAS confirmation.
+
+    Historical governance/source inputs are operator-controlled archived inputs,
+    never embedded snapshots or a packet-selected clock. They verify the original
+    grant, not permission to execute now. Current reader metadata and clock govern
+    lookup. Authorization expiry does not itself erase evidence of an earlier effect.
+    Non-200 stays unknown; invalid evidence/errors raise without state changes.
+    Confirmation is relative to the trusted sandbox/provider, not independent of
+    their operator. A failed/ambiguous CAS never returns a confirmed result.
+    """
+    response = material = token = wire = None
+    writer = None
+    cancelled = False
+    try:
+        durable = (type(consumption_store) is PostgresAtomicAuthorizationConsumptionStore
+                   and type(effect_store) is PostgresAtomicEffectStateStore)
+        if not durable and not (
+            allow_in_memory_for_testing is True
+            and type(consumption_store) is InMemoryAtomicAuthorizationConsumptionStore
+            and type(effect_store) is InMemoryAtomicEffectStateStore
+        ):
+            raise ValueError("durable stores")
+        if type(reader_policy) is not SandboxReaderPolicy or provider is None:
+            raise ValueError("reader policy")
+        if any(type(v) is not str or not v or v != v.strip() for k, v in asdict(reader_policy).items() if k != "ca_pem"):
+            raise ValueError("reader fields")
+        if reader_policy.credential_reference_id == deployment.credential_reference_id:
+            raise ValueError("writer reference")
+        policy_hash = sandbox_reconciliation_policy_hash(deployment, reader_policy)
+        if type(verifier_policy) is not ReconciliationVerifierPolicy or not verifier_policy.approves(VERIFIER_ID, policy_hash):
+            raise ValueError("unapproved policy")
+        binding = verify_sandbox_action_binding(
+            authorization, payload_json, deployment=deployment, source_inputs=issuance_source_inputs,
+            governance_inputs=historical_governance_inputs, trust_inputs=trust_inputs,
+        )
+        verified = verify_native_bind_authorization(
+            authorization, source_inputs=issuance_source_inputs,
+            governance_inputs=historical_governance_inputs, trust_inputs=trust_inputs,
+        )
+        _, _, context = _verified_source(
+            verified.source_runtime_risk_packet, issuance_source_inputs, historical_governance_inputs,
+        )
+        started = trusted_clock()
+        now = _clock(started)
+        stored = await consumption_store.get(verified.authorization_id)
+        if stored is None:
+            raise ValueError("missing consumption")
+        expected = build_authorization_consumption_record(
+            live_adapter_bind_authorization_id=verified.authorization_id,
+            live_adapter_bind_authorization_hash=verified.authorization_hash,
+            idempotency_key=verified.idempotency_key, bind_context_hash=verified.bind_context_hash,
+            execution_intent_id=verified.execution_intent_id, execution_intent_hash=verified.execution_intent_hash,
+            endpoint_identity_binding_digest=context.endpoint_identity_binding_digest,
+            credential_reference_digest=context.credential_reference_digest,
+            credential_scope_binding_digest=context.credential_scope_binding_digest, consumed_at=stored.consumed_at,
+        )
+        consumed_at = datetime.fromisoformat(_timestamp(stored.consumed_at))
+        if stored != expected or not (
+            datetime.fromisoformat(verified.valid_from) <= consumed_at < datetime.fromisoformat(verified.valid_until)
+            and consumed_at <= now
+        ):
+            raise ValueError("consumption lineage")
+        current = await effect_store.get(stored.consumption_id)
+        if current is None:
+            raise ValueError("missing attempt")
+        expected_current = _build_record(
+            consumption=stored, state=EffectExecutionState.EFFECT_UNKNOWN, revision=2,
+            updated_at=current.updated_at,
+            reason_code="SANDBOX_DISPATCH_INTENT_PERSISTED_EFFECT_UNCONFIRMED",
+        )
+        if current != expected_current or not consumed_at <= datetime.fromisoformat(_timestamp(current.updated_at)) <= now:
+            raise ValueError("dispatch lineage")
+        origin = deployment.endpoint_url.removesuffix("/v1/events")
+        host = origin.removeprefix("https://")
+        request = SandboxCredentialRequest(
+            verified.authorization_id, current.operation_id,
+            reader_policy.credential_reference_id, reader_policy.credential_provider_type,
+            reader_policy.credential_version, LOOKUP_SCOPE, reader_policy.credential_environment, origin,
+        )
+        async with asyncio.timeout(5):
+            description = await provider.describe(request)
+            metadata = _validate_metadata(description, request, started, trusted_clock())
+            digest = sha256_of_canonical_json(metadata.model_dump(mode="json"))
+            response = await provider.resolve(request, expected_metadata_digest=digest)
+            if type(response) is not SandboxProviderCredential or type(response.material) is not SecretBytes:
+                raise ValueError("provider response")
+            if _validate_metadata(response.metadata, request, started, trusted_clock()) != metadata:
+                raise ValueError("substituted credential")
+            tls = ssl.create_default_context(cadata=reader_policy.ca_pem)
+            tls.minimum_version = ssl.TLSVersion.TLSv1_2
+            tls.set_alpn_protocols(["http/1.1"])
+            key = validate_key(current.idempotency_key)
+            prefix = (f"GET /v1/operations?idempotency_key={key} HTTP/1.1\r\n"
+                      f"Host: {host}\r\nConnection: close\r\nAuthorization: Bearer ").encode("ascii")
+            stream, writer = await asyncio.open_connection(
+                host, 443, ssl=tls, server_hostname=host, limit=8192, ssl_handshake_timeout=5,
+            )
+            _validate_metadata(metadata, request, started, trusted_clock())
+            material = response.material
+            token = material.get_secret_value()
+            if not 32 <= len(token) <= 4096 or not re.fullmatch(rb"[A-Za-z0-9._~+/-]+=*", token):
+                raise ValueError("token")
+            wire = prefix + token + b"\r\n\r\n"
+            writer.write(wire)
+            material = response = token = wire = None
+            await writer.drain()
+            status, headers, raw = await _read_bounded_response(stream)
+            if status != 200:
+                return SandboxReconciliationResult(current, None)
+            operation = _parse_operation(headers, raw)
+            event = parse_event(binding.binding.payload_json.encode("utf-8"))
+            if (operation.idempotency_key != current.idempotency_key
+                    or operation.event_id != event.event_id
+                    or operation.payload_digest != binding.binding.payload_digest):
+                raise ValueError("external binding")
+            finished = trusted_clock()
+            _validate_metadata(metadata, request, started, finished)
+        observed_at = _timestamp(finished.now)
+        values = dict(
+            operation_id=current.operation_id, authorization_id=current.authorization_id,
+            consumption_id=current.consumption_id, claim=ReconciliationClaim.CONFIRMED_EFFECT,
+            source_type="sandbox-readonly-https", source_identity=origin, observed_at=observed_at,
+            external_operation_reference=operation.operation_id,
+            external_ack_digest=sha256_of_canonical_json(operation.model_dump(mode="json")),
+        )
+        evidence = ReconciliationEvidence(**values, observation_digest="0" * 64)
+        evidence = evidence.model_copy(update={"observation_digest": reconciliation_observation_digest(evidence)})
+        proof = VerifiedReconciliationEvidence(
+            evidence=evidence, verifier_id=VERIFIER_ID, verifier_policy_hash=policy_hash,
+            verification_proof_hash=sha256_of_canonical_json({
+                "observation": evidence.model_dump(mode="json"), "policy_hash": policy_hash,
+                "original_record_hash": current.record_hash, "reader_metadata_digest": digest,
+            }), verified_at=observed_at,
+        )
+        record = _build_record(
+            consumption=stored, state=EffectExecutionState.CONFIRMED_EFFECT,
+            revision=current.revision + 1, updated_at=observed_at,
+            reason_code="SANDBOX_READONLY_LOOKUP_CONFIRMED",
+            reconciliation_evidence_hash=proof.deterministic_digest(),
+        )
+        if await effect_store.get(current.operation_id) != current:
+            raise ValueError("changed attempt")
+        if not verifier_policy.approves(VERIFIER_ID, policy_hash):
+            raise ValueError("withdrawn policy")
+        if await effect_store.transition(
+            operation_id=current.operation_id, expected_state=EffectExecutionState.EFFECT_UNKNOWN, record=record,
+        ) is not True or await effect_store.get(current.operation_id) != record:
+            raise ValueError("confirmation not durable")
+        return SandboxReconciliationResult(record, proof)
+    except asyncio.CancelledError:
+        cancelled = True
+    except Exception:
+        pass
+    finally:
+        response = material = token = wire = None
+        if writer is not None:
+            try:
+                writer.transport.abort()
+            except Exception:
+                pass
+    if cancelled:
+        raise asyncio.CancelledError()
+    raise SandboxReconciliationError("SR_RECONCILIATION_FAILED_NO_RETRY")

--- a/veritas_os/tests/fixtures/sandbox_reader_policy.json
+++ b/veritas_os/tests/fixtures/sandbox_reader_policy.json
@@ -1,0 +1,7 @@
+{
+  "credential_reference_id": "synthetic-readonly-reference",
+  "credential_version": "reader-v1",
+  "credential_provider_type": "synthetic",
+  "credential_environment": "sandbox",
+  "ca_pem": null
+}

--- a/veritas_os/tests/test_sandbox_https_transport.py
+++ b/veritas_os/tests/test_sandbox_https_transport.py
@@ -168,3 +168,17 @@ async def test_timeout_after_write_does_not_retry(monkeypatch):
     with pytest.raises(module.SandboxHTTPTransportError):
         await module.SandboxHTTPSTransport(endpoint_url=ENDPOINT).send_once(request(), take_material=take)
     assert len(writer.writes) == len(calls) == 1 and writer.aborted
+
+
+@pytest.mark.asyncio
+async def test_missing_persisted_state_is_not_inferred(monkeypatch):
+    raw = response()
+    header, body = raw.split(b"\r\n\r\n", 1)
+    payload = json.loads(body)
+    payload.pop("state")
+    body = json.dumps(payload).encode()
+    raw = (f"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n"
+           f"Content-Length: {len(body)}\r\n\r\n").encode() + body
+    writer, calls, taken, take = setup(monkeypatch, raw)
+    with pytest.raises(module.SandboxHTTPTransportError):
+        await module.SandboxHTTPSTransport(endpoint_url=ENDPOINT).send_once(request(), take_material=take)

--- a/veritas_os/tests/test_sandbox_reconciliation.py
+++ b/veritas_os/tests/test_sandbox_reconciliation.py
@@ -1,0 +1,289 @@
+"""Real native verification with synthetic read-only provider and TLS streams."""
+
+import asyncio
+from dataclasses import asdict, replace
+from datetime import timedelta
+import json
+from pathlib import Path
+import ssl
+
+import pytest
+from pydantic import SecretBytes
+
+from veritas_os.policy import sandbox_reconciliation as module
+from veritas_os.policy.sandbox_credential_resolution import SandboxProviderCredential
+from veritas_os.policy.trusted_https_reconciliation import ApprovedReconciliationVerifier
+from veritas_os.tests.test_sandbox_action_binding import PAYLOAD
+from veritas_os.tests.test_sandbox_pre_effect import (
+    issued as issued_fixture, prepared_inputs as prepared_fixture, _args,
+)
+from veritas_os.tests.test_sandbox_credential_resolution import metadata
+from veritas_os.tests.test_sandbox_https_transport import Writer, TOKEN
+
+pytestmark = pytest.mark.slow
+issued = issued_fixture
+prepared_inputs = prepared_fixture
+
+
+def test_reader_sample_roundtrip_and_policy_binding():
+    from veritas_os.tests.test_sandbox_action_binding import deployment
+    values = json.loads((Path(__file__).parent / "fixtures" / "sandbox_reader_policy.json").read_text())
+    policy = module.SandboxReaderPolicy(**values)
+    assert asdict(policy) == values
+    original = module.sandbox_reconciliation_policy_hash(deployment(), policy)
+    for field in values:
+        assert module.sandbox_reconciliation_policy_hash(deployment(), replace(policy, **{field: "changed"})) != original
+
+
+class ReaderProvider:
+    def __init__(self, clock):
+        self.clock = clock
+        self.calls = []
+        self.changes = {}
+
+    async def describe(self, request):
+        self.calls.append(request)
+        fields = asdict(request)
+        fields.pop("authorization_id")
+        fields.pop("attempt_id")
+        self.metadata = metadata(self.clock.now, **(fields | self.changes))
+        return self.metadata
+
+    async def resolve(self, request, *, expected_metadata_digest):
+        self.calls.append(request)
+        assert expected_metadata_digest == module.sha256_of_canonical_json(self.metadata.model_dump(mode="json"))
+        return SandboxProviderCredential(metadata=self.metadata, material=SecretBytes(TOKEN))
+
+
+async def setup_case(prepared_inputs, monkeypatch, status=200, changes=None):
+    artifact, args = await _args(prepared_inputs)
+    args["historical_governance_inputs"] = args.pop("governance_inputs")
+    args.pop("load_current_inputs")
+    current = module._build_record(
+        consumption=prepared_inputs[2], state=module.EffectExecutionState.EFFECT_UNKNOWN,
+        revision=2, updated_at=module._timestamp(prepared_inputs[4].now),
+        reason_code="SANDBOX_DISPATCH_INTENT_PERSISTED_EFFECT_UNCONFIRMED",
+    )
+    args["effect_store"]._records[current.operation_id] = current
+    reader = module.SandboxReaderPolicy("separate-reader", "reader-v1", "synthetic", "sandbox")
+    args["reader_policy"] = reader
+    args["verifier_policy"] = module.ReconciliationVerifierPolicy((ApprovedReconciliationVerifier(
+        module.VERIFIER_ID, module.sandbox_reconciliation_policy_hash(args["deployment"], reader),
+    ),))
+    args["provider"] = ReaderProvider(prepared_inputs[4])
+    writer, calls = Writer(), []
+    operation = dict(
+        operation_id="22222222-2222-4222-8222-222222222222",
+        event_id=PAYLOAD["event_id"], payload_digest=module.sha256_of_canonical_json(PAYLOAD),
+        idempotency_key=artifact.idempotency_key, state="PERSISTED",
+    )
+    operation.update(changes or {})
+
+    async def connect(host, port, **kwargs):
+        calls.append((host, port, kwargs))
+        body = json.dumps(operation).encode()
+        stream = asyncio.StreamReader(limit=8192)
+        stream.feed_data((f"HTTP/1.1 {status} Test\r\nContent-Type: application/json\r\n"
+                          f"Content-Length: {len(body)}\r\n\r\n").encode() + body)
+        stream.feed_eof()
+        return stream, writer
+
+    monkeypatch.setattr(module.asyncio, "open_connection", connect)
+    return artifact, args, current, writer, calls
+
+
+async def reconcile(artifact, args):
+    return await module.reconcile_sandbox_effect(artifact, json.dumps(PAYLOAD), **args)
+
+
+@pytest.mark.asyncio
+async def test_independent_get_binds_original_key_and_confirms(prepared_inputs, monkeypatch):
+    artifact, args, current, writer, calls = await setup_case(prepared_inputs, monkeypatch)
+    result = await reconcile(artifact, args)
+    assert result.record.state == module.EffectExecutionState.CONFIRMED_EFFECT
+    assert result.record.reconciliation_evidence_hash == result.evidence.deterministic_digest()
+    assert result.evidence.evidence.observation_digest == module.reconciliation_observation_digest(result.evidence.evidence)
+    assert len(calls) == len(writer.writes) == 1
+    assert writer.writes[0].startswith(f"GET /v1/operations?idempotency_key={artifact.idempotency_key} HTTP/1.1\r\n".encode())
+    assert b"POST" not in writer.writes[0]
+    assert writer.aborted
+    assert calls[0][2]["ssl"].verify_mode == ssl.CERT_REQUIRED
+    assert calls[0][2]["ssl"].check_hostname
+    assert args["provider"].calls[0].credential_scope == module.LOOKUP_SCOPE
+    assert args["provider"].calls[0].credential_reference_id != args["deployment"].credential_reference_id
+    assert TOKEN.decode() not in repr(result)
+    with pytest.raises(module.SandboxReconciliationError):
+        await reconcile(artifact, args)
+    assert len(calls) == 1
+    assert await args["consumption_store"].get(artifact.authorization_id) == prepared_inputs[2]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [404, 503, 401, 302, 201])
+async def test_non_200_keeps_unknown(prepared_inputs, monkeypatch, status):
+    artifact, args, current, writer, calls = await setup_case(prepared_inputs, monkeypatch, status)
+    result = await reconcile(artifact, args)
+    assert result.record == current and result.evidence is None
+    assert await args["effect_store"].get(current.operation_id) == current
+    assert len(writer.writes) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("field,value", [
+    ("event_id", "other"), ("payload_digest", "0" * 64), ("idempotency_key", "other"),
+    ("operation_id", "not-uuid"), ("state", "SUCCESS"), ("secret", "injected"),
+])
+async def test_external_substitution_never_confirms(prepared_inputs, monkeypatch, field, value):
+    artifact, args, current, writer, calls = await setup_case(prepared_inputs, monkeypatch, changes={field: value})
+    with pytest.raises(module.SandboxReconciliationError) as caught:
+        await reconcile(artifact, args)
+    assert caught.value.__context__ is None
+    assert await args["effect_store"].get(current.operation_id) == current
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["unapproved", "writer", "contract", "source", "lineage", "state", "hash", "durability"])
+async def test_untrusted_configuration_or_lineage_prevents_lookup(prepared_inputs, monkeypatch, mode):
+    artifact, args, current, writer, calls = await setup_case(prepared_inputs, monkeypatch)
+    if mode == "unapproved":
+        args["verifier_policy"] = module.ReconciliationVerifierPolicy(())
+    elif mode == "writer":
+        args["reader_policy"] = replace(args["reader_policy"], credential_reference_id=args["deployment"].credential_reference_id)
+    elif mode == "contract":
+        gov = args["historical_governance_inputs"]
+        args["historical_governance_inputs"] = replace(gov, action_contract=replace(gov.action_contract, human_approval_rules={"required": True}))
+    elif mode == "source":
+        args["issuance_source_inputs"] = replace(args["issuance_source_inputs"], current_endpoint={})
+    elif mode == "durability":
+        args["allow_in_memory_for_testing"] = False
+    else:
+        updates = {"lineage": {"authorization_id": "other"}, "state": {"state": module.EffectExecutionState.IN_FLIGHT}, "hash": {"record_hash": "0" * 64}}
+        args["effect_store"]._records[current.operation_id] = current.model_copy(update=updates[mode])
+    with pytest.raises(module.SandboxReconciliationError):
+        await reconcile(artifact, args)
+    assert not calls and not writer.writes and not args["provider"].calls
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("changes", [{"revoked": True}, {"credential_scope": "admin"}, {"audience": "https://other.test"}, {"credential_version": "changed"}])
+async def test_reader_metadata_fail_closed(prepared_inputs, monkeypatch, changes):
+    artifact, args, current, writer, calls = await setup_case(prepared_inputs, monkeypatch)
+    args["provider"].changes = changes
+    with pytest.raises(module.SandboxReconciliationError):
+        await reconcile(artifact, args)
+    assert not calls and len(args["provider"].calls) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["false", "lost_ack", "readback", "cancel", "tls"])
+async def test_failure_never_returns_confirmed_result(prepared_inputs, monkeypatch, mode):
+    artifact, args, current, writer, calls = await setup_case(prepared_inputs, monkeypatch)
+    store = args["effect_store"]
+    original = store.transition
+
+    async def transition(**kwargs):
+        if mode == "false":
+            return False
+        result = await original(**kwargs)
+        if mode == "lost_ack":
+            raise RuntimeError(TOKEN.decode())
+        if mode == "readback":
+            store._records[current.operation_id] = current
+        return result
+
+    monkeypatch.setattr(store, "transition", transition)
+    if mode in {"cancel", "tls"}:
+        async def fail(*args, **kwargs):
+            if mode == "cancel":
+                raise asyncio.CancelledError(TOKEN.decode())
+            raise ssl.SSLError(TOKEN.decode())
+        monkeypatch.setattr(module.asyncio, "open_connection", fail)
+    error = asyncio.CancelledError if mode == "cancel" else module.SandboxReconciliationError
+    with pytest.raises(error) as caught:
+        await reconcile(artifact, args)
+    assert caught.value.__context__ is None and TOKEN.decode() not in str(caught.value)
+
+
+@pytest.mark.asyncio
+async def test_reconciliation_after_authorization_expiry_is_not_reauthorization(prepared_inputs, monkeypatch):
+    artifact, args, current, writer, calls = await setup_case(prepared_inputs, monkeypatch)
+    old = prepared_inputs[4]
+    later = old.now + timedelta(days=1)
+    clock = replace(old, now=later, health_checked_at=later, monotonic_seconds=old.monotonic_seconds + 86400)
+    args["trusted_clock"] = lambda: clock
+    args["provider"] = ReaderProvider(clock)
+    result = await reconcile(artifact, args)
+    assert result.record.state == module.EffectExecutionState.CONFIRMED_EFFECT
+    assert len(writer.writes) == 1 and writer.writes[0].startswith(b"GET ")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["scope", "version", "late_tls", "rollback"])
+async def test_post_resolution_and_tls_rechecks(prepared_inputs, monkeypatch, mode):
+    artifact, args, current, writer, calls = await setup_case(prepared_inputs, monkeypatch)
+    if mode in {"scope", "version"}:
+        original = args["provider"].resolve
+
+        async def resolve(request, **kwargs):
+            response = await original(request, **kwargs)
+            field = "credential_scope" if mode == "scope" else "credential_version"
+            return response.model_copy(update={"metadata": response.metadata.model_copy(update={field: "changed"})})
+
+        args["provider"].resolve = resolve
+    else:
+        cell = [prepared_inputs[4]]
+        args["trusted_clock"] = lambda: cell[0]
+        original_connect = module.asyncio.open_connection
+
+        async def connect(*positional, **kwargs):
+            result = await original_connect(*positional, **kwargs)
+            delta = 5.01 if mode == "late_tls" else -0.01
+            cell[0] = replace(cell[0], now=cell[0].now + timedelta(seconds=delta),
+                              monotonic_seconds=cell[0].monotonic_seconds + delta)
+            return result
+
+        monkeypatch.setattr(module.asyncio, "open_connection", connect)
+    with pytest.raises(module.SandboxReconciliationError):
+        await reconcile(artifact, args)
+    assert not writer.writes
+    assert await args["effect_store"].get(current.operation_id) == current
+
+
+@pytest.mark.asyncio
+async def test_competing_reconcilers_only_one_terminal_transition(prepared_inputs, monkeypatch):
+    artifact, args, current, writer, calls = await setup_case(prepared_inputs, monkeypatch)
+    results = await asyncio.gather(reconcile(artifact, args), reconcile(artifact, args), return_exceptions=True)
+    assert sum(isinstance(r, module.SandboxReconciliationResult) for r in results) == 1
+    assert sum(isinstance(r, module.SandboxReconciliationError) for r in results) == 1
+    assert (await args["effect_store"].get(current.operation_id)).revision == 3
+
+
+@pytest.mark.asyncio
+async def test_real_native_dispatch_to_readonly_reconciliation(prepared_inputs, monkeypatch):
+    from veritas_os.tests.test_sandbox_bind_execution import Transport, run
+    from veritas_os.tests.test_sandbox_credential_resolution_integration import Provider
+    artifact, dispatch_args = await _args(prepared_inputs)
+    observation = await run(artifact, dispatch_args, Provider(prepared_inputs, dispatch_args), Transport(dispatch_args))
+    assert observation.state == "UNKNOWN"
+    _, args, _, writer, calls = await setup_case(prepared_inputs, monkeypatch)
+    args["consumption_store"] = dispatch_args["consumption_store"]
+    args["effect_store"] = dispatch_args["effect_store"]
+    result = await reconcile(artifact, args)
+    assert result.record.state == module.EffectExecutionState.CONFIRMED_EFFECT
+    assert result.record.consumption_id == observation.consumption_id
+    assert len(writer.writes) == 1 and writer.writes[0].startswith(b"GET ")
+
+
+@pytest.mark.asyncio
+async def test_lookup_timeout_retains_unknown_without_resend(prepared_inputs, monkeypatch):
+    artifact, args, current, writer, calls = await setup_case(prepared_inputs, monkeypatch)
+
+    async def timeout(reader):
+        raise TimeoutError(TOKEN.decode())
+
+    monkeypatch.setattr(module, "_read_bounded_response", timeout)
+    with pytest.raises(module.SandboxReconciliationError) as caught:
+        await reconcile(artifact, args)
+    assert TOKEN.decode() not in str(caught.value) and caught.value.__context__ is None
+    assert len(calls) == len(writer.writes) == 1
+    assert await args["effect_store"].get(current.operation_id) == current


### PR DESCRIPTION
## Purpose

Add an owning, read-only reconciliation path for the native v2 sandbox effect. It independently retrieves the sandbox operation by the original idempotency key and confirms an existing EFFECT_UNKNOWN record only after every original lineage and current reader-policy binding matches.

## Changes

- Re-verify the original native authorization with independent archived source/governance/trust inputs and rebuild the exact action and complete consumption row.
- Accept only the matching revision-2 sandbox dispatch-intent EFFECT_UNKNOWN record; reject substituted, terminal and non-sandbox state.
- Require a separate reader credential reference with fixed `sandbox.operation.lookup.v1` scope and an independently approved verifier-policy hash over deployment, reader, CA and interpretation inputs.
- Revalidate provider audience, scope, version, revocation, validity and clock health before/after resolution and after TLS connection.
- Perform one GET to the original origin using the original idempotency key; no POST, redirect, proxy or retry.
- Require an explicit five-field PERSISTED operation. Validate operation UUID, original key, event ID and payload digest; do not infer missing state from model defaults.
- Bind canonical lookup evidence, verifier policy, original state hash and reader metadata digest before a compare-and-set transition to CONFIRMED_EFFECT.
- Keep 404/401/503/redirect responses UNKNOWN. Malformed responses, substitution, timeout or storage ambiguity return no confirmed result.
- Allow investigation after original authorization expiry without restoring execution authority.
- Add committed reader-policy sample, roundtrip/drift test and EN/JA specification updates.

## Validation

- Related local tests: **130 passed**, four existing jsonschema deprecation warnings.
- New reconciliation module statement coverage: **90.98%** before the final timeout regression addition; 90% gate passed.
- Adversarial coverage includes key/event/digest/state substitution, missing state, contract/source/lineage substitution, unapproved policy, writer-reference reuse, reader metadata drift, TLS/timeout/clock failure, concurrent reconcilers, CAS failure/readback/acknowledgement loss and expired-authorization investigation.
- Ruff, Bandit (zero medium/high findings), bilingual-doc, responsibility-boundary, raw-httpx usage and git diff checks passed.
- Published head: `1f64ddd694439efb6c34aaa4eea02c978052dc6b`.
- Exact local/published tree: `1088f04a5ec49778358b8aa3a105a9d1332ce46b`.
- Local commit `15440568575c8bbb65209a49cbdd71cbae56cc2c` differs from the Git Data API publication head; tree equality was verified.
- Full GitHub CI is pending.

## Security boundaries and remaining work

The result confirms persistence relative to the trusted sandbox service/provider and independently of the dispatch response; it is not independent of the sandbox operator. Tests use synthetic credentials, real native verifiers, simulated streams and explicitly opted-in in-memory stores.

No live credential, external request, new execution authorization, Human Approval, BindReceipt or Outcome is created. Real TLS plus PostgreSQL composition, full verified-evidence archival, atomic Receipt/Outcome publication, replacement-authorization blocking and terminal recovery remain incomplete. This PR is not the complete Decision-to-Effect E2E proof.

Draft for human security review. Do not merge automatically.
