### PR TITLE
feat: add automatic sandbox crash recovery coordinator

### DIFF
--- a/docs/en/architecture/native-v2-sandbox-event-spec-v1.md
+++ b/docs/en/architecture/native-v2-sandbox-event-spec-v1.md
@@ -660,3 +660,49 @@ sandbox attempts have been handled under deployment procedures. The repository
 still does not claim a complete automatic recovery coordinator, real
 TLS/provider/host-clock/PostgreSQL deployment composition, TrustLog exactly-once
 publication, or a passing real Decision-to-Effect E2E proof.
+
+
+## 23. Automatic crash recovery coordinator
+
+`recover_sandbox_attempt` is the owning recovery composition for the native v2
+sandbox path. It is deliberately not a scheduler and never creates a new execution
+attempt. Every invocation re-verifies the original native authorization/action and
+durable consumption lineage, then reads the stored effect state before selecting a
+recovery action. The coordinator has no POST/re-dispatch path and never re-consumes
+the authorization.
+
+An exact revision-1 `IN_FLIGHT` row with reason
+`SANDBOX_PRE_EFFECT_ATTEMPT_CLAIMED` may be closed as
+`CONFIRMED_NO_EFFECT`. This is safe because `execute_sandbox_bind` cannot enter
+transport until that same row has durably advanced to revision-2
+`EFFECT_UNKNOWN` and a matching readback has succeeded. A durable revision-1
+read therefore proves that this attempt did not cross the transport-entry gate.
+The no-effect transition uses compare-and-set, requires committed readback, and
+releases the business-event claim in the existing atomic state update. A lost
+transition acknowledgement is recovered from a fresh durable read rather than
+from the return value.
+
+`EFFECT_UNKNOWN` never becomes no-effect from absence. The coordinator delegates
+one read-only GET attempt to `reconcile_sandbox_effect`. Matching persisted
+evidence advances to `CONFIRMED_EFFECT`; 404, lookup outage and other non-confirming
+results remain `EFFECT_UNKNOWN`. No blind resend, replacement authorization,
+writer credential or dispatch transport is used.
+
+A durable `CONFIRMED_EFFECT` row is handed to `publish_sandbox_receipts`, which
+revalidates the archived reconciliation lineage and returns/persists the same
+deterministic BindReceipt/Outcome pair. Repeating recovery after a lost receipt
+publication acknowledgement does not perform another lookup or external effect.
+`CONFIRMED_NO_EFFECT` created by the exact pre-dispatch recovery rule is returned
+idempotently. Unexpected terminal provenance, substituted lineage, storage
+ambiguity or cancellation fails closed and never sets
+`external_effect_retry_permitted`.
+
+Synthetic composition tests cover pre-dispatch crash, lost transition
+acknowledgement, non-confirming lookup, unknown-to-confirmed recovery, terminal
+restart and receipt reuse without POST. A real PostgreSQL test covers the
+pre-dispatch terminal transition, fresh-store readback and business-event claim
+release. These tests close the repository's automatic recovery coordinator for the
+sandbox path; they do not establish real TLS/provider/host-clock deployment
+composition, TrustLog exactly-once publication, or a passing real
+Decision-to-Effect E2E proof. Section 9 deployment prerequisites remain required
+before any live external effect.

--- a/docs/en/architecture/native-v2-sandbox-event-spec-v1.md
+++ b/docs/en/architecture/native-v2-sandbox-event-spec-v1.md
@@ -575,8 +575,9 @@ evidence; operators must preserve it under the applicable retention policy first
 Real PostgreSQL tests in the effect-state CI workflow exercise rollback, lost
 commit acknowledgement, contention, fresh-store readback and missing evidence.
 They establish storage behavior, not the combined real-TLS/receiver E2E proof.
-Receipt/Outcome publication, replacement-authorization blocking, automated crash
-recovery and real TLS/provider/host-clock composition remain outstanding. Section
+Receipt/Outcome publication and replacement-authorization blocking are now implemented;
+automatic recovery is composed in section 23. Real TLS/provider/host-clock
+composition remains outstanding. Section
 9 deployment prerequisites continue to apply; no live external access is enabled.
 
 ## 21. Retrospective BindReceipt / Outcome publication
@@ -615,9 +616,9 @@ publisher; retain receipt data before any downgrade that removes the column.
 
 This closes the database-backed artifact connection for confirmed sandbox effects.
 It does not publish TrustLog entries: `trustlog_hash` remains empty and metadata
-explicitly records `NOT_PUBLISHED`. It does not claim crash-safe exactly-once
-TrustLog delivery, a complete automatic recovery coordinator, or real
-Decision-to-Effect E2E completion. Those and section 9 deployment prerequisites
+explicitly records `NOT_PUBLISHED`. The publisher alone does not claim crash-safe exactly-once TrustLog delivery or
+complete recovery composition; section 23 now composes the recovery path. It still
+does not establish real Decision-to-Effect E2E completion. Those and section 9 deployment prerequisites
 remain separate work. No live credentials or external effects are authorized by
 this implementation or its synthetic tests.
 
