### PR TITLE
benchmark: produce source-bound Phase B current-head measurement

### DIFF
--- a/.github/workflows/benchmark-rebaseline-phase-b.yml
+++ b/.github/workflows/benchmark-rebaseline-phase-b.yml
@@ -1,0 +1,188 @@
+name: Benchmark Rebaseline Phase B
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: benchmark-rebaseline-phase-b-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  current-head-local:
+    name: benchmark-rebaseline-phase-b
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout measured source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install deterministic benchmark dependencies
+        run: |
+          set -euxo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install -r veritas_os/requirements-ci.txt
+
+      - name: Run canonical Phase B measurement
+        id: benchmark
+        run: |
+          set -euxo pipefail
+          SOURCE_SHA="$(git rev-parse HEAD)"
+          echo "source_sha=${SOURCE_SHA}" >> "$GITHUB_OUTPUT"
+          python scripts/benchmarks/run_performance_metrics.py --iterations 100 --warmup 10 --output docs/en/benchmarks/local-performance-metrics.latest.json
+
+      - name: Validate source-bound benchmark contract
+        env:
+          SOURCE_SHA: ${{ steps.benchmark.outputs.source_sha }}
+        run: |
+          set -euxo pipefail
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          artifact_path = Path("docs/en/benchmarks/local-performance-metrics.latest.json")
+          contract_path = Path("docs/benchmarks/benchmark-rebaseline-contract-v1.json")
+          phase_b_path = Path("docs/benchmarks/benchmark-rebaseline-phase-b-v1.json")
+
+          artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+          contract = json.loads(contract_path.read_text(encoding="utf-8"))
+          phase_b = json.loads(phase_b_path.read_text(encoding="utf-8"))
+
+          source_sha = os.environ["SOURCE_SHA"]
+          if artifact["source_commit_sha"] != source_sha:
+              raise SystemExit(
+                  "benchmark source SHA mismatch: "
+                  f"{artifact['source_commit_sha']} != {source_sha}"
+              )
+
+          required = set(contract["required_artifact_fields"])
+          missing = sorted(required.difference(artifact))
+          if missing:
+              raise SystemExit(f"missing required artifact fields: {missing}")
+
+          expected_command = phase_b["canonical_measurement"]["exact_command"]
+          if artifact["exact_command"] != expected_command:
+              raise SystemExit(
+                  "benchmark command mismatch: "
+                  f"{artifact['exact_command']!r} != {expected_command!r}"
+              )
+
+          if artifact["failure_count"] != 0:
+              raise SystemExit("benchmark recorded failures")
+          if artifact["counters"]["failure"] != 0:
+              raise SystemExit("benchmark counters recorded failures")
+          if artifact["iterations"] != 100 or artifact["warmup"] != 10:
+              raise SystemExit("benchmark iteration/warmup contract mismatch")
+          if artifact["iterations_or_run_count"] != 100:
+              raise SystemExit("benchmark run-count provenance mismatch")
+          if artifact["warmup_when_relevant"] != 10:
+              raise SystemExit("benchmark warmup provenance mismatch")
+          if artifact["environment"]["implementation"] != "cpython":
+              raise SystemExit("Phase B canonical implementation must be CPython")
+          if not artifact["environment"]["python_version"].startswith("3.12."):
+              raise SystemExit("Phase B canonical Python minor must be 3.12")
+          if artifact["claim_boundary"]["external_network_required"] is not False:
+              raise SystemExit("Phase B benchmark must not require external network")
+          if artifact["claim_boundary"]["external_llm_or_api_allowed"] is not False:
+              raise SystemExit("Phase B benchmark must not allow external LLM/API calls")
+
+          required_non_claims = {
+              "production latency",
+              "production SLA",
+              "customer-environment performance",
+              "third-party certification",
+              "superiority over named vendors",
+          }
+          if not required_non_claims.issubset(
+              set(artifact["claim_boundary"]["non_claims"])
+          ):
+              raise SystemExit("Phase B benchmark claim boundary is incomplete")
+
+          print(
+              json.dumps(
+                  {
+                      "source_commit_sha": source_sha,
+                      "mean_ms": artifact["metrics"]["mean_ms"],
+                      "p95_ms": artifact["metrics"]["p95_ms"],
+                      "p99_ms": artifact["metrics"]["p99_ms"],
+                      "failure_count": artifact["failure_count"],
+                  },
+                  sort_keys=True,
+              )
+          )
+          PY
+
+      - name: Package source-bound artifact and run manifest
+        env:
+          SOURCE_SHA: ${{ steps.benchmark.outputs.source_sha }}
+        run: |
+          set -euxo pipefail
+          mkdir -p artifacts/benchmark-rebaseline/phase-b
+          cp docs/en/benchmarks/local-performance-metrics.latest.json \
+            "artifacts/benchmark-rebaseline/phase-b/local-performance-metrics.${SOURCE_SHA}.json"
+          python - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          source_sha = os.environ["SOURCE_SHA"]
+          root = Path("artifacts/benchmark-rebaseline/phase-b")
+          artifact = root / f"local-performance-metrics.{source_sha}.json"
+          digest = hashlib.sha256(artifact.read_bytes()).hexdigest()
+          report = json.loads(artifact.read_text(encoding="utf-8"))
+
+          manifest = {
+              "format_version": "benchmark-rebaseline-phase-b-run/v1",
+              "source_commit_sha": source_sha,
+              "benchmark_artifact": artifact.name,
+              "benchmark_artifact_sha256": digest,
+              "schema_version": report["schema_version"],
+              "run_timestamp": report["run_timestamp"],
+              "exact_command": report["exact_command"],
+              "environment": report["environment"],
+              "iterations_or_run_count": report["iterations_or_run_count"],
+              "warmup_when_relevant": report["warmup_when_relevant"],
+              "failure_count": report["failure_count"],
+              "claim_boundary": report["claim_boundary"],
+              "github": {
+                  "repository": os.environ["GITHUB_REPOSITORY"],
+                  "run_id": os.environ["GITHUB_RUN_ID"],
+                  "run_attempt": os.environ["GITHUB_RUN_ATTEMPT"],
+                  "event_name": os.environ["GITHUB_EVENT_NAME"],
+                  "workflow": os.environ["GITHUB_WORKFLOW"],
+              },
+          }
+          (root / "run-manifest.json").write_text(
+              json.dumps(manifest, ensure_ascii=False, sort_keys=True, indent=2) + "\n",
+              encoding="utf-8",
+          )
+          PY
+
+      - name: Upload Phase B benchmark evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-rebaseline-phase-b-${{ steps.benchmark.outputs.source_sha }}
+          path: artifacts/benchmark-rebaseline/phase-b/
+          if-no-files-found: error
+          retention-days: 90

