### PR TITLE
test: prove reproducible current-head Decision-to-Effect E2E

### DIFF
--- a/.github/workflows/reproducible-decision-to-effect-e2e.yml
+++ b/.github/workflows/reproducible-decision-to-effect-e2e.yml
@@ -1,0 +1,210 @@
+name: Reproducible Decision-to-Effect E2E
+
+on:
+  pull_request:
+    paths:
+      - "veritas_os/tests/test_decision_to_effect_controlled_e2e.py"
+      - "veritas_os/tests/helpers/live_decision_capture.py"
+      - "scripts/run_native_v2_sandbox_service.py"
+      - "veritas_os/policy/canonical_verified_decision_promotion.py"
+      - "veritas_os/policy/native_bind_authorization.py"
+      - "veritas_os/policy/native_bind_authorization_consumption.py"
+      - "veritas_os/policy/sandbox_*.py"
+      - "veritas_os/policy/bind_effect_reconciliation.py"
+      - "veritas_os/policy/live_adapter_bind_authorization_consumption_store.py"
+      - "alembic/**"
+      - ".github/workflows/reproducible-decision-to-effect-e2e.yml"
+      - "artifacts/real-decision-to-effect-e2e/**"
+      - "docs/en/architecture/native-v2-sandbox-event-spec-v1.md"
+      - "docs/ja/architecture/native-v2-sandbox-event-spec-v1.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  reproducible-decision-to-effect-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: veritas
+          POSTGRES_PASSWORD: veritas
+          POSTGRES_DB: veritas_decision_e2e
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U veritas -d veritas_decision_e2e"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+
+    env:
+      VERITAS_DATABASE_URL: postgresql+psycopg://veritas:veritas@127.0.0.1:5432/veritas_decision_e2e
+      VERITAS_SANDBOX_DATABASE_URL: postgresql://veritas:veritas@127.0.0.1:5432/veritas_decision_e2e_sandbox
+      VERITAS_SANDBOX_WRITER_TOKEN: decision-e2e-writer-token-0123456789abcdef0123456789
+      VERITAS_SANDBOX_READER_TOKEN: decision-e2e-reader-token-fedcba9876543210fedcba9876
+      VERITAS_SANDBOX_CA_FILE: /tmp/veritas-decision-e2e/ca.crt
+      VERITAS_SANDBOX_LOOKUP_OUTAGE_FLAG: /tmp/veritas-decision-e2e/lookup-outage
+      VERITAS_DECISION_TO_EFFECT_REPORT: artifacts/real-decision-to-effect-e2e/report.json
+      VERITAS_DECISION_TO_EFFECT_EVIDENCE: artifacts/real-decision-to-effect-e2e/evidence.json
+      VERITAS_DECISION_TO_EFFECT_E2E: "1"
+      VERITAS_E2E_SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      VERITAS_E2E_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+      PYTHONUNBUFFERED: "1"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install proof dependencies
+        run: |
+          set -euxo pipefail
+          python -m pip install --upgrade pip --retries 5 --timeout 60
+          python -m pip install --retries 5 --timeout 60 -r veritas_os/requirements.txt
+          python -m pip install --retries 5 --timeout 60 \
+            "psycopg[binary]" psycopg-pool alembic pytest pytest-asyncio httpx cryptography
+
+      - name: Create dedicated sandbox database
+        run: |
+          python - <<'PY'
+          import psycopg
+          conn = psycopg.connect(
+              "postgresql://veritas:veritas@127.0.0.1:5432/postgres",
+              autocommit=True,
+          )
+          try:
+              conn.execute("CREATE DATABASE veritas_decision_e2e_sandbox")
+          finally:
+              conn.close()
+          PY
+
+      - name: Apply current VERITAS PostgreSQL migrations
+        run: alembic upgrade head
+
+      - name: Create controlled CA and authorization-pinned certificate
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/veritas-decision-e2e
+          openssl req -x509 -newkey rsa:2048 -nodes -days 1 \
+            -keyout /tmp/veritas-decision-e2e/ca.key \
+            -out /tmp/veritas-decision-e2e/ca.crt \
+            -subj "/CN=VERITAS Decision-to-Effect Controlled CA"
+          openssl req -newkey rsa:2048 -nodes \
+            -keyout /tmp/veritas-decision-e2e/server.key \
+            -out /tmp/veritas-decision-e2e/server.csr \
+            -subj "/CN=sandbox.example.invalid"
+          cat >/tmp/veritas-decision-e2e/ext.cnf <<'EOF'
+          subjectAltName=DNS:sandbox.example.invalid
+          extendedKeyUsage=serverAuth
+          EOF
+          openssl x509 -req -days 1 \
+            -in /tmp/veritas-decision-e2e/server.csr \
+            -CA /tmp/veritas-decision-e2e/ca.crt \
+            -CAkey /tmp/veritas-decision-e2e/ca.key \
+            -CAcreateserial \
+            -out /tmp/veritas-decision-e2e/server.crt \
+            -extfile /tmp/veritas-decision-e2e/ext.cnf
+          chmod 600 /tmp/veritas-decision-e2e/ca.key /tmp/veritas-decision-e2e/server.key
+
+      - name: Bind authorization-pinned sandbox hostname to loopback
+        run: echo "127.0.0.1 sandbox.example.invalid" | sudo tee -a /etc/hosts
+
+      - name: Start independent sandbox HTTPS service
+        run: |
+          set -euo pipefail
+          sudo -E env PYTHONPATH="$GITHUB_WORKSPACE" "$(which python)" \
+            scripts/run_native_v2_sandbox_service.py \
+            --host 0.0.0.0 \
+            --port 443 \
+            --cert /tmp/veritas-decision-e2e/server.crt \
+            --key /tmp/veritas-decision-e2e/server.key \
+            >/tmp/veritas-decision-e2e/service.log 2>&1 &
+          echo $! >/tmp/veritas-decision-e2e/service.pid
+
+          status=""
+          for i in $(seq 1 30); do
+            status="$(curl --silent --show-error \
+              --cacert "$VERITAS_SANDBOX_CA_FILE" \
+              -H "Authorization: Bearer $VERITAS_SANDBOX_READER_TOKEN" \
+              -o /tmp/veritas-decision-e2e/health.json \
+              -w '%{http_code}' \
+              'https://sandbox.example.invalid/v1/operations?idempotency_key=not-created' \
+              || true)"
+            if [ "$status" = "404" ]; then
+              break
+            fi
+            sleep 0.5
+          done
+
+          test "$status" = "404"
+          grep -q "SSE_NOT_FOUND_NOT_PROOF_OF_NO_EFFECT" \
+            /tmp/veritas-decision-e2e/health.json
+
+      - name: Run current-head Decision-to-Effect proof
+        run: |
+          set -euxo pipefail
+          PYTHONPATH=. pytest \
+            veritas_os/tests/test_decision_to_effect_controlled_e2e.py \
+            -v -s --tb=short
+
+      - name: Assert proof conjunction
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          report = json.loads(
+              Path("artifacts/real-decision-to-effect-e2e/report.json").read_text()
+          )
+          evidence = json.loads(
+              Path("artifacts/real-decision-to-effect-e2e/evidence.json").read_text()
+          )
+
+          assert report["result"] == "PASS"
+          assert report["proof"] == "CONTROLLED_CURRENT_HEAD_DECISION_TO_EFFECT_E2E"
+          assert report["production_claim"] is False
+          assert report["controlled_decision_to_effect_e2e_proven"] is True
+          assert report["production_decision_to_effect_e2e_proven"] is False
+          assert report["trustlog_exactly_once_proven"] is False
+          assert report["production_validation_proven"] is False
+          assert report["alembic_head"] == "0008"
+          assert report["normal"]["dispatch_reason"] == "HTTP_201_MATCHING_ACK"
+          assert report["normal"]["terminal_effect_state"] == "CONFIRMED_EFFECT"
+          assert report["fault"]["dispatch_reason"] == "TRANSPORT_FAILED_OR_UNKNOWN"
+          assert report["fault"]["transport_delegate_observation"] == "HTTP_201_MATCHING_ACK"
+          assert report["fault"]["lookup_outage_state"] == "EFFECT_UNKNOWN"
+          assert report["fault"]["lookup_outage_retry_permitted"] is False
+          assert report["fault"]["terminal_effect_state"] == "CONFIRMED_EFFECT"
+          assert report["fault"]["transport_calls"] == 1
+          assert report["sandbox_rows_added"] == 2
+          assert all(report["proof_conjunction"].values())
+          assert evidence["source_sha"] == report["source_sha"]
+          assert evidence["base_sha"] == report["base_sha"]
+          PY
+
+      - name: Upload Decision-to-Effect proof artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: reproducible-decision-to-effect-e2e
+          path: |
+            artifacts/real-decision-to-effect-e2e/report.json
+            artifacts/real-decision-to-effect-e2e/evidence.json
+            /tmp/veritas-decision-e2e/service.log
+          if-no-files-found: warn
+
+      - name: Stop controlled sandbox service
+        if: always()
+        run: |
+          if [ -f /tmp/veritas-decision-e2e/service.pid ]; then
+            sudo kill "$(cat /tmp/veritas-decision-e2e/service.pid)" || true
+          fi
+          rm -f "$VERITAS_SANDBOX_LOOKUP_OUTAGE_FLAG"

