### PR TITLE
benchmark: freeze rebaseline Phase A contract

### DIFF
--- a/docs/benchmarks/VERITAS_EVIDENCE_BENCHMARK_PLAN.md
+++ b/docs/benchmarks/VERITAS_EVIDENCE_BENCHMARK_PLAN.md
@@ -5,6 +5,10 @@
 この計画は、VERITAS OS の強みを「主観的な説明」ではなく、
 **再現可能なベンチマーク証跡**で示すためのものです。
 
+TASK-011 Benchmark Rebaselineでは、
+`docs/benchmarks/benchmark-rebaseline-contract-v1.json`
+をベンチマークの正本契約として扱います。
+
 対象の差別化軸:
 
 1. auditability
@@ -50,17 +54,24 @@
 ## 3. Benchmark Design
 
 ### 3.1 Comparison Target
-- system A: `veritas`（VERITAS OS 出力）
-- system B: `generic`（generic agent loop 出力）
+- system A: `veritas`（VERITAS OS fixture）
+- system B: `generic`（generic agent loop fixture）
 
 同一ケースを両者で評価し、同一メトリクスで比較する。
+
+**重要なclaim boundary:**
+現在の `sample_cases.jsonl` にある `veritas` / `generic` は、
+repository内で管理されたsynthetic fixtureである。
+この結果を、独立第三者による競合検証、実製品比較、またはnamed vendorに対する優位性の証明として扱ってはならない。
 
 ### 3.2 Dataset / Fixture
 - 形式: JSONL
 - 1行1ケース
-- 各ケースに `systems.veritas` と `systems.generic` の観測結果を埋める
+- 各ケースに `systems.veritas` と `systems.generic` の観測/fixture結果を埋める
+- TASK-011 Phase A時点のcanonical fixture: `veritas_os/benchmarks/evidence/fixtures/sample_cases.jsonl`
+- Phase A時点では2ケース
 
-これにより、API 実行済みログを後からオフライン評価可能。
+これにより、同じfixtureに対してオフラインで再評価できる。
 
 ### 3.3 Output Format
 - JSON（`veritas_os/benchmarks/evidence/output_schema.json` で定義）
@@ -68,29 +79,54 @@
 
 ## 4. Reproducibility Rules
 
-- ハーネス入力（fixtures）を Git 管理し、同一入力で同一出力を得る。
+- ハーネス入力（fixtures）を Git 管理し、同一入力で同一評価を得る。
 - 計算式を `metrics_definition.yaml` に明記する。
 - 推定値や外挿値を禁止し、観測できるキーのみを判定に使う。
+- Current-headとして公開するartifactはsource commit SHAを記録する。
+- exact command / runtime identity / fixture identity / claim boundaryを記録する。
 
 ## 5. Security Warnings
 
 - フィクスチャに生ログを入れる場合は PII を必ず除去する。
 - trust log 系の実データは改ざん防止目的のため、テスト用コピーを使う。
 - 署名検証を伴うデータを共有する場合は鍵情報を含めない。
+- Benchmark実行のために外部LLM/APIを暗黙に有効化しない。
 
 ## 6. Execution
+
+TASK-011 canonical command:
 
 ```bash
 python -m veritas_os.scripts.evidence_benchmark \
   --fixtures veritas_os/benchmarks/evidence/fixtures/sample_cases.jsonl \
-  --output veritas_os/scripts/logs/evidence_benchmark_report.json
+  --output /tmp/veritas-evidence-benchmark.json
 ```
 
 ## 7. Publishable Summary Template
+
+公開可能なのは、synthetic fixtureであることを明記した上での以下の記述です。
 
 - 「Xケース中、Fail-Closed要件を満たした割合」
 - 「監査可能性（必須監査キー充足率）」
 - 「Replay差分可視化率」
 - 「Trust Log整合性キー充足率」
 
-上記を `veritas` と `generic` で並列表記する。
+`veritas` と `generic` の並列表記は可能ですが、
+**synthetic fixture comparison** と明示し、第三者競合benchmarkのように表現しません。
+
+## 8. TASK-011 Phase A Boundary
+
+Phase Aでは新しいbenchmark数値を公開しません。
+
+先に固定するもの:
+
+- canonical harness
+- metrics definition
+- fixture/input identity
+- output schema
+- exact command
+- source commit identity
+- environment requirements
+- claim / non-claim boundary
+
+Current-head数値の生成はPhase Bで行います。