--- a/docs/benchmarks/benchmark-rebaseline-phase-b-v1.json
+++ b/docs/benchmarks/benchmark-rebaseline-phase-b-v1.json
@@ -1,0 +1,74 @@
+{
+  "format_version": "benchmark-rebaseline-phase-b/v1",
+  "status": "IMPLEMENTATION_REVIEW",
+  "task": "TASK-011",
+  "phase": "B",
+  "baseline_source_commit": "ad92ec663b962183327b1b96192378fd562da794",
+  "frozen_controlled_e2e_anchor": "ada46f2fe324dd3cbcff6be59d56c4f75c4a6bdc",
+  "phase_a_contract": "docs/benchmarks/benchmark-rebaseline-contract-v1.json",
+  "scope": "source-SHA-bound deterministic local performance measurement only",
+  "canonical_measurement": {
+    "harness": "scripts/benchmarks/run_performance_metrics.py",
+    "exact_command": "python scripts/benchmarks/run_performance_metrics.py --iterations 100 --warmup 10 --output docs/en/benchmarks/local-performance-metrics.latest.json",
+    "iterations": 100,
+    "warmup": 10,
+    "scenario": "local_deterministic_smoke",
+    "python_family": "CPython",
+    "canonical_python_minor": "3.12",
+    "platform_class": "Linux x86_64",
+    "external_network_required": false,
+    "external_llm_or_api_allowed": false
+  },
+  "workflow": {
+    "path": ".github/workflows/benchmark-rebaseline-phase-b.yml",
+    "pull_request_behavior": "measure the checked-out PR head and validate provenance",
+    "main_behavior": "measure the exact pushed main commit and upload the source-bound artifact",
+    "artifact_name_prefix": "benchmark-rebaseline-phase-b-",
+    "retention_days": 90
+  },
+  "artifact_policy": {
+    "committed_pre_rebaseline_latest_classification": "STALE_PRE_REBASELINE_REFERENCE",
+    "authoritative_phase_b_current_head_location": "GitHub Actions artifact produced by the Phase B workflow on push to main",
+    "source_commit_must_equal_checked_out_commit": true,
+    "required_fields_source": "docs/benchmarks/benchmark-rebaseline-contract-v1.json::required_artifact_fields",
+    "publication_requires_zero_failures": true
+  },
+  "provenance_fields_added_to_performance_metrics_v1": [
+    "source_commit_sha",
+    "run_timestamp",
+    "exact_command",
+    "iterations_or_run_count",
+    "warmup_when_relevant",
+    "failure_count",
+    "harness_identity",
+    "input_identity",
+    "raw_machine_readable_result",
+    "summary",
+    "claim_boundary",
+    "reproducibility_instructions"
+  ],
+  "runtime_integrity": {
+    "runtime_semantics_changed": false,
+    "benchmark_path_optimized_for_score": false,
+    "authorization_bind_effect_reconciliation_semantics_changed": false
+  },
+  "non_claims": [
+    "production latency",
+    "production SLA",
+    "customer-environment performance",
+    "real customer endpoint performance",
+    "external provider latency",
+    "third-party certification",
+    "regulatory approval",
+    "superiority over named vendors"
+  ],
+  "phase_b_exit": {
+    "implementation_merged": false,
+    "main_current_head_artifact_generated": false,
+    "source_sha_bound": true,
+    "exact_command_recorded": true,
+    "environment_recorded": true,
+    "claim_boundary_recorded": true,
+    "next_phase_after_success": "PHASE_C_EVIDENCE_BENCHMARK_REBASELINE"
+  }
+}

