### PR TITLE
feat: add provider-neutral external measurement evidence boundary

### DIFF
--- a/docs/en/architecture/external-measurement-evidence-boundary-v1.md
+++ b/docs/en/architecture/external-measurement-evidence-boundary-v1.md
@@ -1,0 +1,174 @@
+# External Measurement Evidence Boundary v1
+
+## Status
+
+Provider-neutral interoperability boundary for externally produced measurement evidence.
+
+This boundary is intentionally independent of any one measurement provider or artifact format. Provider-specific adapters are layered on top of this contract in separate changes.
+
+## Purpose
+
+VERITAS needs to consume measurements produced outside its own trust domain without allowing a signed external artifact to become execution authority.
+
+The boundary is:
+
+```text
+Untrusted external artifact
+        ↓
+VERITAS-controlled provider-specific verifier
+        ↓
+provider / verifier trust-policy binding
+        ↓
+normalized ExternalMeasurementEvidence
+        ↓
+freshness + expiry + semantic consistency + replay checks
+        ↓
+VerifiedExternalMeasurementEvidence
+        ↓
+separate VERITAS policy / authority / approval / execution evaluation
+```
+
+The core invariant is:
+
+```text
+ExternalMeasurementEvidence
+!= AuthorityEvidence
+!= HumanApproval
+!= BindAuthorization
+!= GovernanceDecision
+```
+
+A valid signature proves only what the approved provider-specific verifier and the independently configured VERITAS trust policy establish. It does not grant permission to act.
+
+## Runtime types
+
+`veritas_os.governance.external_measurement_evidence` defines:
+
+- `ExternalMeasurementEvidence`
+- `ExternalMeasurementProviderVerificationResult`
+- `ExternalMeasurementProviderVerifier`
+- `ApprovedExternalMeasurementProvider`
+- `ExternalMeasurementTrustPolicy`
+- `ExternalMeasurementReplayGuard`
+- `VerifiedExternalMeasurementEvidence`
+- `verify_external_measurement_artifact_to_evidence(...)`
+- `validate_verified_external_measurement_evidence(...)`
+
+## Provider-neutral normalized evidence
+
+The normalized evidence records only measurement-domain facts and provenance:
+
+- VERITAS evidence id
+- provider id
+- provider artifact id/type/version
+- verified payload hash
+- observation / issuance / expiry timestamps
+- replay token
+- measured scope
+- optional measurement coverage
+- provider-specific semantic facts represented as data
+- provenance
+- non-authoritative metadata
+
+No field in this object grants authority, satisfies human approval, creates a Bind authorization, or makes an ALLOW/DENY governance decision.
+
+## Provider-specific verifier seam
+
+A provider adapter implements `ExternalMeasurementProviderVerifier`.
+
+The verifier is responsible for native-format concerns such as:
+
+- provider schema/version validation
+- canonicalization rules
+- payload reconstruction
+- payload/hash verification
+- provider signature verification
+- provider key selection
+- provider-specific semantic consistency
+
+Those concerns do not belong in the provider-neutral boundary.
+
+The generic boundary does not trust an artifact-supplied public key or trust declaration. The verifier result must match an independently configured `ExternalMeasurementTrustPolicy` entry for the provider/verifier pair.
+
+## VERITAS-controlled checks
+
+After provider-specific verification succeeds, the generic boundary independently requires:
+
+1. approved provider/verifier binding;
+2. exact verifier trust-level / policy identity match;
+3. non-empty evidence, provider, artifact, version, and replay identities;
+4. SHA-256-shaped payload identity;
+5. non-empty measured scope;
+6. measurement coverage in `[0.0, 1.0]` when coverage is supplied;
+7. timezone-aware observation / issuance / expiry timestamps;
+8. observation and issuance not beyond configured future skew;
+9. issuance not before observation;
+10. observation not older than the configured maximum age;
+11. expiry present when policy requires it and not expired;
+12. provider-specific semantic consistency explicitly verified;
+13. atomic replay consumption through `ExternalMeasurementReplayGuard`.
+
+Any failure is fail-closed and no verified evidence object is emitted.
+
+## Replay semantics
+
+Replay protection uses an atomic `consume_once(...)` seam. The replay key binds:
+
+- provider id
+- artifact id
+- payload hash
+- provider replay token
+
+The production replay implementation is intentionally outside this first provider-neutral slice. A provider adapter or deployment composition must supply a durable implementation appropriate to its execution environment.
+
+## Verified proof semantics
+
+`VerifiedExternalMeasurementEvidence` binds the normalized evidence to:
+
+- evidence content hash
+- signature key / algorithm identity reported by the approved verifier
+- verifier id / trust level / policy identity
+- VERITAS trust-policy identity and hash
+- verification timestamp and reason
+- replay key
+- deterministic verification proof hash
+
+A serialized or caller-constructed verified object is not portable trust. Runtime revalidation checks both the proof hash and the process-local sealed-proof registry, following the same defensive pattern used by other strict VERITAS proof boundaries.
+
+## Explicit non-goals for PR1
+
+This first slice does **not** implement:
+
+- a NeoMundi-specific adapter
+- RGC schema fields or status mapping
+- JWKS lookup
+- any provider-specific signature backend
+- external network calls
+- AuthorityEvidence conversion
+- HumanApproval satisfaction
+- Bind authorization issuance
+- direct ALLOW/DENY mapping
+- changes to the frozen Decision-to-Effect execution semantics
+
+Provider-specific integration belongs in a separate PR.
+
+## Frozen execution boundary
+
+This module is an evidence-ingress boundary only. It does not modify:
+
+- native v2 authorization
+- single-use authorization consumption
+- current governance rechecks
+- credential resolution
+- durable dispatch intent
+- external-effect retry semantics
+- `EFFECT_UNKNOWN`
+- read-only reconciliation
+- BindReceipt / Outcome publication
+- crash recovery
+
+The controlled Decision-to-Effect Architecture Freeze remains intact.
+
+## Next step
+
+After this provider-neutral boundary is reviewed and merged, the next isolated change is a concrete provider adapter that converts one provider's independently verified native measurement artifact into `ExternalMeasurementEvidence` without expanding execution authority.