@@ -656,10 +657,9 @@ property that no replacement reaches credential or network execution.
 
 Migration 0008 does not invent business-event identities for legacy rows. Apply it
 before enabling this sandbox execution path and confirm that any pre-migration
-sandbox attempts have been handled under deployment procedures. The repository
-still does not claim a complete automatic recovery coordinator, real
-TLS/provider/host-clock/PostgreSQL deployment composition, TrustLog exactly-once
-publication, or a passing real Decision-to-Effect E2E proof.
+sandbox attempts have been handled under deployment procedures. Section 23 now composes the automatic recovery coordinator. The repository still
+does not claim real TLS/provider/host-clock/PostgreSQL deployment composition,
+TrustLog exactly-once publication, or a passing real Decision-to-Effect E2E proof.
 
 
 ## 23. Automatic crash recovery coordinator

--- a/docs/ja/architecture/native-v2-sandbox-event-spec-v1.md
+++ b/docs/ja/architecture/native-v2-sandbox-event-spec-v1.md
@@ -534,3 +534,40 @@ migration 0008はlegacy行へ架空のbusiness-event identityをbackfillしま�
 有効化する前にmigrationを適用し、migration前のsandbox attemptが存在する場合はdeployment手順で確認します。
 完全なautomatic recovery coordinator、実TLS/provider/host-clock/PostgreSQLの配備結合、TrustLogの
 exactly-once発行、passing real Decision-to-Effect E2E proofは引き続き未完です。
+
+
+## 23. Automatic crash recovery coordinator
+
+`recover_sandbox_attempt`はnative v2 sandbox pathのowning recovery compositionです。
+schedulerではなく、新しいexecution attemptを作りません。呼出しごとに元のnative authorization/actionと
+durable consumption lineageを再検証し、保存済みeffect stateを読んでから復旧経路を決めます。
+POST・re-dispatch経路は持たず、authorizationを再消費しません。
+
+revision 1、reasonが`SANDBOX_PRE_EFFECT_ATTEMPT_CLAIMED`の完全一致する
+`IN_FLIGHT`だけは`CONFIRMED_NO_EFFECT`へ閉じられます。
+`execute_sandbox_bind`は同じ行をrevision 2の`EFFECT_UNKNOWN`へ永続化し、
+一致するreadbackを確認するまでtransportへ入れないため、durableなrevision 1の読出しは
+このattemptがtransport-entry gateを越えていないことを示します。no-effect遷移はCASと
+commit後readbackを要求し、既存のatomic state updateでbusiness-event claimを解放します。
+transition応答を失ってもreturn valueではなくfresh durable readから復旧します。
+
+`EFFECT_UNKNOWN`は「見つからない」ことからno-effectを推論しません。
+coordinatorは`reconcile_sandbox_effect`へread-only GETを1回委譲します。
+一致するpersisted evidenceがあれば`CONFIRMED_EFFECT`へ進み、404・lookup outage・
+非確定応答は`EFFECT_UNKNOWN`のままです。blind resend、replacement authorization、
+writer credential、dispatch transportは使用しません。
+
+durableな`CONFIRMED_EFFECT`は`publish_sandbox_receipts`へ渡し、保存済みreconciliation
+lineageを再検証して同じdeterministic BindReceipt/Outcome pairを返し、必要ならwrite-once保存します。
+receipt publicationの応答喪失後に再実行しても、新しいlookupやexternal effectは発生しません。
+正確なpre-dispatch recoveryで作られた`CONFIRMED_NO_EFFECT`はidempotentに返します。
+想定外terminal provenance、lineage置換、storage ambiguity、cancellationはfail closedで、
+`external_effect_retry_permitted`をtrueにしません。
+
+synthetic composition testはpre-dispatch crash、transition応答喪失、lookup非確定、
+unknownからconfirmedへの復旧、terminal restart、POSTなしのreceipt再利用を確認します。
+実PostgreSQL testはpre-dispatch terminal transition、別storeからのreadback、
+business-event claim解放を確認します。これによりsandbox pathのautomatic recovery
+coordinatorはrepository上で閉じますが、実TLS/provider/host-clockのdeployment composition、
+TrustLog exactly-once publication、passing real Decision-to-Effect E2E proofは未完です。
+live external effectの前には第9節のdeployment prerequisitesが引き続き必要です。

--- a/docs/ja/architecture/native-v2-sandbox-event-spec-v1.md
+++ b/docs/ja/architecture/native-v2-sandbox-event-spec-v1.md
@@ -469,8 +469,8 @@ commit応答喪失時は、両方が保存済みでも例外を返す可能性�
 旧行とhashは維持します。downgradeは証拠を削除するため、operatorは先に保持方針に従って
 保存する必要があります。effect-state CIの実PostgreSQL試験はrollback・commit応答喪失・
 競合・別storeからの読戻し・証拠欠落を検証します。これは保存処理の試験であり、実TLSとreceiverを
