### PR TITLE
feat: publish sandbox BindReceipt and Outcome atomically

### DIFF
--- a/alembic/versions/0007_sandbox_receipt_bundle.py
+++ b/alembic/versions/0007_sandbox_receipt_bundle.py
@@ -1,0 +1,21 @@
+"""Write-once sandbox BindReceipt and OutcomeReceipt pair.
+
+Revision ID: 0007
+Revises: 0006
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0007"
+down_revision = "0006"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("bind_effect_states", sa.Column("sandbox_receipt_bundle", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    # Operators must preserve receipts under their retention policy first.
+    op.drop_column("bind_effect_states", "sandbox_receipt_bundle")

--- a/docs/en/architecture/native-v2-sandbox-event-spec-v1.md
+++ b/docs/en/architecture/native-v2-sandbox-event-spec-v1.md
@@ -578,3 +578,45 @@ They establish storage behavior, not the combined real-TLS/receiver E2E proof.
 Receipt/Outcome publication, replacement-authorization blocking, automated crash
 recovery and real TLS/provider/host-clock composition remain outstanding. Section
 9 deployment prerequisites continue to apply; no live external access is enabled.
+
+## 21. Retrospective BindReceipt / Outcome publication
+
+`publish_sandbox_receipts` re-verifies the original native authorization and exact
+sandbox action against independent historical source/governance/trust inputs. It
+rebuilds the complete consumption row and confirmed effect record, validates the
+stored archive, matches its event ID/payload digest/origin to the authorized action,
+and requires approval of the exact archived reconciliation policy configuration.
+Neither caller-supplied receipts nor dispatch acknowledgements are accepted.
+
+The publisher reuses the existing BindReceipt and OutcomeReceipt schemas. The
+BindReceipt is explicitly retrospective: `bind_ts` is the stored dispatch-intent
+time, not an invented timestamp of a live check. Missing live constraint, drift
+and risk results are marked `LIVE_RESULTS_NOT_ARCHIVED`; no new admissibility or
+execution permission is asserted. COMMITTED and the passed outcome postcondition
+mean only the independently reconciled persistence of the bound sandbox event.
+No before/after system-state fingerprints are invented. Historical human-approval
+status and proof digest are linked without creating another approval receipt.
+
+Both receipts bind authorization, consumption, intent/decision, exact payload,
+external operation, confirmed record and archived evidence hashes. Outcome links
+the BindReceipt hash. IDs and times are deterministic from original records; a
+bundle hash covers the complete pair. The returned dictionaries are detached from
+stored values. Event messages, credentials and raw HTTP data are not copied.
+
+Migration 0007 adds a nullable `sandbox_receipt_bundle` to the same effect row.
+One conditional UPDATE stores the pair only once against the exact confirmed
+record and archive. Identical repeat publishers return the same pair; differing
+stored contents, missing evidence and readback failures raise sanitized errors.
+A commit acknowledgement can be lost after publication. Repeating the publisher
+with the same independently verified inputs recovers the pair without another
+POST, lookup, consumption or effect-state transition. Publication does not change
+the effect record or reconciliation archive. Apply migration 0007 before using this
+publisher; retain receipt data before any downgrade that removes the column.
+
+This closes the database-backed artifact connection for confirmed sandbox effects.
+It does not publish TrustLog entries: `trustlog_hash` remains empty and metadata
+explicitly records `NOT_PUBLISHED`. It does not claim crash-safe exactly-once
+TrustLog delivery, a complete automatic recovery coordinator, replacement-grant
+blocking, or real Decision-to-Effect E2E completion. Those and section 9 deployment
+prerequisites remain separate work. No live credentials or external effects are
+authorized by this implementation or its synthetic tests.

--- a/docs/ja/architecture/native-v2-sandbox-event-spec-v1.md
+++ b/docs/ja/architecture/native-v2-sandbox-event-spec-v1.md
@@ -472,3 +472,34 @@ commit応答喪失時は、両方が保存済みでも例外を返す可能性�
 結合したE2E証明ではありません。Receipt/Outcome発行、代替認可による重複実行の抑止、自動障害復旧、
 実TLS/provider/host-clockの結合検証は未完です。第9節の配備条件は引き続き適用し、実外部アクセスは
 有効化しません。
+
+## 21. 保存済み証拠からのBindReceipt / Outcome発行
+
+publish_sandbox_receiptsは独立した過去時点のsource/governance/trust入力で元のnative認可と
+sandbox actionを再検証します。消費行全体と確定effect行を再構築し、保存archiveを検証して、
+event ID・payload digest・originが認可されたactionと一致することを確認します。保存時の
+reconciliation policy設定全体への承認も必要です。呼出側が作ったreceiptや送信ACKは受け付けません。
+
+既存のBindReceiptとOutcomeReceipt形式を再利用します。BindReceiptは事後の記録で、bind_tsは
+保存済みdispatch-intentの時刻です。実行時の検証時刻を捏造しません。保存されていないconstraint・
+drift・riskの検証結果はLIVE_RESULTS_NOT_ARCHIVEDとし、新しい適格性や実行許可を主張しません。
+COMMITTEDとoutcomeのpostcondition passedは、対象sandbox eventの保存を独立照合で確認した意味に
+限定します。前後のシステム状態fingerprintは補いません。過去の人間承認statusとproof digestを
+関連付けますが、新しい承認receiptは作りません。
+
+両receiptに認可・消費・intent/decision・payload・外部operation・確定行・保存証拠hashを結び付け、
+OutcomeからBindReceipt hashを参照します。IDと時刻は元の記録から決定的に導出し、bundle hashで
+組全体を結び付けます。返却dictを変更しても保存値は変わりません。event message・credential・
+生HTTPデータはコピーしません。
+
+migration 0007は同じeffect行にnullableのsandbox_receipt_bundle列を追加します。元の確定行と
+archiveの完全一致を条件に、一つのUPDATEで組全体を一度だけ保存します。同一入力の再呼出しは
+同じ組を返し、異なる保存内容・証拠欠落・readback失敗は情報を漏らさない例外にします。commit応答
+喪失時は保存済みの可能性があります。同じ独立検証入力で再呼出しすると、POST・lookup・追加消費・
+effect状態変更なしで組を回収できます。effect行の元の記録とarchiveは変更しません。利用前に
+migration 0007を適用し、列を削除するdowngrade前にはreceiptを保持方針に従って保存します。
+
+これにより確定sandbox effectとDB保存されたartifactを接続します。TrustLogへは発行せず、
+trustlog_hashは空、metadataはNOT_PUBLISHEDを明示します。障害に強いTrustLogへの一度だけの配信、
+完全な自動復旧、代替認可による重複実行抑止、実Decision-to-Effect E2Eは未完です。これらと第9節の
+配備条件は別工程に残ります。本実装と合成試験は実credential・外部作用を許可しません。

--- a/veritas_os/policy/bind_effect_reconciliation.py
+++ b/veritas_os/policy/bind_effect_reconciliation.py
@@ -174,6 +174,7 @@ class InMemoryAtomicEffectStateStore:
         self._lock = asyncio.Lock()
         self._records: dict[str, EffectStateRecord] = {}
         self._archives: dict[str, SandboxReconciliationArchive] = {}
+        self._sandbox_receipts: dict[str, str] = {}
 
     async def create_in_flight(self, record: EffectStateRecord) -> bool:
         async with self._lock:

--- a/veritas_os/policy/sandbox_receipt_outcome.py
+++ b/veritas_os/policy/sandbox_receipt_outcome.py
@@ -1,0 +1,200 @@
+"""Publish deterministic BindReceipt/Outcome pairs from durable sandbox evidence.
+
+This is retrospective, narrowly scoped evidence of sandbox event persistence.
+It never reruns Bind, fabricates live check results, renews execution authority,
+or appends a TrustLog entry. Publication is an atomic, write-once database pair.
+"""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import replace
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict
+
+from veritas_os.governance.outcome_receipt import build_outcome_receipt, validate_outcome_receipt
+from veritas_os.policy.bind_artifacts import BindReceipt, FinalOutcome, hash_bind_receipt
+from veritas_os.policy.bind_core.normalizers import normalize_execution_intent
+from veritas_os.policy.bind_effect_reconciliation import (
+    EffectExecutionState, InMemoryAtomicEffectStateStore, PostgresAtomicEffectStateStore, _build_record,
+)
+from veritas_os.policy.live_adapter_bind_authorization_codec import _timestamp
+from veritas_os.policy.live_adapter_bind_authorization_consumption_store import (
+    InMemoryAtomicAuthorizationConsumptionStore, PostgresAtomicAuthorizationConsumptionStore,
+    build_authorization_consumption_record,
+)
+from veritas_os.policy.live_adapter_bind_authorization_contracts import (
+    BindAuthorizationTrustInputs, RealBindAuthorizationGovernanceInputs,
+)
+from veritas_os.policy.native_bind_authorization import (
+    NativeAuthorizationSourceInputs, _verified_source, verify_native_bind_authorization,
+)
+from veritas_os.policy.sandbox_action_binding import SandboxDeployment, verify_sandbox_action_binding
+from veritas_os.policy.sandbox_event_store import parse_event
+from veritas_os.policy.sandbox_reconciliation import (
+    SandboxReaderPolicy, VERIFIER_ID, sandbox_reconciliation_policy_hash,
+)
+from veritas_os.policy.sandbox_reconciliation_archive import validate_archive
+from veritas_os.policy.sandbox_receipt_store import _persist_receipts
+from veritas_os.policy.trusted_https_reconciliation import ReconciliationVerifierPolicy
+from veritas_os.security.hash import sha256_of_canonical_json
+
+
+class SandboxReceiptError(ValueError):
+    """Sanitized failure: no publication success or external-effect retry implied."""
+
+
+class SandboxReceiptBundle(BaseModel):
+    """Detached serialized existing artifact schemas, persisted as one pair."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    format_version: Literal["sandbox-receipt-bundle/v1"] = "sandbox-receipt-bundle/v1"
+    bind_receipt: dict[str, Any]
+    outcome_receipt: dict[str, Any]
+    bundle_hash: str
+
+
+async def publish_sandbox_receipts(
+    authorization: Any, payload_json: str, *, deployment: SandboxDeployment,
+    issuance_source_inputs: NativeAuthorizationSourceInputs,
+    historical_governance_inputs: RealBindAuthorizationGovernanceInputs,
+    trust_inputs: BindAuthorizationTrustInputs,
+    consumption_store: PostgresAtomicAuthorizationConsumptionStore | InMemoryAtomicAuthorizationConsumptionStore,
+    effect_store: PostgresAtomicEffectStateStore | InMemoryAtomicEffectStateStore,
+    reader_policy: SandboxReaderPolicy, verifier_policy: ReconciliationVerifierPolicy,
+    allow_in_memory_for_testing: bool = False,
+) -> SandboxReceiptBundle:
+    """Rebuild native lineage and publish only an exact archived confirmed result.
+
+    Caller-provided receipts, verified flags and dispatch acknowledgements are not
+    accepted. Historical issuance and trusted storage are rechecked on every call.
+    Time and IDs derive from the stored evidence, so repeats return the same pair.
+    No current-time authority or bind-time live checks are asserted by this call.
+    """
+    cancelled = False
+    try:
+        durable = (type(consumption_store) is PostgresAtomicAuthorizationConsumptionStore
+                   and type(effect_store) is PostgresAtomicEffectStateStore)
+        if not durable and not (
+            allow_in_memory_for_testing is True
+            and type(consumption_store) is InMemoryAtomicAuthorizationConsumptionStore
+            and type(effect_store) is InMemoryAtomicEffectStateStore
+        ):
+            raise ValueError("durable stores")
+        if type(reader_policy) is not SandboxReaderPolicy or type(verifier_policy) is not ReconciliationVerifierPolicy:
+            raise ValueError("policy")
+        policy_hash = sandbox_reconciliation_policy_hash(deployment, reader_policy)
+        if not verifier_policy.approves(VERIFIER_ID, policy_hash):
+            raise ValueError("unapproved archive policy")
+        binding = verify_sandbox_action_binding(
+            authorization, payload_json, deployment=deployment, source_inputs=issuance_source_inputs,
+            governance_inputs=historical_governance_inputs, trust_inputs=trust_inputs,
+        )
+        verified = verify_native_bind_authorization(
+            authorization, source_inputs=issuance_source_inputs,
+            governance_inputs=historical_governance_inputs, trust_inputs=trust_inputs,
+        )
+        _, _, context = _verified_source(
+            verified.source_runtime_risk_packet, issuance_source_inputs, historical_governance_inputs,
+        )
+        consumption = await consumption_store.get(verified.authorization_id)
+        if consumption is None:
+            raise ValueError("missing consumption")
+        expected = build_authorization_consumption_record(
+            live_adapter_bind_authorization_id=verified.authorization_id,
+            live_adapter_bind_authorization_hash=verified.authorization_hash,
+            idempotency_key=verified.idempotency_key, bind_context_hash=verified.bind_context_hash,
+            execution_intent_id=verified.execution_intent_id, execution_intent_hash=verified.execution_intent_hash,
+            endpoint_identity_binding_digest=context.endpoint_identity_binding_digest,
+            credential_reference_digest=context.credential_reference_digest,
+            credential_scope_binding_digest=context.credential_scope_binding_digest,
+            consumed_at=consumption.consumed_at,
+        )
+        consumed_at = datetime.fromisoformat(_timestamp(consumption.consumed_at))
+        if consumption != expected or not datetime.fromisoformat(verified.valid_from) <= consumed_at < datetime.fromisoformat(verified.valid_until):
+            raise ValueError("consumption lineage")
+        record = await effect_store.get(consumption.consumption_id)
+        archive = await effect_store.get_reconciliation(consumption.consumption_id)
+        if record is None or archive is None:
+            raise ValueError("missing archived result")
+        validate_archive(record, archive)
+        expected_record = _build_record(
+            consumption=consumption, state=EffectExecutionState.CONFIRMED_EFFECT, revision=3,
+            updated_at=archive.proof.verified_at, reason_code="SANDBOX_READONLY_LOOKUP_CONFIRMED",
+            reconciliation_evidence_hash=archive.proof.deterministic_digest(),
+        )
+        event = parse_event(binding.binding.payload_json.encode("utf-8"))
+        if (record != expected_record or archive.operation.event_id != event.event_id
+                or archive.operation.payload_digest != binding.binding.payload_digest
+                or archive.proof.verifier_policy_hash != policy_hash
+                or archive.proof.evidence.source_identity != deployment.endpoint_url.removesuffix("/v1/events")
+                or consumed_at > datetime.fromisoformat(_timestamp(archive.original_record.updated_at))):
+            raise ValueError("archived action binding")
+        intent = normalize_execution_intent(verified.execution_intent)
+        scope = context.authority_evidence_reference_bundle.get("bundle_scope")
+        if type(scope) is not list or not scope or any(type(x) is not str or not x.strip() for x in scope):
+            raise ValueError("scope")
+        lineage = {
+            "recording_basis": "RETROSPECTIVE_SANDBOX_RECONCILIATION",
+            "authorization_id": verified.authorization_id, "authorization_hash": verified.authorization_hash,
+            "consumption_id": consumption.consumption_id, "consumption_hash": consumption.consumption_hash,
+            "effect_record_hash": record.record_hash,
+            "reconciliation_evidence_hash": archive.proof.deterministic_digest(),
+            "archive_hash": sha256_of_canonical_json(archive.model_dump(mode="json")),
+            "payload_digest": binding.binding.payload_digest,
+            "external_operation_reference": archive.operation.operation_id,
+            "human_approval_requirement_status": verified.human_approval_requirement_status,
+            "human_approval_verification_proof_digest": verified.human_approval_verification_proof_digest,
+            "external_effect_claim": "SANDBOX_EVENT_PERSISTENCE_ONLY",
+            "trustlog_publication": "NOT_PUBLISHED",
+        }
+        receipt = BindReceipt(
+            bind_receipt_id="sandbox-bind-" + consumption.consumption_id,
+            execution_intent_id=intent.execution_intent_id, decision_id=intent.decision_id,
+            bind_ts=archive.original_record.updated_at,
+            execution_intent_hash=verified.execution_intent_hash, decision_hash=intent.decision_hash,
+            policy_snapshot_id=intent.policy_snapshot_id, actor_identity=intent.actor_identity,
+            authority_check_result={"status": "HISTORICAL_NATIVE_ISSUANCE_VERIFIED"},
+            constraint_check_result={"status": "LIVE_RESULTS_NOT_ARCHIVED"},
+            drift_check_result={"status": "LIVE_RESULTS_NOT_ARCHIVED"},
+            risk_check_result={"status": "LIVE_RESULTS_NOT_ARCHIVED"},
+            admissibility_result={"status": "RETROSPECTIVE_RECORD_NOT_EXECUTION_PERMISSION"},
+            final_outcome=FinalOutcome.COMMITTED,
+            governance_identity=lineage,
+            bind_reason_code="SANDBOX_PERSISTENCE_INDEPENDENTLY_RECONCILED",
+            idempotency_key=consumption.idempotency_key, idempotency_status="CONSUMED",
+            retry_safety="NO_EXTERNAL_EFFECT_RETRY", target_path=deployment.endpoint_url,
+            target_type="sandbox-event", action_contract_id=historical_governance_inputs.action_contract.id,
+            action_contract_version=historical_governance_inputs.action_contract.version,
+            commit_boundary_result="RECONCILED_SANDBOX_PERSISTENCE",
+        )
+        receipt = replace(receipt, bind_receipt_hash=hash_bind_receipt(receipt))
+        outcome = build_outcome_receipt(
+            decision_id=intent.decision_id, execution_intent_id=intent.execution_intent_id,
+            bind_receipt_id=receipt.bind_receipt_id, operation_id=consumption.consumption_id,
+            action_class=historical_governance_inputs.action_contract.action_class,
+            target_system=intent.target_system, target_resource=intent.target_resource,
+            intended_action=intent.intended_action, requested_scope=scope,
+            final_outcome="COMMITTED", postcondition_status="passed",
+            observed_effects=[{"kind": "sandbox_event_persisted", "event_id": event.event_id,
+                               "payload_digest": binding.binding.payload_digest,
+                               "operation_id": archive.operation.operation_id}],
+            evaluated_at=archive.proof.verified_at,
+            metadata={**lineage, "bind_receipt_hash": receipt.bind_receipt_hash,
+                      "idempotency_key": consumption.idempotency_key},
+        )
+        if not validate_outcome_receipt(outcome).is_valid or outcome.outcome_hash != outcome.deterministic_digest():
+            raise ValueError("outcome validation")
+        values = {"format_version": "sandbox-receipt-bundle/v1", "bind_receipt": receipt.to_dict(),
+                  "outcome_receipt": outcome.to_dict()}
+        bundle = SandboxReceiptBundle(**values, bundle_hash=sha256_of_canonical_json(values))
+        await _persist_receipts(effect_store, record=record, archive=archive, bundle=bundle.model_dump(mode="json"))
+        return bundle
+    except asyncio.CancelledError:
+        cancelled = True
+    except Exception:
+        pass
+    if cancelled:
+        raise asyncio.CancelledError()
+    raise SandboxReceiptError("SRO_PUBLICATION_FAILED_NO_EFFECT_RETRY")

