### PR TITLE
test: consolidate exact duplicate plan behavior coverage

### DIFF
--- a/.github/workflows/large-consolidation-audit-phase2.yml
+++ b/.github/workflows/large-consolidation-audit-phase2.yml
@@ -105,13 +105,23 @@ jobs:
           assert trust["verify_entries"]["classification"] == "COMPATIBILITY_CANDIDATE"
           assert all(row["deletion_permitted"] is False for row in trust.values())
 
-          overlaps = data["plan8_plan17_matrix"]["known_overlap_groups"]
+          overlaps = {
+              row["behavior"]: row
+              for row in data["plan8_plan17_matrix"]["known_overlap_groups"]
+          }
           assert len(overlaps) >= 5
-          assert any(
-              row["behavior"] == "replay_decision_query_param_failure_defaults_mock_true"
-              and row["classification"] == "DUPLICATE_CANDIDATE"
-              for row in overlaps
-          )
+          assert overlaps[
+              "replay_decision_query_param_failure_defaults_mock_true"
+          ]["resolution"] == "CONSOLIDATED"
+          assert overlaps[
+              "unknown_rollout_strategy_safe_full"
+          ]["resolution"] == "CONSOLIDATED"
+          assert overlaps[
+              "pipeline_unavailable_lazy_state_reset"
+          ]["resolution"] == "PRESERVE_DISTINCT_VARIANTS"
+          assert overlaps[
+              "nonce_cleanup_scheduler_failure_handling"
+          ]["resolution"] == "PARTIALLY_CONSOLIDATED_PRESERVE_DISTINCT_STATES"
           PY
 
       - name: Upload Phase 2 evidence

--- a/artifacts/consolidation-audit/2026-09-10-consolidation-002.md
+++ b/artifacts/consolidation-audit/2026-09-10-consolidation-002.md
@@ -1,0 +1,128 @@
+# Consolidation 002 — Exact Duplicate Behavior Tests
+
+Status: **IMPLEMENTED IN PR — awaiting merge**  
+Source main: `bb114ecf0172db0b03f7ff2da4d30effffae7406`  
+Audit basis: PR #2218 Phase 2 overlap matrix
+
+## Objective
+
+Reduce maintenance duplication in the sequential plan8–plan17 coverage suites
+without changing runtime behavior or removing distinct safety/failure-mode
+coverage.
+
+## Removed duplicate tests
+
+Four duplicate tests were removed after line-by-line comparison:
+
+1. `test_replay_decision_endpoint_query_params_error_defaults_true`
+2. `test_replay_decision_endpoint_defaults_mock_true_on_query_error`
+3. `test_rollout_enforcement_unknown_strategy_defaults_to_safe_full`
+4. `test_schedule_nonce_cleanup_reschedules_even_after_cleanup_error`
+
+## Canonical retained coverage
+
+### Replay query-parameter failure
+
+Retained:
+
+`test_routes_replay_decision_query_param_error_defaults_to_mock_true`
+
+This retained test proves:
+
+- query parameter access failure is handled;
+- the exact decision id is forwarded;
+- `mock_external_apis=True` is forced;
+- the replay response is returned unchanged.
+
+It subsumes the two removed weaker variants.
+
+### Unknown rollout strategy
+
+Retained:
+
+`test_pipeline_rollout_unknown_strategy_falls_back_to_safe_full`
+
+This retained test proves:
+
+- unknown strategy does not disable enforcement;
+- state is `full_unknown_strategy`; and
+- a warning is emitted.
+
+It subsumes the removed outcome-only variant.
+
+### Nonce cleanup scheduler failure while active
+
+Retained and strengthened:
+
+`test_rate_nonce_scheduler_logs_when_cleanup_raises`
+
+It now proves:
+
+- cleanup failure emits a warning;
+- exactly one replacement timer is created;
+- the replacement interval remains 60 seconds; and
+- the replacement timer starts.
+
+This subsumes the removed weaker active-scheduler variant.
+
+## Explicitly preserved as distinct
+
+The following were reviewed and **not** consolidated.
+
+### Pipeline unavailable / lazy-state reset
+
+Both remain because they exercise different surrounding conditions:
+
+- `test_decide_pipeline_unavailable_resets_lazy_state`
+- `test_decide_pipeline_unavailable_resets_lazy_state_when_mutated`
+
+The variants differ in response handling and event-publication behavior, so they
+are not safe duplicates.
+
+### Nonce cleanup scheduler stopped state
+
+Retained:
+
+`test_schedule_nonce_cleanup_logs_and_stops_when_timer_cleared`
+
+This covers cleanup failure when the scheduler has been stopped and therefore
+must not reschedule. It is semantically distinct from the active-scheduler case.
+
+### Effective nonce max branches
+
+All remain:
+
+- import-error fallback
+- non-integer override fallback
+- valid integer override
+
+They target different branches and are not duplicate coverage.
+
+## Audit tooling update
+
+The Phase 2 matrix now marks:
+
+- replay query-failure group → `CONSOLIDATED`
+- unknown rollout strategy group → `CONSOLIDATED`
+- pipeline unavailable group → `PRESERVE_DISTINCT_VARIANTS`
+- nonce scheduler failure group → `PARTIALLY_CONSOLIDATED_PRESERVE_DISTINCT_STATES`
+- effective nonce max group → `PRESERVE_DISTINCT_BRANCHES`
+
+A regression guard verifies that the four removed test names are absent and all
+required retained cases remain present.
+
+## Runtime impact
+
+**None.**
+
+No production/runtime Python module is changed.
+
+No authorization, policy decision, Bind, effect, reconciliation, receipt,
+outcome, credential, migration, TrustLog runtime, or network behavior changes.
+
+## Proof boundary
+
+The frozen controlled Decision-to-Effect architecture remains unchanged.
+
+Full CI and the frozen reproducible Decision-to-Effect proof must pass before
+merge.