--- a/docs/benchmarks/benchmark-rebaseline-contract-v1.json
+++ b/docs/benchmarks/benchmark-rebaseline-contract-v1.json
@@ -1,0 +1,124 @@
+{
+  "format_version": "benchmark-rebaseline-contract/v1",
+  "status": "PHASE_A_CONTRACT_FROZEN",
+  "source_commit": "53e8e2974123024348b92ddfb7155cd645371620",
+  "frozen_controlled_e2e_anchor": "ada46f2fe324dd3cbcff6be59d56c4f75c4a6bdc",
+  "task": "TASK-011",
+  "phase": "A",
+  "publication_gate": {
+    "new_benchmark_numbers_permitted": false,
+    "reason": "Phase A freezes benchmark inventory, canonical harnesses, inputs, environment requirements, and claim boundaries before current-head measurements are published."
+  },
+  "canonical_surfaces": [
+    {
+      "id": "local_deterministic_smoke",
+      "role": "CANONICAL_PERFORMANCE_HARNESS",
+      "harness": "scripts/benchmarks/run_performance_metrics.py",
+      "schema_version": "performance_metrics.v1",
+      "exact_command": "python scripts/benchmarks/run_performance_metrics.py --iterations 100 --warmup 10 --output docs/en/benchmarks/local-performance-metrics.latest.json",
+      "input_identity": {
+        "type": "embedded_deterministic_fixture",
+        "location": "scripts/benchmarks/run_performance_metrics.py::_run_iteration",
+        "scenario": "local_deterministic_smoke"
+      },
+      "required_runtime_identity": {
+        "python_family": "CPython",
+        "canonical_python_minor": "3.12",
+        "platform_class": "Linux x86_64",
+        "capture_exact_platform_in_output": true
+      },
+      "external_network_required": false,
+      "external_llm_or_api_allowed": false,
+      "claim_scope": "lightweight deterministic local function-path timing only"
+    },
+    {
+      "id": "evidence_axes_fixture",
+      "role": "CANONICAL_EVIDENCE_HARNESS",
+      "harness": "veritas_os/scripts/evidence_benchmark.py",
+      "metrics_definition": "veritas_os/benchmarks/evidence/metrics_definition.yaml",
+      "output_schema": "veritas_os/benchmarks/evidence/output_schema.json",
+      "fixture": "veritas_os/benchmarks/evidence/fixtures/sample_cases.jsonl",
+      "exact_command": "python -m veritas_os.scripts.evidence_benchmark --fixtures veritas_os/benchmarks/evidence/fixtures/sample_cases.jsonl --output /tmp/veritas-evidence-benchmark.json",
+      "input_identity": {
+        "type": "repository_fixture_at_source_commit",
+        "fixture_case_count": 2,
+        "systems": ["veritas", "generic"],
+        "synthetic_comparison": true
+      },
+      "required_runtime_identity": {
+        "python_family": "CPython",
+        "canonical_python_minor": "3.12"
+      },
+      "external_network_required": false,
+      "external_llm_or_api_allowed": false,
+      "claim_scope": "deterministic fixture scoring for auditability, fail-closed safety, governance change control, replay/divergence visibility, and TrustLog integrity"
+    }
+  ],
+  "supporting_noncanonical_surfaces": [
+    {
+      "id": "one_day_poc_http",
+      "path": "scripts/demo/one_day_poc_benchmark.py",
+      "classification": "POC_SUPPORTING_NOT_PHASE_A_CANONICAL",
+      "reason": "Measures configured HTTP PoC endpoints, requires VERITAS_API_KEY, and depends on server/environment configuration."
+    },
+    {
+      "id": "enhanced_yaml_decide_runner",
+      "path": "veritas_os/scripts/run_benchmarks_enhanced.py",
+      "classification": "LEGACY_MAINTENANCE_NOT_REBASELINE_CANONICAL",
+      "reason": "Posts YAML cases to /v1/decide and writes runtime benchmark logs; it is not the canonical deterministic Phase B measurement harness."
+    }
+  ],
+  "existing_published_artifacts": [
+    {
+      "path": "docs/en/benchmarks/local-performance-metrics.latest.json",
+      "classification": "STALE_PRE_REBASELINE_REFERENCE",
+      "generated_at": "2026-05-09T02:05:00.659731+00:00",
+      "source_commit_recorded": false,
+      "current_head_claim_permitted": false
+    },
+    {
+      "path": "docs/en/benchmarks/local-performance-metrics.latest.md",
+      "classification": "STALE_PRE_REBASELINE_REFERENCE",
+      "current_head_claim_permitted": false
+    }
+  ],
+  "required_phase_b_measurements": [
+    "local deterministic smoke latency",
+    "/v1/decide controlled route latency without external providers",
+    "Bind-boundary decision/current-governance-recheck overhead",
+    "TrustLog append latency split by JSONL and PostgreSQL where available",
+    "controlled Decision-to-Effect timing components"
+  ],
+  "required_artifact_fields": [
+    "source_commit_sha",
+    "schema_version",
+    "run_timestamp",
+    "environment",
+    "exact_command",
+    "iterations_or_run_count",
+    "warmup_when_relevant",
+    "raw_machine_readable_result",
+    "summary",
+    "failure_count",
+    "claim_boundary",
+    "reproducibility_instructions"
+  ],
+  "non_claims": [
+    "production latency",
+    "customer-environment performance",
+    "real customer credentials or endpoints",
+    "independent infrastructure validation",
+    "third-party certification",
+    "regulatory approval",
+    "production SLA",
+    "superiority over named vendors",
+    "third-party competitive validation from synthetic generic fixtures"
+  ],
+  "phase_a_exit": {
+    "canonical_surfaces_identified": true,
+    "stale_artifacts_explicitly_classified": true,
+    "claim_boundary_frozen": true,
+    "benchmark_values_updated": false,
+    "next_phase": "PHASE_B_CURRENT_HEAD_DETERMINISTIC_MEASUREMENTS"
+  }
+}