--- a/veritas_os/governance/__init__.py
+++ b/veritas_os/governance/__init__.py
@@ -27,6 +27,17 @@ from veritas_os.governance.authority_evidence import (
     verify_authority_evidence_artifact_to_proof,
     authority_signature_payload,
 )
+from veritas_os.governance.external_measurement_evidence import (
+    ApprovedExternalMeasurementProvider,
+    ExternalMeasurementEvidence,
+    ExternalMeasurementProviderVerificationResult,
+    ExternalMeasurementProviderVerifier,
+    ExternalMeasurementReplayGuard,
+    ExternalMeasurementTrustPolicy,
+    VerifiedExternalMeasurementEvidence,
+    validate_verified_external_measurement_evidence,
+    verify_external_measurement_artifact_to_evidence,
+)
 from veritas_os.governance.action_contracts import (
     ActionClassContract,
     ActionClassContractValidationError,
@@ -107,6 +118,15 @@ __all__ = [
     "AuthorityRevocationVerificationResult",
     "VerifiedAuthorityEvidence",
     "VerificationResult",
+    "ApprovedExternalMeasurementProvider",
+    "ExternalMeasurementEvidence",
+    "ExternalMeasurementProviderVerificationResult",
+    "ExternalMeasurementProviderVerifier",
+    "ExternalMeasurementReplayGuard",
+    "ExternalMeasurementTrustPolicy",
+    "VerifiedExternalMeasurementEvidence",
+    "validate_verified_external_measurement_evidence",
+    "verify_external_measurement_artifact_to_evidence",
     "ActionClassContract",
     "ActionClassContractValidationError",
     "validate_human_approval_context_binding",

--- a/veritas_os/governance/external_measurement_evidence.py
+++ b/veritas_os/governance/external_measurement_evidence.py
@@ -1,0 +1,420 @@
+"""Provider-neutral external measurement evidence trust boundary.
+
+External measurement artifacts are evidence inputs only.  They do not become
+AuthorityEvidence, HumanApproval, BindAuthorization, or a GovernanceDecision by
+being signed or verified.
+
+Provider-specific adapters are responsible for parsing and cryptographically
+verifying their native artifact formats.  This module then applies
+VERITAS-controlled trust, temporal, semantic, and replay checks before sealing a
+``VerifiedExternalMeasurementEvidence`` object.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import Any, Protocol
+
+from veritas_os.security.hash import sha256_of_canonical_json
+
+EXTERNAL_MEASUREMENT_VERIFICATION_SOURCE = "external_measurement_provider_verifier"
+_VERIFIED_EXTERNAL_MEASUREMENT_REGISTRY: dict[int, str] = {}
+
+
+@dataclass(frozen=True)
+class ExternalMeasurementEvidence:
+    """Provider-neutral normalized measurement facts; not execution authority."""
+
+    evidence_id: str
+    provider_id: str
+    artifact_id: str
+    artifact_type: str
+    artifact_version: str
+    payload_hash: str
+    observed_at: str
+    issued_at: str
+    expires_at: str | None
+    replay_token: str
+    measured_scope: dict[str, Any]
+    measurement_coverage: float | None = None
+    semantic_facts: dict[str, Any] = field(default_factory=dict)
+    provenance: dict[str, Any] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return JSON-compatible normalized evidence fields."""
+        return {
+            "evidence_id": self.evidence_id,
+            "provider_id": self.provider_id,
+            "artifact_id": self.artifact_id,
+            "artifact_type": self.artifact_type,
+            "artifact_version": self.artifact_version,
+            "payload_hash": self.payload_hash,
+            "observed_at": self.observed_at,
+            "issued_at": self.issued_at,
+            "expires_at": self.expires_at,
+            "replay_token": self.replay_token,
+            "measured_scope": dict(self.measured_scope),
+            "measurement_coverage": self.measurement_coverage,
+            "semantic_facts": dict(self.semantic_facts),
+            "provenance": dict(self.provenance),
+            "metadata": dict(self.metadata),
+        }
+
+    def deterministic_digest(self) -> str:
+        """Return content identity for the normalized measurement evidence."""
+        return sha256_of_canonical_json(self.to_dict())
+
+
+@dataclass(frozen=True)
+class ExternalMeasurementProviderVerificationResult:
+    """Result emitted by a VERITAS-controlled provider-specific verifier."""
+
+    verified: bool
+    evidence: ExternalMeasurementEvidence | None = None
+    verifier_id: str | None = None
+    verifier_trust_level: str | None = None
+    verifier_policy_id: str | None = None
+    verifier_policy_hash: str | None = None
+    key_id: str | None = None
+    algorithm: str | None = None
+    semantic_consistent: bool = False
+    reason: str | None = None
+
+
+class ExternalMeasurementProviderVerifier(Protocol):
+    """Provider-specific verification seam owned by VERITAS deployment policy."""
+
+    def verify(
+        self, artifact: dict[str, Any]
+    ) -> ExternalMeasurementProviderVerificationResult:
+        """Verify a native provider artifact and return normalized evidence."""
+        ...
+
+
+@dataclass(frozen=True)
+class ApprovedExternalMeasurementProvider:
+    """Deployment-owned allowlist entry for one measurement provider verifier."""
+
+    provider_id: str
+    verifier_id: str
+    verifier_trust_level: str
+    verifier_policy_id: str
+    verifier_policy_hash: str
+
+
+@dataclass(frozen=True)
+class ExternalMeasurementTrustPolicy:
+    """VERITAS-controlled trust, freshness, and verifier policy."""
+
+    policy_id: str
+    approved_providers: list[ApprovedExternalMeasurementProvider]
+    max_age_seconds: int
+    max_future_skew_seconds: int = 0
+    require_expiry: bool = True
+
+    def approved(
+        self, provider_id: str, verifier_id: str
+    ) -> ApprovedExternalMeasurementProvider | None:
+        """Return the exact independently configured provider/verifier binding."""
+        return next(
+            (
+                item
+                for item in self.approved_providers
+                if item.provider_id == provider_id and item.verifier_id == verifier_id
+            ),
+            None,
+        )
+
+    def deterministic_hash(self) -> str:
+        """Return stable identity for the effective external-measurement policy."""
+        return sha256_of_canonical_json(
+            {
+                "policy_id": self.policy_id,
+                "approved_providers": sorted(
+                    (
+                        {
+                            "provider_id": item.provider_id,
+                            "verifier_id": item.verifier_id,
+                            "verifier_trust_level": item.verifier_trust_level,
+                            "verifier_policy_id": item.verifier_policy_id,
+                            "verifier_policy_hash": item.verifier_policy_hash,
+                        }
+                        for item in self.approved_providers
+                    ),
+                    key=lambda item: (item["provider_id"], item["verifier_id"]),
+                ),
+                "max_age_seconds": self.max_age_seconds,
+                "max_future_skew_seconds": self.max_future_skew_seconds,
+                "require_expiry": self.require_expiry,
+            }
+        )
+
+
+class ExternalMeasurementReplayGuard(Protocol):
+    """Atomic single-use guard for accepted external measurement artifacts."""
+
+    def consume_once(self, replay_key: str, *, observed_at: datetime) -> bool:
+        """Return true only for the first accepted use of ``replay_key``."""
+        ...
+
+
+@dataclass(frozen=True)
+class VerifiedExternalMeasurementEvidence:
+    """Runtime-sealed external measurement proof; never execution authority."""
+
+    evidence: ExternalMeasurementEvidence
+    evidence_hash: str
+    key_id: str
+    algorithm: str
+    verifier_id: str
+    verifier_trust_level: str
+    verifier_policy_id: str
+    verifier_policy_hash: str
+    trust_policy_id: str
+    trust_policy_hash: str
+    verified_at: str
+    verification_reason: str
+    verification_source: str
+    replay_key: str
+    verification_proof_hash: str
+
+    def proof_hash_payload(self) -> dict[str, Any]:
+        """Return the exact data bound into the sealed verification proof."""
+        return {
+            "evidence": self.evidence.to_dict(),
+            "evidence_hash": self.evidence_hash,
+            "key_id": self.key_id,
+            "algorithm": self.algorithm,
+            "verifier_id": self.verifier_id,
+            "verifier_trust_level": self.verifier_trust_level,
+            "verifier_policy_id": self.verifier_policy_id,
+            "verifier_policy_hash": self.verifier_policy_hash,
+            "trust_policy_id": self.trust_policy_id,
+            "trust_policy_hash": self.trust_policy_hash,
+            "verified_at": self.verified_at,
+            "verification_reason": self.verification_reason,
+            "verification_source": self.verification_source,
+            "replay_key": self.replay_key,
+        }
+
+
+def _aware_datetime(value: str, reason: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (AttributeError, TypeError, ValueError) as exc:
+        raise ValueError(reason) from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError(reason + "_timezone_required")
+    return parsed
+
+
+def _validate_payload_hash(value: str) -> None:
+    if len(value) != 64:
+        raise ValueError("external_measurement_payload_hash_invalid")
+    try:
+        int(value, 16)
+    except ValueError as exc:
+        raise ValueError("external_measurement_payload_hash_invalid") from exc
+
+
+def _validate_normalized_evidence(
+    evidence: ExternalMeasurementEvidence,
+    *,
+    policy: ExternalMeasurementTrustPolicy,
+    now: datetime,
+) -> datetime:
+    for value, reason in (
+        (evidence.evidence_id, "external_measurement_evidence_id_missing"),
+        (evidence.provider_id, "external_measurement_provider_id_missing"),
+        (evidence.artifact_id, "external_measurement_artifact_id_missing"),
+        (evidence.artifact_type, "external_measurement_artifact_type_missing"),
+        (evidence.artifact_version, "external_measurement_artifact_version_missing"),
+        (evidence.replay_token, "external_measurement_replay_token_missing"),
+    ):
+        if not value.strip():
+            raise ValueError(reason)
+    _validate_payload_hash(evidence.payload_hash)
+    if not evidence.measured_scope:
+        raise ValueError("external_measurement_scope_missing")
+    if evidence.measurement_coverage is not None and not (
+        0.0 <= evidence.measurement_coverage <= 1.0
+    ):
+        raise ValueError("external_measurement_coverage_invalid")
+
+    observed_at = _aware_datetime(
+        evidence.observed_at, "external_measurement_observed_at_invalid"
+    )
+    issued_at = _aware_datetime(
+        evidence.issued_at, "external_measurement_issued_at_invalid"
+    )
+    future_limit = now + timedelta(seconds=policy.max_future_skew_seconds)
+    if observed_at > future_limit or issued_at > future_limit:
+        raise ValueError("external_measurement_timestamp_future")
+    if issued_at < observed_at:
+        raise ValueError("external_measurement_timestamp_order_invalid")
+    if now - observed_at > timedelta(seconds=policy.max_age_seconds):
+        raise ValueError("external_measurement_stale")
+
+    if evidence.expires_at is None:
+        if policy.require_expiry:
+            raise ValueError("external_measurement_expiry_missing")
+    else:
+        expires_at = _aware_datetime(
+            evidence.expires_at, "external_measurement_expires_at_invalid"
+        )
+        if expires_at < issued_at:
+            raise ValueError("external_measurement_expiry_order_invalid")
+        if now >= expires_at:
+            raise ValueError("external_measurement_expired")
+    return observed_at
+
+
+def _validate_verifier_binding(
+    result: ExternalMeasurementProviderVerificationResult,
+    approved: ApprovedExternalMeasurementProvider,
+) -> None:
+    expected = (
+        approved.verifier_trust_level,
+        approved.verifier_policy_id,
+        approved.verifier_policy_hash,
+    )
+    actual = (
+        result.verifier_trust_level,
+        result.verifier_policy_id,
+        result.verifier_policy_hash,
+    )
+    if actual != expected:
+        raise ValueError("external_measurement_verifier_binding_mismatch")
+    if not result.key_id or not result.algorithm:
+        raise ValueError("external_measurement_signature_identity_missing")
+
+
+def verify_external_measurement_artifact_to_evidence(
+    artifact: dict[str, Any],
+    *,
+    provider_verifier: ExternalMeasurementProviderVerifier,
+    trust_policy: ExternalMeasurementTrustPolicy,
+    replay_guard: ExternalMeasurementReplayGuard,
+    now: datetime | None = None,
+) -> VerifiedExternalMeasurementEvidence:
+    """Verify and seal one provider artifact as non-authoritative evidence.
+
+    The provider artifact itself is never accepted as a trust anchor.  A
+    VERITAS-controlled provider verifier must first authenticate and normalize
+    it, after which this boundary applies independently configured trust,
+    freshness, semantic-consistency, and replay requirements.
+    """
+    current = now or datetime.now(UTC)
+    if current.tzinfo is None or current.utcoffset() is None:
+        raise ValueError("external_measurement_validation_now_timezone_required")
+    if trust_policy.max_age_seconds < 0 or trust_policy.max_future_skew_seconds < 0:
+        raise ValueError("external_measurement_trust_policy_invalid")
+
+    result = provider_verifier.verify(artifact)
+    if not result.verified:
+        raise ValueError("external_measurement_provider_verification_failed")
+    if result.evidence is None:
+        raise ValueError("external_measurement_normalized_evidence_missing")
+    if not result.semantic_consistent:
+        raise ValueError("external_measurement_semantic_inconsistent")
+    if not result.verifier_id:
+        raise ValueError("external_measurement_verifier_id_missing")
+
+    evidence = result.evidence
+    approved = trust_policy.approved(evidence.provider_id, result.verifier_id)
+    if approved is None:
+        raise ValueError("external_measurement_provider_verifier_unapproved")
+    _validate_verifier_binding(result, approved)
+    observed_at = _validate_normalized_evidence(
+        evidence, policy=trust_policy, now=current
+    )
+
+    replay_key = sha256_of_canonical_json(
+        {
+            "provider_id": evidence.provider_id,
+            "artifact_id": evidence.artifact_id,
+            "payload_hash": evidence.payload_hash,
+            "replay_token": evidence.replay_token,
+        }
+    )
+    if not replay_guard.consume_once(replay_key, observed_at=observed_at):
+        raise ValueError("external_measurement_replay_detected")
+
+    evidence_hash = evidence.deterministic_digest()
+    proof_data = {
+        "evidence": evidence,
+        "evidence_hash": evidence_hash,
+        "key_id": str(result.key_id),
+        "algorithm": str(result.algorithm),
+        "verifier_id": result.verifier_id,
+        "verifier_trust_level": str(result.verifier_trust_level),
+        "verifier_policy_id": str(result.verifier_policy_id),
+        "verifier_policy_hash": str(result.verifier_policy_hash),
+        "trust_policy_id": trust_policy.policy_id,
+        "trust_policy_hash": trust_policy.deterministic_hash(),
+        "verified_at": current.isoformat(),
+        "verification_reason": str(result.reason or "verified"),
+        "verification_source": EXTERNAL_MEASUREMENT_VERIFICATION_SOURCE,
+        "replay_key": replay_key,
+    }
+    temporary = VerifiedExternalMeasurementEvidence(
+        **proof_data, verification_proof_hash=""
+    )
+    proof_hash = sha256_of_canonical_json(temporary.proof_hash_payload())
+    proof = VerifiedExternalMeasurementEvidence(
+        **proof_data, verification_proof_hash=proof_hash
+    )
+    _VERIFIED_EXTERNAL_MEASUREMENT_REGISTRY[id(proof)] = proof_hash
+    return proof
+
+
+def validate_verified_external_measurement_evidence(
+    proof: VerifiedExternalMeasurementEvidence,
+    *,
+    trust_policy: ExternalMeasurementTrustPolicy,
+    now: datetime | None = None,
+) -> list[str]:
+    """Revalidate sealed proof integrity, trust binding, and current freshness."""
+    failures: list[str] = []
+    current = now or datetime.now(UTC)
+    if current.tzinfo is None or current.utcoffset() is None:
+        return ["external_measurement_validation_now_timezone_required"]
+
+    expected_hash = sha256_of_canonical_json(proof.proof_hash_payload())
+    if (
+        proof.verification_proof_hash != expected_hash
+        or _VERIFIED_EXTERNAL_MEASUREMENT_REGISTRY.get(id(proof)) != expected_hash
+    ):
+        failures.append("external_measurement_verification_proof_invalid")
+    if proof.evidence_hash != proof.evidence.deterministic_digest():
+        failures.append("external_measurement_evidence_hash_mismatch")
+    if proof.trust_policy_id != trust_policy.policy_id:
+        failures.append("external_measurement_trust_policy_id_mismatch")
+    if proof.trust_policy_hash != trust_policy.deterministic_hash():
+        failures.append("external_measurement_trust_policy_hash_mismatch")
+
+    approved = trust_policy.approved(proof.evidence.provider_id, proof.verifier_id)
+    if approved is None:
+        failures.append("external_measurement_provider_verifier_unapproved")
+    else:
+        expected_binding = (
+            approved.verifier_trust_level,
+            approved.verifier_policy_id,
+            approved.verifier_policy_hash,
+        )
+        actual_binding = (
+            proof.verifier_trust_level,
+            proof.verifier_policy_id,
+            proof.verifier_policy_hash,
+        )
+        if actual_binding != expected_binding:
+            failures.append("external_measurement_verifier_binding_mismatch")
+
+    try:
+        _validate_normalized_evidence(proof.evidence, policy=trust_policy, now=current)
+        _aware_datetime(proof.verified_at, "external_measurement_verified_at_invalid")
+    except ValueError as exc:
+        failures.append(str(exc))
+    return failures

--- a/veritas_os/tests/test_external_measurement_evidence.py
+++ b/veritas_os/tests/test_external_measurement_evidence.py
@@ -1,0 +1,278 @@
+"""Tests for the provider-neutral external measurement evidence boundary."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from veritas_os.governance.external_measurement_evidence import (
+    ApprovedExternalMeasurementProvider,
+    ExternalMeasurementEvidence,
+    ExternalMeasurementProviderVerificationResult,
+    ExternalMeasurementTrustPolicy,
+    validate_verified_external_measurement_evidence,
+    verify_external_measurement_artifact_to_evidence,
+)
+
+NOW = datetime(2026, 9, 11, 0, 0, tzinfo=UTC)
+
+
+class _Verifier:
+    def __init__(self, result: ExternalMeasurementProviderVerificationResult) -> None:
+        self.result = result
+        self.calls = 0
+
+    def verify(
+        self, artifact: dict[str, Any]
+    ) -> ExternalMeasurementProviderVerificationResult:
+        self.calls += 1
+        assert artifact == {"native": "provider-artifact"}
+        return self.result
+
+
+class _ReplayGuard:
+    def __init__(self) -> None:
+        self.seen: set[str] = set()
+        self.calls = 0
+
+    def consume_once(self, replay_key: str, *, observed_at: datetime) -> bool:
+        self.calls += 1
+        assert observed_at.tzinfo is not None
+        if replay_key in self.seen:
+            return False
+        self.seen.add(replay_key)
+        return True
+
+
+def _evidence(**changes: Any) -> ExternalMeasurementEvidence:
+    base = ExternalMeasurementEvidence(
+        evidence_id="eme-001",
+        provider_id="provider.example",
+        artifact_id="artifact-001",
+        artifact_type="measurement_observation",
+        artifact_version="v1",
+        payload_hash="a" * 64,
+        observed_at=(NOW - timedelta(seconds=20)).isoformat(),
+        issued_at=(NOW - timedelta(seconds=10)).isoformat(),
+        expires_at=(NOW + timedelta(minutes=5)).isoformat(),
+        replay_token="nonce-001",
+        measured_scope={"request_id": "request-001", "domain": "runtime"},
+        measurement_coverage=0.75,
+        semantic_facts={"status": "observed"},
+        provenance={"source": "signed-provider-artifact"},
+        metadata={"purpose": "interop-test"},
+    )
+    return replace(base, **changes)
+
+
+def _result(**changes: Any) -> ExternalMeasurementProviderVerificationResult:
+    base = ExternalMeasurementProviderVerificationResult(
+        verified=True,
+        evidence=_evidence(),
+        verifier_id="provider-verifier-v1",
+        verifier_trust_level="production",
+        verifier_policy_id="provider-policy-v1",
+        verifier_policy_hash="b" * 64,
+        key_id="key-001",
+        algorithm="Ed25519",
+        semantic_consistent=True,
+        reason="signature_and_semantics_verified",
+    )
+    return replace(base, **changes)
+
+
+def _policy(**changes: Any) -> ExternalMeasurementTrustPolicy:
+    base = ExternalMeasurementTrustPolicy(
+        policy_id="external-measurement-trust-v1",
+        approved_providers=[
+            ApprovedExternalMeasurementProvider(
+                provider_id="provider.example",
+                verifier_id="provider-verifier-v1",
+                verifier_trust_level="production",
+                verifier_policy_id="provider-policy-v1",
+                verifier_policy_hash="b" * 64,
+            )
+        ],
+        max_age_seconds=300,
+        max_future_skew_seconds=5,
+        require_expiry=True,
+    )
+    return replace(base, **changes)
+
+
+def _verify(
+    result: ExternalMeasurementProviderVerificationResult | None = None,
+    *,
+    policy: ExternalMeasurementTrustPolicy | None = None,
+    replay: _ReplayGuard | None = None,
+):
+    verifier = _Verifier(result or _result())
+    replay_guard = replay or _ReplayGuard()
+    proof = verify_external_measurement_artifact_to_evidence(
+        {"native": "provider-artifact"},
+        provider_verifier=verifier,
+        trust_policy=policy or _policy(),
+        replay_guard=replay_guard,
+        now=NOW,
+    )
+    return proof, verifier, replay_guard
+
+
+def test_success_seals_provider_neutral_non_authoritative_evidence() -> None:
+    proof, verifier, replay = _verify()
+
+    assert verifier.calls == 1
+    assert replay.calls == 1
+    assert proof.evidence.provider_id == "provider.example"
+    assert proof.evidence.measurement_coverage == 0.75
+    assert proof.verifier_id == "provider-verifier-v1"
+    assert proof.verification_source == "external_measurement_provider_verifier"
+    assert len(proof.evidence_hash) == 64
+    assert len(proof.verification_proof_hash) == 64
+    assert len(proof.replay_key) == 64
+    assert validate_verified_external_measurement_evidence(
+        proof, trust_policy=_policy(), now=NOW
+    ) == []
+
+    # Measurement evidence is structurally separate from authority/approval/bind state.
+    assert not hasattr(proof, "authority_evidence")
+    assert not hasattr(proof, "human_approval")
+    assert not hasattr(proof, "bind_authorization")
+    assert not hasattr(proof, "governance_decision")
+
+
+def test_unapproved_provider_or_verifier_fails_closed_before_replay_consumption() -> None:
+    replay = _ReplayGuard()
+    verifier = _Verifier(_result())
+    policy = _policy(approved_providers=[])
+
+    with pytest.raises(
+        ValueError, match="external_measurement_provider_verifier_unapproved"
+    ):
+        verify_external_measurement_artifact_to_evidence(
+            {"native": "provider-artifact"},
+            provider_verifier=verifier,
+            trust_policy=policy,
+            replay_guard=replay,
+            now=NOW,
+        )
+
+    assert verifier.calls == 1
+    assert replay.calls == 0
+
+
+def test_verifier_binding_must_match_independent_trust_policy() -> None:
+    bad = _result(verifier_policy_hash="c" * 64)
+
+    with pytest.raises(
+        ValueError, match="external_measurement_verifier_binding_mismatch"
+    ):
+        _verify(bad)
+
+
+def test_provider_verification_and_semantic_consistency_are_both_required() -> None:
+    with pytest.raises(
+        ValueError, match="external_measurement_provider_verification_failed"
+    ):
+        _verify(_result(verified=False))
+
+    with pytest.raises(ValueError, match="external_measurement_semantic_inconsistent"):
+        _verify(_result(semantic_consistent=False))
+
+
+def test_stale_future_and_expired_measurements_fail_closed() -> None:
+    stale = _result(
+        evidence=_evidence(observed_at=(NOW - timedelta(minutes=6)).isoformat())
+    )
+    with pytest.raises(ValueError, match="external_measurement_stale"):
+        _verify(stale)
+
+    future = _result(
+        evidence=_evidence(observed_at=(NOW + timedelta(seconds=6)).isoformat())
+    )
+    with pytest.raises(ValueError, match="external_measurement_timestamp_future"):
+        _verify(future)
+
+    expired = _result(
+        evidence=_evidence(expires_at=(NOW - timedelta(seconds=1)).isoformat())
+    )
+    with pytest.raises(ValueError, match="external_measurement_expired"):
+        _verify(expired)
+
+
+def test_scope_payload_hash_and_coverage_are_validated() -> None:
+    with pytest.raises(ValueError, match="external_measurement_scope_missing"):
+        _verify(_result(evidence=_evidence(measured_scope={})))
+
+    with pytest.raises(ValueError, match="external_measurement_payload_hash_invalid"):
+        _verify(_result(evidence=_evidence(payload_hash="not-a-sha256")))
+
+    with pytest.raises(ValueError, match="external_measurement_coverage_invalid"):
+        _verify(_result(evidence=_evidence(measurement_coverage=1.01)))
+
+
+def test_replay_guard_is_atomic_boundary_and_second_use_is_rejected() -> None:
+    replay = _ReplayGuard()
+    first, _, _ = _verify(replay=replay)
+    assert first.evidence.artifact_id == "artifact-001"
+
+    with pytest.raises(ValueError, match="external_measurement_replay_detected"):
+        _verify(replay=replay)
+
+    assert replay.calls == 2
+
+
+def test_forged_or_mutated_verified_object_is_not_portable_trust() -> None:
+    proof, _, _ = _verify()
+    forged = replace(proof, verification_reason="caller_mutated")
+
+    failures = validate_verified_external_measurement_evidence(
+        forged, trust_policy=_policy(), now=NOW
+    )
+
+    assert "external_measurement_verification_proof_invalid" in failures
+
+
+def test_revalidation_detects_policy_change_and_evidence_mutation() -> None:
+    proof, _, _ = _verify()
+    changed_policy = _policy(max_age_seconds=60)
+
+    assert "external_measurement_trust_policy_hash_mismatch" in (
+        validate_verified_external_measurement_evidence(
+            proof, trust_policy=changed_policy, now=NOW
+        )
+    )
+
+    mutated = replace(
+        proof,
+        evidence=replace(proof.evidence, semantic_facts={"status": "rewritten"}),
+    )
+    failures = validate_verified_external_measurement_evidence(
+        mutated, trust_policy=_policy(), now=NOW
+    )
+    assert "external_measurement_verification_proof_invalid" in failures
+    assert "external_measurement_evidence_hash_mismatch" in failures
+
+
+def test_trust_policy_hash_is_order_independent_for_provider_allowlist() -> None:
+    first = ApprovedExternalMeasurementProvider(
+        provider_id="a.example",
+        verifier_id="a-v1",
+        verifier_trust_level="production",
+        verifier_policy_id="a-policy",
+        verifier_policy_hash="1" * 64,
+    )
+    second = ApprovedExternalMeasurementProvider(
+        provider_id="b.example",
+        verifier_id="b-v1",
+        verifier_trust_level="production",
+        verifier_policy_id="b-policy",
+        verifier_policy_hash="2" * 64,
+    )
+    left = _policy(approved_providers=[first, second])
+    right = _policy(approved_providers=[second, first])
+
+    assert left.deterministic_hash() == right.deterministic_hash()


### PR DESCRIPTION
## Purpose

Start the NeoMundi interoperability implementation sequence with **PR1: provider-neutral ExternalMeasurementEvidence boundary**.

This PR deliberately does **not** add a NeoMundi/RGC adapter. It creates the generic VERITAS evidence-ingress boundary first so external measurement artifacts can be verified without becoming execution authority.

## Baseline

Product main:

`0317ca50e5c35270e4cf69673377c3b2a29aa924`

Frozen controlled Decision-to-Effect anchor:

`ada46f2fe324dd3cbcff6be59d56c4f75c4a6bdc`

Benchmark Rebaseline A/B/C is complete on the current product line. This PR does not change the frozen execution path.

## Adds

### Provider-neutral runtime boundary

`veritas_os/governance/external_measurement_evidence.py`

Defines:

- `ExternalMeasurementEvidence`
- `ExternalMeasurementProviderVerificationResult`
- `ExternalMeasurementProviderVerifier`
- `ApprovedExternalMeasurementProvider`
- `ExternalMeasurementTrustPolicy`
- `ExternalMeasurementReplayGuard`
- `VerifiedExternalMeasurementEvidence`
- `verify_external_measurement_artifact_to_evidence(...)`
- `validate_verified_external_measurement_evidence(...)`

The public governance package exports the new boundary types/functions.

## Core invariant

```text
ExternalMeasurementEvidence
!= AuthorityEvidence
!= HumanApproval
!= BindAuthorization
!= GovernanceDecision
```

A signed or verified external measurement does not grant execution authority.

## Verification flow

```text
Untrusted external artifact
        ↓
VERITAS-controlled provider-specific verifier
        ↓
provider/verifier trust-policy binding
        ↓
normalized ExternalMeasurementEvidence
        ↓
freshness + expiry + semantic consistency + replay checks
        ↓
VerifiedExternalMeasurementEvidence
```

Provider-specific parsing, schema rules, canonicalization, signature verification, and native semantic validation stay behind the `ExternalMeasurementProviderVerifier` seam.

The generic boundary independently checks:

- approved provider/verifier binding
- verifier trust/policy identity
- payload-hash shape
- measured scope
- coverage range when present
- timezone-aware observation/issuance/expiry
- future skew
- maximum evidence age
- expiry
- explicit semantic consistency
- atomic single-use replay consumption

## Replay semantics

Replay protection is represented as an atomic `consume_once(...)` protocol. The replay key binds provider id, artifact id, payload hash, and replay token.

This PR does not choose a production persistence backend for replay state.

## Sealed proof semantics

`VerifiedExternalMeasurementEvidence` binds normalized evidence to:

- evidence hash
- signature key/algorithm identity reported by the approved provider verifier
- verifier id/trust/policy identity
- VERITAS trust-policy identity/hash
- verification timestamp/reason
- replay key
- deterministic verification proof hash

Caller-constructed or mutated verified objects do not become portable trust; revalidation checks the proof hash and process-local sealed-proof registry.

## Tests

`veritas_os/tests/test_external_measurement_evidence.py`

Covers:

- successful provider-neutral sealing
- structural separation from authority/approval/bind/governance state
- unapproved provider/verifier rejection
- verifier-policy binding mismatch
- provider verification failure
- semantic inconsistency
- stale/future/expired evidence
- invalid scope/hash/coverage
- replay rejection
- forged/mutated verified object rejection
- trust-policy change detection
- deterministic policy identity

## Documentation

`docs/en/architecture/external-measurement-evidence-boundary-v1.md`

Defines the generic trust boundary and explicit PR1 non-goals.

## Explicit non-goals

This PR does **not** implement:

- NeoMundi-specific code
- RGC v0.2 schema/status mapping
- JWKS lookup
- a provider-specific signature backend
- external network calls
- AuthorityEvidence conversion
- HumanApproval satisfaction
- Bind authorization issuance
- direct ALLOW/DENY mapping
- changes to frozen Decision-to-Effect semantics

## Runtime impact

No existing Authorization / Bind / External Effect / Reconciliation / BindReceipt / Outcome behavior is changed.

The new module is an evidence-ingress boundary only and is not wired into the frozen execution path in PR1.

## Next after merge

PR2 — NeoMundi RGC v0.2 adapter implementing the concrete provider-specific verifier and mapping a verified RGC v0.2 observation into `ExternalMeasurementEvidence`.

Protected-main merge remains a separate Human CEO decision.