--- a/docs/benchmarks/benchmark-rebaseline-phase-b-v1.json
+++ b/docs/benchmarks/benchmark-rebaseline-phase-b-v1.json
@@ -1,6 +1,6 @@
 {
   "format_version": "benchmark-rebaseline-phase-b/v1",
-  "status": "IMPLEMENTATION_REVIEW",
+  "status": "MEASUREMENT_PROTOCOL_DEFINED",
   "task": "TASK-011",
   "phase": "B",
   "baseline_source_commit": "ad92ec663b962183327b1b96192378fd562da794",
@@ -63,12 +63,15 @@
     "superiority over named vendors"
   ],
   "phase_b_exit": {
-    "implementation_merged": false,
-    "main_current_head_artifact_generated": false,
-    "source_sha_bound": true,
-    "exact_command_recorded": true,
-    "environment_recorded": true,
-    "claim_boundary_recorded": true,
+    "completion_conditions": [
+      "the Phase B workflow is merged",
+      "a push-to-main run completes successfully",
+      "the uploaded artifact source_commit_sha equals the measured main commit",
+      "failure_count is zero",
+      "exact command and environment are present",
+      "the non-production claim boundary remains present",
+      "the frozen Decision-to-Effect proof and required repository CI remain green"
+    ],
     "next_phase_after_success": "PHASE_C_EVIDENCE_BENCHMARK_REBASELINE"
   }
 }

--- a/docs/benchmarks/benchmark-rebaseline-phase-b.md
+++ b/docs/benchmarks/benchmark-rebaseline-phase-b.md
@@ -1,0 +1,119 @@
+# TASK-011 Benchmark Rebaseline — Phase B
+
+## Purpose
+
+Phase B produces a reproducible, source-SHA-bound measurement for the canonical
+local deterministic benchmark defined by the Phase A contract.
+
+This phase does not change runtime governance behavior and does not widen the
+benchmark claim boundary.
+
+## Baseline
+
+Phase A merged in product PR #2222.
+
+Phase A merge commit:
+
+`ad92ec663b962183327b1b96192378fd562da794`
+
+Frozen controlled Decision-to-Effect anchor:
+
+`ada46f2fe324dd3cbcff6be59d56c4f75c4a6bdc`
+
+## Canonical command
+
+```bash
+python scripts/benchmarks/run_performance_metrics.py --iterations 100 --warmup 10 --output docs/en/benchmarks/local-performance-metrics.latest.json
+```
+
+The harness now attaches provenance to the existing `performance_metrics.v1`
+payload without changing the timed code path. The measured section remains the
+same deterministic local fixture path.
+
+## Source identity
+
+Every Phase B artifact records:
+
+- full measured source commit SHA;
+- run timestamp;
+- exact command;
+- Python/platform identity;
+- iteration and warmup counts;
+- harness path and SHA-256;
+- embedded fixture/scenario identity;
+- raw metrics/counters and summary;
+- failure count;
+- claim boundary; and
+- reproduction instructions.
+
+The harness resolves the measured SHA from the checked-out Git tree unless an
+explicit full SHA is supplied. It fails rather than silently promoting an
+unbound result when source identity cannot be resolved.
+
+## CI measurement protocol
+
+`.github/workflows/benchmark-rebaseline-phase-b.yml` runs on pull requests,
+pushes to `main`, and manual dispatch.
+
+For pull requests, the workflow checks out and measures the PR head rather than
+implicitly relying on the synthetic pull-request merge SHA.
+
+After merge, the push-to-main run measures the exact pushed `main` commit. It
+validates the Phase A required fields, source SHA, canonical command, CPython
+3.12 runtime family, zero failures, and the non-production claim boundary.
+
+The workflow uploads two files under a source-SHA-specific Actions artifact:
+
+1. `local-performance-metrics.<source-sha>.json`
+2. `run-manifest.json`
+
+The manifest additionally records the benchmark artifact SHA-256 and GitHub
+Actions run identity.
+
+## Existing committed May 2026 artifact
+
+`docs/en/benchmarks/local-performance-metrics.latest.json` remains the historical
+May 2026 pre-rebaseline result in the repository. It lacks measured source SHA
+and remains classified as:
+
+`STALE_PRE_REBASELINE_REFERENCE`
+
+It must not be represented as current-head performance.
+
+The authoritative Phase B current-head evidence is the source-bound GitHub
+Actions artifact produced by a successful push-to-main workflow run.
+
+## Claim boundary
+
+Phase B measures a lightweight deterministic local function path only.
+
+It does not establish:
+
+- production latency;
+- a production SLA;
+- customer-environment performance;
+- real customer endpoint performance;
+- external provider latency;
+- third-party certification;
+- regulatory approval; or
+- superiority over named vendors.
+
+No external LLM/API call is enabled by this benchmark workflow.
+
+## Runtime integrity
+
+No authorization, Bind, external-effect, reconciliation, receipt/outcome,
+credential, TrustLog runtime, or network semantics are changed for benchmark
+performance.
+
+If the benchmark reveals an optimization opportunity, that optimization must be
+a separately reviewed runtime change.
+
+## Exit condition
+
+Phase B is complete only after the workflow is merged and a push-to-main run
+successfully produces a source-SHA-bound artifact with zero benchmark failures,
+while required repository CI and the frozen Decision-to-Effect proof remain
+green.
+
+The next phase is Phase C — Evidence Benchmark Rebaseline.