--- a/veritas_os/policy/sandbox_receipt_store.py
+++ b/veritas_os/policy/sandbox_receipt_store.py
@@ -1,0 +1,68 @@
+"""Atomic write-once receipt pairs on an already reconciled sandbox effect row.
+
+Internal persistence seam: the owning receipt publisher reconstructs and verifies
+all inputs. Matching stored bytes are required on repeat calls and readback.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from veritas_os.policy.bind_effect_reconciliation import (
+    EffectStateRecord, InMemoryAtomicEffectStateStore, PostgresAtomicEffectStateStore,
+)
+from veritas_os.policy.sandbox_reconciliation_archive import SandboxReconciliationArchive, validate_archive
+from veritas_os.security.hash import canonical_json_dumps
+
+
+async def _persist_receipts(
+    store: PostgresAtomicEffectStateStore | InMemoryAtomicEffectStateStore, *,
+    record: EffectStateRecord, archive: SandboxReconciliationArchive, bundle: dict[str, Any],
+) -> None:
+    """Commit the complete pair once; reject stale lineage or different contents.
+
+    No effect state, archive or consumption is changed. A lost acknowledgement
+    can raise after commit; repeating the owning publisher recovers the same pair.
+    """
+    validate_archive(record, archive)
+    expected = canonical_json_dumps(bundle)
+    if type(store) is InMemoryAtomicEffectStateStore:
+        async with store._lock:
+            if store._records.get(record.operation_id) != record or store._archives.get(record.operation_id) != archive:
+                raise ValueError("changed archive")
+            previous = store._sandbox_receipts.get(record.operation_id)
+            if previous is not None and previous != expected:
+                raise ValueError("different receipts")
+            store._sandbox_receipts[record.operation_id] = expected
+        return
+    if type(store) is not PostgresAtomicEffectStateStore:
+        raise ValueError("unsupported store")
+    from psycopg.types.json import Jsonb
+    from veritas_os.storage.db import get_pool
+
+    pool = await get_pool()
+    params = (
+        record.operation_id, record.state.value, record.revision, record.record_hash,
+        Jsonb(record.model_dump(mode="json")), Jsonb(archive.model_dump(mode="json")),
+    )
+    read_query = (
+        "SELECT sandbox_receipt_bundle FROM bind_effect_states WHERE "
+        "operation_id=%s AND state=%s AND revision=%s AND record_hash=%s "
+        "AND record::jsonb=%s::jsonb AND reconciliation_archive::jsonb=%s::jsonb"
+    )
+    async with pool.connection() as conn:
+        await conn.execute(
+            "UPDATE bind_effect_states SET sandbox_receipt_bundle=%s WHERE "
+            "operation_id=%s AND state=%s AND revision=%s AND record_hash=%s "
+            "AND record::jsonb=%s::jsonb AND reconciliation_archive::jsonb=%s::jsonb "
+            "AND sandbox_receipt_bundle IS NULL", (Jsonb(bundle), *params),
+        )
+        cur = await conn.execute(read_query, params)
+        row = await cur.fetchone()
+        if row is None or canonical_json_dumps(row[0]) != expected:
+            raise ValueError("receipt readback")
+    # A separate committed snapshot is required before reporting publication.
+    async with pool.connection() as conn:
+        cur = await conn.execute(read_query, params)
+        row = await cur.fetchone()
+        if row is None or canonical_json_dumps(row[0]) != expected:
+            raise ValueError("committed receipt readback")

--- a/veritas_os/tests/test_pg_bind_effect_state_contention.py
+++ b/veritas_os/tests/test_pg_bind_effect_state_contention.py
@@ -172,3 +172,60 @@ async def test_real_postgres_archive_atomicity_contention_and_restart(monkeypatc
         await conn.execute("UPDATE bind_effect_states SET reconciliation_archive=NULL WHERE operation_id=%s", (original.operation_id,))
     with pytest.raises(BindEffectStateError):
         await store.get_reconciliation(original.operation_id)
+
+
+@pytest.mark.asyncio
+async def test_real_postgres_receipt_pair_write_once_rollback_and_lost_ack(monkeypatch):
+    """Storage semantics for an owning publisher's already reconstructed pair."""
+    from contextlib import asynccontextmanager
+    from veritas_os.storage import db
+    from veritas_os.policy.sandbox_receipt_store import _persist_receipts
+    from veritas_os.tests.test_sandbox_reconciliation_archive import archive_case
+
+    _require_real_postgresql()
+    original, record, archive = archive_case(uuid4().hex)
+    store = PostgresAtomicEffectStateStore()
+    assert await store.create_in_flight(original)
+    assert await store.confirm_reconciliation(expected=original, record=record, archive=archive)
+    # Synthetic pair sent only to the internal storage seam, never claimed as verified artifacts.
+    pair = {"bind_receipt": {"test": "bind"}, "outcome_receipt": {"test": "outcome"}}
+    real_get_pool = db.get_pool
+    pool = await real_get_pool()
+
+    class FaultPool:
+        def __init__(self, mode):
+            self.mode = mode
+
+        @asynccontextmanager
+        async def connection(self):
+            async with pool.connection() as conn:
+                yield conn
+                if self.mode == "rollback":
+                    raise RuntimeError("synthetic rollback")
+            if self.mode == "lost_ack":
+                raise RuntimeError("synthetic lost acknowledgement")
+
+    for mode in ("rollback", "lost_ack"):
+        async def faulty_pool(mode=mode):
+            return FaultPool(mode)
+        monkeypatch.setattr(db, "get_pool", faulty_pool)
+        with pytest.raises(RuntimeError):
+            await _persist_receipts(store, record=record, archive=archive, bundle=pair)
+        monkeypatch.setattr(db, "get_pool", real_get_pool)
+        async with pool.connection() as conn:
+            cur = await conn.execute("SELECT sandbox_receipt_bundle FROM bind_effect_states WHERE operation_id=%s", (record.operation_id,))
+            assert (await cur.fetchone())[0] == (None if mode == "rollback" else pair)
+        assert await store.get(record.operation_id) == record
+        assert await store.get_reconciliation(record.operation_id) == archive
+
+    await _persist_receipts(PostgresAtomicEffectStateStore(), record=record, archive=archive, bundle=pair)
+    with pytest.raises(ValueError):
+        await _persist_receipts(store, record=record, archive=archive, bundle={"different": True})
+    original, record, archive = archive_case(uuid4().hex)
+    assert await store.create_in_flight(original)
+    assert await store.confirm_reconciliation(expected=original, record=record, archive=archive)
+    await asyncio.gather(*(_persist_receipts(PostgresAtomicEffectStateStore(), record=record, archive=archive, bundle=pair) for _ in range(16)))
+    async with pool.connection() as conn:
+        cur = await conn.execute("SELECT sandbox_receipt_bundle FROM bind_effect_states WHERE operation_id=%s", (record.operation_id,))
+        assert (await cur.fetchone())[0] == pair
+    assert await store.get(record.operation_id) == record