-結合したE2E証明ではありません。Receipt/Outcome発行、代替認可による重複実行の抑止、自動障害復旧、
-実TLS/provider/host-clockの結合検証は未完です。第9節の配備条件は引き続き適用し、実外部アクセスは
+結合したE2E証明ではありません。Receipt/Outcome発行と代替認可による重複実行の抑止は実装済みで、自動障害復旧は第23節で
+compositionします。実TLS/provider/host-clockの結合検証は未完です。第9節の配備条件は引き続き適用し、実外部アクセスは
 有効化しません。
 
 ## 21. 保存済み証拠からのBindReceipt / Outcome発行
@@ -500,8 +500,8 @@ effect状態変更なしで組を回収できます。effect行の元の記録�
 migration 0007を適用し、列を削除するdowngrade前にはreceiptを保持方針に従って保存します。
 
 これにより確定sandbox effectとDB保存されたartifactを接続します。TrustLogへは発行せず、
-trustlog_hashは空、metadataはNOT_PUBLISHEDを明示します。障害に強いTrustLogへの一度だけの配信、
-完全な自動復旧、実Decision-to-Effect E2Eは未完です。これらと第9節の配備条件は別工程に残ります。
+trustlog_hashは空、metadataはNOT_PUBLISHEDを明示します。このpublisher単体では障害に強いTrustLogへの一度だけの配信や完全な復旧compositionを
+主張しません。復旧pathは第23節でcompositionします。実Decision-to-Effect E2Eは未完です。これらと第9節の配備条件は別工程に残ります。
 本実装と合成試験は実credential・外部作用を許可しません。
 
 ## 22. 同一business eventのreplacement execution抑止
@@ -532,8 +532,8 @@ issuance自体を禁止するのは別のpolicy surfaceであり、「replacemen
 
 migration 0008はlegacy行へ架空のbusiness-event identityをbackfillしません。このsandbox execution pathを
 有効化する前にmigrationを適用し、migration前のsandbox attemptが存在する場合はdeployment手順で確認します。
-完全なautomatic recovery coordinator、実TLS/provider/host-clock/PostgreSQLの配備結合、TrustLogの
-exactly-once発行、passing real Decision-to-Effect E2E proofは引き続き未完です。
+automatic recovery coordinatorは第23節でcompositionします。実TLS/provider/host-clock/PostgreSQLの
+配備結合、TrustLogのexactly-once発行、passing real Decision-to-Effect E2E proofは引き続き未完です。
 
 
 ## 23. Automatic crash recovery coordinator