--- a/docs/en/benchmarks/local-performance-metrics.latest.md
+++ b/docs/en/benchmarks/local-performance-metrics.latest.md
@@ -8,6 +8,20 @@
 - It is not third-party certified.
 - It is not a customer environment measurement.
 
+## Rebaseline status
+
+The JSON currently committed at `docs/en/benchmarks/local-performance-metrics.latest.json`
+was generated on 2026-05-09 and does not record the measured Git source commit. TASK-011
+Phase A therefore classifies that committed file as `STALE_PRE_REBASELINE_REFERENCE`.
+It must not be described as current-head performance.
+
+TASK-011 Phase B adds a source-SHA-bound measurement workflow at
+`.github/workflows/benchmark-rebaseline-phase-b.yml`. Pull-request runs validate the
+checked-out PR head. After merge, a push-to-main run measures the exact pushed `main`
+commit and uploads the resulting JSON plus a run manifest as a GitHub Actions artifact.
+That uploaded artifact, not the historical May 2026 file below, is the authoritative
+Phase B current-head measurement evidence.
+
 ## Scope
 
 This artifact records one deterministic local benchmark execution only. It does not represent production latency or customer environment behavior.
@@ -25,7 +39,7 @@ python scripts/benchmarks/run_performance_metrics.py --iterations 100 --warmup 1
 
 ## Metrics summary
 
-Local deterministic artifact only (not production latency):
+Historical pre-rebaseline local deterministic artifact only (not current-head and not production latency):
 
 | Field | Value |
 | --- | --- |
@@ -49,6 +63,7 @@ Local deterministic artifact only (not production latency):
 - Not a production SLA.
 - Not third-party certified.
 - Not a customer environment measurement.
+- The committed May 2026 values are not a current-head benchmark.
 
 ## Next measurement targets
 

--- a/docs/ja/benchmarks/local-performance-metrics.latest.md
+++ b/docs/ja/benchmarks/local-performance-metrics.latest.md
@@ -9,6 +9,19 @@
 - 第三者認証ではない。
 - 顧客環境での測定ではない。
 
+## Rebaseline status
+
+現在GitHubにcommitされている `docs/en/benchmarks/local-performance-metrics.latest.json` は、
+2026-05-09に生成されたもので、測定対象のGit source commit SHAを記録していません。
+そのためTASK-011 Phase Aでは、このcommit済みartifactを
+`STALE_PRE_REBASELINE_REFERENCE` と分類しています。現在のhead性能として扱ってはいけません。
+
+TASK-011 Phase Bでは `.github/workflows/benchmark-rebaseline-phase-b.yml` により、
+source SHAに結び付いたdeterministic local measurementを生成します。Pull Requestではcheckoutした
+PR headを検証し、merge後のpush-to-mainでは、その時点の正確な `main` commitを測定して、JSONと
+run manifestをGitHub Actions artifactとして保存します。Phase Bにおけるcurrent-headの正本証拠は、
+下記の2026年5月のcommit済みJSONではなく、そのsource-SHA-bound Actions artifactです。
+
 ## 英語正本
 
 - [Local Performance Metrics Artifact](../../en/benchmarks/local-performance-metrics.latest.md)