--- a/veritas_os/tests/test_sandbox_receipt_outcome.py
+++ b/veritas_os/tests/test_sandbox_receipt_outcome.py
@@ -1,0 +1,169 @@
+"""Native verification and archived-result binding, without live external access."""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import replace
+import json
+
+import pytest
+
+from veritas_os.policy import sandbox_receipt_outcome as module
+from veritas_os.policy.bind_artifacts import BindReceipt, FinalOutcome, hash_bind_receipt
+from veritas_os.governance.outcome_receipt import OutcomeReceipt, validate_outcome_receipt
+from veritas_os.tests.test_sandbox_reconciliation import (
+    issued as issued_fixture, prepared_inputs as prepared_fixture, setup_case, reconcile,
+)
+from veritas_os.tests.test_sandbox_action_binding import PAYLOAD
+from veritas_os.tests.test_sandbox_https_transport import TOKEN
+
+pytestmark = pytest.mark.slow
+issued = issued_fixture
+prepared_inputs = prepared_fixture
+
+
+async def ready(prepared_inputs, monkeypatch):
+    artifact, args, original, writer, calls = await setup_case(prepared_inputs, monkeypatch)
+    result = await reconcile(artifact, args)
+    args.pop("provider")
+    args.pop("trusted_clock")
+    return artifact, args, result, writer, calls
+
+
+async def publish(artifact, args):
+    return await module.publish_sandbox_receipts(artifact, json.dumps(PAYLOAD), **args)
+
+
+@pytest.mark.asyncio
+async def test_publish_existing_artifacts_once_and_bind_full_lineage(prepared_inputs, monkeypatch):
+    artifact, args, result, writer, calls = await ready(prepared_inputs, monkeypatch)
+    first = await publish(artifact, args)
+    repeat = await publish(artifact, args)
+    assert first == repeat
+    bind_data = dict(first.bind_receipt)
+    bind_data["final_outcome"] = FinalOutcome(bind_data["final_outcome"])
+    receipt = BindReceipt(**bind_data)
+    outcome = OutcomeReceipt(**first.outcome_receipt)
+    assert hash_bind_receipt(receipt) == receipt.bind_receipt_hash
+    assert outcome.deterministic_digest() == outcome.outcome_hash
+    assert validate_outcome_receipt(outcome).is_valid
+    assert outcome.committed and outcome.postcondition_status == "passed"
+    assert outcome.bind_receipt_id == receipt.bind_receipt_id
+    assert outcome.metadata["bind_receipt_hash"] == receipt.bind_receipt_hash
+    assert receipt.governance_identity["authorization_id"] == artifact.authorization_id
+    assert receipt.governance_identity["reconciliation_evidence_hash"] == result.record.reconciliation_evidence_hash
+    assert not receipt.trustlog_hash
+    assert receipt.risk_check_result == {"status": "LIVE_RESULTS_NOT_ARCHIVED"}
+    assert receipt.admissibility_result["status"] == "RETROSPECTIVE_RECORD_NOT_EXECUTION_PERMISSION"
+    store = args["effect_store"]
+    assert len(store._sandbox_receipts) == 1
+    assert await store.get(result.record.operation_id) == result.record
+    assert len(calls) == len(writer.writes) == 1
+    assert TOKEN.decode() not in first.model_dump_json()
+    # Returned mutable dictionaries must not mutate durable contents.
+    first.bind_receipt["final_outcome"] = "BLOCKED"
+    assert await publish(artifact, args) == repeat
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["archive", "record", "consumption", "policy", "reader", "source", "durability", "payload", "stored_pair"])
+async def test_missing_or_substituted_lineage_never_publishes(prepared_inputs, monkeypatch, mode):
+    artifact, args, result, writer, calls = await ready(prepared_inputs, monkeypatch)
+    store = args["effect_store"]
+    operation_id = result.record.operation_id
+    if mode == "archive":
+        del store._archives[operation_id]
+    elif mode == "record":
+        store._records[operation_id] = store._archives[operation_id].original_record
+    elif mode == "consumption":
+        original_get = args["consumption_store"].get
+        async def get(key):
+            row = await original_get(key)
+            return row.model_copy(update={"credential_scope_binding_digest": "changed"})
+        monkeypatch.setattr(args["consumption_store"], "get", get)
+    elif mode == "policy":
+        args["verifier_policy"] = module.ReconciliationVerifierPolicy(())
+    elif mode == "reader":
+        args["reader_policy"] = replace(args["reader_policy"], credential_version="changed")
+    elif mode == "source":
+        args["issuance_source_inputs"] = replace(args["issuance_source_inputs"], current_endpoint={})
+    elif mode == "durability":
+        args["allow_in_memory_for_testing"] = False
+    elif mode == "stored_pair":
+        store._sandbox_receipts[operation_id] = '{"forged":true}'
+    if mode == "payload":
+        call = module.publish_sandbox_receipts(artifact, json.dumps(PAYLOAD | {"message": "changed"}), **args)
+    else:
+        call = publish(artifact, args)
+    with pytest.raises(module.SandboxReceiptError) as caught:
+        await call
+    assert caught.value.__context__ is None
+    assert len(calls) == 1
+    if mode != "stored_pair":
+        assert not store._sandbox_receipts
+    else:
+        assert store._sandbox_receipts[operation_id] == '{"forged":true}'
+
+
+@pytest.mark.asyncio
+async def test_concurrent_publishers_return_identical_pair(prepared_inputs, monkeypatch):
+    artifact, args, _, _, calls = await ready(prepared_inputs, monkeypatch)
+    results = await asyncio.gather(*(publish(artifact, args) for _ in range(3)))
+    assert all(result == results[0] for result in results)
+    assert len(args["effect_store"]._sandbox_receipts) == 1 and len(calls) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["before", "lost_ack", "cancel"])
+async def test_publication_failure_and_safe_repeat(prepared_inputs, monkeypatch, mode):
+    artifact, args, _, _, calls = await ready(prepared_inputs, monkeypatch)
+    real_persist = module._persist_receipts
+    async def fail(*positional, **kwargs):
+        if mode == "lost_ack":
+            await real_persist(*positional, **kwargs)
+        if mode == "cancel":
+            raise asyncio.CancelledError(TOKEN.decode())
+        raise RuntimeError(TOKEN.decode())
+    monkeypatch.setattr(module, "_persist_receipts", fail)
+    with pytest.raises(asyncio.CancelledError if mode == "cancel" else module.SandboxReceiptError) as caught:
+        await publish(artifact, args)
+    assert TOKEN.decode() not in str(caught.value) and caught.value.__context__ is None
+    assert bool(args["effect_store"]._sandbox_receipts) == (mode == "lost_ack")
+    saved = dict(args["effect_store"]._sandbox_receipts)
+    monkeypatch.setattr(module, "_persist_receipts", real_persist)
+    assert await publish(artifact, args)
+    if mode == "lost_ack":
+        assert saved == args["effect_store"]._sandbox_receipts
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("field,value", [("event_id", "44444444-4444-4444-8444-444444444444"), ("payload_digest", "f" * 64)])
+async def test_self_consistent_archive_for_different_action_rejected(prepared_inputs, monkeypatch, field, value):
+    from veritas_os.policy.trusted_https_reconciliation import reconciliation_observation_digest
+    artifact, args, result, _, _ = await ready(prepared_inputs, monkeypatch)
+    store = args["effect_store"]
+    archive = store._archives[result.record.operation_id]
+    operation = archive.operation.model_copy(update={field: value})
+    observation = archive.proof.evidence.model_copy(update={
+        "external_ack_digest": module.sha256_of_canonical_json(operation.model_dump(mode="json")),
+    })
+    observation = observation.model_copy(update={"observation_digest": reconciliation_observation_digest(observation)})
+    proof = archive.proof.model_copy(update={
+        "evidence": observation,
+        "verification_proof_hash": module.sha256_of_canonical_json({
+            "observation": observation.model_dump(mode="json"), "policy_hash": archive.proof.verifier_policy_hash,
+            "original_record_hash": archive.original_record.record_hash,
+            "reader_metadata_digest": archive.reader_metadata_digest,
+        }),
+    })
+    archive = archive.model_copy(update={"operation": operation, "proof": proof})
+    record = module._build_record(
+        consumption=prepared_inputs[2], state=module.EffectExecutionState.CONFIRMED_EFFECT,
+        revision=3, updated_at=proof.verified_at, reason_code="SANDBOX_READONLY_LOOKUP_CONFIRMED",
+        reconciliation_evidence_hash=proof.deterministic_digest(),
+    )
+    module.validate_archive(record, archive)
+    store._records[record.operation_id], store._archives[record.operation_id] = record, archive
+    with pytest.raises(module.SandboxReceiptError):
+        await publish(artifact, args)
+    assert not store._sandbox_receipts


