### PR TITLE
feat: atomically archive sandbox reconciliation evidence

### DIFF
--- a/alembic/versions/0006_sandbox_reconciliation_archive.py
+++ b/alembic/versions/0006_sandbox_reconciliation_archive.py
@@ -1,0 +1,21 @@
+"""Atomically retain sandbox reconciliation evidence beside its effect state.
+
+Revision ID: 0006
+Revises: 0005
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0006"
+down_revision = "0005"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("bind_effect_states", sa.Column("reconciliation_archive", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    # Archival data must be exported before an operator chooses this downgrade.
+    op.drop_column("bind_effect_states", "reconciliation_archive")

--- a/docs/en/architecture/native-v2-sandbox-event-spec-v1.md
+++ b/docs/en/architecture/native-v2-sandbox-event-spec-v1.md
@@ -543,3 +543,38 @@ Tests use real native verifiers with synthetic provider/streams and in-memory st
 under explicit test opt-in. Real TLS and PostgreSQL composition and all section 9
 deployment prerequisites remain required. No live credentials or external requests
 are authorized by these tests.
+
+## 20. Atomic reconciliation evidence archival
+
+This section supersedes section 19's digest-only storage limitation. After migration
+0006, the sandbox reconciliation owner commits the CONFIRMED_EFFECT record and a
+full `SandboxReconciliationArchive` in one SQL UPDATE on `bind_effect_states`.
+The compare-and-set checks the exact original JSON record, hash, state and revision,
+and requires an empty archive column. A failed CAS writes neither value. Existing
+transition methods cannot rewrite a row once its archive has been committed.
+
+The archive contains the verified evidence, original UNKNOWN record, five-field
+retrieved operation and reader metadata digest. These are sufficient to recompute
+its observation, acknowledgement, original-record and verification-proof hashes.
+It contains no token, Authorization header, raw response or event message.
+`get_reconciliation` reads the state/archive pair together and validates schemas,
+hashes, times and lineage. Only a successful commit and validated readback allow
+`reconcile_sandbox_effect` to return confirmation. Missing or inconsistent evidence
+fails closed; legacy terminal rows are never backfilled with invented proof.
+
+A lost commit acknowledgement can still raise after both values were committed.
+An operator can subsequently read the archived evidence without a new lookup,
+POST, authorization or state transition. This is integrity-checked retrieval,
+not automatic recovery, renewed HTTPS verification or a Receipt/Outcome. Hashes
+are not signatures and do not protect against a database operator rewriting all
+bound data. The trusted sandbox/provider and database remain trust assumptions.
+
+Deploy migration 0006 before this code, including use of legacy transition methods.
+The nullable column preserves old records and hashes. A downgrade drops archived
+evidence; operators must preserve it under the applicable retention policy first.
+Real PostgreSQL tests in the effect-state CI workflow exercise rollback, lost
+commit acknowledgement, contention, fresh-store readback and missing evidence.
+They establish storage behavior, not the combined real-TLS/receiver E2E proof.
+Receipt/Outcome publication, replacement-authorization blocking, automated crash
+recovery and real TLS/provider/host-clock composition remain outstanding. Section
+9 deployment prerequisites continue to apply; no live external access is enabled.

--- a/docs/ja/architecture/native-v2-sandbox-event-spec-v1.md
+++ b/docs/ja/architecture/native-v2-sandbox-event-spec-v1.md
@@ -444,3 +444,31 @@ effect storeに保持するのは証拠digestで、返した証拠全文の永�
 完全なE2E証明ではありません。試験は実native verifier、合成provider/stream、明示許可した
 in-memory storeを使用します。実TLS・PostgreSQL結合試験と第9節の配備条件は引き続き必須です。
 実credential・外部送信は、この試験では許可しません。
+
+## 20. 照合証拠と確定状態の原子的保存
+
+本節は第19節の「digestのみ保存」という制限を更新します。migration 0006の適用後、
+sandbox reconciliationはCONFIRMED_EFFECT行と証拠全文SandboxReconciliationArchiveを
+bind_effect_statesの一つのSQL UPDATEで保存します。CASは元のJSON行全体・hash・state・
+revisionの一致とarchive列が空であることを要求します。CAS不成立時はどちらも保存せず、
+archive保存済みの行は既存transitionからも更新できません。
+
+archiveには検証済み証拠、元のUNKNOWN行、取得operationの5項目、reader metadata digestを
+保持し、observation・acknowledgement・元の行・verification proofのhashを再計算できます。
+token・Authorization header・生応答・event messageは保存しません。get_reconciliationは
+状態と証拠を一緒に読み、schema・hash・時刻・lineageを検証します。commitと検証済みreadbackが
+成功した場合だけreconcile_sandbox_effectは確定を返します。証拠欠落や不整合は拒否し、
+既存のterminal行へ架空の証拠を補完しません。
+
+commit応答喪失時は、両方が保存済みでも例外を返す可能性があります。その後operatorは
+新しいlookup・POST・認可・状態変更なしで証拠を取得できます。これは保存内容の整合性検証で、
+自動復旧・HTTPS再検証・Receipt/Outcome発行ではありません。hashは署名ではなく、DB管理者が
+関連データ全体を書き換える攻撃は防ぎません。sandbox/providerとDBの信頼は前提に残ります。
+
+既存transitionを含め、このコードの利用前にmigration 0006を適用します。nullable列の追加で
+旧行とhashは維持します。downgradeは証拠を削除するため、operatorは先に保持方針に従って
+保存する必要があります。effect-state CIの実PostgreSQL試験はrollback・commit応答喪失・
+競合・別storeからの読戻し・証拠欠落を検証します。これは保存処理の試験であり、実TLSとreceiverを
+結合したE2E証明ではありません。Receipt/Outcome発行、代替認可による重複実行の抑止、自動障害復旧、
+実TLS/provider/host-clockの結合検証は未完です。第9節の配備条件は引き続き適用し、実外部アクセスは
+有効化しません。

--- a/veritas_os/policy/bind_effect_reconciliation.py
+++ b/veritas_os/policy/bind_effect_reconciliation.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import asyncio
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -25,6 +25,9 @@ from veritas_os.policy.live_adapter_bind_authorization_consumption_store import 
     AuthorizationConsumptionStoreError,
 )
 from veritas_os.security.hash import sha256_of_canonical_json
+
+if TYPE_CHECKING:
+    from veritas_os.policy.sandbox_reconciliation_archive import SandboxReconciliationArchive
 
 _HASH = r"^[0-9a-f]{64}$"
 
@@ -170,6 +173,7 @@ class InMemoryAtomicEffectStateStore:
     def __init__(self) -> None:
         self._lock = asyncio.Lock()
         self._records: dict[str, EffectStateRecord] = {}
+        self._archives: dict[str, SandboxReconciliationArchive] = {}
 
     async def create_in_flight(self, record: EffectStateRecord) -> bool:
         async with self._lock:
@@ -187,12 +191,42 @@ class InMemoryAtomicEffectStateStore:
     ) -> bool:
         async with self._lock:
             current = self._records.get(operation_id)
-            if current is None or current.state != expected_state:
+            if current is None or current.state != expected_state or operation_id in self._archives:
                 return False
             if record.revision != current.revision + 1:
                 return False
             self._records[operation_id] = record
             return True
+
+    async def confirm_reconciliation(
+        self, *, expected: EffectStateRecord, record: EffectStateRecord,
+        archive: SandboxReconciliationArchive,
+    ) -> bool:
+        """Test-only atomic state and archive commit under the same lock."""
+        from veritas_os.policy.sandbox_reconciliation_archive import validate_archive
+
+        archive = validate_archive(record, archive)
+        if archive.original_record != expected:
+            raise BindEffectStateError("BES_ARCHIVE_EXPECTED_MISMATCH")
+        async with self._lock:
+            if self._records.get(expected.operation_id) != expected or expected.operation_id in self._archives:
+                return False
+            self._archives[expected.operation_id] = archive
+            self._records[expected.operation_id] = record
+            return True
+
+    async def get_reconciliation(self, operation_id: str) -> SandboxReconciliationArchive | None:
+        """Read and integrity-check the record/archive pair under one lock."""
+        from veritas_os.policy.sandbox_reconciliation_archive import validate_archive
+
+        async with self._lock:
+            record = self._records.get(operation_id)
+            archive = self._archives.get(operation_id)
+            if record is None and archive is None:
+                return None
+            if record is None or archive is None or record.operation_id != operation_id:
+                raise BindEffectStateError("BES_ARCHIVE_MISSING_OR_MISMATCHED")
+            return validate_archive(record, archive)
 
     async def get(self, operation_id: str) -> EffectStateRecord | None:
         async with self._lock:
@@ -248,7 +282,7 @@ class PostgresAtomicEffectStateStore:
                 cur = await conn.execute(
                     "UPDATE bind_effect_states SET state=%s, revision=%s, record_hash=%s, "
                     "updated_at=%s, record=%s WHERE operation_id=%s AND state=%s "
-                    "AND revision=%s RETURNING operation_id",
+                    "AND revision=%s AND reconciliation_archive IS NULL RETURNING operation_id",
                     (
                         record.state.value,
                         record.revision,
@@ -263,6 +297,69 @@ class PostgresAtomicEffectStateStore:
                 return await cur.fetchone() is not None
         except Exception:
             raise BindEffectStateError("BES_POSTGRES_TRANSITION_FAILED") from None
+
+    async def confirm_reconciliation(
+        self, *, expected: EffectStateRecord, record: EffectStateRecord,
+        archive: SandboxReconciliationArchive,
+    ) -> bool:
+        """One SQL CAS commits full evidence and terminal state together.
+
+        This storage method checks integrity, not external truth. Only the owning
+        verifier may supply evidence. No nested transaction or caller connection
+        is accepted; pool context exit commits before a result is returned.
+        """
+        try:
+            from psycopg.types.json import Jsonb
+            from veritas_os.storage.db import get_pool
+            from veritas_os.policy.sandbox_reconciliation_archive import validate_archive
+
+            archive = validate_archive(record, archive)
+            if archive.original_record != expected:
+                raise ValueError("expected record")
+            pool = await get_pool()
+            async with pool.connection() as conn:
+                cur = await conn.execute(
+                    "UPDATE bind_effect_states SET state=%s, revision=%s, record_hash=%s, "
+                    "updated_at=%s, record=%s, reconciliation_archive=%s "
+                    "WHERE operation_id=%s AND state=%s AND revision=%s AND record_hash=%s "
+                    "AND record::jsonb=%s::jsonb AND reconciliation_archive IS NULL "
+                    "RETURNING operation_id",
+                    (record.state.value, record.revision, record.record_hash, record.updated_at,
+                     Jsonb(record.model_dump(mode="json")), Jsonb(archive.model_dump(mode="json")),
+                     expected.operation_id, expected.state.value, expected.revision, expected.record_hash,
+                     Jsonb(expected.model_dump(mode="json"))),
+                )
+                changed = await cur.fetchone() is not None
+            return changed
+        except Exception:
+            pass
+        raise BindEffectStateError("BES_ARCHIVE_COMMIT_FAILED")
+
+    async def get_reconciliation(self, operation_id: str) -> SandboxReconciliationArchive | None:
+        """Read both values in one snapshot; never return unvalidated evidence."""
+        try:
+            from veritas_os.storage.db import get_pool
+            from veritas_os.policy.sandbox_reconciliation_archive import (
+                SandboxReconciliationArchive, validate_archive,
+            )
+
+            pool = await get_pool()
+            async with pool.connection() as conn:
+                cur = await conn.execute(
+                    "SELECT record, reconciliation_archive FROM bind_effect_states WHERE operation_id=%s",
+                    (operation_id,),
+                )
+                row = await cur.fetchone()
+            if row is None:
+                return None
+            record = EffectStateRecord.model_validate(row[0])
+            # Missing archives (including legacy terminal rows) are not invented.
+            if record.operation_id != operation_id or row[1] is None:
+                raise ValueError("missing archive")
+            return validate_archive(record, SandboxReconciliationArchive.model_validate(row[1]))
+        except Exception:
+            pass
+        raise BindEffectStateError("BES_ARCHIVE_READ_FAILED")
 
     async def get(self, operation_id: str) -> EffectStateRecord | None:
         try:

--- a/veritas_os/policy/sandbox_reconciliation.py
+++ b/veritas_os/policy/sandbox_reconciliation.py
@@ -36,6 +36,7 @@ from veritas_os.policy.sandbox_action_binding import SandboxDeployment, verify_s
 from veritas_os.policy.sandbox_credential_resolution import (
     SandboxCredentialProvider, SandboxCredentialRequest, SandboxProviderCredential, _validate_metadata,
 )
+from veritas_os.policy.sandbox_reconciliation_archive import SandboxReconciliationArchive
 from veritas_os.policy.sandbox_event_store import parse_event, validate_key
 from veritas_os.policy.sandbox_https_transport import _parse_operation, _read_bounded_response
 from veritas_os.policy.sandbox_pre_effect import SandboxClockReading, _clock
@@ -81,9 +82,8 @@ def sandbox_reconciliation_policy_hash(deployment: SandboxDeployment, reader: Sa
 class SandboxReconciliationResult:
     """Local record and independently retrieved evidence, not a Receipt/Outcome.
 