@@ -31,7 +44,7 @@ python scripts/benchmarks/run_performance_metrics.py --iterations 100 --warmup 1
 
 ## Metrics summary
 
-local deterministic artifactのみ（本番レイテンシではない）:
+以下はpre-rebaselineのhistorical local deterministic artifactのみであり、current-headでも本番レイテンシでもありません。
 
 | Field | Value |
 | --- | --- |
@@ -55,6 +68,7 @@ local deterministic artifactのみ（本番レイテンシではない）:
 - 本番SLAではない。
 - 第三者認証ではない。
 - 顧客環境測定ではない。
+- commit済みの2026年5月の値はcurrent-head benchmarkではない。
 
 ## Next measurement targets
 

--- a/scripts/benchmarks/run_performance_metrics.py
+++ b/scripts/benchmarks/run_performance_metrics.py
@@ -7,10 +7,15 @@ and writes a stable JSON report for reproducible benchmarking workflows.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import math
+import os
 import platform
+import re
+import shlex
 import statistics
+import subprocess
 import sys
 import time
 from datetime import datetime, timezone
@@ -29,6 +34,10 @@ from veritas_os.security.wat_verifier import (
     score_drift,
 )
 
+_COMMIT_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+_DEFAULT_SCENARIO = "local_deterministic_smoke"
+_HARNESS_PATH = "scripts/benchmarks/run_performance_metrics.py"
+
 
 def _positive_int(value: str) -> int:
     """Parse CLI integer argument that must be >= 1."""
@@ -44,6 +53,58 @@ def _non_negative_int(value: str) -> int:
     if parsed < 0:
         raise argparse.ArgumentTypeError("must be >= 0")
     return parsed
+
+
+def _normalize_commit_sha(value: str | None) -> str | None:
+    """Return a normalized full commit SHA or ``None`` when invalid."""
+    if value is None:
+        return None
+    candidate = value.strip()
+    if not _COMMIT_SHA_RE.fullmatch(candidate):
+        return None
+    return candidate.lower()
+
+
+def _resolve_source_commit(explicit: str | None = None) -> str:
+    """Resolve the exact Git commit measured by this benchmark.
+
+    Resolution deliberately prefers an explicit override and then the checked
+    out Git tree. ``GITHUB_SHA`` is only a final fallback because pull-request
+    events can otherwise point at a synthetic merge commit rather than the
+    checked-out benchmark source.
+    """
+    for candidate in (explicit, os.getenv("VERITAS_BENCHMARK_SOURCE_COMMIT")):
+        normalized = _normalize_commit_sha(candidate)
+        if candidate is not None and normalized is None:
+            raise ValueError("source commit must be a full 40-character Git SHA")
+        if normalized is not None:
+            return normalized
+
+    try:
+        completed = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=ROOT_DIR,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        completed = None
+
+    if completed is not None and completed.returncode == 0:
+        normalized = _normalize_commit_sha(completed.stdout)
+        if normalized is not None:
+            return normalized
+
+    github_sha = _normalize_commit_sha(os.getenv("GITHUB_SHA"))
+    if github_sha is not None:
+        return github_sha
+
+    raise RuntimeError(
+        "unable to resolve measured source commit; run from a Git checkout or "
+        "pass --source-commit"
+    )
 
 
 def _percentile(sorted_values: list[float], percentile: float) -> float:
@@ -151,9 +212,95 @@ def collect_metrics(iterations: int, warmup: int, scenario: str) -> dict[str, An
             "No external LLM/API calls.",
             "Not a production SLA.",
             "Not third-party certified.",
+            "Not a customer environment measurement.",
         ],
     }
     return report
