### PR TITLE
feat: block replacement sandbox execution on unresolved business events

### DIFF
--- a/alembic/versions/0008_sandbox_business_event_claim.py
+++ b/alembic/versions/0008_sandbox_business_event_claim.py
@@ -1,0 +1,39 @@
+"""Reserve one sandbox business event across replacement attempts.
+
+Revision ID: 0008
+Revises: 0007
+
+The nullable column is intentionally outside the hashed EffectStateRecord JSON.
+It is an execution-ownership index, not new evidence.  PostgreSQL uniqueness
+arbitrates concurrent replacement attempts.  CONFIRMED_NO_EFFECT transitions
+release the reservation; unresolved and confirmed-effect states retain it.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0008"
+down_revision = "0007"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "bind_effect_states",
+        sa.Column("business_event_key", sa.Text(), nullable=True),
+    )
+    op.create_index(
+        "uq_bind_effect_states_business_event_key",
+        "bind_effect_states",
+        ["business_event_key"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "uq_bind_effect_states_business_event_key",
+        table_name="bind_effect_states",
+    )
+    op.drop_column("bind_effect_states", "business_event_key")

--- a/docs/en/architecture/native-v2-sandbox-event-spec-v1.md
+++ b/docs/en/architecture/native-v2-sandbox-event-spec-v1.md
@@ -627,8 +627,8 @@ Migration 0008 adds a nullable unique `business_event_key` column to
 `bind_effect_states`. The key is execution ownership metadata and is deliberately
 kept outside the hashed `EffectStateRecord` JSON so existing evidence hashes do
 not change. New sandbox attempts derive the key from a domain separator, the
-sandbox action, target system, exact HTTPS endpoint and event UUID. Message text,
-authorization ID and idempotency key are excluded. A newly issued authorization
+sandbox action, exact HTTPS endpoint and event UUID. Message text, target-system
+label, authorization ID and idempotency key are excluded. A newly issued authorization
 therefore cannot escape an existing same-event claim merely by changing those
 values.
 

--- a/docs/en/architecture/native-v2-sandbox-event-spec-v1.md
+++ b/docs/en/architecture/native-v2-sandbox-event-spec-v1.md
@@ -616,7 +616,47 @@ publisher; retain receipt data before any downgrade that removes the column.
 This closes the database-backed artifact connection for confirmed sandbox effects.
 It does not publish TrustLog entries: `trustlog_hash` remains empty and metadata
 explicitly records `NOT_PUBLISHED`. It does not claim crash-safe exactly-once
-TrustLog delivery, a complete automatic recovery coordinator, replacement-grant
-blocking, or real Decision-to-Effect E2E completion. Those and section 9 deployment
-prerequisites remain separate work. No live credentials or external effects are
-authorized by this implementation or its synthetic tests.
+TrustLog delivery, a complete automatic recovery coordinator, or real
+Decision-to-Effect E2E completion. Those and section 9 deployment prerequisites
+remain separate work. No live credentials or external effects are authorized by
+this implementation or its synthetic tests.
+
+## 22. Replacement business-event execution blocking
+
+Migration 0008 adds a nullable unique `business_event_key` column to
+`bind_effect_states`. The key is execution ownership metadata and is deliberately
+kept outside the hashed `EffectStateRecord` JSON so existing evidence hashes do
+not change. New sandbox attempts derive the key from a domain separator, the
+sandbox action, target system, exact HTTPS endpoint and event UUID. Message text,
+authorization ID and idempotency key are excluded. A newly issued authorization
+therefore cannot escape an existing same-event claim merely by changing those
+values.
+
+`prepare_sandbox_attempt` supplies the key to the same atomic INSERT that claims
+the effect-state row. PostgreSQL uniqueness is the cross-process race arbiter; the
+in-memory store mirrors this only for explicit tests. No preflight "absence"
+observation is accepted as permission. A failed or ambiguous claim fails closed.
+A replay of the same consumed authorization remains `SPE_ATTEMPT_ALREADY_EXISTS`;
+a different operation colliding on the same business event is rejected as
+`SPE_BUSINESS_EVENT_ALREADY_CLAIMED` before current-governance rechecks,
+credential resolution or transport.
+
+`IN_FLIGHT` and `EFFECT_UNKNOWN` retain the business-event claim.
+`CONFIRMED_EFFECT` also retains it permanently, preventing a second effect for
+the same sandbox business event. A transition to independently established
+`CONFIRMED_NO_EFFECT` releases the unique key in the same state UPDATE, allowing
+a later authorization to make a fresh claim. Storage ambiguity never implies
+no-effect and therefore never authorizes a replacement.
+
+This guard is intentionally at the execution-claim boundary. Native authorization
+artifacts may still be issued or exist for the same event; they do not become
+execution permission while a conflicting durable claim remains. Blocking issuance
+itself would be a separate policy surface and is not required for the safety
+property that no replacement reaches credential or network execution.
+
+Migration 0008 does not invent business-event identities for legacy rows. Apply it
+before enabling this sandbox execution path and confirm that any pre-migration
+sandbox attempts have been handled under deployment procedures. The repository
+still does not claim a complete automatic recovery coordinator, real
+TLS/provider/host-clock/PostgreSQL deployment composition, TrustLog exactly-once
+publication, or a passing real Decision-to-Effect E2E proof.

--- a/docs/ja/architecture/native-v2-sandbox-event-spec-v1.md
+++ b/docs/ja/architecture/native-v2-sandbox-event-spec-v1.md
@@ -501,5 +501,36 @@ migration 0007を適用し、列を削除するdowngrade前にはreceiptを保�
 
 これにより確定sandbox effectとDB保存されたartifactを接続します。TrustLogへは発行せず、
 trustlog_hashは空、metadataはNOT_PUBLISHEDを明示します。障害に強いTrustLogへの一度だけの配信、
-完全な自動復旧、代替認可による重複実行抑止、実Decision-to-Effect E2Eは未完です。これらと第9節の
-配備条件は別工程に残ります。本実装と合成試験は実credential・外部作用を許可しません。
+完全な自動復旧、実Decision-to-Effect E2Eは未完です。これらと第9節の配備条件は別工程に残ります。
+本実装と合成試験は実credential・外部作用を許可しません。
+
+## 22. 同一business eventのreplacement execution抑止
+
+migration 0008は`bind_effect_states`にnullableかつuniqueな`business_event_key`列を追加します。
+このkeyは実行ownership用metadataであり、既存Evidence hashを変えないためhash対象の
+`EffectStateRecord` JSONには追加しません。新しいsandbox attemptはdomain separator、sandbox action、
+target system、正確なHTTPS endpoint、event UUIDからkeyを導出します。message本文・authorization ID・
+idempotency keyは含めません。そのため同じeventについて新しいauthorizationを発行しても、これらの値を
+変えるだけでは既存claimを回避できません。
+
+`prepare_sandbox_attempt`はeffect-state行をclaimする同じatomic INSERTへbusiness-event keyを渡します。
+cross-processの競合はPostgreSQLのunique制約が裁定し、in-memory storeは明示的なtest時だけ同じ挙動を
+再現します。事前の「存在しない」というreadを実行許可として扱いません。claim失敗や結果不明は
+fail closedです。同じconsumed authorizationのreplayは従来どおり`SPE_ATTEMPT_ALREADY_EXISTS`、
+別operationが同じbusiness eventに衝突した場合は`SPE_BUSINESS_EVENT_ALREADY_CLAIMED`として、
+current-governance再確認・credential resolution・transportより前に拒否します。
+
+`IN_FLIGHT`と`EFFECT_UNKNOWN`はbusiness-event claimを保持します。`CONFIRMED_EFFECT`も永久に保持し、
+同じsandbox business eventへの二重作用を防ぎます。独立した証拠により`CONFIRMED_NO_EFFECT`へ遷移する
+場合だけ、同じstate UPDATE内でunique keyを解放し、後続authorizationが新たなclaimを取得できるように
+します。storage ambiguityはno-effectを意味せず、replacementを許可しません。
+
+このguardは意図的にexecution-claim boundaryへ置きます。同じeventのnative authorization artifactが
+発行済み・存在済みでも、競合するdurable claimが残る間はexecution permissionにはなりません。
+issuance自体を禁止するのは別のpolicy surfaceであり、「replacementがcredential/network executionへ
+到達しない」という本safety propertyには必須ではありません。
+
+migration 0008はlegacy行へ架空のbusiness-event identityをbackfillしません。このsandbox execution pathを
+有効化する前にmigrationを適用し、migration前のsandbox attemptが存在する場合はdeployment手順で確認します。
+完全なautomatic recovery coordinator、実TLS/provider/host-clock/PostgreSQLの配備結合、TrustLogの
+exactly-once発行、passing real Decision-to-Effect E2E proofは引き続き未完です。

--- a/docs/ja/architecture/native-v2-sandbox-event-spec-v1.md
+++ b/docs/ja/architecture/native-v2-sandbox-event-spec-v1.md
@@ -509,8 +509,8 @@ trustlog_hashは空、metadataはNOT_PUBLISHEDを明示します。障害に強�
 migration 0008は`bind_effect_states`にnullableかつuniqueな`business_event_key`列を追加します。
 このkeyは実行ownership用metadataであり、既存Evidence hashを変えないためhash対象の
 `EffectStateRecord` JSONには追加しません。新しいsandbox attemptはdomain separator、sandbox action、
-target system、正確なHTTPS endpoint、event UUIDからkeyを導出します。message本文・authorization ID・
-idempotency keyは含めません。そのため同じeventについて新しいauthorizationを発行しても、これらの値を
+正確なHTTPS endpoint、event UUIDからkeyを導出します。message本文・target-system label・
+authorization ID・idempotency keyは含めません。そのため同じeventについて新しいauthorizationを発行しても、これらの値を
 変えるだけでは既存claimを回避できません。
 
 `prepare_sandbox_attempt`はeffect-state行をclaimする同じatomic INSERTへbusiness-event keyを渡します。

--- a/veritas_os/policy/bind_effect_reconciliation.py
+++ b/veritas_os/policy/bind_effect_reconciliation.py
@@ -115,7 +115,9 @@ class ReconciliationEvidenceVerifier(Protocol):
 
 
 class AtomicEffectStateStore(Protocol):
-    async def create_in_flight(self, record: EffectStateRecord) -> bool:
+    async def create_in_flight(
+        self, record: EffectStateRecord, *, business_event_key: str | None = None,
+    ) -> bool:
         ...
 
     async def transition(
@@ -175,12 +177,21 @@ class InMemoryAtomicEffectStateStore:
         self._records: dict[str, EffectStateRecord] = {}
         self._archives: dict[str, SandboxReconciliationArchive] = {}
         self._sandbox_receipts: dict[str, str] = {}
+        self._business_events: dict[str, str] = {}
+        self._operation_business_events: dict[str, str] = {}
 
-    async def create_in_flight(self, record: EffectStateRecord) -> bool:
+    async def create_in_flight(
+        self, record: EffectStateRecord, *, business_event_key: str | None = None,
+    ) -> bool:
         async with self._lock:
             if record.operation_id in self._records:
                 return False
+            if business_event_key is not None and business_event_key in self._business_events:
+                return False
             self._records[record.operation_id] = record
+            if business_event_key is not None:
+                self._business_events[business_event_key] = record.operation_id
+                self._operation_business_events[record.operation_id] = business_event_key
             return True
 
     async def transition(
@@ -197,6 +208,10 @@ class InMemoryAtomicEffectStateStore:
             if record.revision != current.revision + 1:
                 return False
             self._records[operation_id] = record
+            if record.state == EffectExecutionState.CONFIRMED_NO_EFFECT:
+                business_event_key = self._operation_business_events.pop(operation_id, None)
+                if business_event_key is not None:
+                    self._business_events.pop(business_event_key, None)
             return True
 
     async def confirm_reconciliation(
@@ -214,6 +229,10 @@ class InMemoryAtomicEffectStateStore:
                 return False
             self._archives[expected.operation_id] = archive
             self._records[expected.operation_id] = record
+            if record.state == EffectExecutionState.CONFIRMED_NO_EFFECT:
+                business_event_key = self._operation_business_events.pop(expected.operation_id, None)
+                if business_event_key is not None:
+                    self._business_events.pop(business_event_key, None)
             return True
 
     async def get_reconciliation(self, operation_id: str) -> SandboxReconciliationArchive | None:
@@ -239,7 +258,9 @@ class PostgresAtomicEffectStateStore:
 
     production_safe = True
 
-    async def create_in_flight(self, record: EffectStateRecord) -> bool:
+    async def create_in_flight(
+        self, record: EffectStateRecord, *, business_event_key: str | None = None,
+    ) -> bool:
         try:
             from psycopg.types.json import Jsonb
             from veritas_os.storage.db import get_pool
@@ -249,8 +270,8 @@ class PostgresAtomicEffectStateStore:
                 cur = await conn.execute(
                     "INSERT INTO bind_effect_states "
                     "(operation_id, authorization_id, consumption_id, state, revision, "
-                    "record_hash, updated_at, record) "
-                    "VALUES (%s, %s, %s, %s, %s, %s, %s, %s) "
+                    "record_hash, updated_at, record, business_event_key) "
+                    "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s) "
                     "ON CONFLICT DO NOTHING RETURNING operation_id",
                     (
                         record.operation_id,
@@ -261,6 +282,7 @@ class PostgresAtomicEffectStateStore:
                         record.record_hash,
                         record.updated_at,
                         Jsonb(record.model_dump(mode="json")),
+                        business_event_key,
                     ),
                 )
                 return await cur.fetchone() is not None
@@ -282,7 +304,9 @@ class PostgresAtomicEffectStateStore:
             async with pool.connection() as conn:
                 cur = await conn.execute(
                     "UPDATE bind_effect_states SET state=%s, revision=%s, record_hash=%s, "
-                    "updated_at=%s, record=%s WHERE operation_id=%s AND state=%s "
+                    "updated_at=%s, record=%s, "
+                    "business_event_key=CASE WHEN %s THEN NULL ELSE business_event_key END "
+                    "WHERE operation_id=%s AND state=%s "
                     "AND revision=%s AND reconciliation_archive IS NULL RETURNING operation_id",
                     (
                         record.state.value,
@@ -290,6 +314,7 @@ class PostgresAtomicEffectStateStore:
                         record.record_hash,
                         record.updated_at,
                         Jsonb(record.model_dump(mode="json")),
+                        record.state == EffectExecutionState.CONFIRMED_NO_EFFECT,
                         operation_id,
                         expected_state.value,
                         record.revision - 1,
@@ -321,12 +346,14 @@ class PostgresAtomicEffectStateStore:
             async with pool.connection() as conn:
                 cur = await conn.execute(
                     "UPDATE bind_effect_states SET state=%s, revision=%s, record_hash=%s, "
-                    "updated_at=%s, record=%s, reconciliation_archive=%s "
+                    "updated_at=%s, record=%s, reconciliation_archive=%s, "
+                    "business_event_key=CASE WHEN %s THEN NULL ELSE business_event_key END "
                     "WHERE operation_id=%s AND state=%s AND revision=%s AND record_hash=%s "
                     "AND record::jsonb=%s::jsonb AND reconciliation_archive IS NULL "
                     "RETURNING operation_id",
                     (record.state.value, record.revision, record.record_hash, record.updated_at,
                      Jsonb(record.model_dump(mode="json")), Jsonb(archive.model_dump(mode="json")),
+                     record.state == EffectExecutionState.CONFIRMED_NO_EFFECT,
                      expected.operation_id, expected.state.value, expected.revision, expected.record_hash,
                      Jsonb(expected.model_dump(mode="json"))),
                 )

--- a/veritas_os/policy/sandbox_pre_effect.py
+++ b/veritas_os/policy/sandbox_pre_effect.py
@@ -64,7 +64,6 @@ def _sandbox_business_event_key(
     return "sandbox-business-event:v1:sha256:" + sha256_of_canonical_json({
         "domain": "veritas.sandbox-business-event/v1",
         "action": ACTION,
-        "target_system": deployment.target_system,
         "endpoint_url": deployment.endpoint_url,
         "event_id": event_id,
     })

--- a/veritas_os/policy/sandbox_pre_effect.py
+++ b/veritas_os/policy/sandbox_pre_effect.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timedelta
+import json
 import math
 from typing import Any, Callable
 
@@ -34,13 +35,39 @@ from veritas_os.policy.native_bind_authorization import (
     verify_native_bind_authorization,
 )
 from veritas_os.policy.sandbox_action_binding import (
-    SandboxDeployment, VerifiedSandboxActionBinding,
+    ACTION, SandboxDeployment, VerifiedSandboxActionBinding,
     build_sandbox_action_binding, verify_sandbox_action_binding,
 )
+from veritas_os.security.hash import sha256_of_canonical_json
 
 
 class SandboxPreEffectError(ValueError):
     """Sanitized preparation error; never a retry authorization."""
+
+
+def _sandbox_business_event_key(
+    canonical_payload_json: str, deployment: SandboxDeployment,
+) -> str:
+    """Scope one immutable business-event identity to the exact sandbox target.
+
+    The message and authorization/idempotency identifiers are deliberately not
+    part of this key. A replacement authorization for the same event UUID cannot
+    escape the durable claim by changing payload text or authorization identity.
+    """
+    try:
+        payload = json.loads(canonical_payload_json)
+        event_id = payload["event_id"]
+        if type(event_id) is not str:
+            raise ValueError("event id")
+    except Exception:
+        raise SandboxPreEffectError("SPE_BUSINESS_EVENT_IDENTITY_INVALID") from None
+    return "sandbox-business-event:v1:sha256:" + sha256_of_canonical_json({
+        "domain": "veritas.sandbox-business-event/v1",
+        "action": ACTION,
+        "target_system": deployment.target_system,
+        "endpoint_url": deployment.endpoint_url,
+        "event_id": event_id,
+    })
 
 
 @dataclass(frozen=True)
@@ -144,6 +171,9 @@ async def prepare_sandbox_attempt(
         source_inputs=issuance_source_inputs, governance_inputs=governance_inputs,
         trust_inputs=trust_inputs,
     )
+    business_event_key = _sandbox_business_event_key(
+        binding.binding.payload_json, deployment,
+    )
     verified = verify_native_bind_authorization(
         authorization, source_inputs=issuance_source_inputs,
         governance_inputs=governance_inputs, trust_inputs=trust_inputs,
@@ -183,11 +213,22 @@ async def prepare_sandbox_attempt(
         reason_code="SANDBOX_PRE_EFFECT_ATTEMPT_CLAIMED",
     )
     try:
-        claimed = await effect_store.create_in_flight(attempt)
+        claimed = await effect_store.create_in_flight(
+            attempt, business_event_key=business_event_key,
+        )
     except Exception:
         raise SandboxPreEffectError("SPE_CLAIM_FAILED_OR_UNKNOWN") from None
     if claimed is not True:
-        raise SandboxPreEffectError("SPE_ATTEMPT_ALREADY_EXISTS")
+        # Distinguish replay of the same consumed authorization from a new
+        # authorization colliding on the same business event. The unique store
+        # claim remains the race arbiter; this read is classification only.
+        try:
+            existing_attempt = await effect_store.get(attempt.operation_id)
+        except Exception:
+            raise SandboxPreEffectError("SPE_CLAIM_FAILED_OR_UNKNOWN") from None
+        if existing_attempt is not None:
+            raise SandboxPreEffectError("SPE_ATTEMPT_ALREADY_EXISTS")
+        raise SandboxPreEffectError("SPE_BUSINESS_EVENT_ALREADY_CLAIMED")
     risk_hash, finished = _recheck_sandbox_current(
         verified=verified, binding=binding, issued_context=issued_context,
         payload_json=payload_json, deployment=deployment, started=started,

--- a/veritas_os/tests/test_pg_bind_effect_state_contention.py
+++ b/veritas_os/tests/test_pg_bind_effect_state_contention.py
@@ -111,6 +111,58 @@ async def test_real_postgres_consumption_read_and_attempt_creation_have_one_winn
 
 
 @pytest.mark.asyncio
+async def test_real_postgres_business_event_claim_blocks_replacement_until_no_effect() -> None:
+    _require_real_postgresql()
+    key = "sandbox-business-event:v1:sha256:" + uuid4().hex + uuid4().hex
+    first = _consumption(uuid4().hex)
+    replacement = _consumption(uuid4().hex)
+    store = PostgresAtomicEffectStateStore()
+    original = _build_record(
+        consumption=first, state=EffectExecutionState.IN_FLIGHT,
+        revision=1, updated_at=first.consumed_at,
+        reason_code="SANDBOX_PRE_EFFECT_ATTEMPT_CLAIMED",
+    )
+    assert await store.create_in_flight(original, business_event_key=key)
+    unknown = _build_record(
+        consumption=first, state=EffectExecutionState.EFFECT_UNKNOWN,
+        revision=2, updated_at="2026-08-24T00:00:01+00:00",
+        reason_code="SANDBOX_DISPATCH_INTENT_PERSISTED_EFFECT_UNCONFIRMED",
+    )
+    assert await store.transition(
+        operation_id=original.operation_id,
+        expected_state=EffectExecutionState.IN_FLIGHT,
+        record=unknown,
+    )
+    replacement_record = _build_record(
+        consumption=replacement, state=EffectExecutionState.IN_FLIGHT,
+        revision=1, updated_at=replacement.consumed_at,
+        reason_code="SANDBOX_PRE_EFFECT_ATTEMPT_CLAIMED",
+    )
+    results = await asyncio.gather(*(
+        PostgresAtomicEffectStateStore().create_in_flight(
+            replacement_record, business_event_key=key,
+        )
+        for _ in range(8)
+    ))
+    assert results == [False] * 8
+    assert await store.get(replacement_record.operation_id) is None
+
+    no_effect = _build_record(
+        consumption=first, state=EffectExecutionState.CONFIRMED_NO_EFFECT,
+        revision=3, updated_at="2026-08-24T00:00:02+00:00",
+        reason_code="VERIFIED_EXTERNAL_NO_EFFECT_CONFIRMED",
+    )
+    assert await store.transition(
+        operation_id=unknown.operation_id,
+        expected_state=EffectExecutionState.EFFECT_UNKNOWN,
+        record=no_effect,
+    )
+    assert await PostgresAtomicEffectStateStore().create_in_flight(
+        replacement_record, business_event_key=key,
+    )
+
+
+@pytest.mark.asyncio
 async def test_real_postgres_archive_atomicity_contention_and_restart(monkeypatch):
     """A failed commit preserves UNKNOWN; an acknowledged-lost commit retains both."""
     from contextlib import asynccontextmanager

--- a/veritas_os/tests/test_sandbox_business_event_claim.py
+++ b/veritas_os/tests/test_sandbox_business_event_claim.py
@@ -1,6 +1,7 @@
 """Durable sandbox business-event claims block replacement execution attempts."""
 
 import json
+from dataclasses import replace
 
 import pytest
 
@@ -55,7 +56,9 @@ def test_business_event_identity_ignores_message_and_authorization_metadata():
         **PAYLOAD,
         "event_id": "12345678-1234-4234-8234-123456789abd",
     })
+    changed_label = _key(config=replace(deployment(), target_system="renamed-sandbox"))
     assert original == changed_message
+    assert original == changed_label
     assert original != changed_event
     assert original.startswith("sandbox-business-event:v1:sha256:")
 

--- a/veritas_os/tests/test_sandbox_business_event_claim.py
+++ b/veritas_os/tests/test_sandbox_business_event_claim.py
@@ -1,0 +1,118 @@
+"""Durable sandbox business-event claims block replacement execution attempts."""
+
+import json
+
+import pytest
+
+from veritas_os.policy import sandbox_pre_effect as pre_effect
+from veritas_os.policy.bind_effect_reconciliation import (
+    EffectExecutionState,
+    InMemoryAtomicEffectStateStore,
+    _build_record,
+)
+from veritas_os.policy.live_adapter_bind_authorization_consumption_store import (
+    build_authorization_consumption_record,
+)
+from veritas_os.tests.test_sandbox_action_binding import PAYLOAD, deployment
+
+
+def _consumption(token: str):
+    return build_authorization_consumption_record(
+        live_adapter_bind_authorization_id=f"auth-{token}",
+        live_adapter_bind_authorization_hash=(token[0] if token else "a") * 64,
+        idempotency_key=f"idem-{token}",
+        bind_context_hash="b" * 64,
+        execution_intent_id=f"intent-{token}",
+        execution_intent_hash="c" * 64,
+        endpoint_identity_binding_digest="endpoint",
+        credential_reference_digest="credential",
+        credential_scope_binding_digest="scope",
+        consumed_at="2026-09-09T00:00:00+00:00",
+    )
+
+
+def _record(consumption, state=EffectExecutionState.IN_FLIGHT, revision=1):
+    return _build_record(
+        consumption=consumption,
+        state=state,
+        revision=revision,
+        updated_at=f"2026-09-09T00:00:0{min(revision, 9)}+00:00",
+        reason_code=f"TEST_{state.value}",
+    )
+
+
+def _key(payload=None, config=None):
+    return pre_effect._sandbox_business_event_key(
+        json.dumps(PAYLOAD if payload is None else payload),
+        deployment() if config is None else config,
+    )
+
+
+def test_business_event_identity_ignores_message_and_authorization_metadata():
+    original = _key()
+    changed_message = _key({**PAYLOAD, "message": "replacement payload"})
+    changed_event = _key({
+        **PAYLOAD,
+        "event_id": "12345678-1234-4234-8234-123456789abd",
+    })
+    assert original == changed_message
+    assert original != changed_event
+    assert original.startswith("sandbox-business-event:v1:sha256:")
+
+
+@pytest.mark.asyncio
+async def test_unresolved_business_event_blocks_different_authorization():
+    store = InMemoryAtomicEffectStateStore()
+    first = _consumption("a1")
+    replacement = _consumption("d2")
+    key = _key()
+
+    original = _record(first)
+    assert await store.create_in_flight(original, business_event_key=key)
+    unknown = _record(first, EffectExecutionState.EFFECT_UNKNOWN, 2)
+    assert await store.transition(
+        operation_id=original.operation_id,
+        expected_state=EffectExecutionState.IN_FLIGHT,
+        record=unknown,
+    )
+
+    assert not await store.create_in_flight(
+        _record(replacement), business_event_key=key,
+    )
+    assert await store.get(replacement.consumption_id) is None
+    assert await store.get(original.operation_id) == unknown
+
+
+@pytest.mark.asyncio
+async def test_confirmed_effect_keeps_claim_but_confirmed_no_effect_releases_it():
+    key = _key()
+
+    effect_store = InMemoryAtomicEffectStateStore()
+    first = _consumption("a1")
+    replacement = _consumption("d2")
+    original = _record(first)
+    assert await effect_store.create_in_flight(original, business_event_key=key)
+    confirmed = _record(first, EffectExecutionState.CONFIRMED_EFFECT, 2)
+    assert await effect_store.transition(
+        operation_id=original.operation_id,
+        expected_state=EffectExecutionState.IN_FLIGHT,
+        record=confirmed,
+    )
+    assert not await effect_store.create_in_flight(
+        _record(replacement), business_event_key=key,
+    )
+
+    no_effect_store = InMemoryAtomicEffectStateStore()
+    first = _consumption("e3")
+    replacement = _consumption("f4")
+    original = _record(first)
+    assert await no_effect_store.create_in_flight(original, business_event_key=key)
+    no_effect = _record(first, EffectExecutionState.CONFIRMED_NO_EFFECT, 2)
+    assert await no_effect_store.transition(
+        operation_id=original.operation_id,
+        expected_state=EffectExecutionState.IN_FLIGHT,
+        record=no_effect,
+    )
+    assert await no_effect_store.create_in_flight(
+        _record(replacement), business_event_key=key,
+    )

--- a/veritas_os/tests/test_sandbox_pre_effect.py
+++ b/veritas_os/tests/test_sandbox_pre_effect.py
@@ -149,13 +149,62 @@ async def test_post_claim_drift_stops_and_preserves_attempt(prepared_inputs, mod
 
 
 @pytest.mark.asyncio
+async def test_prior_same_business_event_blocks_replacement_before_current_recheck(prepared_inputs):
+    artifact, args = await _args(prepared_inputs)
+    record = prepared_inputs[2]
+    binding = module.verify_sandbox_action_binding(
+        artifact, json.dumps(PAYLOAD), deployment=args["deployment"],
+        source_inputs=args["issuance_source_inputs"],
+        governance_inputs=args["governance_inputs"], trust_inputs=args["trust_inputs"],
+    )
+    key = module._sandbox_business_event_key(binding.binding.payload_json, args["deployment"])
+    prior_consumption = module.build_authorization_consumption_record(
+        live_adapter_bind_authorization_id="replacement-prior-authorization",
+        live_adapter_bind_authorization_hash="d" * 64,
+        idempotency_key="replacement-prior-idempotency",
+        bind_context_hash="e" * 64,
+        execution_intent_id="replacement-prior-intent",
+        execution_intent_hash="f" * 64,
+        endpoint_identity_binding_digest="endpoint",
+        credential_reference_digest="credential",
+        credential_scope_binding_digest="scope",
+        consumed_at=record.consumed_at,
+    )
+    prior = module._build_record(
+        consumption=prior_consumption, state=module.EffectExecutionState.IN_FLIGHT,
+        revision=1, updated_at=record.consumed_at,
+        reason_code="SANDBOX_PRE_EFFECT_ATTEMPT_CLAIMED",
+    )
+    assert await args["effect_store"].create_in_flight(prior, business_event_key=key)
+    unknown = module._build_record(
+        consumption=prior_consumption, state=module.EffectExecutionState.EFFECT_UNKNOWN,
+        revision=2, updated_at=record.consumed_at,
+        reason_code="SANDBOX_DISPATCH_INTENT_PERSISTED_EFFECT_UNCONFIRMED",
+    )
+    assert await args["effect_store"].transition(
+        operation_id=prior.operation_id,
+        expected_state=module.EffectExecutionState.IN_FLIGHT,
+        record=unknown,
+    )
+
+    def must_not_load(_now):
+        pytest.fail("replacement block must happen before current-governance recheck")
+
+    args["load_current_inputs"] = must_not_load
+    with pytest.raises(module.SandboxPreEffectError, match="^SPE_BUSINESS_EVENT_ALREADY_CLAIMED$"):
+        await _prepare(artifact, args)
+    assert await args["effect_store"].get(record.consumption_id) is None
+    assert await args["effect_store"].get(prior.operation_id) == unknown
+
+
+@pytest.mark.asyncio
 async def test_lost_claim_acknowledgement_never_returns_prepared_result(prepared_inputs, monkeypatch):
     artifact, args = await _args(prepared_inputs)
     store = args["effect_store"]
     create = store.create_in_flight
 
-    async def lost(record):
-        await create(record)
+    async def lost(record, **kwargs):
+        await create(record, **kwargs)
         raise RuntimeError("secret-dsn")
 
     monkeypatch.setattr(store, "create_in_flight", lost)


### PR DESCRIPTION
## Purpose

Close the next sandbox safety gap identified by the 2026-09-09 AI CTO current-state audit: a newly issued authorization must not become executable for the same business event while a prior attempt remains unresolved.

This change deliberately enforces the property at the execution-claim boundary. Native authorization artifacts may still exist; they are not execution permission.

## Changes

- Add migration 0008 with a nullable unique `business_event_key` on `bind_effect_states`.
- Derive the sandbox business-event key from the fixed sandbox action, exact HTTPS endpoint, and event UUID.
  - Message text is excluded.
  - target-system label is excluded.
  - authorization ID is excluded.
  - idempotency key is excluded.
  - therefore a replacement authorization cannot bypass the claim by changing those values.
- Claim the business-event key in the same atomic INSERT that creates the sandbox IN_FLIGHT effect-state row.
- Preserve the claim while state is IN_FLIGHT or EFFECT_UNKNOWN.
- Preserve it permanently after CONFIRMED_EFFECT to prevent a second effect for the same business event.
- Release it only when a transition establishes CONFIRMED_NO_EFFECT.
- Fail closed on claim/storage ambiguity.
- Preserve the existing same-authorization replay error separately from a different-operation same-business-event collision.
- Add in-memory and real-PostgreSQL contention/release tests.
- Add an integration regression proving a prior same-event EFFECT_UNKNOWN state blocks the replacement before current-governance rechecks.
- Update EN/JA sandbox specifications.

## Security boundary

This PR does **not**:
- add a live deployment;
- select a production credential provider;
- add a generic adapter framework;
- implement the automatic crash-recovery coordinator;
- publish TrustLog entries;
- claim real Decision-to-Effect E2E completion;
- modify or supersede the existing STOP artifact.

Migration 0008 does not backfill business-event keys for legacy rows. Apply it before enabling the sandbox execution path and review any pre-migration sandbox attempts under deployment procedures.

## Validation

Implementation and focused tests are included in the branch. No local repository checkout or PostgreSQL service was available in this environment, so no local passing-test claim is made here.

GitHub CI / real PostgreSQL validation should be treated as required before merge.

Human security/governance review required. Do not merge automatically.