--- a/scripts/audit_large_consolidation_phase2.py
+++ b/scripts/audit_large_consolidation_phase2.py
@@ -247,21 +247,27 @@ def _plan_test_matrix() -> dict[str, Any]:
         {
             "behavior": "replay_decision_query_param_failure_defaults_mock_true",
             "tests": [
-                "test_replay_decision_endpoint_query_params_error_defaults_true",
-                "test_replay_decision_endpoint_defaults_mock_true_on_query_error",
                 "test_routes_replay_decision_query_param_error_defaults_to_mock_true",
             ],
-            "classification": "DUPLICATE_CANDIDATE",
+            "consolidated_from": [
+                "test_replay_decision_endpoint_query_params_error_defaults_true",
+                "test_replay_decision_endpoint_defaults_mock_true_on_query_error",
+            ],
+            "classification": "ACTIVE_NON_CORE",
             "confidence": "HIGH",
+            "resolution": "CONSOLIDATED",
         },
         {
             "behavior": "unknown_rollout_strategy_safe_full",
             "tests": [
-                "test_rollout_enforcement_unknown_strategy_defaults_to_safe_full",
                 "test_pipeline_rollout_unknown_strategy_falls_back_to_safe_full",
             ],
-            "classification": "DUPLICATE_CANDIDATE",
+            "consolidated_from": [
+                "test_rollout_enforcement_unknown_strategy_defaults_to_safe_full",
+            ],
+            "classification": "ACTIVE_NON_CORE",
             "confidence": "HIGH",
+            "resolution": "CONSOLIDATED",
         },
         {
             "behavior": "pipeline_unavailable_lazy_state_reset",
@@ -269,18 +275,30 @@ def _plan_test_matrix() -> dict[str, Any]:
                 "test_decide_pipeline_unavailable_resets_lazy_state",
                 "test_decide_pipeline_unavailable_resets_lazy_state_when_mutated",
             ],