### PR DESCRIPTION
## Purpose

Connect the durable confirmed sandbox evidence from #2208 to the existing BindReceipt and OutcomeReceipt schemas, without replaying the external effect or fabricating bind-time checks.

## Changes

- Add an owning publisher that re-verifies historical native authorization, the exact action and complete consumption lineage against independent inputs.
- Require a valid stored reconciliation archive, an exact confirmed record, matching event/payload/origin and approval of the archived reconciliation configuration.
- Build deterministic linked BindReceipt and OutcomeReceipt artifacts with the original decision/intent, authorization, consumption and evidence hashes.
- Explicitly mark the BindReceipt as retrospective. Missing live risk/drift/constraint results remain LIVE_RESULTS_NOT_ARCHIVED; no new execution permission or system-state fingerprints are inferred.
- Limit COMMITTED and the passed outcome postcondition to independently reconciled sandbox event persistence.
- Add migration 0007 and atomically persist the complete pair once on the existing effect row, conditioned on the exact record/archive.
- Return identical reconstructed artifacts on repeat calls; reject different stored content. Require committed readback. Lost-acknowledgement recovery never POSTs, looks up, consumes or changes effect state.
- Link historical human-approval status/proof without issuing approval.
- Document semantics and remaining work in EN/JA.

## Validation