--- a/docs/en/benchmarks/benchmark-rebaseline-phase-a.md
+++ b/docs/en/benchmarks/benchmark-rebaseline-phase-a.md
@@ -1,0 +1,158 @@
+# Benchmark Rebaseline — Phase A Contract Freeze
+
+Status: **PHASE A / CONTRACT FROZEN**  
+Source main: `53e8e2974123024348b92ddfb7155cd645371620`  
+Frozen controlled E2E anchor: `ada46f2fe324dd3cbcff6be59d56c4f75c4a6bdc`
+
+Machine-readable contract:
+`docs/benchmarks/benchmark-rebaseline-contract-v1.json`
+
+## Purpose
+
+TASK-011 starts by freezing what each benchmark actually measures before any new
+performance number is published.
+
+The repository already contains several benchmark-like tools with different
+purposes. Treating all of them as one benchmark would create ambiguous claims.
+Phase A separates the canonical rebaseline surfaces from supporting or legacy
+runners and records the exact claim boundary.
+
+## Canonical surface 1 — local deterministic performance
+
+Harness:
+
+`scripts/benchmarks/run_performance_metrics.py`
+
+Canonical command for Phase B:
+
+```bash
+python scripts/benchmarks/run_performance_metrics.py \
+  --iterations 100 \
+  --warmup 10 \
+  --output docs/en/benchmarks/local-performance-metrics.latest.json
+```
+
+Input identity:
+
+- embedded deterministic fixture in `_run_iteration`
+- scenario: `local_deterministic_smoke`
+- canonical JSON serialization
+- SHA-256 hashing
+- WAT drift scoring
+- operator-message construction
+
+Runtime target:
+
+- CPython 3.12
+- Linux x86_64 class environment
+- exact Python/platform identity must be captured in the generated result
+
+This harness performs no external LLM/API calls and is not an HTTP, production,
+customer-environment, or throughput benchmark.
+
+## Canonical surface 2 — evidence-axis benchmark
+
+Harness:
+
+`veritas_os/scripts/evidence_benchmark.py`
+
+Contract inputs:
+
+- `veritas_os/benchmarks/evidence/metrics_definition.yaml`
+- `veritas_os/benchmarks/evidence/output_schema.json`
+- `veritas_os/benchmarks/evidence/fixtures/sample_cases.jsonl`
+
+Canonical command:
+
+```bash
+python -m veritas_os.scripts.evidence_benchmark \
+  --fixtures veritas_os/benchmarks/evidence/fixtures/sample_cases.jsonl \
+  --output /tmp/veritas-evidence-benchmark.json
+```
+
+The current fixture contains two repository-controlled cases and compares labels
+named `veritas` and `generic`. That comparison is **synthetic fixture scoring**.
+It is not independent competitive testing and must not be described as proof
+that VERITAS outperforms a named vendor or third-party system.
+
+## Supporting but non-canonical benchmark surfaces
+
+### One-Day PoC HTTP benchmark
+
+`scripts/demo/one_day_poc_benchmark.py`
+
+This is useful for a configured PoC environment, but it requires
+`VERITAS_API_KEY`, performs HTTP calls, and depends on server/environment setup.
+It is therefore not the canonical deterministic Phase A/initial Phase B
+measurement surface.
+
+### Enhanced YAML /v1/decide runner
+
+`veritas_os/scripts/run_benchmarks_enhanced.py`
+
+This runner posts YAML benchmark requests to `/v1/decide` and writes runtime
+logs. It remains useful as an existing maintenance/test tool, but it is not the
+canonical deterministic rebaseline harness.
+
+## Existing local metrics artifact
+
+`docs/en/benchmarks/local-performance-metrics.latest.json` was generated on
+2026-05-09 and does not record the source commit SHA.
+
+It remains in the repository as a historical local reference, but Phase A marks
+it:
+
+**STALE_PRE_REBASELINE_REFERENCE**
+
+It must not be presented as a measurement of the current post-consolidation
+head. Phase A intentionally does not replace its numbers.
+
+## Required Phase B artifact identity
+
+Every newly published benchmark artifact must record enough information to
+answer:
+
+1. Which source commit was measured?
+2. Which harness/schema was used?
+3. What exact command was run?
+4. What fixture/input was measured?
+5. Which Python/platform environment produced the result?
+6. How many runs/warmups/failures occurred?
+7. What may and may not be concluded from the result?
+
+Phase B must add source-SHA and reproducibility identity before current-head
+numbers are treated as publishable.
+
+## Phase B measurement targets
+
+The next phase should measure, without silently enabling external providers:
+
+- local deterministic smoke latency;
+- controlled `/v1/decide` route latency;
+- Bind-boundary/current-governance-recheck overhead;
+- TrustLog append latency, JSONL and PostgreSQL separated where available; and
+- controlled Decision-to-Effect timing components.
+
+Each measurement requires its own scope statement. A single local microbenchmark
+must not be used as a proxy for the whole Decision-to-Effect path.
+
+## Non-claims
+
+Benchmark Rebaseline does not by itself prove:
+
+- production latency or production SLA;
+- customer-environment performance;
+- real customer credentials/endpoints;
+- independent production infrastructure validation;
+- third-party certification;
+- regulatory approval; or
+- superiority over named vendors.
+
+## Phase A exit
+
+Phase A is complete when this contract and its regression guard pass full CI.
+No benchmark value is changed in this phase.
+
+Next:
+
+**Phase B — Current-head deterministic measurements.**