-            "classification": "DUPLICATE_CANDIDATE",
-            "confidence": "MEDIUM",
+            "classification": "ACTIVE_NON_CORE",
+            "confidence": "HIGH",
+            "resolution": "PRESERVE_DISTINCT_VARIANTS",
+            "note": (
+                "The variants exercise different response/event-publication conditions; "
+                "they are not safe duplicates."
+            ),
         },
         {
             "behavior": "nonce_cleanup_scheduler_failure_handling",
             "tests": [
-                "test_schedule_nonce_cleanup_reschedules_even_after_cleanup_error",
                 "test_schedule_nonce_cleanup_logs_and_stops_when_timer_cleared",
                 "test_rate_nonce_scheduler_logs_when_cleanup_raises",
             ],
-            "classification": "DUPLICATE_CANDIDATE",
-            "confidence": "MEDIUM",
+            "consolidated_from": [
+                "test_schedule_nonce_cleanup_reschedules_even_after_cleanup_error",
+            ],
+            "classification": "ACTIVE_NON_CORE",
+            "confidence": "HIGH",
+            "resolution": "PARTIALLY_CONSOLIDATED_PRESERVE_DISTINCT_STATES",
+            "note": (
+                "One retained test covers the stopped scheduler; the other covers the "
+                "active scheduler and now preserves interval/start assertions."
+            ),
         },
         {
             "behavior": "effective_nonce_max_override_fallbacks",
@@ -291,6 +309,7 @@ def _plan_test_matrix() -> dict[str, Any]:
             ],
             "classification": "ACTIVE_NON_CORE",
             "confidence": "HIGH",