-    Existing effect storage persists the evidence digest. Callers must retain the
-    full returned evidence in their audit pipeline; durable evidence archival and
-    atomic Receipt/Outcome publication are not implemented by this result.
+    Effect storage atomically persists the full verified evidence and its proof
+    inputs with the confirmed state. Receipt/Outcome publication remains separate.
     """
 
     record: EffectStateRecord
@@ -245,9 +245,12 @@ async def reconcile_sandbox_effect(
             raise ValueError("changed attempt")
         if not verifier_policy.approves(VERIFIER_ID, policy_hash):
             raise ValueError("withdrawn policy")
-        if await effect_store.transition(
-            operation_id=current.operation_id, expected_state=EffectExecutionState.EFFECT_UNKNOWN, record=record,
-        ) is not True or await effect_store.get(current.operation_id) != record:
+        archive = SandboxReconciliationArchive(
+            original_record=current, operation=operation, reader_metadata_digest=digest, proof=proof,
+        )
+        if await effect_store.confirm_reconciliation(
+            expected=current, record=record, archive=archive,
+        ) is not True or await effect_store.get_reconciliation(current.operation_id) != archive:
             raise ValueError("confirmation not durable")
         return SandboxReconciliationResult(record, proof)
     except asyncio.CancelledError:

--- a/veritas_os/policy/sandbox_reconciliation_archive.py
+++ b/veritas_os/policy/sandbox_reconciliation_archive.py
@@ -1,0 +1,99 @@
+"""Integrity-checked sandbox reconciliation archive; never execution authority.
+
+Hashes detect inconsistent storage, not a malicious database operator rewriting
+all records. The original HTTPS verifier remains the observation trust boundary.
+No credential material, HTTP headers or event message is archived.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from veritas_os.policy.bind_effect_reconciliation import (
+    EffectExecutionState, EffectStateRecord, ReconciliationClaim,
+    VerifiedReconciliationEvidence, _record_hash_payload,
+)
+from veritas_os.policy.live_adapter_bind_authorization_codec import _timestamp
+from veritas_os.policy.sandbox_event_store import SandboxOperation, validate_uuid, validate_key
+from veritas_os.policy.trusted_https_reconciliation import reconciliation_observation_digest
+from veritas_os.security.hash import sha256_of_canonical_json
+
+
+class SandboxReconciliationArchive(BaseModel):
+    """Full verified evidence and inputs needed to recompute its proof hash."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    format_version: Literal["sandbox-reconciliation-archive/v1"] = "sandbox-reconciliation-archive/v1"
+    original_record: EffectStateRecord
+    operation: SandboxOperation
+    reader_metadata_digest: str = Field(pattern=r"^[0-9a-f]{64}$")
+    proof: VerifiedReconciliationEvidence
+
+    @field_validator("operation", mode="before")
+    @classmethod
+    def explicit_operation(cls, value: object) -> object:
+        """Stored observations cannot infer a missing PERSISTED field."""
+        fields = {"operation_id", "event_id", "idempotency_key", "payload_digest", "state"}
+        if isinstance(value, SandboxOperation):
+            if value.model_fields_set != fields:
+                raise ValueError("operation fields")
+        elif type(value) is not dict or set(value) != fields:
+            raise ValueError("operation fields")
+        return value
+
+
+def validate_archive(record: EffectStateRecord, archive: SandboxReconciliationArchive) -> SandboxReconciliationArchive:
+    """Revalidate stored schemas, canonical hashes and exact terminal lineage.
+
+    Integrity verification only: no new HTTPS observation, policy approval,
+    authorization or outcome receipt is created by reading stored evidence.
+    """
+    archive = SandboxReconciliationArchive.model_validate(archive.model_dump(mode="python", warnings=False))
+    record = EffectStateRecord.model_validate(record.model_dump(mode="python", warnings=False))
+    original, operation, proof = archive.original_record, archive.operation, archive.proof
+    evidence = proof.evidence
+    for item in (original, record):
+        if item.format_version != "bind-effect-state/v1" or item.record_hash != sha256_of_canonical_json(
+            _record_hash_payload(item.model_dump(mode="json"))
+        ):
+            raise ValueError("record hash")
+    if (original.state != EffectExecutionState.EFFECT_UNKNOWN or original.revision != 2
+            or original.reason_code != "SANDBOX_DISPATCH_INTENT_PERSISTED_EFFECT_UNCONFIRMED"
+            or original.reconciliation_evidence_hash is not None
+            or record.state != EffectExecutionState.CONFIRMED_EFFECT or record.revision != 3
+            or record.reason_code != "SANDBOX_READONLY_LOOKUP_CONFIRMED"):
+        raise ValueError("state")
+    for field in ("operation_id", "authorization_id", "authorization_hash", "consumption_id",
+                  "consumption_hash", "execution_intent_id", "idempotency_key"):
+        if getattr(original, field) != getattr(record, field):
+            raise ValueError("lineage")
+    if original.operation_id != original.consumption_id:
+        raise ValueError("operation lineage")
+    for field in ("operation_id", "authorization_id", "consumption_id"):
+        if getattr(evidence, field) != getattr(original, field):
+            raise ValueError("evidence lineage")
+    validate_uuid(operation.operation_id)
+    validate_uuid(operation.event_id)
+    validate_key(operation.idempotency_key)
+    if (operation.state != "PERSISTED" or operation.idempotency_key != original.idempotency_key
+            or evidence.format_version != "bind-effect-reconciliation-evidence/v1"
+            or evidence.claim != ReconciliationClaim.CONFIRMED_EFFECT
+            or evidence.source_type != "sandbox-readonly-https"
+            or proof.verifier_id != "sandbox-readonly-reconciliation/v1"
+            or evidence.external_operation_reference != operation.operation_id
+            or evidence.external_ack_digest != sha256_of_canonical_json(operation.model_dump(mode="json"))
+            or evidence.observation_digest != reconciliation_observation_digest(evidence)
+            or record.reconciliation_evidence_hash != proof.deterministic_digest()
+            or record.updated_at != proof.verified_at or proof.verified_at != evidence.observed_at
+            or datetime.fromisoformat(_timestamp(original.updated_at)) > datetime.fromisoformat(_timestamp(record.updated_at))):
+        raise ValueError("observation")
+    if proof.verification_proof_hash != sha256_of_canonical_json({
+        "observation": evidence.model_dump(mode="json"), "policy_hash": proof.verifier_policy_hash,
+        "original_record_hash": original.record_hash,
+        "reader_metadata_digest": archive.reader_metadata_digest,
+    }):
+        raise ValueError("proof")
+    return archive

--- a/veritas_os/tests/test_pg_bind_effect_state_contention.py
+++ b/veritas_os/tests/test_pg_bind_effect_state_contention.py
@@ -108,3 +108,67 @@ async def test_real_postgres_consumption_read_and_attempt_creation_have_one_winn
     restarted = PostgresAtomicEffectStateStore()
     assert await restarted.get(attempt.operation_id) == attempt
     assert not await restarted.create_in_flight(attempt)
+
+
+@pytest.mark.asyncio
+async def test_real_postgres_archive_atomicity_contention_and_restart(monkeypatch):
+    """A failed commit preserves UNKNOWN; an acknowledged-lost commit retains both."""
+    from contextlib import asynccontextmanager
+    from veritas_os.storage import db
+    from veritas_os.policy.bind_effect_reconciliation import BindEffectStateError
+    from veritas_os.tests.test_sandbox_reconciliation_archive import archive_case
+
+    _require_real_postgresql()
+    real_get_pool = db.get_pool
+    pool = await real_get_pool()
+    original, terminal, archive = archive_case(uuid4().hex)
+    store = PostgresAtomicEffectStateStore()
+    assert await store.create_in_flight(original)
+
+    class FaultPool:
+        def __init__(self, mode):
+            self.mode = mode
+
+        @asynccontextmanager
+        async def connection(self):
+            async with pool.connection() as conn:
+                yield conn
+                if self.mode == "rollback":
+                    raise RuntimeError("synthetic commit failure")
+            if self.mode == "lost_ack":
+                raise RuntimeError("synthetic acknowledgement loss")
+
+    for mode in ("rollback", "lost_ack"):
+        async def faulty_pool(mode=mode):
+            return FaultPool(mode)
+
+        monkeypatch.setattr(db, "get_pool", faulty_pool)
+        with pytest.raises(BindEffectStateError) as caught:
+            await store.confirm_reconciliation(expected=original, record=terminal, archive=archive)
+        assert caught.value.__context__ is None
+        monkeypatch.setattr(db, "get_pool", real_get_pool)
+        restarted = PostgresAtomicEffectStateStore()
+        if mode == "rollback":
+            assert await restarted.get(original.operation_id) == original
+            async with pool.connection() as conn:
+                cur = await conn.execute("SELECT reconciliation_archive FROM bind_effect_states WHERE operation_id=%s", (original.operation_id,))
+                assert (await cur.fetchone())[0] is None
+        else:
+            assert await restarted.get(original.operation_id) == terminal
+            assert await restarted.get_reconciliation(original.operation_id) == archive
+            assert not await restarted.confirm_reconciliation(expected=original, record=terminal, archive=archive)
+            assert not await restarted.transition(operation_id=terminal.operation_id, expected_state=terminal.state,
+                                                  record=terminal.model_copy(update={"revision": 4}))
+
+    original, terminal, archive = archive_case(uuid4().hex)
+    assert await store.create_in_flight(original)
+    outcomes = await asyncio.gather(*(PostgresAtomicEffectStateStore().confirm_reconciliation(
+        expected=original, record=terminal, archive=archive,
+    ) for _ in range(16)))
+    assert outcomes.count(True) == 1
+    assert await PostgresAtomicEffectStateStore().get_reconciliation(original.operation_id) == archive
+    # Corrupt the persisted evidence while retaining the terminal row: reads must fail.
+    async with pool.connection() as conn:
+        await conn.execute("UPDATE bind_effect_states SET reconciliation_archive=NULL WHERE operation_id=%s", (original.operation_id,))
+    with pytest.raises(BindEffectStateError):
+        await store.get_reconciliation(original.operation_id)

--- a/veritas_os/tests/test_sandbox_reconciliation.py
+++ b/veritas_os/tests/test_sandbox_reconciliation.py
@@ -179,7 +179,7 @@ async def test_reader_metadata_fail_closed(prepared_inputs, monkeypatch, changes
 async def test_failure_never_returns_confirmed_result(prepared_inputs, monkeypatch, mode):
     artifact, args, current, writer, calls = await setup_case(prepared_inputs, monkeypatch)
     store = args["effect_store"]
-    original = store.transition
+    original = store.confirm_reconciliation
 
     async def transition(**kwargs):
         if mode == "false":
@@ -191,7 +191,7 @@ async def test_failure_never_returns_confirmed_result(prepared_inputs, monkeypat
             store._records[current.operation_id] = current
         return result
 
-    monkeypatch.setattr(store, "transition", transition)
+    monkeypatch.setattr(store, "confirm_reconciliation", transition)
     if mode in {"cancel", "tls"}:
         async def fail(*args, **kwargs):
             if mode == "cancel":
@@ -287,3 +287,26 @@ async def test_lookup_timeout_retains_unknown_without_resend(prepared_inputs, mo
     assert TOKEN.decode() not in str(caught.value) and caught.value.__context__ is None
     assert len(calls) == len(writer.writes) == 1
     assert await args["effect_store"].get(current.operation_id) == current
+
+
+@pytest.mark.asyncio
+async def test_lost_commit_ack_retains_full_evidence_without_new_lookup(prepared_inputs, monkeypatch):
+    artifact, args, current, writer, calls = await setup_case(prepared_inputs, monkeypatch)
+    store = args["effect_store"]
+    commit = store.confirm_reconciliation
+
+    async def lost_ack(**kwargs):
+        assert await commit(**kwargs)
+        raise RuntimeError(TOKEN.decode())
+
+    monkeypatch.setattr(store, "confirm_reconciliation", lost_ack)
+    with pytest.raises(module.SandboxReconciliationError):
+        await reconcile(artifact, args)
+    archive = await store.get_reconciliation(current.operation_id)
+    assert archive.original_record == current
+    assert archive.proof.deterministic_digest() == (await store.get(current.operation_id)).reconciliation_evidence_hash
+    assert TOKEN.decode() not in archive.model_dump_json()
+    assert len(calls) == len(writer.writes) == 1
+    with pytest.raises(module.SandboxReconciliationError):
+        await reconcile(artifact, args)
+    assert len(calls) == 1

--- a/veritas_os/tests/test_sandbox_reconciliation_archive.py
+++ b/veritas_os/tests/test_sandbox_reconciliation_archive.py
@@ -1,0 +1,142 @@
+"""Storage integrity tests with synthetic evidence, not external-effect proof."""
+from __future__ import annotations
+
+import asyncio
+from copy import deepcopy
+
+import pytest
+
+from veritas_os.policy.bind_effect_reconciliation import (
+    BindEffectStateError, EffectExecutionState, InMemoryAtomicEffectStateStore,
+    ReconciliationClaim, ReconciliationEvidence, VerifiedReconciliationEvidence, _build_record,
+)
+from veritas_os.policy.sandbox_event_store import SandboxOperation
+from veritas_os.policy.sandbox_reconciliation_archive import SandboxReconciliationArchive, validate_archive
+from veritas_os.policy.trusted_https_reconciliation import reconciliation_observation_digest
+from veritas_os.security.hash import sha256_of_canonical_json
+from veritas_os.tests.test_pg_bind_effect_state_contention import _consumption
+
+
+def archive_case(token="archive-test"):
+    consumed = _consumption(token)
+    original = _build_record(
+        consumption=consumed, state=EffectExecutionState.EFFECT_UNKNOWN, revision=2,
+        updated_at="2026-08-24T00:00:01+00:00",
+        reason_code="SANDBOX_DISPATCH_INTENT_PERSISTED_EFFECT_UNCONFIRMED",
+    )
+    operation = SandboxOperation(
+        operation_id="22222222-2222-4222-8222-222222222222",
+        event_id="33333333-3333-4333-8333-333333333333",
+        idempotency_key=original.idempotency_key, payload_digest="a" * 64, state="PERSISTED",
+    )
+    observation = ReconciliationEvidence(
+        operation_id=original.operation_id, authorization_id=original.authorization_id,
+        consumption_id=original.consumption_id, claim=ReconciliationClaim.CONFIRMED_EFFECT,
+        source_type="sandbox-readonly-https", source_identity="https://sandbox.test",
+        observed_at="2026-08-24T00:00:02+00:00", external_operation_reference=operation.operation_id,
+        external_ack_digest=sha256_of_canonical_json(operation.model_dump(mode="json")),
+        observation_digest="0" * 64,
+    )
+    observation = observation.model_copy(update={"observation_digest": reconciliation_observation_digest(observation)})
+    metadata_digest = "b" * 64
+    policy_hash = "c" * 64
+    proof = VerifiedReconciliationEvidence(
+        evidence=observation, verifier_id="sandbox-readonly-reconciliation/v1",
+        verifier_policy_hash=policy_hash, verified_at=observation.observed_at,
+        verification_proof_hash=sha256_of_canonical_json({
+            "observation": observation.model_dump(mode="json"), "policy_hash": policy_hash,
+            "original_record_hash": original.record_hash, "reader_metadata_digest": metadata_digest,
+        }),
+    )
+    record = _build_record(
+        consumption=consumed, state=EffectExecutionState.CONFIRMED_EFFECT, revision=3,
+        updated_at=proof.verified_at, reason_code="SANDBOX_READONLY_LOOKUP_CONFIRMED",
+        reconciliation_evidence_hash=proof.deterministic_digest(),
+    )
+    archive = SandboxReconciliationArchive(
+        original_record=original, operation=operation, reader_metadata_digest=metadata_digest, proof=proof,
+    )
+    return original, record, archive
+
+
+def test_archive_roundtrip_recomputes_all_proof_inputs():
+    _, record, archive = archive_case()
+    restored = SandboxReconciliationArchive.model_validate_json(archive.model_dump_json())
+    assert validate_archive(record, restored) == archive
+
+
+@pytest.mark.parametrize("path,value", [
+    (("reader_metadata_digest",), "f" * 64),
+    (("operation", "event_id"), "44444444-4444-4444-8444-444444444444"),
+    (("operation", "state"), "SUCCESS"),
+    (("operation", "payload_digest"), "f" * 64),
+    (("operation", "operation_id"), "44444444-4444-4444-8444-444444444444"),
+    (("original_record", "record_hash"), "f" * 64),
+    (("proof", "verification_proof_hash"), "f" * 64),
+    (("proof", "verifier_policy_hash"), "f" * 64),
+    (("proof", "evidence", "observation_digest"), "f" * 64),
+    (("proof", "evidence", "authorization_id"), "other"),
+    (("proof", "verified_at"), "2026-08-24T00:00:03+00:00"),
+])
+def test_archive_substitution_is_rejected(path, value):
+    _, record, archive = archive_case()
+    data = deepcopy(archive.model_dump(mode="json"))
+    node = data
+    for field in path[:-1]:
+        node = node[field]
+    node[path[-1]] = value
+    with pytest.raises(ValueError):
+        validate_archive(record, SandboxReconciliationArchive.model_validate(data))
+
+
+def test_missing_operation_state_and_unknown_fields_rejected():
+    _, _, archive = archive_case()
+    for key in archive.operation.model_dump():
+        data = archive.model_dump(mode="json")
+        del data["operation"][key]
+        with pytest.raises(ValueError):
+            SandboxReconciliationArchive.model_validate(data)
+    with pytest.raises(ValueError):
+        SandboxReconciliationArchive.model_validate(archive.model_dump() | {"token": "unwanted"})
+
+
+@pytest.mark.asyncio
+async def test_atomic_archive_has_one_winner_and_cannot_be_rewritten():
+    original, record, archive = archive_case()
+    store = InMemoryAtomicEffectStateStore()
+    assert await store.create_in_flight(original)
+    outcomes = await asyncio.gather(*(store.confirm_reconciliation(
+        expected=original, record=record, archive=archive,
+    ) for _ in range(16)))
+    assert outcomes.count(True) == 1
+    assert await store.get_reconciliation(record.operation_id) == archive
+    assert not await store.transition(
+        operation_id=record.operation_id, expected_state=record.state,
+        record=record.model_copy(update={"revision": 4}),
+    )
+    assert await store.get(record.operation_id) == record
+
+
+@pytest.mark.asyncio
+async def test_missing_mismatched_and_tampered_archives_fail_closed():
+    original, record, archive = archive_case()
+    store = InMemoryAtomicEffectStateStore()
+    assert await store.get_reconciliation(original.operation_id) is None
+    await store.create_in_flight(original)
+    with pytest.raises(BindEffectStateError):
+        await store.get_reconciliation(original.operation_id)
+    with pytest.raises(BindEffectStateError):
+        await store.confirm_reconciliation(expected=record, record=record, archive=archive)
+    assert await store.confirm_reconciliation(expected=original, record=record, archive=archive)
+    store._records[record.operation_id] = original
+    with pytest.raises(ValueError):
+        await store.get_reconciliation(record.operation_id)
+
+
+@pytest.mark.asyncio
+async def test_stale_expected_record_cannot_publish_evidence():
+    original, record, archive = archive_case()
+    store = InMemoryAtomicEffectStateStore()
+    await store.create_in_flight(original.model_copy(update={"record_hash": "f" * 64}))
+    assert not await store.confirm_reconciliation(expected=original, record=record, archive=archive)
+    assert not store._archives


### PR DESCRIPTION
## Purpose

After #2207, a CONFIRMED_EFFECT row retained only an evidence digest. A crash or lost acknowledgement could leave no durable copy of the full evidence. This PR persists the evidence and confirmed state together.

## Changes

- Add migration 0006: nullable reconciliation_archive on the existing effect-state row; existing record hashes remain unchanged.
- Store the verified proof, original UNKNOWN record, retrieved five-field operation and reader metadata digest.
- Atomically commit archive and terminal state in one PostgreSQL UPDATE, comparing the exact original JSON, record hash, state and revision and requiring an empty archive.
- Require validated paired readback before the owning sandbox reconciler returns confirmation.
- Recompute record, acknowledgement, observation and proof hashes and validate lineage/timestamps on archive retrieval.
- Reject missing/corrupted archives and prevent existing transition methods from overwriting archived rows.
- Preserve evidence after lost commit acknowledgement; terminal reconciliation still rejects replay.
- Update EN/JA specification with migration ordering, integrity limits and remaining work.

## Validation

- Related local suite: **122 passed**, five warnings (NumPy reload and existing jsonschema deprecations).
- New archive module coverage: **94.23%**, 90% gate passed.
- Alembic infrastructure tests: **29 passed** (included in the 122).
- Ruff, Bandit (no medium/high findings), bilingual docs, responsibility boundaries, raw-httpx and git diff checks passed.
- Added real PostgreSQL rollback, lost-acknowledgement, concurrent CAS, fresh-store readback and missing-evidence tests to the existing effect-state CI suite. Real PostgreSQL CI passed: **3 tests passed**, including the new archive test covering rollback, lost acknowledgement, concurrent CAS, restart readback and missing evidence. Migration 0006 also passed. [CI run](https://github.com/veritasfuji-japan/veritas_os/actions/runs/34235850706). Eight workflows have succeeded; the general CI workflow is still running.
- Published tree matches tested local tree: `a7e6102cfa199a5771b6ce1b894b10de6e6ea268`.
- Published head: `4ba786c08d732041fc72613b70a5171fdc2a106d`; Git Data API publication differs from local commit `3d260f3e7a4f9bf8bb8d77f5ffbd667dda41491c`, with identical tree.

## Deployment and boundaries

**Apply migration 0006 before running this code, including legacy transition methods.** Downgrade drops archived evidence and requires prior retention/export by the operator.

Archive retrieval establishes stored-data integrity, not a new external observation or authorization. Hashes do not protect against an operator rewriting all bound database data. No credentials, headers or event message are archived by the owning path.

Receipt/Outcome publication, replacement-authorization blocking, automated crash recovery and combined real TLS/provider/host-clock/PostgreSQL E2E remain separate work. No live credentials or external-effect deployment are enabled.

Draft for human security/governance review. Do not merge automatically.