--- a/artifacts/real-decision-to-effect-e2e/README.md
+++ b/artifacts/real-decision-to-effect-e2e/README.md
@@ -1,0 +1,72 @@
+# Reproducible Decision-to-Effect E2E Evidence
+
+This directory is the stable repository location for the TASK-007 proof
+contract. The machine-readable proof files themselves are generated on each
+dedicated GitHub Actions run so they can bind the exact source SHA, ephemeral
+controlled CA, decisions, authorizations, PostgreSQL operations and receipt
+hashes from that run.
+
+## Workflow
+
+`.github/workflows/reproducible-decision-to-effect-e2e.yml`
+
+Required check:
+
+`reproducible-decision-to-effect-e2e`
+
+## Generated artifacts
+
+### report.json
+
+A compact proof report containing:
+
+- source and base commit SHAs;
+- deployment and controlled CA digests;
+- Alembic revision;
+- normal-path decision / promotion / authorization / operation identities;
+- fault-path decision / promotion / authorization / operation identities;
+- reconciliation evidence and receipt-bundle hashes;
+- a machine-checkable proof conjunction;
+- an evidence hash; and
+- a proof-manifest hash.
+
+### evidence.json
+
+The detailed synthetic evidence bundle for both normal and fault cases:
+
+- verified CanonicalDecisionArtifact;
+- canonical verified promotion packet;
+- native v2 authorization artifact;
+- durable authorization-consumption record;
+- archived reconciliation evidence; and
+- deterministic BindReceipt / Outcome bundle.
+
+Bearer material and private keys must never appear in either artifact.
+
+## Required scenarios
+
+### Normal
+
+`/v1/decide -> CDA -> promotion -> native v2 authorization -> consume ->
+current rechecks -> real TLS POST -> PostgreSQL persistence -> read-only
+reconciliation -> receipt/outcome`
+
+### Fault
+
+A real TLS POST commits the sandbox event, but the caller loses the observed
+response. Durable state remains `EFFECT_UNKNOWN`. A controlled read-only lookup
+outage must leave it unknown with retry prohibited. After lookup recovery, the
+same persisted operation is confirmed. No second POST is permitted, and repeat
+recovery must not perform another reconciliation lookup.
+
+## Claim boundary
+
+A passing report proves a **controlled current-head Decision-to-Effect E2E**
+through real TLS and real PostgreSQL with synthetic decisions, credentials and
+business effects.
+
+It does not prove production readiness, customer integration, external clock
+trust, TrustLog exactly-once publication, or regulatory status.
+
+`STOP.md` is retained only as the historical stop record for the older proof
+path.

--- a/artifacts/real-decision-to-effect-e2e/STOP.md
+++ b/artifacts/real-decision-to-effect-e2e/STOP.md
@@ -1,64 +1,74 @@
-# Real Decision-to-Effect E2E — Stop Report
+# Decision-to-Effect E2E — Historical Stop Record
 
 ## Status
 