- Related local suite: **104 passed**, five warnings (NumPy reload and existing jsonschema deprecations).
- Owning publication module coverage: **93.67%**, 90% gate passed. This is not a combined storage-module coverage claim.
- Ruff, Bandit (no medium/high findings), bilingual-doc, responsibility-boundary, raw-httpx and diff checks passed.
- Tests include missing/substituted archive and consumption, unapproved reader policy, changed source/payload, self-consistent archives for a different event or payload, concurrent publication, returned-dictionary mutation, cancellation and acknowledgement loss.
- Added real PostgreSQL pair rollback, lost acknowledgement, repeat/fresh-store retrieval, conflicting contents and concurrent publication to the existing effect-state CI suite. Real PostgreSQL CI passed: **4 tests passed**, including receipt-pair rollback, lost acknowledgement, fresh-store repeat, conflicting contents and contention. Migration 0007 passed. [CI run](https://github.com/veritasfuji-japan/veritas_os/actions/runs/34262279354). No local PostgreSQL server was used.
- Tested/published tree: `94effde7011f307655258c74f23b8a369591c4d0`.
- Published head: `0958419706e362c89d71f17b1acdef35afc5d728`; local commit `21daed317f8561e4b75acd4601145db52effdd3a` has the same tree.

## Deployment and limits

**Apply migration 0007 before using this publisher.** Retain receipt data before a downgrade that removes its column.

This publishes a database-backed artifact pair, not TrustLog entries. TrustLog hashes remain empty and metadata explicitly says NOT_PUBLISHED. Crash-safe exactly-once TrustLog delivery, complete automated recovery, replacement-authorization blocking and combined real Decision-to-Effect E2E remain separate work. Original deployment prerequisites and trust assumptions still apply. No live credentials or external-effect deployment are enabled.

Draft for human security/governance review. Do not merge automatically.