--- a/docs/en/benchmarks/performance-metrics.md
+++ b/docs/en/benchmarks/performance-metrics.md
@@ -104,4 +104,4 @@ artifact identity requirements are implemented.
 - `scripts/benchmarks/run_performance_metrics.py` is the canonical deterministic local performance harness for TASK-011.
 - `scripts/demo/one_day_poc_benchmark.py` measures local/configured HTTP PoC endpoints and requires `VERITAS_API_KEY`; it is a supporting PoC benchmark, not the canonical Phase A/initial Phase B harness.
 - `veritas_os/scripts/run_benchmarks_enhanced.py` remains a maintenance YAML `/v1/decide` runner and is not the canonical deterministic rebaseline harness.
-- None of these benchmark surfaces establishes a production SLA or third-party certification.
+- These benchmark surfaces are not a production SLA and do not establish third-party certification.

--- a/docs/en/benchmarks/performance-metrics.md
+++ b/docs/en/benchmarks/performance-metrics.md
@@ -6,6 +6,13 @@ This document defines the deterministic local performance harness for VERITAS OS
 It is intended to make performance measurement reproducible before publishing
 business-facing numbers.
 
+TASK-011 Benchmark Rebaseline is now governed by:
+
+`docs/benchmarks/benchmark-rebaseline-contract-v1.json`
+
+Phase A freezes benchmark identity and claim boundaries before current-head
+numbers are published.
+
 ## What this benchmark measures
 
 - Deterministic local harness execution time.