-The controlled real Decision-to-Effect E2E proof is **stopped** at base commit
-`e039496cefad9793f342f261940e4009806e5859` (merge commit for PR #2142).
-No passing `report.json` has been produced.
+The stop condition documented here originated at merge commit
+`e039496cefad9793f342f261940e4009806e5859` (PR #2142 era).
 
-## Missing production prerequisite
+It is **superseded for the controlled CI proof scope**.
 
-The reconciliation boundary exposes only the
-`ReconciliationEvidenceVerifier` protocol. The repository has no reusable,
-non-test implementation that independently observes and authenticates an
-external acknowledgement before producing `VerifiedReconciliationEvidence`.
+The repository now has later native-v2 sandbox primitives for certificate-
+validated HTTPS dispatch, independent read-only reconciliation, durable
+reconciliation evidence, atomic BindReceipt / Outcome publication, replacement
+business-event blocking, crash recovery, and controlled real-TLS /
+real-PostgreSQL composition.
 
-`reconcile_effect_unknown(...)` accepts a verifier implementing that protocol,
-but it cannot itself establish that:
+TASK-007 adds a dedicated workflow:
 
-- the acknowledgement came from the authorization-bound TLS endpoint;
-- the acknowledgement digest equals `external_ack_digest`;
-- the observation digest is derived from the independently retrieved response;
-- the external operation reference in the response matches the evidence; or
-- a deployment-controlled verifier policy approved the observation source.
+`.github/workflows/reproducible-decision-to-effect-e2e.yml`
 
-The existing controlled TLS runner fills this gap with the private
-`_HttpsReconciliationVerifier`. That runner-local implementation directly
-constructs `VerifiedReconciliationEvidence`; it is not a production verifier
-primitive and does not validate the evidence's acknowledgement or observation
-digests against the retrieved acknowledgement. Unit tests similarly use a
-private `_Verifier` that returns a verified object without external
-observation.
+That workflow must generate a passing, source-SHA-bound:
 
-Promoting either private implementation into the requested E2E would violate
-the requirements prohibiting test-only reconciliation trust and fake or
-mismatched acknowledgement acceptance.
+- `report.json`; and
+- `evidence.json`
 
-## Smallest prerequisite PR
+under the runtime artifact path `artifacts/real-decision-to-effect-e2e/` and
+upload them as the `reproducible-decision-to-effect-e2e` GitHub Actions
+artifact.
 
-Add one production reconciliation verifier, with focused fail-closed tests,
-that:
+## What resolved this stop for the controlled scope
 
-1. accepts deployment-controlled HTTPS endpoint trust and verifier-policy
-   configuration;
-2. performs certificate-validated, independent acknowledgement retrieval;
-3. canonicalizes the retrieved acknowledgement and verifies
-   `external_ack_digest` and `observation_digest`;
-4. binds operation, authorization, consumption, external reference, source,
-   and observation time;
-5. returns `VerifiedReconciliationEvidence` only after every binding passes;
-6. rejects endpoint substitution, malformed responses, mismatched digests,
-   mismatched operation references, and unapproved verifier policy; and
-7. never accepts bearer material through an artifact or emits it in evidence.
+The controlled proof no longer relies on the old runner-local reconciliation
+shortcut described below. It uses the current sandbox execution/reconciliation
+path and requires the full proof conjunction to pass:
 
-After that prerequisite merges, the Decision-to-Effect composition can use
-the production verifier through `reconcile_effect_unknown(...)` and can
-legitimately derive `reconciliation_evidence_verified`,
-`terminal_effect_confirmed`, and the final E2E conjunction.
+1. current `/v1/decide` route exercised with controlled model output;
+2. CanonicalDecisionArtifact independently verified;
+3. selected sandbox action and deterministic promotion verified;
+4. native v2 authorization verified against that exact promoted intent;
+5. single-use authorization consumed in real PostgreSQL;
+6. current governance rechecks exercised;
+7. one certificate-validated TLS POST reaches the pinned sandbox endpoint;
+8. the synthetic event is durably persisted in a dedicated PostgreSQL database;
+9. independent read-only reconciliation confirms the persisted operation;
+10. reconciliation evidence is archived;
+11. BindReceipt and Outcome link back to the original decision and intent;
+12. a lost-response + lookup-outage fault preserves `EFFECT_UNKNOWN`;
+13. no blind redispatch occurs; and
+14. repeat recovery does not perform another POST or reconciliation lookup.
 
-## Security warning
+The workflow fails unless every controlled proof conjunction is true.
 
-Claiming `CONFIRMED_EFFECT` with the current runner-local verifier would allow
-an acknowledgement/evidence digest mismatch to cross the reconciliation trust
-boundary. The final E2E claim must remain false until the missing verifier is
-implemented and independently tested.
+## Scope boundary
+
+This resolution is intentionally narrower than production validation.
+
+A passing controlled proof does **not** establish:
+
+- production readiness;
+- real customer credentials;
+- a real customer endpoint;
+- independent production infrastructure ownership;
+- external UTC clock trust;
+- TrustLog exactly-once publication;
+- regulatory approval or certification.
+
+Therefore this file must not be interpreted as a production-readiness marker.
+
+## Historical context
+
+The original stop report stated that the then-current proof path could not
+independently authenticate external effect evidence strongly enough to support a
+Decision-to-Effect claim. That warning was correct for that historical commit.
+It is retained here as provenance, but current status must be determined from
+the current source SHA and the dedicated Decision-to-Effect workflow result.

--- a/docs/en/architecture/native-v2-sandbox-event-spec-v1.md
+++ b/docs/en/architecture/native-v2-sandbox-event-spec-v1.md
@@ -754,7 +754,56 @@ A passing controlled-composition report proves the repository components can be
 joined under one isolated, reproducible TLS/PostgreSQL environment with the
 specified fault behavior. It **does not** prove production readiness, real
 customer credentials, independent infrastructure ownership, external clock
-trust, TrustLog exactly-once publication, or a real Decision-to-Effect E2E
-lineage. The authorization remains a signed synthetic native fixture. Production
-deployment validation and the later current-head Decision-to-Effect proof remain
-separate milestones.
+trust, or TrustLog exactly-once publication. Section 25 adds the separate
+current-head Decision-to-Effect lineage proof on top of this composition.
+Production deployment validation remains a later environment-specific milestone.
+
+
+## 25. Reproducible controlled Decision-to-Effect E2E
+
+TASK-007 adds a dedicated current-head proof workflow that starts before native
+authorization, at the actual `POST /v1/decide` route. Model output and external
+infrastructure fixtures remain controlled and synthetic, but the HTTP route,
+decision kernel, signed policy verification, CanonicalDecisionArtifact
+construction/verification, deterministic promotion, native v2 issuance and the
+sandbox execution path all use the repository's current production code paths.
+
+For each proof case the runner binds the exact sandbox action reference into the
+selected decision candidate before capture. It then independently verifies the
+CDA, reconstructs the deterministic promotion packet, builds the native authority
+source chain, issues and re-verifies the native v2 authorization, and requires
+the authorization's exact execution intent ID/hash and source decision ID/hash to
+match the promotion and CDA.
+
+The proof then reuses section 24's controlled environment:
+
+`/v1/decide -> verified CDA -> promotion -> native v2 authorization ->
+PostgreSQL consumption -> current governance rechecks -> credential resolution ->
+durable dispatch intent -> certificate-validated TLS POST -> dedicated PostgreSQL
+event persistence -> read-only TLS reconciliation -> archived evidence ->
+BindReceipt / Outcome -> recovery`.
+
+Two independently captured decisions are required. The normal case receives a
+matching HTTP 201 observation but still remains `EFFECT_UNKNOWN` until the
+read-only reconciliation path independently confirms the persisted operation.
+The fault case commits a second event, deliberately loses the caller-side
+response, forces read-only lookup to 503, and requires `EFFECT_UNKNOWN` plus
+`external_effect_retry_permitted=false`. After lookup availability returns, the
+same operation must be confirmed without another POST. Repeating recovery after
+confirmation must not perform another reconciliation lookup.
+
+The generated `report.json` records the exact source/base SHAs, deployment hash,
+controlled CA digest, migration revision, decision/promotion/authorization
+identities, external operation references, reconciliation evidence hashes,
+receipt bundle hashes and a machine-checkable proof conjunction. The companion
+`evidence.json` contains the synthetic CDA, promotion packet, native
+authorization, consumption record, reconciliation archive and receipt bundle for
+both cases. A hash of the evidence bundle and a proof-manifest hash bind the
+generated artifacts. Bearer material and private keys are explicitly excluded.
+
+A passing dedicated check establishes **controlled current-head
+Decision-to-Effect E2E reproducibility** for this sandbox scope. It does not
+establish production readiness, real customer credentials/endpoints, independent
+production infrastructure, external UTC clock trust, TrustLog exactly-once
+publication, or regulatory approval/certification. Those remain separate claims
+and gates.

--- a/docs/ja/architecture/native-v2-sandbox-event-spec-v1.md
+++ b/docs/ja/architecture/native-v2-sandbox-event-spec-v1.md
@@ -612,6 +612,49 @@ reconciliation proof digest、receipt bundle hashを記録します。Bearer mat
 passing controlled-composition reportが証明するのは、repository componentが指定した
 fault behaviorを保ちながらisolatedで再現可能なTLS/PostgreSQL環境へ結合できることです。
 **production readiness、実顧客credential、独立infrastructure ownership、外部clock trust、
-TrustLog exactly-once publication、real Decision-to-Effect E2E lineageは証明しません。**
-authorizationは引き続きsigned synthetic native fixtureです。production deployment validationと
-current-head Decision-to-Effect proofは後続milestoneに残ります。
+TrustLog exactly-once publicationは証明しません。** 第25節でこのcompositionの上に
+current-head Decision-to-Effect lineage proofを追加します。production deployment validationは
+後続のenvironment-specific milestoneに残ります。
+
+
+## 25. Reproducible controlled Decision-to-Effect E2E
+
+TASK-007ではnative authorizationより上流の実`POST /v1/decide` routeから開始する
+current-head専用proof workflowを追加します。model outputと外部infrastructure fixtureは
+controlled / syntheticですが、HTTP route、decision kernel、signed policy verification、
+CanonicalDecisionArtifactの生成・検証、deterministic promotion、native v2 issuance、
+sandbox execution pathはrepositoryのcurrent production code pathを通します。
+
+各proof caseではdecision captureより前にexact sandbox action referenceをselected candidateへ
+bindingします。その後CDAを独立検証し、deterministic promotion packetを再構築し、
+native authority source chainを作り、native v2 authorizationをissueして再検証します。
+authorizationのexecution intent ID/hashとsource decision ID/hashがpromotionおよびCDAへ
+完全一致することを必須にします。
+
+その後、第24節のcontrolled environmentを再利用して次を接続します。
+
+`/v1/decide -> verified CDA -> promotion -> native v2 authorization ->
+PostgreSQL consumption -> current governance rechecks -> credential resolution ->
+durable dispatch intent -> certificate-validated TLS POST -> dedicated PostgreSQL
+event persistence -> read-only TLS reconciliation -> archived evidence ->
+BindReceipt / Outcome -> recovery`
+
+独立にcaptureした2つのdecisionを使います。normal caseではmatching HTTP 201を観測しても、
+read-only reconciliationがpersisted operationを独立確認するまでは`EFFECT_UNKNOWN`です。
+fault caseでは2件目eventをcommitした後caller-side responseを意図的に失わせ、read-only lookupを
+503へ落とし、`EFFECT_UNKNOWN`と`external_effect_retry_permitted=false`を要求します。
+lookup復旧後は同じoperationを追加POSTなしで確認し、confirmation後のrepeat recoveryでは
+reconciliation lookupも再実行しません。
+
+生成する`report.json`にはexact source/base SHA、deployment hash、controlled CA digest、
+migration revision、decision/promotion/authorization identity、external operation reference、
+reconciliation evidence hash、receipt bundle hash、machine-checkable proof conjunctionを記録します。
+`evidence.json`には両caseのsynthetic CDA、promotion packet、native authorization、
+consumption record、reconciliation archive、receipt bundleを格納します。evidence bundle hashと
+proof-manifest hashでartifactをbindingし、Bearer materialとprivate keyは明示的に除外します。
+
+dedicated checkのPASSが証明するのは、このsandbox scopeにおける
+**controlled current-head Decision-to-Effect E2E reproducibility**です。
+production readiness、実顧客credential/endpoint、独立production infrastructure、
+external UTC clock trust、TrustLog exactly-once publication、規制上の承認・認証は証明しません。
+これらは別のclaim / gateとして残ります。

--- a/veritas_os/tests/test_decision_to_effect_controlled_e2e.py
+++ b/veritas_os/tests/test_decision_to_effect_controlled_e2e.py
@@ -301,7 +301,10 @@ async def _migration_head() -> str:
 
 
 def _load_current(inputs):
+    calls = {"count": 0}
+
     def load(now: datetime) -> SandboxCurrentInputs:
+        calls["count"] += 1
         risk, source = _fresh(inputs, now)
         return SandboxCurrentInputs(
             source=source,
@@ -309,7 +312,7 @@ def _load_current(inputs):
             runtime_risk_packet=risk,
         )
 
-    return load
+    return load, calls
 
 
 def _reader_inputs(config, ca_pem: str, token: str, suffix: str):
@@ -370,6 +373,7 @@ async def _run_normal_case(case, *, ca_pem: str, writer_token: str, reader_token
     effect_store = PostgresAtomicEffectStateStore()
     writer = ControlledCredentialProvider(writer_token)
     transport = SandboxHTTPSTransport(endpoint_url=config.endpoint_url, ca_pem=ca_pem)
+    load_current, governance_calls = _load_current(inputs)
 
     dispatch = await execute_sandbox_bind(
         artifact,
@@ -381,7 +385,7 @@ async def _run_normal_case(case, *, ca_pem: str, writer_token: str, reader_token
         consumption_store=consumption_store,
         effect_store=effect_store,
         trusted_clock=_clock,
-        load_current_inputs=_load_current(inputs),
+        load_current_inputs=load_current,
         provider=writer,
         transport=transport,
     )
@@ -423,6 +427,7 @@ async def _run_normal_case(case, *, ca_pem: str, writer_token: str, reader_token
         "archive": archive,
         "consumption": consumption,
         "reader_calls": reader.describe_calls,
+        "governance_recheck_calls": governance_calls["count"],
     }
 
 
@@ -441,6 +446,7 @@ async def _run_fault_case(
     transport = LoseObservedResponseTransport(
         SandboxHTTPSTransport(endpoint_url=config.endpoint_url, ca_pem=ca_pem)
     )
+    load_current, governance_calls = _load_current(inputs)
 
     dispatch = await execute_sandbox_bind(
         artifact,
@@ -452,7 +458,7 @@ async def _run_fault_case(
         consumption_store=consumption_store,
         effect_store=effect_store,
         trusted_clock=_clock,
-        load_current_inputs=_load_current(inputs),
+        load_current_inputs=load_current,
         provider=writer,
         transport=transport,
     )
@@ -544,6 +550,7 @@ async def _run_fault_case(
         "transport_delegate_observation": transport.delegate_observation,
         "reader_calls_after_confirmation": reader_calls_after_confirmation,
         "reader_calls_after_repeat": reader.describe_calls,
+        "governance_recheck_calls": governance_calls["count"],
     }
 
 
@@ -618,7 +625,10 @@ async def test_current_head_decision_to_effect_normal_and_fault_e2e(tmp_path):
         "execution_intent_lineage_proven": True,
         "native_v2_authorizations_verified": True,
         "real_postgresql_consumption": True,
-        "current_governance_rechecks_exercised": True,
+        "current_governance_rechecks_exercised": (
+            normal["governance_recheck_calls"] >= 3
+            and fault["governance_recheck_calls"] >= 3
+        ),
         "real_certificate_validated_tls_post": True,
         "dedicated_postgresql_effect_persistence": True,
         "read_only_reconciliation_confirmed": True,
@@ -660,6 +670,7 @@ async def test_current_head_decision_to_effect_normal_and_fault_e2e(tmp_path):
             "external_operation_reference": normal["archive"].operation.operation_id,
             "reconciliation_evidence_hash": normal["archive"].proof.deterministic_digest(),
             "receipt_bundle_hash": normal["recovered"].receipt_bundle.bundle_hash,
+            "governance_recheck_calls": normal["governance_recheck_calls"],
         },
         "fault": {
             "decision_id": fault_case["cda"].decision_id,
@@ -676,6 +687,7 @@ async def test_current_head_decision_to_effect_normal_and_fault_e2e(tmp_path):
             "reconciliation_evidence_hash": fault["archive"].proof.deterministic_digest(),
             "receipt_bundle_hash": fault["recovered"].receipt_bundle.bundle_hash,
             "transport_calls": fault["transport_calls"],
+            "governance_recheck_calls": fault["governance_recheck_calls"],
         },
         "sandbox_rows_added": rows_after_fault - rows_before,
         "evidence_hash": evidence_hash,

--- a/veritas_os/tests/test_decision_to_effect_controlled_e2e.py
+++ b/veritas_os/tests/test_decision_to_effect_controlled_e2e.py
@@ -1,0 +1,714 @@
+"""Current-head controlled Decision-to-Effect E2E proof.
+
+This opt-in proof starts at the actual /v1/decide route with controlled model
+output, verifies the CanonicalDecisionArtifact, promotes the exact chosen sandbox
+action, issues a native v2 authorization through the existing source chain, and
+then reuses the merged real-TLS / real-PostgreSQL sandbox composition.
+
+It is a reproducible controlled proof, not a production deployment. All action
+payloads, credentials, keys and external effects are synthetic.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from datetime import UTC, datetime, timedelta
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import time
+from typing import Any
+
+import psycopg
+import pytest
+from pydantic import SecretBytes
+
+from veritas_os.governance.canonical_decision_artifact import (
+    verify_canonical_decision_artifact,
+)
+from veritas_os.policy import sandbox_action_binding as binding
+from veritas_os.policy.bind_effect_reconciliation import (
+    EffectExecutionState,
+    PostgresAtomicEffectStateStore,
+)
+from veritas_os.policy.canonical_verified_decision_promotion import (
+    build_canonical_verified_decision_promotion_packet,
+    canonical_verified_decision_promotion_proof,
+    verify_canonical_verified_decision_promotion_packet,
+)
+from veritas_os.policy.live_adapter_bind_authorization_consumption_store import (
+    PostgresAtomicAuthorizationConsumptionStore,
+)
+from veritas_os.policy.native_bind_authorization import verify_native_bind_authorization
+from veritas_os.policy.native_bind_authorization_consumption import (
+    consume_native_bind_authorization,
+)
+from veritas_os.policy.sandbox_bind_execution import execute_sandbox_bind
+from veritas_os.policy.sandbox_credential_resolution import (
+    SandboxCredentialMetadata,
+    SandboxProviderCredential,
+)
+from veritas_os.policy.sandbox_https_transport import SandboxHTTPSTransport
+from veritas_os.policy.sandbox_pre_effect import SandboxClockReading, SandboxCurrentInputs
+from veritas_os.policy.sandbox_reconciliation import (
+    SandboxReaderPolicy,
+    VERIFIER_ID,
+    sandbox_reconciliation_policy_hash,
+)
+from veritas_os.policy.sandbox_recovery import recover_sandbox_attempt
+from veritas_os.policy.trusted_https_reconciliation import (
+    ApprovedReconciliationVerifier,
+    ReconciliationVerifierPolicy,
+)
+from veritas_os.security.hash import sha256_of_canonical_json
+from veritas_os.storage.db import close_pool, get_pool
+from veritas_os.tests import (
+    test_canonical_promotion_live_adapter_dry_run_credential_authorization as credentials,
+)
+from veritas_os.tests import (
+    test_canonical_promotion_live_adapter_dry_run_endpoint_allowlist as endpoints,
+)
+from veritas_os.tests.helpers.native_approval_source import build_native_authority_source
+from veritas_os.tests.test_native_bind_authorization import _setup
+from veritas_os.tests.test_native_bind_authorization_consumption import _fresh
+from veritas_os.tests.test_sandbox_action_binding import contract, deployment
+
+pytestmark = [
+    pytest.mark.slow,
+    pytest.mark.postgresql,
+    pytest.mark.skipif(
+        os.getenv("VERITAS_DECISION_TO_EFFECT_E2E") != "1",
+        reason="controlled Decision-to-Effect E2E workflow only",
+    ),
+]
+
+NORMAL_PAYLOAD = {
+    "event_id": "32345678-1234-4234-8234-123456789abc",
+    "message": "controlled decision-to-effect normal",
+}
+FAULT_PAYLOAD = {
+    "event_id": "32345678-1234-4234-8234-123456789abd",
+    "message": "controlled decision-to-effect lost-response fault",
+}
+
+
+def _clock() -> SandboxClockReading:
+    now = datetime.now(UTC)
+    return SandboxClockReading(
+        now=now,
+        monotonic_seconds=time.monotonic(),
+        health_checked_at=now,
+        uncertainty_seconds=0.05,
+    )
+
+
+class ControlledCredentialProvider:
+    """CI-only provider binding one synthetic token to an exact request."""
+
+    def __init__(self, token: str) -> None:
+        self._token = token
+        self._metadata: SandboxCredentialMetadata | None = None
+        self.describe_calls = 0
+        self.resolve_calls = 0
+
+    async def describe(self, request):
+        self.describe_calls += 1
+        now = datetime.now(UTC)
+        self._metadata = SandboxCredentialMetadata(
+            credential_reference_id=request.credential_reference_id,
+            credential_provider_type=request.credential_provider_type,
+            credential_version=request.credential_version,
+            credential_scope=request.credential_scope,
+            credential_environment=request.credential_environment,
+            audience=request.audience,
+            credential_kind="bearer",
+            valid_from=(now - timedelta(minutes=2)).isoformat(),
+            valid_until=(now + timedelta(minutes=5)).isoformat(),
+            observed_at=now.isoformat(),
+            revoked=False,
+        )
+        return self._metadata
+
+    async def resolve(self, request, *, expected_metadata_digest):
+        self.resolve_calls += 1
+        if self._metadata is None:
+            raise RuntimeError("descriptor required")
+        if expected_metadata_digest != sha256_of_canonical_json(
+            self._metadata.model_dump(mode="json")
+        ):
+            raise RuntimeError("descriptor digest mismatch")
+        for name in (
+            "credential_reference_id",
+            "credential_provider_type",
+            "credential_version",
+            "credential_scope",
+            "credential_environment",
+            "audience",
+        ):
+            if getattr(request, name) != getattr(self._metadata, name):
+                raise RuntimeError("request changed")
+        return SandboxProviderCredential(
+            metadata=self._metadata,
+            material=SecretBytes(self._token.encode("ascii")),
+        )
+
+
+class LoseObservedResponseTransport:
+    """Perform one real POST, then model caller-side response loss."""
+
+    def __init__(self, delegate: SandboxHTTPSTransport) -> None:
+        self._delegate = delegate
+        self.delegate_observation: str | None = None
+        self.calls = 0
+
+    async def send_once(self, request, *, take_material):
+        self.calls += 1
+        self.delegate_observation = await self._delegate.send_once(
+            request,
+            take_material=take_material,
+        )
+        raise RuntimeError("controlled response loss after remote commit")
+
+
+def _build_decision_case(case_dir: Path, payload: dict[str, str]) -> dict[str, Any]:
+    """Capture /v1/decide, verify CDA/promotion, then issue exact native v2 auth."""
+
+    case_dir.mkdir(parents=True, exist_ok=True)
+    output = case_dir / "decision-capture.json"
+    config = deployment()
+    action_contract = contract()
+    action_binding = binding.build_sandbox_action_binding(
+        json.dumps(payload),
+        deployment=config,
+        expected_contract=action_contract,
+    )
+    overrides = {
+        "intended_action": binding.ACTION,
+        "target_system": config.target_system,
+        "target_resource": config.endpoint_url,
+        "evidence_refs": [action_binding.reference],
+    }
+    code = (
+        "import json,sys; from pathlib import Path; "
+        "from veritas_os.tests.helpers.live_decision_capture import capture; "
+        "capture(Path(sys.argv[1]), candidate_overrides=json.loads(sys.argv[2]))"
+    )
+    subprocess.run(
+        [sys.executable, "-c", code, str(output), json.dumps(overrides)],
+        cwd=Path(__file__).resolve().parents[2],
+        check=True,
+        timeout=180,
+        capture_output=True,
+        text=True,
+    )
+    captured = json.loads(output.read_text())
+    assert captured["pipeline_ok"] is True
+    assert captured["infrastructure_calls"]["kms_sign_calls"] > 0
+    assert captured["infrastructure_calls"]["object_lock_put_calls"] > 0
+
+    verification = verify_canonical_decision_artifact(
+        captured["canonical_decision_artifact"]
+    )
+    assert verification.is_valid and verification.artifact is not None
+    cda = verification.artifact
+
+    promoted_at = datetime.fromisoformat(captured["observed_at"])
+    promotion = build_canonical_verified_decision_promotion_packet(
+        captured["canonical_decision_artifact"],
+        captured["candidate"],
+        promoted_at=promoted_at,
+        ttl_seconds=300,
+        expected_state_fingerprint="synthetic:sandbox:empty",
+    )
+    verified_promotion = verify_canonical_verified_decision_promotion_packet(promotion)
+    promotion_proof = canonical_verified_decision_promotion_proof(verified_promotion)
+    assert promotion_proof["canonical_decision_verified"] is True
+    assert promotion_proof["decision_lineage_proven"] is True
+    assert promotion_proof["execution_intent_lineage_proven"] is True
+
+    # Adapt only synthetic fixture metadata. Production source/crypto verifiers
+    # and all promotion/native issuance builders execute unchanged.
+    original_endpoint = endpoints._candidate
+    original_reference = credentials._reference
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(
+            endpoints,
+            "_candidate",
+            lambda **kw: original_endpoint(
+                **kw,
+                endpoint_host="sandbox.example.invalid",
+                endpoint_path_prefix="/v1/events",
+            ),
+        )
+        patch.setattr(
+            credentials,
+            "_reference",
+            lambda **kw: original_reference(
+                **kw,
+                credential_scope=config.credential_scope,
+                credential_environment=config.credential_environment,
+            ),
+        )
+        source = build_native_authority_source(promotion, promoted_at)
+
+    artifact, inputs, *_ = _setup(source, action_contract, promoted_at)
+    verified_authorization = verify_native_bind_authorization(artifact, **inputs)
+    assert verified_authorization == artifact
+    assert artifact.execution_intent == promotion.exact_execution_intent
+    assert artifact.execution_intent_id == promotion.execution_intent_id
+    assert artifact.execution_intent_hash == promotion.execution_intent_hash
+    assert artifact.execution_intent["decision_id"] == cda.decision_id
+    assert artifact.execution_intent["decision_hash"] == cda.decision_hash
+    assert artifact.execution_intent["decision_ts"] == cda.decision_ts
+
+    return {
+        "payload": payload,
+        "captured": captured,
+        "cda": cda,
+        "promotion": promotion,
+        "promotion_proof": promotion_proof,
+        "artifact": artifact,
+        "inputs": inputs,
+        "deployment": config,
+        "action_binding": action_binding,
+    }
+
+
+async def _sandbox_row_count() -> int:
+    dsn = os.environ["VERITAS_SANDBOX_DATABASE_URL"].replace(
+        "postgresql+psycopg://", "postgresql://", 1
+    )
+    conn = await psycopg.AsyncConnection.connect(dsn)
+    try:
+        cur = await conn.execute("SELECT count(*) FROM sandbox_events")
+        return int((await cur.fetchone())[0])
+    finally:
+        await conn.close()
+
+
+async def _migration_head() -> str:
+    pool = await get_pool()
+    async with pool.connection() as conn:
+        cur = await conn.execute("SELECT version_num FROM alembic_version")
+        row = await cur.fetchone()
+    if row is None:
+        raise RuntimeError("missing alembic version")
+    return str(row[0])
+
+
+def _load_current(inputs):
+    def load(now: datetime) -> SandboxCurrentInputs:
+        risk, source = _fresh(inputs, now)
+        return SandboxCurrentInputs(
+            source=source,
+            governance=inputs["governance_inputs"],
+            runtime_risk_packet=risk,
+        )
+
+    return load
+
+
+def _reader_inputs(config, ca_pem: str, token: str, suffix: str):
+    policy = SandboxReaderPolicy(
+        credential_reference_id=f"controlled-e2e-reader-{suffix}",
+        credential_version="1",
+        credential_provider_type="CONTROLLED_CI_PROVIDER",
+        credential_environment="sandbox",
+        ca_pem=ca_pem,
+    )
+    verifier = ReconciliationVerifierPolicy(
+        (
+            ApprovedReconciliationVerifier(
+                VERIFIER_ID,
+                sandbox_reconciliation_policy_hash(config, policy),
+            ),
+        )
+    )
+    return policy, verifier, ControlledCredentialProvider(token)
+
+
+async def _consume(case):
+    artifact = case["artifact"]
+    inputs = case["inputs"]
+    store = PostgresAtomicAuthorizationConsumptionStore()
+    consume_at = datetime.now(UTC)
+    current_risk, current_source = _fresh(inputs, consume_at)
+    consumed = await consume_native_bind_authorization(
+        artifact,
+        issuance_source_inputs=inputs["source_inputs"],
+        governance_inputs=inputs["governance_inputs"],
+        trust_inputs=inputs["trust_inputs"],
+        current_source_inputs=current_source,
+        current_runtime_risk_packet=current_risk,
+        now=consume_at,
+        consumption_store=store,
+    )
+    return store, consumed.consumption_record
+
+
+def _assert_receipt_decision_lineage(case, bundle) -> None:
+    cda = case["cda"]
+    promotion = case["promotion"]
+    bind_receipt = bundle.bind_receipt
+    outcome = bundle.outcome_receipt
+    assert bind_receipt["decision_id"] == cda.decision_id
+    assert bind_receipt["decision_hash"] == cda.decision_hash
+    assert bind_receipt["execution_intent_id"] == promotion.execution_intent_id
+    assert bind_receipt["execution_intent_hash"] == promotion.execution_intent_hash
+    assert outcome["decision_id"] == cda.decision_id
+    assert outcome["execution_intent_id"] == promotion.execution_intent_id
+    assert outcome["bind_receipt_id"] == bind_receipt["bind_receipt_id"]
+
+
+async def _run_normal_case(case, *, ca_pem: str, writer_token: str, reader_token: str):
+    artifact, inputs, config = case["artifact"], case["inputs"], case["deployment"]
+    consumption_store, consumption = await _consume(case)
+    effect_store = PostgresAtomicEffectStateStore()
+    writer = ControlledCredentialProvider(writer_token)
+    transport = SandboxHTTPSTransport(endpoint_url=config.endpoint_url, ca_pem=ca_pem)
+
+    dispatch = await execute_sandbox_bind(
+        artifact,
+        json.dumps(case["payload"]),
+        deployment=config,
+        issuance_source_inputs=inputs["source_inputs"],
+        governance_inputs=inputs["governance_inputs"],
+        trust_inputs=inputs["trust_inputs"],
+        consumption_store=consumption_store,
+        effect_store=effect_store,
+        trusted_clock=_clock,
+        load_current_inputs=_load_current(inputs),
+        provider=writer,
+        transport=transport,
+    )
+    state = await effect_store.get(consumption.consumption_id)
+    assert state is not None and state.state == EffectExecutionState.EFFECT_UNKNOWN
+    assert dispatch.reason_code == "HTTP_201_MATCHING_ACK"
+
+    reader_policy, verifier_policy, reader = _reader_inputs(
+        config,
+        ca_pem,
+        reader_token,
+        "normal",
+    )
+    recovered = await recover_sandbox_attempt(
+        artifact,
+        json.dumps(case["payload"]),
+        deployment=config,
+        issuance_source_inputs=inputs["source_inputs"],
+        historical_governance_inputs=inputs["governance_inputs"],
+        trust_inputs=inputs["trust_inputs"],
+        consumption_store=consumption_store,
+        effect_store=effect_store,
+        reader_policy=reader_policy,
+        verifier_policy=verifier_policy,
+        provider=reader,
+        trusted_clock=_clock,
+    )
+    assert recovered.state == EffectExecutionState.CONFIRMED_EFFECT
+    assert recovered.recovery_status == "CONFIRMED_EFFECT"
+    assert recovered.external_effect_retry_permitted is False
+    assert recovered.receipt_bundle is not None
+    _assert_receipt_decision_lineage(case, recovered.receipt_bundle)
+    archive = await effect_store.get_reconciliation(consumption.consumption_id)
+    assert archive is not None
+    return {
+        "dispatch": dispatch,
+        "state_after_dispatch": state,
+        "recovered": recovered,
+        "archive": archive,
+        "consumption": consumption,
+        "reader_calls": reader.describe_calls,
+    }
+
+
+async def _run_fault_case(
+    case,
+    *,
+    ca_pem: str,
+    writer_token: str,
+    reader_token: str,
+    outage_flag: Path,
+):
+    artifact, inputs, config = case["artifact"], case["inputs"], case["deployment"]
+    consumption_store, consumption = await _consume(case)
+    effect_store = PostgresAtomicEffectStateStore()
+    writer = ControlledCredentialProvider(writer_token)
+    transport = LoseObservedResponseTransport(
+        SandboxHTTPSTransport(endpoint_url=config.endpoint_url, ca_pem=ca_pem)
+    )
+
+    dispatch = await execute_sandbox_bind(
+        artifact,
+        json.dumps(case["payload"]),
+        deployment=config,
+        issuance_source_inputs=inputs["source_inputs"],
+        governance_inputs=inputs["governance_inputs"],
+        trust_inputs=inputs["trust_inputs"],
+        consumption_store=consumption_store,
+        effect_store=effect_store,
+        trusted_clock=_clock,
+        load_current_inputs=_load_current(inputs),
+        provider=writer,
+        transport=transport,
+    )
+    state = await effect_store.get(consumption.consumption_id)
+    assert state is not None and state.state == EffectExecutionState.EFFECT_UNKNOWN
+    assert dispatch.reason_code == "TRANSPORT_FAILED_OR_UNKNOWN"
+    assert transport.delegate_observation == "HTTP_201_MATCHING_ACK"
+    assert transport.calls == 1
+
+    reader_policy, verifier_policy, reader = _reader_inputs(
+        config,
+        ca_pem,
+        reader_token,
+        "fault",
+    )
+    outage_flag.parent.mkdir(parents=True, exist_ok=True)
+    outage_flag.touch()
+    try:
+        unavailable = await recover_sandbox_attempt(
+            artifact,
+            json.dumps(case["payload"]),
+            deployment=config,
+            issuance_source_inputs=inputs["source_inputs"],
+            historical_governance_inputs=inputs["governance_inputs"],
+            trust_inputs=inputs["trust_inputs"],
+            consumption_store=consumption_store,
+            effect_store=effect_store,
+            reader_policy=reader_policy,
+            verifier_policy=verifier_policy,
+            provider=reader,
+            trusted_clock=_clock,
+        )
+        assert unavailable.state == EffectExecutionState.EFFECT_UNKNOWN
+        assert unavailable.recovery_status == "STILL_UNKNOWN"
+        assert unavailable.external_effect_retry_permitted is False
+        assert transport.calls == 1
+    finally:
+        outage_flag.unlink(missing_ok=True)
+
+    recovered = await recover_sandbox_attempt(
+        artifact,
+        json.dumps(case["payload"]),
+        deployment=config,
+        issuance_source_inputs=inputs["source_inputs"],
+        historical_governance_inputs=inputs["governance_inputs"],
+        trust_inputs=inputs["trust_inputs"],
+        consumption_store=consumption_store,
+        effect_store=effect_store,
+        reader_policy=reader_policy,
+        verifier_policy=verifier_policy,
+        provider=reader,
+        trusted_clock=_clock,
+    )
+    assert recovered.state == EffectExecutionState.CONFIRMED_EFFECT
+    assert recovered.recovery_status == "CONFIRMED_EFFECT"
+    assert recovered.receipt_bundle is not None
+    _assert_receipt_decision_lineage(case, recovered.receipt_bundle)
+    reader_calls_after_confirmation = reader.describe_calls
+
+    repeated = await recover_sandbox_attempt(
+        artifact,
+        json.dumps(case["payload"]),
+        deployment=config,
+        issuance_source_inputs=inputs["source_inputs"],
+        historical_governance_inputs=inputs["governance_inputs"],
+        trust_inputs=inputs["trust_inputs"],
+        consumption_store=consumption_store,
+        effect_store=effect_store,
+        reader_policy=reader_policy,
+        verifier_policy=verifier_policy,
+        provider=reader,
+        trusted_clock=_clock,
+    )
+    assert repeated == recovered
+    assert transport.calls == 1
+    assert reader.describe_calls == reader_calls_after_confirmation
+
+    archive = await effect_store.get_reconciliation(consumption.consumption_id)
+    assert archive is not None
+    return {
+        "dispatch": dispatch,
+        "state_after_dispatch": state,
+        "unavailable": unavailable,
+        "recovered": recovered,
+        "repeated": repeated,
+        "archive": archive,
+        "consumption": consumption,
+        "transport_calls": transport.calls,
+        "transport_delegate_observation": transport.delegate_observation,
+        "reader_calls_after_confirmation": reader_calls_after_confirmation,
+        "reader_calls_after_repeat": reader.describe_calls,
+    }
+
+
+def _case_evidence(case, result) -> dict[str, Any]:
+    return {
+        "canonical_decision_artifact": case["cda"].model_dump(mode="json"),
+        "promotion_packet": case["promotion"].model_dump(mode="json"),
+        "native_authorization": case["artifact"].model_dump(mode="json"),
+        "consumption": result["consumption"].model_dump(mode="json"),
+        "reconciliation_archive": result["archive"].model_dump(mode="json"),
+        "receipt_bundle": result["recovered"].receipt_bundle.model_dump(mode="json"),
+    }
+
+
+@pytest.mark.asyncio
+async def test_current_head_decision_to_effect_normal_and_fault_e2e(tmp_path):
+    source_sha = os.environ.get("VERITAS_E2E_SOURCE_SHA", "")
+    base_sha = os.environ.get("VERITAS_E2E_BASE_SHA", "")
+    assert re.fullmatch(r"[0-9a-f]{40}", source_sha)
+    assert re.fullmatch(r"[0-9a-f]{40}", base_sha)
+
+    ca_path = Path(os.environ["VERITAS_SANDBOX_CA_FILE"])
+    ca_pem = ca_path.read_text()
+    writer_token = os.environ["VERITAS_SANDBOX_WRITER_TOKEN"]
+    reader_token = os.environ["VERITAS_SANDBOX_READER_TOKEN"]
+    outage_flag = Path(os.environ["VERITAS_SANDBOX_LOOKUP_OUTAGE_FLAG"])
+    report_path = Path(os.environ["VERITAS_DECISION_TO_EFFECT_REPORT"])
+    evidence_path = Path(os.environ["VERITAS_DECISION_TO_EFFECT_EVIDENCE"])
+    assert writer_token != reader_token
+
+    rows_before = await _sandbox_row_count()
+
+    normal_case = _build_decision_case(tmp_path / "normal", NORMAL_PAYLOAD)
+    normal = await _run_normal_case(
+        normal_case,
+        ca_pem=ca_pem,
+        writer_token=writer_token,
+        reader_token=reader_token,
+    )
+    rows_after_normal = await _sandbox_row_count()
+    assert rows_after_normal == rows_before + 1
+
+    fault_case = _build_decision_case(tmp_path / "fault", FAULT_PAYLOAD)
+    fault = await _run_fault_case(
+        fault_case,
+        ca_pem=ca_pem,
+        writer_token=writer_token,
+        reader_token=reader_token,
+        outage_flag=outage_flag,
+    )
+    rows_after_fault = await _sandbox_row_count()
+    assert rows_after_fault == rows_before + 2
+
+    migration = await _migration_head()
+    assert migration == "0008"
+
+    evidence = {
+        "format_version": "controlled-decision-to-effect-evidence/v1",
+        "source_sha": source_sha,
+        "base_sha": base_sha,
+        "normal": _case_evidence(normal_case, normal),
+        "fault": _case_evidence(fault_case, fault),
+    }
+    evidence_hash = sha256_of_canonical_json(evidence)
+
+    proof_conjunction = {
+        "current_head_source_recorded": True,
+        "real_decide_route_exercised": True,
+        "canonical_decisions_verified": True,
+        "selected_action_bindings_verified": True,
+        "decision_lineage_proven": True,
+        "execution_intent_lineage_proven": True,
+        "native_v2_authorizations_verified": True,
+        "real_postgresql_consumption": True,
+        "current_governance_rechecks_exercised": True,
+        "real_certificate_validated_tls_post": True,
+        "dedicated_postgresql_effect_persistence": True,
+        "read_only_reconciliation_confirmed": True,
+        "bind_receipt_decision_lineage_verified": True,
+        "outcome_decision_lineage_verified": True,
+        "fault_unknown_preserved": (
+            fault["unavailable"].state == EffectExecutionState.EFFECT_UNKNOWN
+            and fault["unavailable"].external_effect_retry_permitted is False
+        ),
+        "no_blind_redispatch": fault["transport_calls"] == 1,
+        "repeat_recovery_avoids_lookup": (
+            fault["reader_calls_after_repeat"]
+            == fault["reader_calls_after_confirmation"]
+        ),
+    }
+    controlled_e2e = all(proof_conjunction.values())
+
+    report_body = {
+        "format_version": "controlled-decision-to-effect-e2e/v1",
+        "result": "PASS" if controlled_e2e else "FAIL",
+        "proof": "CONTROLLED_CURRENT_HEAD_DECISION_TO_EFFECT_E2E",
+        "production_claim": False,
+        "source_sha": source_sha,
+        "base_sha": base_sha,
+        "decision_capture_mode": "REAL_POST_V1_DECIDE_WITH_CONTROLLED_MODEL_OUTPUT",
+        "external_effect_scope": "SYNTHETIC_SANDBOX_EVENT_PERSISTENCE",
+        "endpoint": deployment().endpoint_url,
+        "deployment_hash": sha256_of_canonical_json(asdict(deployment())),
+        "ca_sha256": hashlib.sha256(ca_path.read_bytes()).hexdigest(),
+        "alembic_head": migration,
+        "normal": {
+            "decision_id": normal_case["cda"].decision_id,
+            "decision_hash": normal_case["cda"].decision_hash,
+            "promotion_hash": normal_case["promotion"].promotion_hash,
+            "authorization_id": normal_case["artifact"].authorization_id,
+            "consumption_id": normal["consumption"].consumption_id,
+            "dispatch_reason": normal["dispatch"].reason_code,
+            "terminal_effect_state": normal["recovered"].state.value,
+            "external_operation_reference": normal["archive"].operation.operation_id,
+            "reconciliation_evidence_hash": normal["archive"].proof.deterministic_digest(),
+            "receipt_bundle_hash": normal["recovered"].receipt_bundle.bundle_hash,
+        },
+        "fault": {
+            "decision_id": fault_case["cda"].decision_id,
+            "decision_hash": fault_case["cda"].decision_hash,
+            "promotion_hash": fault_case["promotion"].promotion_hash,
+            "authorization_id": fault_case["artifact"].authorization_id,
+            "consumption_id": fault["consumption"].consumption_id,
+            "dispatch_reason": fault["dispatch"].reason_code,
+            "transport_delegate_observation": fault["transport_delegate_observation"],
+            "lookup_outage_state": fault["unavailable"].state.value,
+            "lookup_outage_retry_permitted": fault["unavailable"].external_effect_retry_permitted,
+            "terminal_effect_state": fault["recovered"].state.value,
+            "external_operation_reference": fault["archive"].operation.operation_id,
+            "reconciliation_evidence_hash": fault["archive"].proof.deterministic_digest(),
+            "receipt_bundle_hash": fault["recovered"].receipt_bundle.bundle_hash,
+            "transport_calls": fault["transport_calls"],
+        },
+        "sandbox_rows_added": rows_after_fault - rows_before,
+        "evidence_hash": evidence_hash,
+        "proof_conjunction": proof_conjunction,
+        "controlled_decision_to_effect_e2e_proven": controlled_e2e,
+        "production_decision_to_effect_e2e_proven": False,
+        "trustlog_exactly_once_proven": False,
+        "production_validation_proven": False,
+        "proof_non_claims": [
+            "production readiness",
+            "real customer credentials",
+            "real customer endpoint",
+            "independent production infrastructure",
+            "external UTC clock trust",
+            "TrustLog exactly-once publication",
+            "regulatory approval or certification",
+        ],
+    }
+    report = {
+        **report_body,
+        "proof_manifest_hash": sha256_of_canonical_json(report_body),
+    }
+
+    evidence_serialized = json.dumps(evidence, indent=2, sort_keys=True)
+    report_serialized = json.dumps(report, indent=2, sort_keys=True)
+    for secret in (writer_token, reader_token):
+        assert secret not in evidence_serialized
+        assert secret not in report_serialized
+
+    evidence_path.parent.mkdir(parents=True, exist_ok=True)
+    evidence_path.write_text(evidence_serialized + "\n")
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(report_serialized + "\n")
+
+    assert controlled_e2e is True
+    await close_pool()


### PR DESCRIPTION
## Purpose

Implement TASK-007 by producing a reproducible, current-head Decision-to-Effect proof that starts at the actual `/v1/decide` route and reuses the merged controlled real-TLS / real-PostgreSQL sandbox composition.

## Proof chain

`/v1/decide`
→ verified CanonicalDecisionArtifact
→ deterministic promotion
→ native v2 authorization
→ PostgreSQL consumption
→ current governance rechecks
→ credential resolution
→ durable dispatch intent
→ real certificate-validated TLS POST
→ dedicated PostgreSQL sandbox persistence
→ read-only TLS reconciliation
→ archived evidence
→ deterministic BindReceipt / Outcome
→ automatic recovery

## Normal scenario

- real `/v1/decide` route with controlled model output
- CDA and selected action verified
- promotion and execution-intent lineage verified
- native v2 authorization verified against the exact promoted intent
- one real TLS POST returns `HTTP_201_MATCHING_ACK`
- durable state remains `EFFECT_UNKNOWN` until independent read-only reconciliation
- recovery confirms the same persisted operation
- BindReceipt and Outcome are checked back to the original decision ID/hash and intent ID/hash

## Fault scenario

A second independently captured decision uses a distinct sandbox event.

- one real TLS POST commits remotely
- caller-side matching response is deliberately lost
- sender remains `EFFECT_UNKNOWN`
- controlled read-only lookup outage returns 503
- state remains `EFFECT_UNKNOWN`
- external-effect retry remains prohibited
- no blind redispatch occurs
- after lookup recovery, the same persisted operation is confirmed
- repeat recovery performs neither another POST nor another lookup

## Proof artifacts

The dedicated workflow generates and uploads:

- `artifacts/real-decision-to-effect-e2e/report.json`
- `artifacts/real-decision-to-effect-e2e/evidence.json`

The repository also contains a durable artifact contract README and retains `STOP.md` as an explicitly historical/superseded stop record.

The report binds exact source/base SHAs, deployment/CA hashes, lineage IDs/hashes, proof conjunction, evidence hash and proof-manifest hash. Synthetic bearer material and private keys are excluded.

## Current validation

The dedicated `reproducible-decision-to-effect-e2e` check has passed on the current PR head after the documentation/proof-contract update. Full repository CI must still be green before merge.

## Explicit non-claims

This proof does **not** claim:

- production readiness
- real customer credentials
- real customer endpoint
- independent production infrastructure
- external UTC clock trust
- TrustLog exactly-once publication
- regulatory approval or certification

The decision route and product governance/runtime components are real code paths, while model output, keys, credentials and business effect are controlled synthetic inputs.

Human review required before merge.