--- a/veritas_os/policy/sandbox_recovery.py
+++ b/veritas_os/policy/sandbox_recovery.py
@@ -1,0 +1,351 @@
+"""Owning crash-recovery coordinator for the native v2 sandbox path.
+
+Recovery never resends an external effect. It reads durable state first and then
+chooses exactly one safe path:
+
+* pre-dispatch IN_FLIGHT -> terminal CONFIRMED_NO_EFFECT when the exact stored
+  sandbox pre-effect claim proves transport was never eligible to start;
+* EFFECT_UNKNOWN -> one independent read-only reconciliation attempt;
+* CONFIRMED_EFFECT -> deterministic retrospective receipt publication/recovery;
+* terminal CONFIRMED_NO_EFFECT -> idempotent terminal return.
+
+Lookup absence, provider failure, storage ambiguity, substituted lineage or an
+unexpected state never become permission to retry execution.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict
+
+from veritas_os.policy.bind_effect_reconciliation import (
+    EffectExecutionState,
+    EffectStateRecord,
+    InMemoryAtomicEffectStateStore,
+    PostgresAtomicEffectStateStore,
+    _build_record,
+)
+from veritas_os.policy.live_adapter_bind_authorization_codec import _timestamp
+from veritas_os.policy.live_adapter_bind_authorization_consumption_store import (
+    AuthorizationConsumptionRecord,
+    InMemoryAtomicAuthorizationConsumptionStore,
+    PostgresAtomicAuthorizationConsumptionStore,
+    build_authorization_consumption_record,
+)
+from veritas_os.policy.live_adapter_bind_authorization_contracts import (
+    BindAuthorizationTrustInputs,
+    RealBindAuthorizationGovernanceInputs,
+)
+from veritas_os.policy.native_bind_authorization import (
+    NativeAuthorizationSourceInputs,
+    _verified_source,
+    verify_native_bind_authorization,
+)
+from veritas_os.policy.sandbox_action_binding import SandboxDeployment, verify_sandbox_action_binding
+from veritas_os.policy.sandbox_credential_resolution import SandboxCredentialProvider
+from veritas_os.policy.sandbox_pre_effect import SandboxClockReading, _clock
+from veritas_os.policy.sandbox_receipt_outcome import SandboxReceiptBundle, publish_sandbox_receipts
+from veritas_os.policy.sandbox_reconciliation import (
+    SandboxReaderPolicy,
+    reconcile_sandbox_effect,
+)
+from veritas_os.policy.trusted_https_reconciliation import ReconciliationVerifierPolicy
+
+
+class SandboxRecoveryError(ValueError):
+    """Sanitized failure. The coordinator never implies that retry is safe."""
+
+
+class SandboxRecoveryResult(BaseModel):
+    """Durable recovery result; never execution authority."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    format_version: Literal["sandbox-crash-recovery/v1"] = "sandbox-crash-recovery/v1"
+    operation_id: str
+    authorization_id: str
+    state: EffectExecutionState
+    recovery_status: Literal[
+        "CONFIRMED_NO_EFFECT",
+        "STILL_UNKNOWN",
+        "CONFIRMED_EFFECT",
+    ]
+    reason_code: str
+    external_effect_retry_permitted: Literal[False] = False
+    receipt_bundle: SandboxReceiptBundle | None = None
+
+
+async def _verified_recovery_lineage(
+    authorization: Any,
+    payload_json: str,
+    *,
+    deployment: SandboxDeployment,
+    issuance_source_inputs: NativeAuthorizationSourceInputs,
+    historical_governance_inputs: RealBindAuthorizationGovernanceInputs,
+    trust_inputs: BindAuthorizationTrustInputs,
+    consumption_store: PostgresAtomicAuthorizationConsumptionStore | InMemoryAtomicAuthorizationConsumptionStore,
+) -> AuthorizationConsumptionRecord:
+    """Rebuild the exact historical sandbox consumption without reauthorizing."""
+
+    verify_sandbox_action_binding(
+        authorization,
+        payload_json,
+        deployment=deployment,
+        source_inputs=issuance_source_inputs,
+        governance_inputs=historical_governance_inputs,
+        trust_inputs=trust_inputs,
+    )
+    verified = verify_native_bind_authorization(
+        authorization,
+        source_inputs=issuance_source_inputs,
+        governance_inputs=historical_governance_inputs,
+        trust_inputs=trust_inputs,
+    )
+    _, _, context = _verified_source(
+        verified.source_runtime_risk_packet,
+        issuance_source_inputs,
+        historical_governance_inputs,
+    )
+    stored = await consumption_store.get(verified.authorization_id)
+    if stored is None:
+        raise ValueError("missing consumption")
+    expected = build_authorization_consumption_record(
+        live_adapter_bind_authorization_id=verified.authorization_id,
+        live_adapter_bind_authorization_hash=verified.authorization_hash,
+        idempotency_key=verified.idempotency_key,
+        bind_context_hash=verified.bind_context_hash,
+        execution_intent_id=verified.execution_intent_id,
+        execution_intent_hash=verified.execution_intent_hash,
+        endpoint_identity_binding_digest=context.endpoint_identity_binding_digest,
+        credential_reference_digest=context.credential_reference_digest,
+        credential_scope_binding_digest=context.credential_scope_binding_digest,
+        consumed_at=stored.consumed_at,
+    )
+    consumed_at = datetime.fromisoformat(_timestamp(stored.consumed_at))
+    if stored != expected or not (
+        datetime.fromisoformat(verified.valid_from)
+        <= consumed_at
+        < datetime.fromisoformat(verified.valid_until)
+    ):
+        raise ValueError("consumption lineage")
+    return stored
+
+
+def _exact_pre_dispatch_record(
+    consumption: AuthorizationConsumptionRecord,
+    current: EffectStateRecord,
+) -> EffectStateRecord:
+    expected = _build_record(
+        consumption=consumption,
+        state=EffectExecutionState.IN_FLIGHT,
+        revision=1,
+        updated_at=current.updated_at,
+        reason_code="SANDBOX_PRE_EFFECT_ATTEMPT_CLAIMED",
+    )
+    if current != expected:
+        raise ValueError("not exact sandbox pre-dispatch state")
+    return expected
+
+
+async def _confirm_pre_dispatch_no_effect(
+    *,
+    consumption: AuthorizationConsumptionRecord,
+    current: EffectStateRecord,
+    effect_store: PostgresAtomicEffectStateStore | InMemoryAtomicEffectStateStore,
+    observed_at: str,
+) -> EffectStateRecord:
+    """Close only an exact pre-dispatch claim.
+
+    execute_sandbox_bind cannot enter transport until the same row has durably
+    advanced to EFFECT_UNKNOWN and readback matches. Therefore an exact durable
+    revision-1 sandbox pre-effect row proves this attempt never crossed the
+    transport-entry gate.
+    """
+
+    _exact_pre_dispatch_record(consumption, current)
+    terminal = _build_record(
+        consumption=consumption,
+        state=EffectExecutionState.CONFIRMED_NO_EFFECT,
+        revision=2,
+        updated_at=observed_at,
+        reason_code="SANDBOX_RECOVERY_PRE_DISPATCH_CONFIRMED_NO_EFFECT",
+    )
+    try:
+        changed = await effect_store.transition(
+            operation_id=current.operation_id,
+            expected_state=EffectExecutionState.IN_FLIGHT,
+            record=terminal,
+        )
+    except Exception:
+        changed = False
+
+    # The transition acknowledgement may be lost. Trust a fresh durable read,
+    # never the return value alone.
+    stored = await effect_store.get(current.operation_id)
+    if stored == terminal:
+        return terminal
+    if changed is True:
+        raise ValueError("no-effect readback mismatch")
+    if stored is not None and stored.state in {
+        EffectExecutionState.EFFECT_UNKNOWN,
+        EffectExecutionState.CONFIRMED_EFFECT,
+        EffectExecutionState.CONFIRMED_NO_EFFECT,
+    }:
+        return stored
+    raise ValueError("pre-dispatch recovery ambiguous")
+
+
+async def recover_sandbox_attempt(
+    authorization: Any,
+    payload_json: str,
+    *,
+    deployment: SandboxDeployment,
+    issuance_source_inputs: NativeAuthorizationSourceInputs,
+    historical_governance_inputs: RealBindAuthorizationGovernanceInputs,
+    trust_inputs: BindAuthorizationTrustInputs,
+    consumption_store: PostgresAtomicAuthorizationConsumptionStore | InMemoryAtomicAuthorizationConsumptionStore,
+    effect_store: PostgresAtomicEffectStateStore | InMemoryAtomicEffectStateStore,
+    reader_policy: SandboxReaderPolicy,
+    verifier_policy: ReconciliationVerifierPolicy,
+    provider: SandboxCredentialProvider,
+    trusted_clock: Any,
+    allow_in_memory_for_testing: bool = False,
+) -> SandboxRecoveryResult:
+    """Recover one sandbox attempt from durable state without redispatch.
+
+    This function is an owning composition boundary, not a scheduler. Repeated
+    invocations are safe with respect to external effects: there is no POST,
+    no authorization consumption, no credential use for execution and no
+    transport resend. EFFECT_UNKNOWN may perform one read-only GET through the
+    existing reconciler.
+    """
+
+    cancelled = False
+    try:
+        durable = (
+            type(consumption_store) is PostgresAtomicAuthorizationConsumptionStore
+            and type(effect_store) is PostgresAtomicEffectStateStore
+        )
+        test_only = (
+            allow_in_memory_for_testing is True
+            and type(consumption_store) is InMemoryAtomicAuthorizationConsumptionStore
+            and type(effect_store) is InMemoryAtomicEffectStateStore
+        )
+        if not durable and not test_only:
+            raise ValueError("durable stores")
+
+        consumption = await _verified_recovery_lineage(
+            authorization,
+            payload_json,
+            deployment=deployment,
+            issuance_source_inputs=issuance_source_inputs,
+            historical_governance_inputs=historical_governance_inputs,
+            trust_inputs=trust_inputs,
+            consumption_store=consumption_store,
+        )
+        current = await effect_store.get(consumption.consumption_id)
+        if current is None:
+            raise ValueError("missing effect state")
+        if (
+            current.operation_id != consumption.consumption_id
+            or current.authorization_id != consumption.live_adapter_bind_authorization_id
+            or current.authorization_hash != consumption.live_adapter_bind_authorization_hash
+            or current.consumption_hash != consumption.consumption_hash
+            or current.idempotency_key != consumption.idempotency_key
+        ):
+            raise ValueError("effect lineage")
+
+        if current.state == EffectExecutionState.IN_FLIGHT:
+            reading: SandboxClockReading = trusted_clock()
+            now = _clock(reading)
+            consumed_at = datetime.fromisoformat(_timestamp(consumption.consumed_at))
+            if now < consumed_at:
+                raise ValueError("clock before consumption")
+            current = await _confirm_pre_dispatch_no_effect(
+                consumption=consumption,
+                current=current,
+                effect_store=effect_store,
+                observed_at=_timestamp(reading.now),
+            )
+
+        if current.state == EffectExecutionState.IN_FLIGHT:
+            raise ValueError("in-flight not closed")
+
+        if current.state == EffectExecutionState.EFFECT_UNKNOWN:
+            reconciled = await reconcile_sandbox_effect(
+                authorization,
+                payload_json,
+                deployment=deployment,
+                issuance_source_inputs=issuance_source_inputs,
+                historical_governance_inputs=historical_governance_inputs,
+                trust_inputs=trust_inputs,
+                consumption_store=consumption_store,
+                effect_store=effect_store,
+                reader_policy=reader_policy,
+                verifier_policy=verifier_policy,
+                provider=provider,
+                trusted_clock=trusted_clock,
+                allow_in_memory_for_testing=allow_in_memory_for_testing,
+            )
+            current = reconciled.record
+            if current.state == EffectExecutionState.EFFECT_UNKNOWN:
+                return SandboxRecoveryResult(
+                    operation_id=current.operation_id,
+                    authorization_id=current.authorization_id,
+                    state=current.state,
+                    recovery_status="STILL_UNKNOWN",
+                    reason_code="SANDBOX_RECOVERY_LOOKUP_DID_NOT_CONFIRM",
+                )
+
+        if current.state == EffectExecutionState.CONFIRMED_EFFECT:
+            bundle = await publish_sandbox_receipts(
+                authorization,
+                payload_json,
+                deployment=deployment,
+                issuance_source_inputs=issuance_source_inputs,
+                historical_governance_inputs=historical_governance_inputs,
+                trust_inputs=trust_inputs,
+                consumption_store=consumption_store,
+                effect_store=effect_store,
+                reader_policy=reader_policy,
+                verifier_policy=verifier_policy,
+                allow_in_memory_for_testing=allow_in_memory_for_testing,
+            )
+            return SandboxRecoveryResult(
+                operation_id=current.operation_id,
+                authorization_id=current.authorization_id,
+                state=current.state,
+                recovery_status="CONFIRMED_EFFECT",
+                reason_code="SANDBOX_RECOVERY_CONFIRMED_EFFECT_ARTIFACTS_AVAILABLE",
+                receipt_bundle=bundle,
+            )
+
+        if current.state == EffectExecutionState.CONFIRMED_NO_EFFECT:
+            if current.reason_code != "SANDBOX_RECOVERY_PRE_DISPATCH_CONFIRMED_NO_EFFECT":
+                raise ValueError("unexpected no-effect lineage")
+            return SandboxRecoveryResult(
+                operation_id=current.operation_id,
+                authorization_id=current.authorization_id,
+                state=current.state,
+                recovery_status="CONFIRMED_NO_EFFECT",
+                reason_code=current.reason_code,
+            )
+
+        raise ValueError("unsupported recovery state")
+    except asyncio.CancelledError:
+        cancelled = True
+    except Exception:
+        pass
+    if cancelled:
+        raise asyncio.CancelledError()
+    raise SandboxRecoveryError("SRC_RECOVERY_FAILED_NO_EFFECT_RETRY")
+
+
+__all__ = [
+    "SandboxRecoveryError",
+    "SandboxRecoveryResult",
+    "recover_sandbox_attempt",
+]