@@ -26,13 +33,18 @@ business-facing numbers.
 
 ## How to run
 
+Canonical Phase B command:
+
 ```bash
-python scripts/benchmarks/run_performance_metrics.py --iterations 100 --output /tmp/veritas-performance-metrics.json
+python scripts/benchmarks/run_performance_metrics.py \
+  --iterations 100 \
+  --warmup 10 \
+  --output docs/en/benchmarks/local-performance-metrics.latest.json
 ```
 
 ## JSON output schema
 
-The harness outputs `performance_metrics.v1` JSON with:
+The current harness outputs `performance_metrics.v1` JSON with:
 
 - metadata (`schema_version`, `generated_at`, `scenario`)
 - environment details
@@ -40,6 +52,10 @@ The harness outputs `performance_metrics.v1` JSON with:
 - aggregate timing metrics (`mean_ms`, `median_ms`, `p95_ms`, `p99_ms`, etc.)
 - success/failure counters
 - explicit scope notes
+
+TASK-011 Phase B must extend current-head publication identity so the benchmark
+artifact also records the measured source commit, exact command, and explicit
+claim/reproducibility boundary.
 
 ## Interpreting results
 
@@ -58,23 +74,34 @@ Do not present this output as production throughput, customer latency, or extern
 ## Next measurement targets
 
 - API route latency
-- Bind boundary decision latency
+- Bind boundary decision latency/current-governance-recheck overhead
 - TrustLog append latency, JSONL and PostgreSQL separately
-- provider adapter overhead
+- controlled Decision-to-Effect timing components
 - one-day PoC end-to-end scenario latency
-- cost-per-request estimation when LLM providers are used
+- provider adapter overhead where separately scoped
+- cost-per-request estimation only when external providers are intentionally enabled
 
-## Latest local artifact
+## Existing local artifact during Phase A
 
-- Latest local deterministic artifact:
-  - `docs/en/benchmarks/local-performance-metrics.latest.json`
-  - `docs/en/benchmarks/local-performance-metrics.latest.md`
-- Japanese companion:
-  - `docs/ja/benchmarks/local-performance-metrics.latest.md`
-- This artifact is local/deterministic only and not a production SLA.
+The files below remain in the repository:
+
+- `docs/en/benchmarks/local-performance-metrics.latest.json`
+- `docs/en/benchmarks/local-performance-metrics.latest.md`
+- `docs/ja/benchmarks/local-performance-metrics.latest.md`
+
+However, the current JSON artifact was generated on 2026-05-09 and does not
+record the measured source commit. Under the TASK-011 Phase A contract it is
+classified as:
+
+**STALE_PRE_REBASELINE_REFERENCE**
+
+It is local/deterministic only and must not be presented as a measurement of the
+current post-consolidation head. Phase B will replace/rebaseline it only after
+artifact identity requirements are implemented.
 
 ## Relationship to One-Day PoC benchmark
 
-- `scripts/benchmarks/run_performance_metrics.py` is deterministic local and non-HTTP.
-- `scripts/demo/one_day_poc_benchmark.py` measures local/configured HTTP PoC endpoints and requires `VERITAS_API_KEY`.
-- Neither benchmark is a production SLA or third-party certified result.
+- `scripts/benchmarks/run_performance_metrics.py` is the canonical deterministic local performance harness for TASK-011.
+- `scripts/demo/one_day_poc_benchmark.py` measures local/configured HTTP PoC endpoints and requires `VERITAS_API_KEY`; it is a supporting PoC benchmark, not the canonical Phase A/initial Phase B harness.
+- `veritas_os/scripts/run_benchmarks_enhanced.py` remains a maintenance YAML `/v1/decide` runner and is not the canonical deterministic rebaseline harness.
+- None of these benchmark surfaces establishes a production SLA or third-party certification.