+            "resolution": "PRESERVE_DISTINCT_BRANCHES",
         },
     ]
     return {

--- a/veritas_os/tests/test_large_consolidation_audit_phase2.py
+++ b/veritas_os/tests/test_large_consolidation_audit_phase2.py
@@ -104,7 +104,7 @@ def test_phase2_trustlog_role_matrix_prevents_false_duplicate_conclusion() -> No
     assert all(row["deletion_permitted"] is False for row in roles.values())
 
 
-def test_phase2_plan_overlap_matrix_distinguishes_duplicates_from_branch_coverage() -> None:
+def test_phase2_plan_overlap_matrix_records_resolved_duplicates_and_preserved_variants() -> None:
     module = _load_module()
     data = module.build_phase2()
     matrix = data["plan8_plan17_matrix"]
@@ -113,18 +113,38 @@ def test_phase2_plan_overlap_matrix_distinguishes_duplicates_from_branch_coverag
     overlaps = {row["behavior"]: row for row in matrix["known_overlap_groups"]}
 
     replay = overlaps["replay_decision_query_param_failure_defaults_mock_true"]
-    assert replay["classification"] == "DUPLICATE_CANDIDATE"
-    assert replay["confidence"] == "HIGH"
-    assert len(replay["tests"]) == 3
+    assert replay["classification"] == "ACTIVE_NON_CORE"
+    assert replay["resolution"] == "CONSOLIDATED"
+    assert replay["tests"] == [
+        "test_routes_replay_decision_query_param_error_defaults_to_mock_true"
+    ]
+    assert len(replay["consolidated_from"]) == 2
 
     rollout = overlaps["unknown_rollout_strategy_safe_full"]
-    assert rollout["classification"] == "DUPLICATE_CANDIDATE"
-    assert len(rollout["tests"]) == 2
+    assert rollout["classification"] == "ACTIVE_NON_CORE"
+    assert rollout["resolution"] == "CONSOLIDATED"
+    assert rollout["tests"] == [
+        "test_pipeline_rollout_unknown_strategy_falls_back_to_safe_full"
+    ]
+
+    pipeline = overlaps["pipeline_unavailable_lazy_state_reset"]
+    assert pipeline["resolution"] == "PRESERVE_DISTINCT_VARIANTS"
+    assert len(pipeline["tests"]) == 2
+
+    scheduler = overlaps["nonce_cleanup_scheduler_failure_handling"]
+    assert (
+        scheduler["resolution"]
+        == "PARTIALLY_CONSOLIDATED_PRESERVE_DISTINCT_STATES"
+    )
+    assert len(scheduler["tests"]) == 2
+    assert scheduler["consolidated_from"] == [
+        "test_schedule_nonce_cleanup_reschedules_even_after_cleanup_error"
+    ]
 
     nonce = overlaps["effective_nonce_max_override_fallbacks"]
     assert nonce["classification"] == "ACTIVE_NON_CORE"
+    assert nonce["resolution"] == "PRESERVE_DISTINCT_BRANCHES"
     assert len(nonce["tests"]) == 3
-
 
 def test_phase2_dry_run_matrix_records_parallelism_without_authorizing_collapse() -> None:
     module = _load_module()

--- a/veritas_os/tests/test_large_consolidation_audit_phase2.py
+++ b/veritas_os/tests/test_large_consolidation_audit_phase2.py
@@ -146,6 +146,37 @@ def test_phase2_plan_overlap_matrix_records_resolved_duplicates_and_preserved_va
     assert nonce["resolution"] == "PRESERVE_DISTINCT_BRANCHES"
     assert len(nonce["tests"]) == 3
 
+def test_consolidation_002_removed_only_resolved_duplicate_test_names() -> None:
+    module = _load_module()
+    data = module.build_phase2()
+    present = {
+        test_name
+        for row in data["plan8_plan17_matrix"]["files"]
+        for test_name in row["tests"]
+    }
+
+    for removed in (
+        "test_replay_decision_endpoint_query_params_error_defaults_true",
+        "test_replay_decision_endpoint_defaults_mock_true_on_query_error",
+        "test_rollout_enforcement_unknown_strategy_defaults_to_safe_full",
+        "test_schedule_nonce_cleanup_reschedules_even_after_cleanup_error",
+    ):
+        assert removed not in present
+
+    for retained in (
+        "test_routes_replay_decision_query_param_error_defaults_to_mock_true",
+        "test_pipeline_rollout_unknown_strategy_falls_back_to_safe_full",
+        "test_decide_pipeline_unavailable_resets_lazy_state",
+        "test_decide_pipeline_unavailable_resets_lazy_state_when_mutated",
+        "test_schedule_nonce_cleanup_logs_and_stops_when_timer_cleared",
+        "test_rate_nonce_scheduler_logs_when_cleanup_raises",
+        "test_effective_nonce_max_import_error_uses_default",
+        "test_effective_nonce_max_uses_default_when_server_override_is_non_int",
+        "test_effective_nonce_max_prefers_server_integer_override",
+    ):
+        assert retained in present
+
+
 def test_phase2_dry_run_matrix_records_parallelism_without_authorizing_collapse() -> None:
     module = _load_module()
     data = module.build_phase2()

--- a/veritas_os/tests/unit/test_plan10_pipeline_routes_rate_abnormal.py
+++ b/veritas_os/tests/unit/test_plan10_pipeline_routes_rate_abnormal.py
@@ -7,7 +7,6 @@ from typing import Any
 
 import pytest
 
-from veritas_os.api import rate_limiting as rl
 from veritas_os.api import routes_decide as rd
 from veritas_os.core.pipeline import pipeline_execute as pe
 from veritas_os.core.pipeline.pipeline_types import PipelineContext
@@ -112,43 +111,3 @@ def test_call_fuji_supports_action_only_validate_fallback() -> None:
     out = rd._call_fuji(_FujiCore(), "block", {"foo": "bar"})
 
     assert out == {"status": "ok", "used": "action_only"}
-
-
-def test_schedule_nonce_cleanup_reschedules_even_after_cleanup_error(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Nonce scheduler should continue operating after one cleanup exception."""
-
-    class _DummyTimer:
-        def __init__(self, interval: float, callback: Any) -> None:
-            self.interval = interval
-            self.callback = callback
-            self.daemon = False
-            self.started = False
-
-        def start(self) -> None:
-            self.started = True
-
-        def cancel(self) -> None:
-            self.started = False
-
-    created: list[_DummyTimer] = []
-
-    def _timer_factory(interval: float, callback: Any) -> _DummyTimer:
-        timer = _DummyTimer(interval, callback)
-        created.append(timer)
-        return timer
-
-    monkeypatch.setattr(rl, "_cleanup_nonces", lambda: (_ for _ in ()).throw(RuntimeError("boom")))
-    monkeypatch.setattr(rl.threading, "Timer", _timer_factory)
-
-    old_timer = rl._nonce_cleanup_timer
-    try:
-        rl._nonce_cleanup_timer = object()
-        rl._schedule_nonce_cleanup()
-    finally:
-        rl._nonce_cleanup_timer = old_timer
-
-    assert len(created) == 1
-    assert created[0].interval == 60.0
-    assert created[0].started is True

--- a/veritas_os/tests/unit/test_plan12_pipeline_routes_rate_abnormal_followup.py
+++ b/veritas_os/tests/unit/test_plan12_pipeline_routes_rate_abnormal_followup.py
@@ -74,37 +74,6 @@ def test_call_fuji_falls_back_to_positional_validate_action() -> None:
     assert result["action"] == "approve"
 
 
-@pytest.mark.anyio
-async def test_replay_decision_endpoint_defaults_mock_true_on_query_error(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Replay endpoint should fail-safe to mock_external_apis=True on query parsing errors."""
-
-    class _DummyPipeline:
-        async def replay_decision(self, *, decision_id: str, mock_external_apis: bool) -> dict[str, Any]:
-            return {"decision_id": decision_id, "mock_external_apis": mock_external_apis}
-
-    class _DummyServer:
-        @staticmethod
-        def get_decision_pipeline() -> _DummyPipeline:
-            return _DummyPipeline()
-
-    class _BrokenQuery:
-        @staticmethod
-        def get(_key: str) -> str:
-            raise RuntimeError("query unavailable")
-
-    class _DummyRequest:
-        query_params = _BrokenQuery()
-
-    monkeypatch.setattr(rd, "_get_server", lambda: _DummyServer())
-
-    response = await rd.replay_decision_endpoint("decision-1", _DummyRequest())
-
-    assert response["decision_id"] == "decision-1"
-    assert response["mock_external_apis"] is True
-
-
 def test_fuji_validate_returns_500_when_core_interface_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/veritas_os/tests/unit/test_plan14_pipeline_routes_rate_abnormal_priority2.py
+++ b/veritas_os/tests/unit/test_plan14_pipeline_routes_rate_abnormal_priority2.py
@@ -87,6 +87,7 @@ def test_rate_nonce_scheduler_logs_when_cleanup_raises(
     )
 
     started = {"value": False}
+    created: list[Any] = []
 
     class _DummyTimer:
         daemon = False
@@ -94,6 +95,7 @@ def test_rate_nonce_scheduler_logs_when_cleanup_raises(
         def __init__(self, _interval: float, _cb: Any) -> None:
             self.interval = _interval
             self.cb = _cb
+            created.append(self)
 
         def start(self) -> None:
             started["value"] = True
@@ -109,4 +111,6 @@ def test_rate_nonce_scheduler_logs_when_cleanup_raises(
         rl._nonce_cleanup_timer = old_timer
 
     assert "nonce cleanup failed" in caplog.text
+    assert len(created) == 1
+    assert created[0].interval == 60.0
     assert started["value"] is True

--- a/veritas_os/tests/unit/test_plan8_low_coverage_edges.py
+++ b/veritas_os/tests/unit/test_plan8_low_coverage_edges.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any
 
@@ -14,55 +13,6 @@ from veritas_os.core.pipeline import pipeline_execute as pe
 from veritas_os.core.pipeline import pipeline_gate as pg
 from veritas_os.core.pipeline import pipeline_response as pr
 from veritas_os.core.pipeline.pipeline_types import PipelineContext
-
-
-@dataclass
-class _DummyPipeline:
-    """Minimal replay pipeline stub used by replay endpoint tests."""
-
-    seen_mock_external_apis: bool | None = None
-
-    async def replay_decision(
-        self,
-        *,
-        decision_id: str,
-        mock_external_apis: bool,
-    ) -> dict[str, Any]:
-        self.seen_mock_external_apis = mock_external_apis
-        return {
-            "decision_id": decision_id,
-            "mock_external_apis": mock_external_apis,
-        }
-
-
-class _BrokenQueryParams:
-    def get(self, _key: str) -> str:
-        raise RuntimeError("query params unavailable")
-
-
-class _DummyRequest:
-    query_params = _BrokenQueryParams()
-
-
-@pytest.mark.anyio
-async def test_replay_decision_endpoint_query_params_error_defaults_true(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """When query param access fails, replay endpoint should fail closed to True."""
-    dummy_pipeline = _DummyPipeline()
-
-    class _DummyServer:
-        @staticmethod
-        def get_decision_pipeline() -> _DummyPipeline:
-            return dummy_pipeline
-
-    monkeypatch.setattr(rd, "_get_server", lambda: _DummyServer())
-
-    out = await rd.replay_decision_endpoint("dec-1", _DummyRequest())
-
-    assert out["decision_id"] == "dec-1"
-    assert out["mock_external_apis"] is True
-    assert dummy_pipeline.seen_mock_external_apis is True
 
 
 def test_finalize_evidence_invalid_payload_falls_back_to_empty_list() -> None:

--- a/veritas_os/tests/unit/test_plan9_pipeline_routes_rate_edges.py
+++ b/veritas_os/tests/unit/test_plan9_pipeline_routes_rate_edges.py
@@ -34,29 +34,6 @@ def test_rollback_metadata_skips_non_triggered_or_invalid_metadata() -> None:
     assert pp._resolve_rollback_metadata(decision) == {}
 
 
-def test_rollout_enforcement_unknown_strategy_defaults_to_safe_full(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Unknown rollout strategy should fail safe to full enforcement."""
-    monkeypatch.setattr(pp, "_coerce_policy_enforce_flag", lambda _raw: True)
-
-    decision = {
-        "policy_results": [
-            {
-                "triggered": True,
-                "metadata": {
-                    "rollout_controls": {"strategy": "mystery_mode"},
-                },
-            }
-        ]
-    }
-
-    enabled, state = pp._is_enforcement_enabled_for_rollout({}, decision)
-
-    assert enabled is True
-    assert state == "full_unknown_strategy"
-
-
 def test_rollout_enforcement_canary_skip_when_bucket_outside_percent(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Purpose

Apply Consolidation 002 from the Large Consolidation Audit.

This PR removes only behaviorally redundant tests from the sequential plan8-plan17 coverage suites. It makes **no runtime code changes**.

## Baseline

Product main:

`bb114ecf0172db0b03f7ff2da4d30effffae7406`

Audit basis:

- PR #2217 — Phase 1 inventory
- PR #2218 — Phase 2 dependency / consumer matrices
- PR #2219 — Consolidation 001

## Removed duplicate tests

Four duplicate tests are removed:

1. `test_replay_decision_endpoint_query_params_error_defaults_true`
2. `test_replay_decision_endpoint_defaults_mock_true_on_query_error`
3. `test_rollout_enforcement_unknown_strategy_defaults_to_safe_full`
4. `test_schedule_nonce_cleanup_reschedules_even_after_cleanup_error`

## Retained canonical coverage

### Replay query parsing failure

Retained:

`test_routes_replay_decision_query_param_error_defaults_to_mock_true`

It verifies:
- query access failure
- exact decision id forwarding
- fail-safe `mock_external_apis=True`
- unchanged replay response

### Unknown rollout strategy

Retained:

`test_pipeline_rollout_unknown_strategy_falls_back_to_safe_full`

It verifies:
- enforcement remains enabled
- `full_unknown_strategy`
- warning emission

### Active nonce cleanup failure

Retained and strengthened:

`test_rate_nonce_scheduler_logs_when_cleanup_raises`

It now verifies:
- warning emission
- exactly one replacement timer
- 60-second interval
- timer starts

## Explicitly preserved distinct tests

The following are not consolidated:

- pipeline unavailable / lazy-state reset variants
- stopped-scheduler nonce cleanup failure
- effective nonce max import-error / non-int / valid-int branches

They exercise distinct conditions.

## Audit tooling update

The Phase 2 matrix now records resolved status:

- replay query failure → `CONSOLIDATED`
- unknown rollout strategy → `CONSOLIDATED`
- pipeline unavailable → `PRESERVE_DISTINCT_VARIANTS`
- nonce cleanup failure → `PARTIALLY_CONSOLIDATED_PRESERVE_DISTINCT_STATES`
- effective nonce max → `PRESERVE_DISTINCT_BRANCHES`

A regression guard checks that removed test names stay absent while all retained coverage remains present.

## Runtime impact

None.

No runtime Python module is changed.

No changes to:

- authorization
- policy decision semantics
- Bind execution
- credential resolution
- external effect
- reconciliation
- BindReceipt / Outcome
- TrustLog runtime
- migrations
- network behavior

## Proof boundary

The frozen controlled Decision-to-Effect architecture is unchanged.

Full CI and the dedicated reproducible Decision-to-Effect proof must pass before merge.

Human review required before merge.