--- a/veritas_os/tests/test_pg_bind_effect_state_contention.py
+++ b/veritas_os/tests/test_pg_bind_effect_state_contention.py
@@ -281,3 +281,44 @@ async def test_real_postgres_receipt_pair_write_once_rollback_and_lost_ack(monke
         cur = await conn.execute("SELECT sandbox_receipt_bundle FROM bind_effect_states WHERE operation_id=%s", (record.operation_id,))
         assert (await cur.fetchone())[0] == pair
     assert await store.get(record.operation_id) == record
+
+
+@pytest.mark.asyncio
+async def test_real_postgres_pre_dispatch_recovery_releases_business_event_claim() -> None:
+    """Crash recovery closes only exact pre-dispatch state and permits a fresh claim."""
+    from veritas_os.policy.sandbox_recovery import _confirm_pre_dispatch_no_effect
+
+    _require_real_postgresql()
+    key = "sandbox-business-event:v1:sha256:" + uuid4().hex + uuid4().hex
+    first = _consumption(uuid4().hex)
+    replacement = _consumption(uuid4().hex)
+    store = PostgresAtomicEffectStateStore()
+    inflight = _build_record(
+        consumption=first,
+        state=EffectExecutionState.IN_FLIGHT,
+        revision=1,
+        updated_at=first.consumed_at,
+        reason_code="SANDBOX_PRE_EFFECT_ATTEMPT_CLAIMED",
+    )
+    assert await store.create_in_flight(inflight, business_event_key=key)
+
+    terminal = await _confirm_pre_dispatch_no_effect(
+        consumption=first,
+        current=inflight,
+        effect_store=PostgresAtomicEffectStateStore(),
+        observed_at="2026-08-24T00:00:01+00:00",
+    )
+    assert terminal.state == EffectExecutionState.CONFIRMED_NO_EFFECT
+    assert await PostgresAtomicEffectStateStore().get(inflight.operation_id) == terminal
+
+    replacement_record = _build_record(
+        consumption=replacement,
+        state=EffectExecutionState.IN_FLIGHT,
+        revision=1,
+        updated_at=replacement.consumed_at,
+        reason_code="SANDBOX_PRE_EFFECT_ATTEMPT_CLAIMED",
+    )
+    assert await PostgresAtomicEffectStateStore().create_in_flight(
+        replacement_record,
+        business_event_key=key,
+    )

--- a/veritas_os/tests/test_sandbox_recovery.py
+++ b/veritas_os/tests/test_sandbox_recovery.py
@@ -1,0 +1,185 @@
+"""Automatic sandbox recovery composes durable state without redispatch."""
+
+import json
+
+import pytest
+
+from veritas_os.policy import sandbox_recovery as module
+from veritas_os.policy import sandbox_reconciliation as reconciliation
+from veritas_os.policy.trusted_https_reconciliation import ApprovedReconciliationVerifier
+from veritas_os.tests.test_sandbox_action_binding import PAYLOAD
+from veritas_os.tests.test_sandbox_pre_effect import (
+    _args as pre_effect_args,
+    _prepare,
+    prepared_inputs,
+)
+from veritas_os.tests.test_sandbox_reconciliation import (
+    ReaderProvider,
+    setup_case,
+)
+
+pytestmark = pytest.mark.slow
+
+
+class BombProvider:
+    async def describe(self, request):
+        pytest.fail("recovery touched reader provider before EFFECT_UNKNOWN")
+
+    async def resolve(self, request, *, expected_metadata_digest):
+        pytest.fail("recovery resolved a credential before EFFECT_UNKNOWN")
+
+
+def _reader_args(args):
+    reader = reconciliation.SandboxReaderPolicy(
+        "separate-reader",
+        "reader-v1",
+        "synthetic",
+        "sandbox",
+    )
+    args["reader_policy"] = reader
+    args["verifier_policy"] = reconciliation.ReconciliationVerifierPolicy(
+        (
+            ApprovedReconciliationVerifier(
+                reconciliation.VERIFIER_ID,
+                reconciliation.sandbox_reconciliation_policy_hash(
+                    args["deployment"],
+                    reader,
+                ),
+            ),
+        )
+    )
+    return args
+
+
+async def _pre_dispatch_case(prepared_inputs):
+    artifact, args = await pre_effect_args(prepared_inputs)
+    await _prepare(artifact, args)
+    args["historical_governance_inputs"] = args.pop("governance_inputs")
+    args.pop("load_current_inputs")
+    args["provider"] = BombProvider()
+    _reader_args(args)
+    return artifact, args
+
+
+async def _recover(artifact, args):
+    return await module.recover_sandbox_attempt(
+        artifact,
+        json.dumps(PAYLOAD),
+        **args,
+    )
+
+
+@pytest.mark.asyncio
+async def test_pre_dispatch_crash_closes_no_effect_without_reader_or_resend(prepared_inputs):
+    artifact, args = await _pre_dispatch_case(prepared_inputs)
+    operation_id = prepared_inputs[2].consumption_id
+    before = await args["effect_store"].get(operation_id)
+    assert before is not None
+    assert before.state == module.EffectExecutionState.IN_FLIGHT
+    assert before.reason_code == "SANDBOX_PRE_EFFECT_ATTEMPT_CLAIMED"
+
+    result = await _recover(artifact, args)
+    assert result.recovery_status == "CONFIRMED_NO_EFFECT"
+    assert result.state == module.EffectExecutionState.CONFIRMED_NO_EFFECT
+    assert result.external_effect_retry_permitted is False
+    assert result.receipt_bundle is None
+
+    stored = await args["effect_store"].get(operation_id)
+    assert stored == result.model_copy(
+        update={},
+    ) or stored.state == module.EffectExecutionState.CONFIRMED_NO_EFFECT
+    assert stored.reason_code == "SANDBOX_RECOVERY_PRE_DISPATCH_CONFIRMED_NO_EFFECT"
+
+    # Idempotent restart: terminal no-effect is returned without any reader access.
+    repeated = await _recover(artifact, args)
+    assert repeated == result
+
+
+@pytest.mark.asyncio
+async def test_lost_no_effect_transition_ack_is_recovered_from_durable_read(prepared_inputs, monkeypatch):
+    artifact, args = await _pre_dispatch_case(prepared_inputs)
+    store = args["effect_store"]
+    original = store.transition
+
+    async def lost_ack(**kwargs):
+        changed = await original(**kwargs)
+        if changed:
+            raise RuntimeError("synthetic acknowledgement loss")
+        return changed
+
+    monkeypatch.setattr(store, "transition", lost_ack)
+    result = await _recover(artifact, args)
+    assert result.recovery_status == "CONFIRMED_NO_EFFECT"
+    assert (await store.get(result.operation_id)).state == module.EffectExecutionState.CONFIRMED_NO_EFFECT
+
+
+@pytest.mark.asyncio
+async def test_unexpected_in_flight_lineage_fails_closed(prepared_inputs):
+    artifact, args = await _pre_dispatch_case(prepared_inputs)
+    operation_id = prepared_inputs[2].consumption_id
+    current = await args["effect_store"].get(operation_id)
+    args["effect_store"]._records[operation_id] = current.model_copy(
+        update={"reason_code": "UNTRUSTED_PRE_DISPATCH_REASON"},
+    )
+
+    with pytest.raises(module.SandboxRecoveryError, match="NO_EFFECT_RETRY"):
+        await _recover(artifact, args)
+    assert (await args["effect_store"].get(operation_id)).state == module.EffectExecutionState.IN_FLIGHT
+
+
+@pytest.mark.asyncio
+async def test_lookup_absence_remains_unknown_and_never_posts(prepared_inputs, monkeypatch):
+    artifact, args, current, writer, calls = await setup_case(
+        prepared_inputs,
+        monkeypatch,
+        status=404,
+    )
+    result = await _recover(artifact, args)
+
+    assert result.recovery_status == "STILL_UNKNOWN"
+    assert result.state == module.EffectExecutionState.EFFECT_UNKNOWN
+    assert result.external_effect_retry_permitted is False
+    assert result.receipt_bundle is None
+    assert await args["effect_store"].get(current.operation_id) == current
+    assert len(writer.writes) == 1
+    assert writer.writes[0].startswith(b"GET ")
+    assert b"POST" not in writer.writes[0]
+
+
+@pytest.mark.asyncio
+async def test_unknown_to_confirmed_effect_publishes_once_and_restart_does_not_lookup(
+    prepared_inputs,
+    monkeypatch,
+):
+    artifact, args, current, writer, calls = await setup_case(
+        prepared_inputs,
+        monkeypatch,
+        status=200,
+    )
+    provider = args["provider"]
+
+    result = await _recover(artifact, args)
+    assert result.recovery_status == "CONFIRMED_EFFECT"
+    assert result.state == module.EffectExecutionState.CONFIRMED_EFFECT
+    assert result.receipt_bundle is not None
+    assert result.receipt_bundle.bind_receipt["final_outcome"] == "COMMITTED"
+    assert result.receipt_bundle.outcome_receipt["final_outcome"] == "COMMITTED"
+    assert len(writer.writes) == 1
+    assert writer.writes[0].startswith(b"GET ")
+    assert b"POST" not in writer.writes[0]
+    provider_calls = len(provider.calls)
+
+    # Restart/lost receipt acknowledgement recovery uses stored archive/pair only.
+    repeated = await _recover(artifact, args)
+    assert repeated == result
+    assert len(writer.writes) == 1
+    assert len(provider.calls) == provider_calls
+
+
+@pytest.mark.asyncio
+async def test_in_memory_requires_explicit_test_opt_in(prepared_inputs):
+    artifact, args = await _pre_dispatch_case(prepared_inputs)
+    args["allow_in_memory_for_testing"] = False
+
+    with pytest.raises(module.SandboxRecoveryError):
+        await _recover(artifact, args)

--- a/veritas_os/tests/test_sandbox_recovery.py
+++ b/veritas_os/tests/test_sandbox_recovery.py
@@ -85,9 +85,8 @@ async def test_pre_dispatch_crash_closes_no_effect_without_reader_or_resend(prep
     assert result.receipt_bundle is None
 
     stored = await args["effect_store"].get(operation_id)
-    assert stored == result.model_copy(
-        update={},
-    ) or stored.state == module.EffectExecutionState.CONFIRMED_NO_EFFECT
+    assert stored is not None
+    assert stored.state == module.EffectExecutionState.CONFIRMED_NO_EFFECT
     assert stored.reason_code == "SANDBOX_RECOVERY_PRE_DISPATCH_CONFIRMED_NO_EFFECT"
 
     # Idempotent restart: terminal no-effect is returned without any reader access.

--- a/veritas_os/tests/test_sandbox_recovery.py
+++ b/veritas_os/tests/test_sandbox_recovery.py
@@ -11,8 +11,12 @@ from veritas_os.tests.test_sandbox_action_binding import PAYLOAD
 from veritas_os.tests.test_sandbox_pre_effect import (
     _args as pre_effect_args,
     _prepare,
-    prepared_inputs,
+    issued as issued_fixture,
+    prepared_inputs as prepared_fixture,
 )
+
+issued = issued_fixture
+prepared_inputs = prepared_fixture
 from veritas_os.tests.test_sandbox_reconciliation import (
     ReaderProvider,
     setup_case,


### PR DESCRIPTION
## Purpose

Close the next Execution Proof roadmap step by composing the existing durable sandbox primitives into one owning crash-recovery path.

## What this PR adds

### `recover_sandbox_attempt`

The coordinator reads durable state before choosing a recovery action and has **no POST/re-dispatch path**.

State behavior:

- exact sandbox pre-dispatch `IN_FLIGHT`
  - may close as `CONFIRMED_NO_EFFECT`
  - only when the stored revision/reason prove transport was never eligible to start
  - CAS + committed readback required
  - lost transition acknowledgement recovered from durable state
- `EFFECT_UNKNOWN`
  - delegates one read-only reconciliation GET
  - matching persisted evidence may confirm effect
  - 404/outage/non-confirming lookup remains unknown
  - never infers no-effect from absence
- `CONFIRMED_EFFECT`
  - publishes/recovers the same deterministic BindReceipt + Outcome pair
  - no new lookup or external effect on restart
- recovery-created `CONFIRMED_NO_EFFECT`
  - returned idempotently

Every result fixes `external_effect_retry_permitted=false`.

## Replacement-claim interaction

The exact pre-dispatch no-effect transition uses the existing effect-state CAS.
The current storage implementation releases `business_event_key` only on
`CONFIRMED_NO_EFFECT`, so a later authorization can claim the event only after
the original attempt is durably proven not to have crossed transport entry.

## Tests

Added synthetic composition tests for:
- pre-dispatch crash
- lost transition acknowledgement
- unexpected IN_FLIGHT lineage
- lookup absence / still unknown
- unknown -> confirmed effect -> deterministic receipt publication
- restart without repeat lookup
- explicit in-memory test opt-in

Added real PostgreSQL coverage for:
- pre-dispatch terminal transition
- restart/fresh-store readback
- business-event claim release

## Documentation

English/Japanese native-v2 sandbox specification now includes section 23:
Automatic crash recovery coordinator.

## Explicit non-goals

This PR does not claim:
- real TLS/provider/host-clock/PostgreSQL deployment composition
- live external credentials or effects
- TrustLog exactly-once publication
- passing real Decision-to-Effect E2E proof
- Architecture Freeze

No blind resend is introduced.

Human review required before merge.