--- a/veritas_os/tests/test_benchmark_rebaseline_contract.py
+++ b/veritas_os/tests/test_benchmark_rebaseline_contract.py
@@ -1,0 +1,127 @@
+"""Regression guards for TASK-011 Benchmark Rebaseline Phase A."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CONTRACT = ROOT / "docs" / "benchmarks" / "benchmark-rebaseline-contract-v1.json"
+PHASE_A_DOC = ROOT / "docs" / "en" / "benchmarks" / "benchmark-rebaseline-phase-a.md"
+CURRENT_LOCAL = (
+    ROOT / "docs" / "en" / "benchmarks" / "local-performance-metrics.latest.json"
+)
+
+
+def _contract() -> dict:
+    return json.loads(CONTRACT.read_text(encoding="utf-8"))
+
+
+def test_phase_a_contract_is_pinned_to_post_consolidation_head() -> None:
+    data = _contract()
+    assert data["format_version"] == "benchmark-rebaseline-contract/v1"
+    assert data["status"] == "PHASE_A_CONTRACT_FROZEN"
+    assert data["source_commit"] == "53e8e2974123024348b92ddfb7155cd645371620"
+    assert (
+        data["frozen_controlled_e2e_anchor"]
+        == "ada46f2fe324dd3cbcff6be59d56c4f75c4a6bdc"
+    )
+    assert data["task"] == "TASK-011"
+    assert data["phase"] == "A"
+
+
+def test_phase_a_does_not_publish_new_benchmark_numbers() -> None:
+    data = _contract()
+    gate = data["publication_gate"]
+    assert gate["new_benchmark_numbers_permitted"] is False
+    assert data["phase_a_exit"]["benchmark_values_updated"] is False
+    assert (
+        data["phase_a_exit"]["next_phase"]
+        == "PHASE_B_CURRENT_HEAD_DETERMINISTIC_MEASUREMENTS"
+    )
+
+
+def test_canonical_benchmark_surfaces_exist_and_are_distinct() -> None:
+    data = _contract()
+    surfaces = {row["id"]: row for row in data["canonical_surfaces"]}
+    assert set(surfaces) == {"local_deterministic_smoke", "evidence_axes_fixture"}
+
+    local = surfaces["local_deterministic_smoke"]
+    assert local["role"] == "CANONICAL_PERFORMANCE_HARNESS"
+    assert local["schema_version"] == "performance_metrics.v1"
+    assert local["external_network_required"] is False
+    assert local["external_llm_or_api_allowed"] is False
+    assert (ROOT / local["harness"]).exists()
+
+    evidence = surfaces["evidence_axes_fixture"]
+    assert evidence["role"] == "CANONICAL_EVIDENCE_HARNESS"
+    assert evidence["external_network_required"] is False
+    assert evidence["external_llm_or_api_allowed"] is False
+    for key in ("harness", "metrics_definition", "output_schema", "fixture"):
+        assert (ROOT / evidence[key]).exists()
+
+
+def test_evidence_fixture_identity_is_explicitly_synthetic() -> None:
+    data = _contract()
+    evidence = next(
+        row for row in data["canonical_surfaces"] if row["id"] == "evidence_axes_fixture"
+    )
+    identity = evidence["input_identity"]
+    assert identity["synthetic_comparison"] is True
+    assert identity["systems"] == ["veritas", "generic"]
+
+    fixture_path = ROOT / evidence["fixture"]
+    cases = [
+        json.loads(line)
+        for line in fixture_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert len(cases) == identity["fixture_case_count"] == 2
+    assert all(set(case["systems"]) == {"veritas", "generic"} for case in cases)
+
+
+def test_existing_local_artifact_is_marked_stale_pre_rebaseline() -> None:
+    data = _contract()
+    published = {
+        row["path"]: row for row in data["existing_published_artifacts"]
+    }
+    row = published["docs/en/benchmarks/local-performance-metrics.latest.json"]
+    assert row["classification"] == "STALE_PRE_REBASELINE_REFERENCE"
+    assert row["source_commit_recorded"] is False
+    assert row["current_head_claim_permitted"] is False
+
+    current = json.loads(CURRENT_LOCAL.read_text(encoding="utf-8"))
+    assert current["generated_at"] == row["generated_at"]
+    assert current["schema_version"] == "performance_metrics.v1"
+
+
+def test_supporting_runners_are_not_misclassified_as_canonical() -> None:
+    data = _contract()
+    supporting = {row["id"]: row for row in data["supporting_noncanonical_surfaces"]}
+    assert supporting["one_day_poc_http"]["classification"] == (
+        "POC_SUPPORTING_NOT_PHASE_A_CANONICAL"
+    )
+    assert supporting["enhanced_yaml_decide_runner"]["classification"] == (
+        "LEGACY_MAINTENANCE_NOT_REBASELINE_CANONICAL"
+    )
+    assert all((ROOT / row["path"]).exists() for row in supporting.values())
+
+
+def test_contract_keeps_claim_boundary_conservative() -> None:
+    data = _contract()
+    non_claims = set(data["non_claims"])
+    required = {
+        "production latency",
+        "customer-environment performance",
+        "third-party certification",
+        "production SLA",
+        "superiority over named vendors",
+        "third-party competitive validation from synthetic generic fixtures",
+    }
+    assert required.issubset(non_claims)
+
+    doc = PHASE_A_DOC.read_text(encoding="utf-8")
+    assert "STALE_PRE_REBASELINE_REFERENCE" in doc
+    assert "synthetic fixture scoring" in doc
+    assert "No benchmark value is changed in this phase." in doc


### PR DESCRIPTION
## Purpose

Start TASK-011 Benchmark Rebaseline with Phase A inventory and contract freeze before publishing any new benchmark number.

## Baseline

Product main:

`53e8e2974123024348b92ddfb7155cd645371620`

Frozen controlled E2E anchor:

`ada46f2fe324dd3cbcff6be59d56c4f75c4a6bdc`

Large Consolidation Audit is complete through Consolidation 003.

## Added

### Machine-readable rebaseline contract

`docs/benchmarks/benchmark-rebaseline-contract-v1.json`

It fixes:
- canonical benchmark surfaces
- exact commands
- fixture/input identity
- source commit identity
- runtime/environment requirements
- supporting/non-canonical runners
- stale pre-rebaseline artifacts
- Phase B target measurements
- required artifact fields
- explicit non-claims

### Human-readable Phase A record

`docs/en/benchmarks/benchmark-rebaseline-phase-a.md`

### Regression guard

`veritas_os/tests/test_benchmark_rebaseline_contract.py`

The guard proves:
- contract is pinned to the post-consolidation source head
- Phase A does not publish new benchmark numbers
- canonical harness/input files exist
- the evidence comparison fixture is explicitly synthetic
- the current May 2026 local artifact is marked stale/pre-rebaseline
- supporting PoC/legacy runners are not confused with canonical deterministic harnesses
- production/customer/SLA/vendor-superiority claims remain excluded

## Canonical surfaces

### 1. Local deterministic performance

Harness:

`scripts/benchmarks/run_performance_metrics.py`

Canonical Phase B command:

`python scripts/benchmarks/run_performance_metrics.py --iterations 100 --warmup 10 --output docs/en/benchmarks/local-performance-metrics.latest.json`

Scope:
lightweight local deterministic function-path timing only; no external LLM/API calls.

### 2. Evidence-axis benchmark

Harness:

`veritas_os/scripts/evidence_benchmark.py`

Inputs:
- `veritas_os/benchmarks/evidence/metrics_definition.yaml`
- `veritas_os/benchmarks/evidence/output_schema.json`
- `veritas_os/benchmarks/evidence/fixtures/sample_cases.jsonl`

The current two-case `veritas` / `generic` comparison is explicitly classified as a repository-controlled synthetic fixture comparison, not independent competitive validation.

## Supporting / non-canonical surfaces

- `scripts/demo/one_day_poc_benchmark.py` — PoC-supporting HTTP benchmark requiring configured server/API key
- `veritas_os/scripts/run_benchmarks_enhanced.py` — existing YAML `/v1/decide` maintenance runner, not the canonical deterministic rebaseline harness

## Existing artifact status

`docs/en/benchmarks/local-performance-metrics.latest.json` was generated on 2026-05-09 and does not record a measured source commit.

It remains unchanged in this PR and is classified as:

`STALE_PRE_REBASELINE_REFERENCE`

It must not be described as current-head performance.

## Explicit non-change

This PR does **not**:
- generate or update benchmark performance numbers
- change runtime behavior
- enable external providers
- change authorization / Bind / effect / reconciliation / receipt / outcome semantics
- change the frozen Decision-to-Effect architecture
- claim production latency, customer performance, SLA, certification, or vendor superiority

## CI note

An initial CI run exposed a documentation-boundary wording mismatch in `docs/en/benchmarks/performance-metrics.md`: the existing regression test requires the literal phrase `not a production SLA`. The underlying claim boundary was unchanged; the wording is being corrected to retain the established test contract.

## Next after merge

Phase B — implement reproducible current-head benchmark artifact identity and run deterministic measurements under the frozen contract.

Human review required before merge.