+
+
+def _build_exact_command(args: argparse.Namespace) -> str:
+    """Build the canonical, copyable command represented by parsed arguments."""
+    command = [
+        "python",
+        _HARNESS_PATH,
+        "--iterations",
+        str(args.iterations),
+        "--warmup",
+        str(args.warmup),
+    ]
+    if args.output is not None:
+        command.extend(["--output", args.output.as_posix()])
+    if args.scenario != _DEFAULT_SCENARIO:
+        command.extend(["--scenario", args.scenario])
+    if args.source_commit is not None:
+        command.extend(["--source-commit", args.source_commit])
+    return shlex.join(command)
+
+
+def _attach_provenance(
+    report: dict[str, Any],
+    *,
+    args: argparse.Namespace,
+    source_commit_sha: str,
+) -> None:
+    """Attach Phase B provenance without changing measured runtime behavior."""
+    exact_command = _build_exact_command(args)
+    harness_sha256 = hashlib.sha256(Path(__file__).read_bytes()).hexdigest()
+    metrics = dict(report["metrics"])
+    counters = dict(report["counters"])
+
+    report.update(
+        {
+            "source_commit_sha": source_commit_sha,
+            "run_timestamp": report["generated_at"],
+            "exact_command": exact_command,
+            "iterations_or_run_count": args.iterations,
+            "warmup_when_relevant": args.warmup,
+            "failure_count": counters["failure"],
+            "harness_identity": {
+                "path": _HARNESS_PATH,
+                "sha256": harness_sha256,
+            },
+            "input_identity": {
+                "type": "embedded_deterministic_fixture",
+                "location": f"{_HARNESS_PATH}::_run_iteration",
+                "scenario": args.scenario,
+            },
+            "raw_machine_readable_result": {
+                "metrics": metrics,
+                "counters": counters,
+            },
+            "summary": {
+                "scenario": args.scenario,
+                "mean_ms": metrics["mean_ms"],
+                "p95_ms": metrics["p95_ms"],
+                "p99_ms": metrics["p99_ms"],
+                "success_count": counters["success"],
+                "failure_count": counters["failure"],
+            },
+            "claim_boundary": {
+                "scope": "lightweight deterministic local function-path timing only",
+                "external_network_required": False,
+                "external_llm_or_api_allowed": False,
+                "non_claims": [
+                    "production latency",
+                    "production SLA",
+                    "customer-environment performance",
+                    "real customer endpoint performance",
+                    "external provider latency",
+                    "third-party certification",
+                    "regulatory approval",
+                    "superiority over named vendors",
+                ],
+            },
+            "reproducibility_instructions": {
+                "checkout": f"git checkout {source_commit_sha}",
+                "command": exact_command,
+                "canonical_python_minor": "3.12",
+                "platform_class": "Linux x86_64",
+            },
+        }
+    )
 
 
 def main() -> int:
@@ -162,10 +309,16 @@ def main() -> int:
     parser.add_argument("--iterations", type=_positive_int, default=100)
     parser.add_argument("--warmup", type=_non_negative_int, default=10)
     parser.add_argument("--output", type=Path)
-    parser.add_argument("--scenario", default="local_deterministic_smoke")
+    parser.add_argument("--scenario", default=_DEFAULT_SCENARIO)
+    parser.add_argument(
+        "--source-commit",
+        help="Optional full Git SHA override for source-bound benchmark provenance.",
+    )
     args = parser.parse_args()
 
+    source_commit_sha = _resolve_source_commit(args.source_commit)
     report = collect_metrics(args.iterations, args.warmup, args.scenario)
+    _attach_provenance(report, args=args, source_commit_sha=source_commit_sha)
     rendered = json.dumps(report, ensure_ascii=False, sort_keys=True, indent=2)
 
     if args.output:

--- a/veritas_os/tests/test_benchmark_rebaseline_phase_b.py
+++ b/veritas_os/tests/test_benchmark_rebaseline_phase_b.py
@@ -24,7 +24,7 @@ def test_phase_b_record_is_pinned_to_phase_a_merge() -> None:
     data = _load(PHASE_B_RECORD)
 
     assert data["format_version"] == "benchmark-rebaseline-phase-b/v1"
-    assert data["status"] == "IMPLEMENTATION_REVIEW"
+    assert data["status"] == "MEASUREMENT_PROTOCOL_DEFINED"
     assert data["task"] == "TASK-011"
     assert data["phase"] == "B"
     assert (
@@ -36,6 +36,7 @@ def test_phase_b_record_is_pinned_to_phase_a_merge() -> None:
         == "ada46f2fe324dd3cbcff6be59d56c4f75c4a6bdc"
     )
     assert data["runtime_integrity"]["runtime_semantics_changed"] is False
+    assert len(data["phase_b_exit"]["completion_conditions"]) >= 6
 
 
 def test_phase_b_cli_emits_required_source_bound_provenance(tmp_path: Path) -> None:

--- a/veritas_os/tests/test_benchmark_rebaseline_phase_b.py
+++ b/veritas_os/tests/test_benchmark_rebaseline_phase_b.py
@@ -1,0 +1,145 @@
+"""Regression guards for TASK-011 Benchmark Rebaseline Phase B."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+HARNESS = ROOT / "scripts/benchmarks/run_performance_metrics.py"
+PHASE_A_CONTRACT = ROOT / "docs/benchmarks/benchmark-rebaseline-contract-v1.json"
+PHASE_B_RECORD = ROOT / "docs/benchmarks/benchmark-rebaseline-phase-b-v1.json"
+WORKFLOW = ROOT / ".github/workflows/benchmark-rebaseline-phase-b.yml"
+STALE_LATEST = ROOT / "docs/en/benchmarks/local-performance-metrics.latest.json"
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_phase_b_record_is_pinned_to_phase_a_merge() -> None:
+    data = _load(PHASE_B_RECORD)
+
+    assert data["format_version"] == "benchmark-rebaseline-phase-b/v1"
+    assert data["status"] == "IMPLEMENTATION_REVIEW"
+    assert data["task"] == "TASK-011"
+    assert data["phase"] == "B"
+    assert (
+        data["baseline_source_commit"]
+        == "ad92ec663b962183327b1b96192378fd562da794"
+    )
+    assert (
+        data["frozen_controlled_e2e_anchor"]
+        == "ada46f2fe324dd3cbcff6be59d56c4f75c4a6bdc"
+    )
+    assert data["runtime_integrity"]["runtime_semantics_changed"] is False
+
+
+def test_phase_b_cli_emits_required_source_bound_provenance(tmp_path: Path) -> None:
+    source_sha = "a" * 40
+    output = tmp_path / "phase-b.json"
+
+    subprocess.run(
+        [
+            sys.executable,
+            str(HARNESS),
+            "--iterations",
+            "3",
+            "--warmup",
+            "1",
+            "--output",
+            str(output),
+            "--source-commit",
+            source_sha,
+        ],
+        cwd=ROOT,
+        check=True,
+    )
+
+    data = _load(output)
+    contract = _load(PHASE_A_CONTRACT)
+
+    assert set(contract["required_artifact_fields"]).issubset(data)
+    assert data["source_commit_sha"] == source_sha
+    assert data["run_timestamp"] == data["generated_at"]
+    assert data["iterations_or_run_count"] == data["iterations"] == 3
+    assert data["warmup_when_relevant"] == data["warmup"] == 1
+    assert data["failure_count"] == data["counters"]["failure"] == 0
+    assert data["raw_machine_readable_result"]["metrics"] == data["metrics"]
+    assert data["raw_machine_readable_result"]["counters"] == data["counters"]
+
+    harness_identity = data["harness_identity"]
+    assert harness_identity["path"] == "scripts/benchmarks/run_performance_metrics.py"
+    assert harness_identity["sha256"] == hashlib.sha256(HARNESS.read_bytes()).hexdigest()
+
+    input_identity = data["input_identity"]
+    assert input_identity["type"] == "embedded_deterministic_fixture"
+    assert input_identity["scenario"] == "local_deterministic_smoke"
+
+    assert data["reproducibility_instructions"]["checkout"] == (
+        f"git checkout {source_sha}"
+    )
+    assert "--source-commit" in data["exact_command"]
+    assert source_sha in data["exact_command"]
+
+
+def test_phase_b_claim_boundary_remains_non_production() -> None:
+    data = _load(PHASE_B_RECORD)
+    non_claims = set(data["non_claims"])
+
+    assert {
+        "production latency",
+        "production SLA",
+        "customer-environment performance",
+        "real customer endpoint performance",
+        "external provider latency",
+        "third-party certification",
+        "regulatory approval",
+        "superiority over named vendors",
+    }.issubset(non_claims)
+
+    assert data["canonical_measurement"]["external_network_required"] is False
+    assert data["canonical_measurement"]["external_llm_or_api_allowed"] is False
+
+
+def test_phase_b_workflow_measures_checked_out_source_and_uploads_evidence() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    record = _load(PHASE_B_RECORD)
+    exact_command = record["canonical_measurement"]["exact_command"]
+
+    assert "pull_request:" in text
+    assert "push:" in text
+    assert "branches: [main]" in text
+    assert "ref: ${{ github.event.pull_request.head.sha || github.sha }}" in text
+    assert 'SOURCE_SHA="$(git rev-parse HEAD)"' in text
+    assert exact_command in text
+    assert "benchmark source SHA mismatch" in text
+    assert "actions/upload-artifact@v4" in text
+    assert "retention-days: 90" in text
+    assert "OPENAI_API_KEY" not in text
+    assert "VERITAS_API_KEY" not in text
+
+
+def test_committed_may_artifact_remains_explicitly_pre_rebaseline() -> None:
+    old = _load(STALE_LATEST)
+    phase_a = _load(PHASE_A_CONTRACT)
+    phase_b = _load(PHASE_B_RECORD)
+
+    old_row = next(
+        row
+        for row in phase_a["existing_published_artifacts"]
+        if row["path"] == "docs/en/benchmarks/local-performance-metrics.latest.json"
+    )
+
+    assert old["generated_at"] == "2026-05-09T02:05:00.659731+00:00"
+    assert "source_commit_sha" not in old
+    assert old_row["classification"] == "STALE_PRE_REBASELINE_REFERENCE"
+    assert phase_b["artifact_policy"][
+        "committed_pre_rebaseline_latest_classification"
+    ] == "STALE_PRE_REBASELINE_REFERENCE"
+    assert "GitHub Actions artifact" in phase_b["artifact_policy"][
+        "authoritative_phase_b_current_head_location"
+    ]


### PR DESCRIPTION
## Purpose

Implement TASK-011 Benchmark Rebaseline Phase B under the Phase A contract merged in PR #2222.

This PR makes the canonical local deterministic benchmark source-SHA-bound and adds a dedicated GitHub Actions measurement workflow. It does **not** change runtime governance semantics and does **not** promote the historical May 2026 committed benchmark as current-head performance.

## Baseline

Phase A merge commit:

`ad92ec663b962183327b1b96192378fd562da794`

Frozen controlled Decision-to-Effect anchor:

`ada46f2fe324dd3cbcff6be59d56c4f75c4a6bdc`

## Canonical Phase B measurement

Harness:

`scripts/benchmarks/run_performance_metrics.py`

Canonical command:

```bash
python scripts/benchmarks/run_performance_metrics.py --iterations 100 --warmup 10 --output docs/en/benchmarks/local-performance-metrics.latest.json
```

The timed code path is unchanged. The harness now attaches additive provenance fields to the existing `performance_metrics.v1` payload.

## Added provenance

The generated artifact records:

- `source_commit_sha`
- `run_timestamp`
- `exact_command`
- `iterations_or_run_count`
- `warmup_when_relevant`
- `failure_count`
- harness path + SHA-256
- embedded fixture/scenario identity
- raw machine-readable metrics/counters
- summary
- claim boundary
- reproduction instructions

Source identity is resolved from the checked-out Git tree unless an explicit full SHA is supplied. An unbound result fails rather than being silently promoted.

## New Phase B workflow

`.github/workflows/benchmark-rebaseline-phase-b.yml`

Runs on:

- pull requests to `main`
- pushes to `main`
- manual dispatch

For pull requests, it checks out and measures the PR head. After merge, the push-to-main run measures the exact pushed `main` commit.

The workflow validates:

- artifact source SHA equals checked-out source
- all Phase A required artifact fields are present
- the exact canonical command is recorded
- CPython 3.12 is used
- iterations=100 / warmup=10
- benchmark failure count is zero
- external network / LLM/API use remains disabled
- non-production claim boundaries remain present

It uploads:

- `local-performance-metrics.<source-sha>.json`
- `run-manifest.json`

The run manifest also records the artifact SHA-256 and GitHub Actions run identity.

## Existing committed artifact

`docs/en/benchmarks/local-performance-metrics.latest.json` remains unchanged in this PR.

It is still the May 2026 result without measured source commit identity and remains:

`STALE_PRE_REBASELINE_REFERENCE`

The EN/JA summary docs now make that status explicit. The authoritative Phase B current-head evidence is the source-bound Actions artifact from a successful push-to-main run.

## Claim boundary

This PR does **not** establish:

- production latency
- production SLA
- customer-environment performance
- real customer endpoint performance
- external provider latency
- third-party certification
- regulatory approval
- superiority over named vendors

## Runtime impact

None to the governed execution path.

No change to authorization, policy semantics, Bind execution, credentials, external effect, reconciliation, BindReceipt/Outcome, TrustLog runtime, migrations, or network authority.

## Validation

Added `veritas_os/tests/test_benchmark_rebaseline_phase_b.py` to guard source binding, required provenance, workflow behavior, stale-artifact handling, and claim boundaries.

Full repository CI and the frozen reproducible Decision-to-Effect proof must pass before merge.

## Phase B exit

Phase B is complete only after this implementation is merged and the push-to-main Phase B workflow successfully produces a source-SHA-bound current-head artifact with zero failures.

Next after successful Phase B exit: Phase C — Evidence Benchmark Rebaseline.

Human review required before protected-branch merge.