### PR TITLE
benchmark: add source-bound Phase C evidence rebaseline

### DIFF
--- a/.github/workflows/benchmark-rebaseline-phase-c.yml
+++ b/.github/workflows/benchmark-rebaseline-phase-c.yml
@@ -1,0 +1,219 @@
+name: Benchmark Rebaseline Phase C
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: benchmark-rebaseline-phase-c-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  evidence-current-head:
+    name: benchmark-rebaseline-phase-c
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout measured source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install schema validation dependency
+        run: |
+          set -euxo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install jsonschema==4.23.0
+
+      - name: Run canonical Phase C evidence benchmark
+        id: benchmark
+        run: |
+          set -euxo pipefail
+          SOURCE_SHA="$(git rev-parse HEAD)"
+          echo "source_sha=${SOURCE_SHA}" >> "$GITHUB_OUTPUT"
+          python -m veritas_os.scripts.evidence_benchmark --fixtures veritas_os/benchmarks/evidence/fixtures/sample_cases.jsonl --output /tmp/veritas-evidence-benchmark.json
+
+      - name: Validate frozen evidence contract
+        env:
+          SOURCE_SHA: ${{ steps.benchmark.outputs.source_sha }}
+        run: |
+          set -euxo pipefail
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          from jsonschema import validate
+
+          report_path = Path("/tmp/veritas-evidence-benchmark.json")
+          phase_c_path = Path("docs/benchmarks/benchmark-rebaseline-phase-c-v1.json")
+          schema_path = Path("veritas_os/benchmarks/evidence/output_schema.json")
+
+          report = json.loads(report_path.read_text(encoding="utf-8"))
+          phase_c = json.loads(phase_c_path.read_text(encoding="utf-8"))
+          schema = json.loads(schema_path.read_text(encoding="utf-8"))
+
+          validate(instance=report, schema=schema)
+
+          canonical = phase_c["canonical_measurement"]
+          expected_axes = set(canonical["axes"])
+          expected_systems = set(canonical["systems"])
+          expected_case_count = canonical["fixture_case_count"]
+
+          if len(report["cases"]) != expected_case_count:
+              raise SystemExit(
+                  f"fixture case count mismatch: {len(report['cases'])} != {expected_case_count}"
+              )
+          if set(report["aggregate"]) != expected_systems:
+              raise SystemExit("benchmark system set mismatch")
+
+          for system in expected_systems:
+              metrics = report["aggregate"][system]
+              if set(metrics) != expected_axes:
+                  raise SystemExit(f"axis set mismatch for {system}")
+              for axis in expected_axes:
+                  row = metrics[axis]
+                  if row["total"] != expected_case_count:
+                      raise SystemExit(f"case total mismatch for {system}/{axis}")
+                  if row["pass"] < 0 or row["pass"] > row["total"]:
+                      raise SystemExit(f"invalid pass count for {system}/{axis}")
+                  if row["rate"] < 0 or row["rate"] > 1:
+                      raise SystemExit(f"invalid rate for {system}/{axis}")
+
+          if canonical["synthetic_comparison"] is not True:
+              raise SystemExit("Phase C fixture must remain explicitly synthetic")
+          if canonical["external_llm_or_api_allowed"] is not False:
+              raise SystemExit("Phase C must not allow external LLM/API calls")
+          if phase_c["claim_boundary"]["independent_competitive_validation"] is not False:
+              raise SystemExit("synthetic benchmark cannot claim independent validation")
+          if phase_c["runtime_integrity"]["runtime_semantics_changed"] is not False:
+              raise SystemExit("Phase C must not change runtime semantics")
+
+          print(
+              json.dumps(
+                  {
+                      "source_commit_sha": os.environ["SOURCE_SHA"],
+                      "case_count": len(report["cases"]),
+                      "systems": sorted(report["aggregate"]),
+                      "axes": sorted(expected_axes),
+                      "validation_failures": 0,
+                  },
+                  sort_keys=True,
+              )
+          )
+          PY
+
+      - name: Package source-bound Phase C evidence
+        env:
+          SOURCE_SHA: ${{ steps.benchmark.outputs.source_sha }}
+        run: |
+          set -euxo pipefail
+          mkdir -p artifacts/benchmark-rebaseline/phase-c
+          cp /tmp/veritas-evidence-benchmark.json \
+            "artifacts/benchmark-rebaseline/phase-c/evidence-benchmark.${SOURCE_SHA}.json"
+          python - <<'PY'
+          import hashlib
+          import json
+          import os
+          import platform
+          import sys
+          from pathlib import Path
+
+          source_sha = os.environ["SOURCE_SHA"]
+          root = Path("artifacts/benchmark-rebaseline/phase-c")
+          raw_path = root / f"evidence-benchmark.{source_sha}.json"
+          phase_c = json.loads(
+              Path("docs/benchmarks/benchmark-rebaseline-phase-c-v1.json").read_text(
+                  encoding="utf-8"
+              )
+          )
+          report = json.loads(raw_path.read_text(encoding="utf-8"))
+
+          inputs = {
+              "harness": Path(phase_c["canonical_measurement"]["harness"]),
+              "metrics_definition": Path(
+                  phase_c["canonical_measurement"]["metrics_definition"]
+              ),
+              "output_schema": Path(
+                  phase_c["canonical_measurement"]["output_schema"]
+              ),
+              "fixture": Path(phase_c["canonical_measurement"]["fixture"]),
+          }
+          input_identity = {
+              key: {
+                  "path": str(path),
+                  "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+              }
+              for key, path in inputs.items()
+          }
+
+          manifest = {
+              "format_version": "benchmark-rebaseline-phase-c-run/v1",
+              "source_commit_sha": source_sha,
+              "schema_version": phase_c["artifact_policy"]["schema_version"],
+              "run_timestamp": report["meta"]["generated_at"],
+              "environment": {
+                  "implementation": platform.python_implementation().lower(),
+                  "python_version": platform.python_version(),
+                  "platform": platform.platform(),
+              },
+              "exact_command": phase_c["canonical_measurement"]["exact_command"],
+              "iterations_or_run_count": len(report["cases"]),
+              "warmup_when_relevant": None,
+              "raw_machine_readable_result": raw_path.name,
+              "summary": report["aggregate"],
+              "failure_count": 0,
+              "claim_boundary": phase_c["claim_boundary"],
+              "reproducibility_instructions": {
+                  "checkout": f"git checkout {source_sha}",
+                  "command": phase_c["canonical_measurement"]["exact_command"],
+                  "python": "CPython 3.12",
+              },
+              "input_identity": input_identity,
+              "raw_result_sha256": hashlib.sha256(raw_path.read_bytes()).hexdigest(),
+              "github": {
+                  "repository": os.environ["GITHUB_REPOSITORY"],
+                  "run_id": os.environ["GITHUB_RUN_ID"],
+                  "run_attempt": os.environ["GITHUB_RUN_ATTEMPT"],
+                  "event_name": os.environ["GITHUB_EVENT_NAME"],
+                  "workflow": os.environ["GITHUB_WORKFLOW"],
+              },
+          }
+
+          if manifest["source_commit_sha"] != source_sha:
+              raise SystemExit("Phase C source SHA mismatch")
+          if manifest["environment"]["implementation"] != "cpython":
+              raise SystemExit("Phase C canonical implementation must be CPython")
+          if not manifest["environment"]["python_version"].startswith("3.12."):
+              raise SystemExit("Phase C canonical Python minor must be 3.12")
+
+          (root / "run-manifest.json").write_text(
+              json.dumps(manifest, ensure_ascii=False, sort_keys=True, indent=2) + "\n",
+              encoding="utf-8",
+          )
+          PY
+
+      - name: Upload Phase C benchmark evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-rebaseline-phase-c-${{ steps.benchmark.outputs.source_sha }}
+          path: artifacts/benchmark-rebaseline/phase-c/
+          if-no-files-found: error
+          retention-days: 90

--- a/docs/benchmarks/benchmark-rebaseline-phase-c-v1.json
+++ b/docs/benchmarks/benchmark-rebaseline-phase-c-v1.json
@@ -1,0 +1,96 @@
+{
+  "format_version": "benchmark-rebaseline-phase-c/v1",
+  "status": "EVIDENCE_MEASUREMENT_PROTOCOL_DEFINED",
+  "task": "TASK-011",
+  "phase": "C",
+  "baseline_source_commit": "cb8bde7dc9d191e872d5bfcefe17e1597e70ddcd",
+  "phase_b_measured_main_commit": "bbf6fdd69f4c2cc5d77903f60f42163528818a03",
+  "frozen_controlled_e2e_anchor": "ada46f2fe324dd3cbcff6be59d56c4f75c4a6bdc",
+  "phase_a_contract": "docs/benchmarks/benchmark-rebaseline-contract-v1.json",
+  "phase_b_record": "docs/benchmarks/benchmark-rebaseline-phase-b-v1.json",
+  "scope": "source-SHA-bound deterministic evidence-axis scoring over repository-controlled synthetic fixtures",
+  "canonical_measurement": {
+    "harness": "veritas_os/scripts/evidence_benchmark.py",
+    "metrics_definition": "veritas_os/benchmarks/evidence/metrics_definition.yaml",
+    "output_schema": "veritas_os/benchmarks/evidence/output_schema.json",
+    "fixture": "veritas_os/benchmarks/evidence/fixtures/sample_cases.jsonl",
+    "exact_command": "python -m veritas_os.scripts.evidence_benchmark --fixtures veritas_os/benchmarks/evidence/fixtures/sample_cases.jsonl --output /tmp/veritas-evidence-benchmark.json",
+    "fixture_case_count": 2,
+    "systems": [
+      "veritas",
+      "generic"
+    ],
+    "axes": [
+      "auditability",
+      "fail_closed_safety",
+      "governance_change_control",
+      "replay_divergence_visibility",
+      "trust_log_integrity"
+    ],
+    "python_family": "CPython",
+    "canonical_python_minor": "3.12",
+    "benchmark_workload_external_network_required": false,
+    "external_llm_or_api_allowed": false,
+    "synthetic_comparison": true
+  },
+  "workflow": {
+    "path": ".github/workflows/benchmark-rebaseline-phase-c.yml",
+    "pull_request_behavior": "score the checked-out PR head, validate the frozen schema and inputs, and package source-bound evidence",
+    "main_behavior": "score the exact pushed main commit and upload the authoritative source-bound Phase C artifact",
+    "artifact_name_prefix": "benchmark-rebaseline-phase-c-",
+    "retention_days": 90
+  },
+  "artifact_policy": {
+    "authoritative_phase_c_current_head_location": "GitHub Actions artifact produced by the Phase C workflow on push to main",
+    "source_commit_must_equal_checked_out_commit": true,
+    "raw_report_must_validate_against_output_schema": true,
+    "input_sha256_required": [
+      "harness",
+      "metrics_definition",
+      "output_schema",
+      "fixture"
+    ],
+    "publication_requires_zero_execution_or_validation_failures": true,
+    "schema_version": "benchmark-rebaseline-phase-c-run/v1"
+  },
+  "claim_boundary": {
+    "comparison_classification": "REPOSITORY_CONTROLLED_SYNTHETIC_FIXTURE_SCORING",
+    "independent_competitive_validation": false,
+    "named_vendor_superiority_claim_permitted": false,
+    "production_performance_claim_permitted": false,
+    "production_readiness_claim_permitted": false,
+    "third_party_certification_claim_permitted": false,
+    "external_llm_or_api_allowed": false
+  },
+  "runtime_integrity": {
+    "runtime_semantics_changed": false,
+    "benchmark_fixture_changed_for_score": false,
+    "metric_definition_changed_for_score": false,
+    "authorization_bind_effect_reconciliation_semantics_changed": false
+  },
+  "non_claims": [
+    "production latency",
+    "production SLA",
+    "customer-environment performance",
+    "production readiness",
+    "real customer credentials or endpoints",
+    "independent infrastructure validation",
+    "third-party certification",
+    "regulatory approval",
+    "superiority over named vendors",
+    "third-party competitive validation from synthetic generic fixtures"
+  ],
+  "phase_c_exit": {
+    "completion_conditions": [
+      "the Phase C workflow is merged",
+      "a push-to-main Phase C run completes successfully",
+      "the uploaded artifact source_commit_sha equals the measured main commit",
+      "the raw report validates against the frozen output schema",
+      "the harness, metrics definition, output schema, and fixture SHA-256 identities are recorded",
+      "the exact command and runtime environment are recorded",
+      "the synthetic comparison claim boundary remains explicit",
+      "the frozen Decision-to-Effect proof and required repository CI remain green"
+    ],
+    "next_phase_after_success": "TASK_011_DONE_EXTERNAL_POC_PACKAGING"
+  }
+}

--- a/docs/benchmarks/benchmark-rebaseline-phase-c.md
+++ b/docs/benchmarks/benchmark-rebaseline-phase-c.md
@@ -1,0 +1,74 @@
+# TASK-011 Benchmark Rebaseline — Phase C
+
+## Purpose
+
+Phase C regenerates the repository's evidence-axis benchmark under the frozen
+TASK-011 contract and binds the resulting evidence package to the exact measured
+Git commit.
+
+The canonical benchmark surfaces are unchanged:
+
+- harness: `veritas_os/scripts/evidence_benchmark.py`
+- metrics: `veritas_os/benchmarks/evidence/metrics_definition.yaml`
+- schema: `veritas_os/benchmarks/evidence/output_schema.json`
+- fixture: `veritas_os/benchmarks/evidence/fixtures/sample_cases.jsonl`
+
+Canonical command:
+
+```bash
+python -m veritas_os.scripts.evidence_benchmark \
+  --fixtures veritas_os/benchmarks/evidence/fixtures/sample_cases.jsonl \
+  --output /tmp/veritas-evidence-benchmark.json
+```
+
+## What is measured
+
+The two repository-controlled fixture cases are scored on the five existing
+axes:
+
+1. auditability
+2. fail-closed safety
+3. governance change control
+4. replay/divergence visibility
+5. TrustLog integrity
+
+No external model or provider is invoked by the benchmark workload.
+
+## Source-bound evidence
+
+`.github/workflows/benchmark-rebaseline-phase-c.yml` runs on pull requests,
+pushes to `main`, and manual dispatch. It checks out the exact measured source,
+runs the canonical harness, validates the raw JSON against the frozen output
+schema, records SHA-256 identities for the harness/metrics/schema/fixture, and
+uploads both the raw report and a run manifest.
+
+For a merged Phase C baseline, the authoritative current-head evidence is the
+GitHub Actions artifact produced by the push-to-main run. A pull-request artifact
+is review evidence for the PR head, not the final merged-main baseline.
+
+## Claim boundary
+
+The `veritas` and `generic` entries in `sample_cases.jsonl` are synthetic,
+repository-controlled fixtures. The Phase C result may be described as
+**synthetic fixture scoring under fixed metric definitions**.
+
+It must not be described as:
+
+- independent competitive validation;
+- superiority over a named vendor;
+- production readiness;
+- production latency or a production SLA;
+- customer-environment performance;
+- third-party certification or regulatory approval.
+
+The benchmark does not change Authorization, Bind, External Effect,
+Reconciliation, BindReceipt, or Outcome runtime semantics.
+
+## Completion
+
+Phase C is complete only after the workflow is merged, the push-to-main run
+succeeds, the artifact is bound to that exact main SHA, full required CI remains
+green, and the frozen Decision-to-Effect proof remains passing.
+
+After that, TASK-011 can be closed and the roadmap moves to External PoC
+packaging/execution.

--- a/veritas_os/tests/test_benchmark_rebaseline_phase_c.py
+++ b/veritas_os/tests/test_benchmark_rebaseline_phase_c.py
@@ -1,0 +1,158 @@
+"""Regression guards for TASK-011 Benchmark Rebaseline Phase C."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+PHASE_C_RECORD = ROOT / "docs/benchmarks/benchmark-rebaseline-phase-c-v1.json"
+HARNESS = ROOT / "veritas_os/scripts/evidence_benchmark.py"
+METRICS = ROOT / "veritas_os/benchmarks/evidence/metrics_definition.yaml"
+SCHEMA = ROOT / "veritas_os/benchmarks/evidence/output_schema.json"
+FIXTURE = ROOT / "veritas_os/benchmarks/evidence/fixtures/sample_cases.jsonl"
+WORKFLOW = ROOT / ".github/workflows/benchmark-rebaseline-phase-c.yml"
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_phase_c_record_is_pinned_to_current_post_phase_b_main() -> None:
+    data = _load(PHASE_C_RECORD)
+
+    assert data["format_version"] == "benchmark-rebaseline-phase-c/v1"
+    assert data["status"] == "EVIDENCE_MEASUREMENT_PROTOCOL_DEFINED"
+    assert data["task"] == "TASK-011"
+    assert data["phase"] == "C"
+    assert data["baseline_source_commit"] == (
+        "cb8bde7dc9d191e872d5bfcefe17e1597e70ddcd"
+    )
+    assert data["phase_b_measured_main_commit"] == (
+        "bbf6fdd69f4c2cc5d77903f60f42163528818a03"
+    )
+    assert data["frozen_controlled_e2e_anchor"] == (
+        "ada46f2fe324dd3cbcff6be59d56c4f75c4a6bdc"
+    )
+    assert data["runtime_integrity"]["runtime_semantics_changed"] is False
+    assert data["runtime_integrity"]["benchmark_fixture_changed_for_score"] is False
+    assert data["runtime_integrity"]["metric_definition_changed_for_score"] is False
+
+
+def test_phase_c_uses_frozen_canonical_evidence_inputs() -> None:
+    data = _load(PHASE_C_RECORD)
+    canonical = data["canonical_measurement"]
+
+    assert canonical["harness"] == "veritas_os/scripts/evidence_benchmark.py"
+    assert canonical["metrics_definition"] == (
+        "veritas_os/benchmarks/evidence/metrics_definition.yaml"
+    )
+    assert canonical["output_schema"] == (
+        "veritas_os/benchmarks/evidence/output_schema.json"
+    )
+    assert canonical["fixture"] == (
+        "veritas_os/benchmarks/evidence/fixtures/sample_cases.jsonl"
+    )
+    assert canonical["fixture_case_count"] == 2
+    assert set(canonical["systems"]) == {"veritas", "generic"}
+    assert set(canonical["axes"]) == {
+        "auditability",
+        "fail_closed_safety",
+        "governance_change_control",
+        "replay_divergence_visibility",
+        "trust_log_integrity",
+    }
+    assert canonical["synthetic_comparison"] is True
+    assert canonical["external_llm_or_api_allowed"] is False
+    assert canonical["benchmark_workload_external_network_required"] is False
+
+    for path in (HARNESS, METRICS, SCHEMA, FIXTURE):
+        assert path.is_file()
+        assert len(hashlib.sha256(path.read_bytes()).hexdigest()) == 64
+
+
+def test_phase_c_harness_scores_the_frozen_fixture_deterministically(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "evidence.json"
+
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "veritas_os.scripts.evidence_benchmark",
+            "--fixtures",
+            str(FIXTURE.relative_to(ROOT)),
+            "--output",
+            str(output),
+        ],
+        cwd=ROOT,
+        check=True,
+    )
+
+    report = _load(output)
+    record = _load(PHASE_C_RECORD)
+    canonical = record["canonical_measurement"]
+
+    assert report["meta"]["harness_version"] == "0.1.0"
+    assert len(report["cases"]) == canonical["fixture_case_count"]
+    assert set(report["aggregate"]) == set(canonical["systems"])
+
+    for system in canonical["systems"]:
+        assert set(report["aggregate"][system]) == set(canonical["axes"])
+        for axis in canonical["axes"]:
+            row = report["aggregate"][system][axis]
+            assert row["total"] == canonical["fixture_case_count"]
+            assert 0 <= row["pass"] <= row["total"]
+            assert 0.0 <= row["rate"] <= 1.0
+
+
+def test_phase_c_claim_boundary_forbids_competitive_overstatement() -> None:
+    data = _load(PHASE_C_RECORD)
+    boundary = data["claim_boundary"]
+    non_claims = set(data["non_claims"])
+
+    assert boundary["comparison_classification"] == (
+        "REPOSITORY_CONTROLLED_SYNTHETIC_FIXTURE_SCORING"
+    )
+    assert boundary["independent_competitive_validation"] is False
+    assert boundary["named_vendor_superiority_claim_permitted"] is False
+    assert boundary["production_performance_claim_permitted"] is False
+    assert boundary["production_readiness_claim_permitted"] is False
+    assert boundary["third_party_certification_claim_permitted"] is False
+    assert boundary["external_llm_or_api_allowed"] is False
+
+    assert {
+        "production latency",
+        "production SLA",
+        "customer-environment performance",
+        "production readiness",
+        "third-party certification",
+        "superiority over named vendors",
+        "third-party competitive validation from synthetic generic fixtures",
+    }.issubset(non_claims)
+
+
+def test_phase_c_workflow_binds_raw_report_and_inputs_to_source_sha() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    record = _load(PHASE_C_RECORD)
+    exact_command = record["canonical_measurement"]["exact_command"]
+
+    assert "pull_request:" in text
+    assert "push:" in text
+    assert "branches: [main]" in text
+    assert "ref: ${{ github.event.pull_request.head.sha || github.sha }}" in text
+    assert 'SOURCE_SHA="$(git rev-parse HEAD)"' in text
+    assert exact_command in text
+    assert "validate(instance=report, schema=schema)" in text
+    assert "hashlib.sha256(path.read_bytes()).hexdigest()" in text
+    assert '"source_commit_sha": source_sha' in text
+    assert '"failure_count": 0' in text
+    assert "actions/upload-artifact@v4" in text
+    assert "retention-days: 90" in text
+    assert "OPENAI_API_KEY" not in text
+    assert "ANTHROPIC_API_KEY" not in text
+    assert "VERITAS_API_KEY" not in text


### PR DESCRIPTION
## Summary

Implements TASK-011 Benchmark Rebaseline Phase C under the Human CEO-approved scope.

### Adds
- `docs/benchmarks/benchmark-rebaseline-phase-c-v1.json`
- `docs/benchmarks/benchmark-rebaseline-phase-c.md`
- `.github/workflows/benchmark-rebaseline-phase-c.yml`
- `veritas_os/tests/test_benchmark_rebaseline_phase_c.py`

### Phase C behavior
- uses the frozen canonical evidence harness: `veritas_os/scripts/evidence_benchmark.py`
- uses the existing metrics definition, output schema, and `sample_cases.jsonl` fixture unchanged
- runs against the exact checked-out PR/main source SHA
- validates raw evidence output against the frozen JSON schema
- records SHA-256 identities for harness, metrics definition, schema, and fixture
- packages the raw report plus a source-bound run manifest
- uploads a 90-day GitHub Actions artifact
- records exact command, CPython/runtime identity, case count, result summary, failure count, claim boundary, and reproduction instructions

### Claim boundary
The `veritas` / `generic` comparison remains **repository-controlled synthetic fixture scoring**. It is not independent competitive validation, named-vendor superiority evidence, production readiness, production latency/SLA evidence, customer-environment performance, certification, or regulatory approval.

### Runtime impact
None. No Authorization / Bind / External Effect / Reconciliation / BindReceipt / Outcome semantics are changed. No external LLM/API provider is enabled by the benchmark workload.

### Exit gate
Do not mark TASK-011 complete from the PR run alone. Phase C completes only after merge, a successful push-to-main source-bound Phase C artifact, full required CI green, and the frozen Decision-to-Effect proof remaining green.

Protected-main merge remains a separate Human CEO decision.