### PR TITLE
feat(governance): add NeoMundi RGC v0.2 external measurement adapter

### DIFF
--- a/docs/en/architecture/neomundi-rgc-v02-adapter.md
+++ b/docs/en/architecture/neomundi-rgc-v02-adapter.md
@@ -1,0 +1,195 @@
+# NeoMundi RGC v0.2 External Measurement Adapter
+
+## Status
+
+Provider-specific interoperability adapter layered on the provider-neutral `ExternalMeasurementEvidence` boundary introduced in PR #2225.
+
+This adapter targets NeoMundi Measurement Interoperability Contract RGC JSON v0.2 only:
+
+```text
+identity.schema_version == "0.2.0"
+```
+
+RGC v0.1 remains a historical contract and is not silently interpreted under v0.2 semantics.
+
+## Boundary
+
+```text
+Untrusted NeoMundi RGC v0.2 artifact
+        ↓
+VERITAS-controlled RGC structure / semantic checks
+        ↓
+canonical payload reconstruction
+        ↓
+SHA-256 payload verification
+        ↓
+Ed25519 / compact JWS verification
+        ↓
+consumer-controlled trusted JWKS binding
+        ↓
+ExternalMeasurementEvidence
+        ↓
+provider-neutral VERITAS trust / freshness / replay boundary
+        ↓
+independent VERITAS governance
+```
+
+The governing invariants are:
+
+```text
+Measurement != Authority
+Advisory != Authorization
+Within Bounds != ALLOW
+Valid Signature != Trusted Provider
+External Evidence != Governance Decision
+```
+
+The adapter never creates `AuthorityEvidence`, `HumanApproval`, `BindAuthorization`, an ALLOW/DENY decision, or execution permission.
+
+## Canonical payload
+
+The adapter independently reconstructs the same payload described by NeoMundi's public RGC v0.2 reference consumer:
+
+```json
+{
+  "identity": "...",
+  "provenance": "...",
+  "observation": "...",
+  "governance": "..."
+}
+```
+
+`integrity` is excluded from its own payload identity.
+
+Canonicalization is sorted compact JSON encoded as UTF-8 and hashed with SHA-256.
+
+The received artifact must physically contain:
+
+```text
+integrity.hash_algorithm == "sha256"
+integrity.canonicalization == "sorted-json-utf8"
+```
+
+Schema defaults are not used as substitutes for those trust-boundary inputs.
+
+## Signature verification
+
+The adapter accepts compact JWS with:
+
+```text
+alg == "EdDSA"
+```
+
+The selected JWK must be consumer-controlled and must use:
+
+```text
+kty == "OKP"
+crv == "Ed25519"
+```
+
+`integrity.key_id` selects a key from the JWKS supplied by the VERITAS deployment. Public-key material supplied by the artifact does not bootstrap trust.
+
+When the JWS protected header contains `kid`, it must equal `integrity.key_id`.
+
+The following signed claims must exactly match the received contract:
+
+- `payload_hash`
+- `hash_algorithm`
+- `schema_version`
+- `request_id`
+- `timestamp`
+
+## Measurement semantics
+
+The first interoperability slice preserves NeoMundi's epistemic boundary:
+
+- coverage must be within `0.0` and `1.0`;
+- `complete` requires coverage `1.0`;
+- `partial` requires coverage below `1.0`;
+- a `measured` signal requires a numeric value;
+- `not_measured` and `insufficient_coverage` require `null`;
+- `null` is never promoted to zero, safe, normal, or within-bounds meaning;
+- `not_assessed` remains a bounded measurement statement;
+- `single_request` remains a single-observation scope and does not establish persistence, recurrence, frequency, trend, or drift.
+
+The adapter also requires explicit measurement limitations and a measurement boundary.
+
+## Governance semantics
+
+For this PoC adapter, the received artifact must explicitly contain:
+
+```text
+governance.governance_boundary.authorization_status == "not_applicable"
+governance.governance_boundary.execution_permission_changed == false
+```
+
+Omission of `execution_permission_changed` is not interpreted as false.
+
+Supported review recommendation values are:
+
+```text
+not_indicated
+recommended
+required
+```
+
+These values are preserved as provider advisory evidence. They do not directly produce a VERITAS HOLD, DENY, approval requirement, or execution decision.
+
+## Normalized evidence mapping
+
+The verified RGC artifact maps to provider-neutral evidence using deterministic identities.
+
+The RGC request identifier becomes the provider artifact id. The verified RGC timestamp is used as both `observed_at` and `issued_at` for this first adapter because RGC v0.2 exposes one contract timestamp rather than separate observation and issuance timestamps. This is a protocol mapping, not a claim that two independently observed events occurred.
+
+RGC v0.2 does not supply an expiry semantic, so the adapter emits:
+
+```text
+expires_at = None
+```
+
+Deployments accepting RGC v0.2 must therefore configure the provider-neutral `ExternalMeasurementTrustPolicy` with an explicit freshness limit and `require_expiry=False`. The generic default is not weakened.
+
+Replay protection remains owned by the existing provider-neutral `ExternalMeasurementReplayGuard`; the adapter does not introduce a second replay subsystem.
+
+## Trusted-key policy
+
+PR2 performs no live JWKS network lookup. Trusted JWKS material is injected through VERITAS-controlled configuration when constructing `NeoMundiRgcV02Verifier`.
+
+The verifier policy hash deterministically binds the configured trusted JWKS, verifier identity, trust level, protocol version, canonicalization, hash algorithm, and JWS algorithm. The existing generic trust policy must independently approve that exact verifier binding.
+
+## Tests versus live interoperability
+
+The test suite generates non-production Ed25519 keys and synthetic signed RGC v0.2 artifacts to verify deterministic positive and negative paths.
+
+Those fixtures prove VERITAS adapter behavior only. They are not evidence that a real NeoMundi runtime observation has been verified.
+
+The next interoperability milestone after this adapter is merged is:
+
+```text
+real NeoMundi runtime observation
+        ↓
+real NeoMundi-generated signed RGC v0.2 artifact
+        ↓
+independent VERITAS verification
+        ↓
+VerifiedExternalMeasurementEvidence
+        ↓
+External PoC #1 evidence chain
+```
+
+## Non-goals
+
+This adapter does not modify:
+
+- native v2 authorization;
+- single-use authorization consumption;
+- credential resolution;
+- durable dispatch intent;
+- external-effect retry behavior;
+- `EFFECT_UNKNOWN` handling;
+- BindReceipt or Outcome semantics;
+- reconciliation;
+- crash recovery;
+- the frozen Decision-to-Effect execution architecture.
+
+It also performs no external effects and no network calls.

--- a/veritas_os/governance/neomundi_rgc_v02.py
+++ b/veritas_os/governance/neomundi_rgc_v02.py
@@ -1,0 +1,563 @@
+"""NeoMundi RGC v0.2 provider adapter for external measurement evidence.
+
+This module verifies NeoMundi Measurement Interoperability Contracts as
+measurement evidence only.  A valid contract never becomes AuthorityEvidence,
+HumanApproval, BindAuthorization, or a GovernanceDecision.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import copy
+import hashlib
+import json
+import re
+from datetime import datetime
+from typing import Any
+
+from veritas_os.governance.external_measurement_evidence import (
+    ExternalMeasurementEvidence,
+    ExternalMeasurementProviderVerificationResult,
+)
+from veritas_os.security.hash import sha256_of_canonical_json
+
+NEOMUNDI_PROVIDER_ID = "neomundi"
+NEOMUNDI_RGC_V02_VERIFIER_ID = "neomundi_rgc_v02"
+NEOMUNDI_RGC_V02_SCHEMA_VERSION = "0.2.0"
+NEOMUNDI_RGC_ARTIFACT_TYPE = "neomundi_rgc"
+NEOMUNDI_RGC_HASH_ALGORITHM = "sha256"
+NEOMUNDI_RGC_CANONICALIZATION = "sorted-json-utf8"
+NEOMUNDI_RGC_JWS_ALGORITHM = "EdDSA"
+
+_SIGNAL_NAMES = (
+    "stability_score",
+    "coherence_score",
+    "factual_hallucination_score",
+    "semantic_instability_score",
+    "semantic_risk",
+)
+_SIGNAL_STATES = {"measured", "not_measured", "insufficient_coverage"}
+_OBSERVATION_CLASSES = {"within_bounds", "flagged", "not_assessed"}
+_REVIEW_RECOMMENDATIONS = {"not_indicated", "recommended", "required"}
+_B64URL_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+class _NeoMundiVerificationError(ValueError):
+    """Internal deterministic verification failure."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+def _fail(reason: str) -> None:
+    raise _NeoMundiVerificationError(reason)
+
+
+def _require_dict(parent: dict[str, Any], key: str, reason: str) -> dict[str, Any]:
+    value = parent.get(key)
+    if not isinstance(value, dict):
+        _fail(reason)
+    return value
+
+
+def _require_nonempty_string(
+    parent: dict[str, Any], key: str, reason: str
+) -> str:
+    value = parent.get(key)
+    if not isinstance(value, str) or not value.strip():
+        _fail(reason)
+    return value
+
+
+def _require_number(value: Any, reason: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        _fail(reason)
+    numeric = float(value)
+    if not 0.0 <= numeric <= 1.0:
+        _fail(reason)
+    return numeric
+
+
+def _strict_json_object(raw: bytes, reason: str) -> dict[str, Any]:
+    def no_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                _fail(reason)
+            result[key] = value
+        return result
+
+    try:
+        value = json.loads(raw.decode("utf-8"), object_pairs_hook=no_duplicates)
+    except (UnicodeDecodeError, json.JSONDecodeError, TypeError):
+        _fail(reason)
+    if not isinstance(value, dict):
+        _fail(reason)
+    return value
+
+
+def _strict_b64url_decode(value: str, reason: str) -> bytes:
+    if not isinstance(value, str) or not value or not _B64URL_RE.fullmatch(value):
+        _fail(reason)
+    try:
+        return base64.b64decode(
+            value + "=" * (-len(value) % 4),
+            altchars=b"-_",
+            validate=True,
+        )
+    except (binascii.Error, ValueError):
+        _fail(reason)
+
+
+def _canonical_payload_hash(artifact: dict[str, Any]) -> str:
+    """Match NeoMundi's published sorted compact JSON reference consumer."""
+    sections = {
+        "identity": artifact["identity"],
+        "provenance": artifact["provenance"],
+        "observation": artifact["observation"],
+        "governance": artifact["governance"],
+    }
+    canonical = json.dumps(sections, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _validate_timestamp(value: str) -> None:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (AttributeError, TypeError, ValueError):
+        _fail("neomundi_rgc_timestamp_invalid")
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        _fail("neomundi_rgc_timestamp_timezone_required")
+
+
+def _validate_structure_and_semantics(
+    artifact: dict[str, Any],
+) -> tuple[
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+]:
+    if not isinstance(artifact, dict):
+        _fail("neomundi_rgc_artifact_invalid")
+
+    identity = _require_dict(artifact, "identity", "neomundi_rgc_identity_missing")
+    provenance = _require_dict(
+        artifact, "provenance", "neomundi_rgc_provenance_missing"
+    )
+    observation = _require_dict(
+        artifact, "observation", "neomundi_rgc_observation_missing"
+    )
+    governance = _require_dict(
+        artifact, "governance", "neomundi_rgc_governance_missing"
+    )
+    integrity = _require_dict(
+        artifact, "integrity", "neomundi_rgc_integrity_missing"
+    )
+
+    schema_version = identity.get("schema_version")
+    if schema_version != NEOMUNDI_RGC_V02_SCHEMA_VERSION:
+        _fail("neomundi_rgc_version_unsupported")
+
+    for key in ("request_id", "trace_id", "system_id", "model", "mode"):
+        _require_nonempty_string(identity, key, f"neomundi_rgc_identity_{key}_invalid")
+    timestamp = _require_nonempty_string(
+        identity, "timestamp", "neomundi_rgc_timestamp_invalid"
+    )
+    _validate_timestamp(timestamp)
+
+    _require_nonempty_string(
+        provenance,
+        "measurement_version",
+        "neomundi_rgc_provenance_measurement_version_invalid",
+    )
+    _require_nonempty_string(
+        provenance,
+        "normalizer_version",
+        "neomundi_rgc_provenance_normalizer_version_invalid",
+    )
+
+    runtime_scope = _require_nonempty_string(
+        observation, "runtime_scope", "neomundi_rgc_runtime_scope_missing"
+    )
+    if runtime_scope == "single_request" and observation.get("observation_window") not in (
+        None,
+        "",
+    ):
+        # A single-request observation may carry an informational window, but the
+        # adapter never turns it into persistence/trend semantics. No rejection.
+        pass
+
+    measurement_status = observation.get("measurement_status")
+    if measurement_status not in {"complete", "partial"}:
+        _fail("neomundi_rgc_measurement_status_invalid")
+    coverage = _require_number(
+        observation.get("measurement_coverage"),
+        "neomundi_rgc_measurement_coverage_invalid",
+    )
+    if measurement_status == "complete" and coverage != 1.0:
+        _fail("neomundi_rgc_measurement_semantics_invalid")
+    if measurement_status == "partial" and coverage >= 1.0:
+        _fail("neomundi_rgc_measurement_semantics_invalid")
+
+    limitations = observation.get("limitations")
+    if (
+        not isinstance(limitations, list)
+        or not limitations
+        or any(not isinstance(item, str) or not item.strip() for item in limitations)
+    ):
+        _fail("neomundi_rgc_limitations_missing")
+    _require_nonempty_string(
+        observation,
+        "measurement_boundary",
+        "neomundi_rgc_measurement_boundary_missing",
+    )
+
+    observed_signals = _require_dict(
+        observation, "observed_signals", "neomundi_rgc_observed_signals_missing"
+    )
+    signal_status = _require_dict(
+        observed_signals,
+        "signal_status",
+        "neomundi_rgc_signal_status_missing",
+    )
+    for name in _SIGNAL_NAMES:
+        if name not in observed_signals or name not in signal_status:
+            _fail("neomundi_rgc_signal_missing")
+        state = signal_status[name]
+        if state not in _SIGNAL_STATES:
+            _fail("neomundi_rgc_signal_status_invalid")
+        value = observed_signals[name]
+        if state == "measured":
+            _require_number(value, "neomundi_rgc_measured_signal_invalid")
+        elif value is not None:
+            _fail("neomundi_rgc_unmeasured_signal_must_be_null")
+
+    if observed_signals.get("observation_class") not in _OBSERVATION_CLASSES:
+        _fail("neomundi_rgc_observation_class_invalid")
+    _require_number(
+        observed_signals.get("confidence"),
+        "neomundi_rgc_confidence_invalid",
+    )
+
+    governance_boundary = _require_dict(
+        governance,
+        "governance_boundary",
+        "neomundi_rgc_governance_boundary_missing",
+    )
+    if "execution_permission_changed" not in governance_boundary:
+        _fail("neomundi_rgc_execution_permission_missing")
+    if governance_boundary["execution_permission_changed"] is not False:
+        _fail("neomundi_rgc_execution_permission_invalid")
+    if governance_boundary.get("authorization_status") != "not_applicable":
+        _fail("neomundi_rgc_authorization_status_invalid")
+
+    advisory = _require_dict(
+        governance, "advisory", "neomundi_rgc_advisory_missing"
+    )
+    if advisory.get("review_recommendation") not in _REVIEW_RECOMMENDATIONS:
+        _fail("neomundi_rgc_review_recommendation_invalid")
+    interpretation_policy = _require_dict(
+        advisory,
+        "interpretation_policy",
+        "neomundi_rgc_interpretation_policy_missing",
+    )
+    _require_nonempty_string(
+        interpretation_policy,
+        "policy_id",
+        "neomundi_rgc_interpretation_policy_invalid",
+    )
+    _require_nonempty_string(
+        interpretation_policy,
+        "policy_version",
+        "neomundi_rgc_interpretation_policy_invalid",
+    )
+
+    if "hash_algorithm" not in integrity:
+        _fail("neomundi_rgc_hash_algorithm_missing")
+    if integrity.get("hash_algorithm") != NEOMUNDI_RGC_HASH_ALGORITHM:
+        _fail("neomundi_rgc_hash_algorithm_invalid")
+    if "canonicalization" not in integrity:
+        _fail("neomundi_rgc_canonicalization_missing")
+    if integrity.get("canonicalization") != NEOMUNDI_RGC_CANONICALIZATION:
+        _fail("neomundi_rgc_canonicalization_invalid")
+
+    payload_hash = _require_nonempty_string(
+        integrity, "payload_hash", "neomundi_rgc_payload_hash_invalid"
+    )
+    if not re.fullmatch(r"[0-9a-f]{64}", payload_hash):
+        _fail("neomundi_rgc_payload_hash_invalid")
+    _require_nonempty_string(
+        integrity, "signature", "neomundi_rgc_signature_missing"
+    )
+    _require_nonempty_string(
+        integrity, "signer_identity", "neomundi_rgc_signer_identity_missing"
+    )
+    _require_nonempty_string(integrity, "key_id", "neomundi_rgc_key_id_missing")
+
+    return identity, provenance, observation, governance, integrity
+
+
+class NeoMundiRgcV02Verifier:
+    """VERITAS-controlled verifier for NeoMundi RGC JSON v0.2 artifacts."""
+
+    verifier_id = NEOMUNDI_RGC_V02_VERIFIER_ID
+
+    def __init__(
+        self,
+        *,
+        trusted_jwks: dict[str, Any],
+        verifier_policy_id: str,
+        verifier_trust_level: str = "cryptographic",
+    ) -> None:
+        if not isinstance(verifier_policy_id, str) or not verifier_policy_id.strip():
+            raise ValueError("neomundi_rgc_verifier_policy_id_invalid")
+        if not isinstance(verifier_trust_level, str) or not verifier_trust_level.strip():
+            raise ValueError("neomundi_rgc_verifier_trust_level_invalid")
+        if not isinstance(trusted_jwks, dict) or not isinstance(
+            trusted_jwks.get("keys"), list
+        ):
+            raise ValueError("neomundi_rgc_trusted_jwks_invalid")
+
+        keys_by_id: dict[str, dict[str, Any]] = {}
+        policy_keys: list[dict[str, Any]] = []
+        for item in trusted_jwks["keys"]:
+            if not isinstance(item, dict):
+                raise ValueError("neomundi_rgc_trusted_jwks_invalid")
+            if "d" in item:
+                raise ValueError("neomundi_rgc_private_jwk_not_allowed")
+            kid = item.get("kid")
+            if not isinstance(kid, str) or not kid.strip() or kid in keys_by_id:
+                raise ValueError("neomundi_rgc_trusted_jwks_invalid")
+            keys_by_id[kid] = copy.deepcopy(item)
+            policy_keys.append(copy.deepcopy(item))
+
+        if not keys_by_id:
+            raise ValueError("neomundi_rgc_trusted_jwks_empty")
+
+        self._keys_by_id = keys_by_id
+        self.verifier_policy_id = verifier_policy_id
+        self.verifier_trust_level = verifier_trust_level
+        self.verifier_policy_hash = sha256_of_canonical_json(
+            {
+                "provider_id": NEOMUNDI_PROVIDER_ID,
+                "verifier_id": self.verifier_id,
+                "verifier_policy_id": verifier_policy_id,
+                "verifier_trust_level": verifier_trust_level,
+                "trusted_jwks": sorted(policy_keys, key=lambda item: item["kid"]),
+                "schema_version": NEOMUNDI_RGC_V02_SCHEMA_VERSION,
+                "hash_algorithm": NEOMUNDI_RGC_HASH_ALGORITHM,
+                "canonicalization": NEOMUNDI_RGC_CANONICALIZATION,
+                "jws_algorithm": NEOMUNDI_RGC_JWS_ALGORITHM,
+            }
+        )
+
+    def _failure(
+        self, reason: str, *, key_id: str | None = None
+    ) -> ExternalMeasurementProviderVerificationResult:
+        return ExternalMeasurementProviderVerificationResult(
+            verified=False,
+            evidence=None,
+            verifier_id=self.verifier_id,
+            verifier_trust_level=self.verifier_trust_level,
+            verifier_policy_id=self.verifier_policy_id,
+            verifier_policy_hash=self.verifier_policy_hash,
+            key_id=key_id,
+            algorithm=NEOMUNDI_RGC_JWS_ALGORITHM,
+            semantic_consistent=False,
+            reason=reason,
+        )
+
+    def _verify_jws(
+        self,
+        signature: str,
+        *,
+        key_id: str,
+        expected_claims: dict[str, Any],
+    ) -> None:
+        key = self._keys_by_id.get(key_id)
+        if key is None:
+            _fail("neomundi_rgc_key_untrusted")
+        if key.get("kty") != "OKP" or key.get("crv") != "Ed25519":
+            _fail("neomundi_rgc_key_invalid")
+
+        try:
+            protected_segment, payload_segment, signature_segment = signature.split(".")
+        except ValueError:
+            _fail("neomundi_rgc_jws_malformed")
+
+        header = _strict_json_object(
+            _strict_b64url_decode(
+                protected_segment, "neomundi_rgc_jws_header_invalid"
+            ),
+            "neomundi_rgc_jws_header_invalid",
+        )
+        if header.get("alg") != NEOMUNDI_RGC_JWS_ALGORITHM:
+            _fail("neomundi_rgc_jws_algorithm_invalid")
+        if header.get("kid") is not None and header.get("kid") != key_id:
+            _fail("neomundi_rgc_jws_kid_mismatch")
+
+        claims = _strict_json_object(
+            _strict_b64url_decode(
+                payload_segment, "neomundi_rgc_jws_payload_invalid"
+            ),
+            "neomundi_rgc_jws_payload_invalid",
+        )
+        for claim, expected in expected_claims.items():
+            if claims.get(claim) != expected:
+                _fail(f"neomundi_rgc_signed_claim_{claim}_mismatch")
+
+        raw_signature = _strict_b64url_decode(
+            signature_segment, "neomundi_rgc_jws_signature_invalid"
+        )
+        public_x = key.get("x")
+        if not isinstance(public_x, str):
+            _fail("neomundi_rgc_key_invalid")
+        raw_public_key = _strict_b64url_decode(
+            public_x, "neomundi_rgc_key_invalid"
+        )
+        if len(raw_public_key) != 32 or len(raw_signature) != 64:
+            _fail("neomundi_rgc_signature_invalid")
+
+        try:
+            from cryptography.exceptions import InvalidSignature
+            from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+                Ed25519PublicKey,
+            )
+        except ImportError:
+            _fail("neomundi_rgc_crypto_unavailable")
+
+        try:
+            public_key = Ed25519PublicKey.from_public_bytes(raw_public_key)
+            public_key.verify(
+                raw_signature,
+                f"{protected_segment}.{payload_segment}".encode("ascii"),
+            )
+        except InvalidSignature:
+            _fail("neomundi_rgc_signature_invalid")
+        except (TypeError, ValueError):
+            _fail("neomundi_rgc_key_invalid")
+
+    def verify(
+        self, artifact: dict[str, Any]
+    ) -> ExternalMeasurementProviderVerificationResult:
+        key_id: str | None = None
+        try:
+            (
+                identity,
+                provenance,
+                observation,
+                governance,
+                integrity,
+            ) = _validate_structure_and_semantics(artifact)
+            key_id = integrity["key_id"]
+
+            recomputed_hash = _canonical_payload_hash(artifact)
+            if recomputed_hash != integrity["payload_hash"]:
+                _fail("neomundi_rgc_payload_hash_mismatch")
+
+            expected_claims = {
+                "payload_hash": integrity["payload_hash"],
+                "hash_algorithm": integrity["hash_algorithm"],
+                "schema_version": identity["schema_version"],
+                "request_id": identity["request_id"],
+                "timestamp": identity["timestamp"],
+            }
+            self._verify_jws(
+                integrity["signature"],
+                key_id=key_id,
+                expected_claims=expected_claims,
+            )
+
+            governance_boundary = governance["governance_boundary"]
+            observed_signals = observation["observed_signals"]
+            replay_token = sha256_of_canonical_json(
+                {
+                    "provider_id": NEOMUNDI_PROVIDER_ID,
+                    "request_id": identity["request_id"],
+                    "trace_id": identity["trace_id"],
+                    "payload_hash": recomputed_hash,
+                }
+            )
+            evidence_id = "external-measurement:" + sha256_of_canonical_json(
+                {
+                    "provider_id": NEOMUNDI_PROVIDER_ID,
+                    "artifact_id": identity["request_id"],
+                    "payload_hash": recomputed_hash,
+                }
+            )
+
+            evidence = ExternalMeasurementEvidence(
+                evidence_id=evidence_id,
+                provider_id=NEOMUNDI_PROVIDER_ID,
+                artifact_id=identity["request_id"],
+                artifact_type=NEOMUNDI_RGC_ARTIFACT_TYPE,
+                artifact_version=identity["schema_version"],
+                payload_hash=recomputed_hash,
+                observed_at=identity["timestamp"],
+                issued_at=identity["timestamp"],
+                expires_at=None,
+                replay_token=replay_token,
+                measured_scope={
+                    "runtime_scope": observation["runtime_scope"],
+                    "observation_window": observation.get("observation_window"),
+                    "measurement_boundary": observation["measurement_boundary"],
+                },
+                measurement_coverage=float(observation["measurement_coverage"]),
+                semantic_facts={
+                    "measurement_status": observation["measurement_status"],
+                    "observation_class": observed_signals["observation_class"],
+                    "confidence": float(observed_signals["confidence"]),
+                    "observed_signals": copy.deepcopy(observed_signals),
+                    "limitations": list(observation["limitations"]),
+                    "advisory": copy.deepcopy(governance["advisory"]),
+                    "governance_boundary": {
+                        "authorization_status": governance_boundary[
+                            "authorization_status"
+                        ],
+                        "execution_permission_changed": governance_boundary[
+                            "execution_permission_changed"
+                        ],
+                    },
+                },
+                provenance={
+                    **copy.deepcopy(provenance),
+                    "request_id": identity["request_id"],
+                    "trace_id": identity["trace_id"],
+                    "system_id": identity["system_id"],
+                    "model": identity["model"],
+                    "mode": identity["mode"],
+                    "signer_identity": integrity["signer_identity"],
+                    "key_id": key_id,
+                    "hash_algorithm": integrity["hash_algorithm"],
+                    "canonicalization": integrity["canonicalization"],
+                },
+                metadata={
+                    "adapter": self.verifier_id,
+                    "schema_version": NEOMUNDI_RGC_V02_SCHEMA_VERSION,
+                    "evidence_role": "measurement_only",
+                    "authority_imported": False,
+                    "approval_imported": False,
+                    "execution_permission_imported": False,
+                },
+            )
+
+            return ExternalMeasurementProviderVerificationResult(
+                verified=True,
+                evidence=evidence,
+                verifier_id=self.verifier_id,
+                verifier_trust_level=self.verifier_trust_level,
+                verifier_policy_id=self.verifier_policy_id,
+                verifier_policy_hash=self.verifier_policy_hash,
+                key_id=key_id,
+                algorithm=NEOMUNDI_RGC_JWS_ALGORITHM,
+                semantic_consistent=True,
+                reason="neomundi_rgc_v02_verified",
+            )
+        except _NeoMundiVerificationError as exc:
+            return self._failure(exc.reason, key_id=key_id)
+        except (KeyError, TypeError, ValueError):
+            return self._failure("neomundi_rgc_artifact_invalid", key_id=key_id)

--- a/veritas_os/tests/test_neomundi_rgc_v02.py
+++ b/veritas_os/tests/test_neomundi_rgc_v02.py
@@ -1,0 +1,578 @@
+"""Tests for the NeoMundi RGC v0.2 external measurement adapter."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+from veritas_os.governance.external_measurement_evidence import (
+    ApprovedExternalMeasurementProvider,
+    ExternalMeasurementTrustPolicy,
+    verify_external_measurement_artifact_to_evidence,
+)
+from veritas_os.governance.neomundi_rgc_v02 import (
+    NEOMUNDI_PROVIDER_ID,
+    NEOMUNDI_RGC_V02_VERIFIER_ID,
+    NeoMundiRgcV02Verifier,
+)
+
+NOW = datetime(2026, 9, 11, 2, 5, tzinfo=UTC)
+
+
+class _ReplayGuard:
+    def __init__(self) -> None:
+        self.seen: set[str] = set()
+
+    def consume_once(self, replay_key: str, *, observed_at: datetime) -> bool:
+        assert observed_at.tzinfo is not None
+        if replay_key in self.seen:
+            return False
+        self.seen.add(replay_key)
+        return True
+
+
+def _b64url(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _payload_hash(artifact: dict[str, Any]) -> str:
+    payload = {
+        "identity": artifact["identity"],
+        "provenance": artifact["provenance"],
+        "observation": artifact["observation"],
+        "governance": artifact["governance"],
+    }
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+@pytest.fixture
+def signing_material() -> tuple[Ed25519PrivateKey, dict[str, Any]]:
+    private_key = Ed25519PrivateKey.generate()
+    raw_public = private_key.public_key().public_bytes(
+        Encoding.Raw, PublicFormat.Raw
+    )
+    jwks = {
+        "keys": [
+            {
+                "kty": "OKP",
+                "crv": "Ed25519",
+                "kid": "neomundi-test-key",
+                "alg": "EdDSA",
+                "x": _b64url(raw_public),
+            }
+        ]
+    }
+    return private_key, jwks
+
+
+def _artifact() -> dict[str, Any]:
+    return {
+        "identity": {
+            "schema_version": "0.2.0",
+            "request_id": "req-neomundi-001",
+            "trace_id": "00-" + ("a" * 32) + "-" + ("b" * 16) + "-01",
+            "timestamp": "2026-09-11T02:04:30+00:00",
+            "system_id": "neomundi-poc",
+            "model": "local",
+            "mode": "poc",
+        },
+        "provenance": {
+            "measurement_version": "measurement-0.2",
+            "normalizer_version": "normalizer-0.2",
+            "checks_emitted": 4,
+            "source_batch_id": None,
+            "canonicalization_method": "sorted-json-utf8",
+        },
+        "observation": {
+            "runtime_scope": "single_request",
+            "observation_window": None,
+            "measurement_status": "complete",
+            "measurement_coverage": 1.0,
+            "observed_signals": {
+                "stability_score": 0.91,
+                "coherence_score": 0.88,
+                "factual_hallucination_score": None,
+                "semantic_instability_score": 0.12,
+                "semantic_risk": 0.20,
+                "signal_status": {
+                    "stability_score": "measured",
+                    "coherence_score": "measured",
+                    "factual_hallucination_score": "not_measured",
+                    "semantic_instability_score": "measured",
+                    "semantic_risk": "measured",
+                },
+                "observation_class": "within_bounds",
+                "confidence": 0.93,
+            },
+            "limitations": ["single request observation only"],
+            "measurement_boundary": "declared runtime output signals",
+        },
+        "governance": {
+            "governance_boundary": {
+                "authorization_status": "not_applicable",
+                "execution_permission_changed": False,
+            },
+            "advisory": {
+                "review_recommendation": "not_indicated",
+                "review_trigger": [],
+                "recommended_review_type": [],
+                "interpretation_policy": {
+                    "policy_id": "neomundi-reference",
+                    "policy_version": "0.2",
+                },
+            },
+        },
+        "integrity": {
+            "payload_hash": "",
+            "hash_algorithm": "sha256",
+            "canonicalization": "sorted-json-utf8",
+            "signature": "",
+            "signer_identity": "neomundi-test-signer",
+            "key_id": "neomundi-test-key",
+            "confidentiality_class": "controlled",
+            "retention_reference": None,
+        },
+    }
+
+
+def _sign(
+    artifact: dict[str, Any],
+    private_key: Ed25519PrivateKey,
+    *,
+    alg: str = "EdDSA",
+    header_kid: str | None = "neomundi-test-key",
+    claims_override: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    artifact["integrity"]["payload_hash"] = _payload_hash(artifact)
+    claims = {
+        "payload_hash": artifact["integrity"]["payload_hash"],
+        "hash_algorithm": artifact["integrity"]["hash_algorithm"],
+        "schema_version": artifact["identity"]["schema_version"],
+        "request_id": artifact["identity"]["request_id"],
+        "timestamp": artifact["identity"]["timestamp"],
+    }
+    claims.update(claims_override or {})
+    header: dict[str, Any] = {"alg": alg, "typ": "JWT"}
+    if header_kid is not None:
+        header["kid"] = header_kid
+    protected = _b64url(
+        json.dumps(header, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    )
+    payload = _b64url(
+        json.dumps(claims, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    )
+    signature = _b64url(
+        private_key.sign(f"{protected}.{payload}".encode("ascii"))
+    )
+    artifact["integrity"]["signature"] = f"{protected}.{payload}.{signature}"
+    return artifact
+
+
+def _verifier(jwks: dict[str, Any]) -> NeoMundiRgcV02Verifier:
+    return NeoMundiRgcV02Verifier(
+        trusted_jwks=jwks,
+        verifier_policy_id="neomundi-rgc-poc-v02",
+        verifier_trust_level="poc",
+    )
+
+
+def _valid(
+    signing_material: tuple[Ed25519PrivateKey, dict[str, Any]]
+) -> tuple[dict[str, Any], NeoMundiRgcV02Verifier]:
+    private_key, jwks = signing_material
+    artifact = _sign(_artifact(), private_key)
+    return artifact, _verifier(jwks)
+
+
+def test_valid_signed_rgc_v02_maps_to_measurement_only_evidence(
+    signing_material: tuple[Ed25519PrivateKey, dict[str, Any]]
+) -> None:
+    artifact, verifier = _valid(signing_material)
+    result = verifier.verify(artifact)
+
+    assert result.verified is True
+    assert result.semantic_consistent is True
+    assert result.reason == "neomundi_rgc_v02_verified"
+    assert result.key_id == "neomundi-test-key"
+    assert result.algorithm == "EdDSA"
+    assert result.evidence is not None
+    assert result.evidence.provider_id == NEOMUNDI_PROVIDER_ID
+    assert result.evidence.artifact_id == "req-neomundi-001"
+    assert result.evidence.artifact_version == "0.2.0"
+    assert result.evidence.expires_at is None
+    assert result.evidence.observed_at == result.evidence.issued_at
+    assert result.evidence.measured_scope["runtime_scope"] == "single_request"
+    assert (
+        result.evidence.semantic_facts["observed_signals"][
+            "factual_hallucination_score"
+        ]
+        is None
+    )
+    assert result.evidence.metadata["authority_imported"] is False
+    assert result.evidence.metadata["approval_imported"] is False
+    assert result.evidence.metadata["execution_permission_imported"] is False
+    assert not hasattr(result.evidence, "authority_evidence")
+    assert not hasattr(result.evidence, "human_approval")
+    assert not hasattr(result.evidence, "bind_authorization")
+    assert not hasattr(result.evidence, "governance_decision")
+
+
+@pytest.mark.parametrize(
+    ("mutation", "reason"),
+    [
+        (lambda a: a["identity"].pop("schema_version"), "neomundi_rgc_version_unsupported"),
+        (
+            lambda a: a["identity"].__setitem__("schema_version", "0.1.0"),
+            "neomundi_rgc_version_unsupported",
+        ),
+        (
+            lambda a: a["integrity"].pop("hash_algorithm"),
+            "neomundi_rgc_hash_algorithm_missing",
+        ),
+        (
+            lambda a: a["integrity"].__setitem__("hash_algorithm", "sha512"),
+            "neomundi_rgc_hash_algorithm_invalid",
+        ),
+        (
+            lambda a: a["integrity"].pop("canonicalization"),
+            "neomundi_rgc_canonicalization_missing",
+        ),
+        (
+            lambda a: a["integrity"].__setitem__("canonicalization", "json"),
+            "neomundi_rgc_canonicalization_invalid",
+        ),
+        (
+            lambda a: a["governance"]["governance_boundary"].pop(
+                "execution_permission_changed"
+            ),
+            "neomundi_rgc_execution_permission_missing",
+        ),
+        (
+            lambda a: a["governance"]["governance_boundary"].__setitem__(
+                "execution_permission_changed", True
+            ),
+            "neomundi_rgc_execution_permission_invalid",
+        ),
+        (
+            lambda a: a["governance"]["governance_boundary"].__setitem__(
+                "authorization_status", "authorized"
+            ),
+            "neomundi_rgc_authorization_status_invalid",
+        ),
+        (
+            lambda a: a["governance"]["advisory"].__setitem__(
+                "review_recommendation", "deny"
+            ),
+            "neomundi_rgc_review_recommendation_invalid",
+        ),
+        (
+            lambda a: a["observation"].__setitem__("measurement_coverage", 1.1),
+            "neomundi_rgc_measurement_coverage_invalid",
+        ),
+        (
+            lambda a: a["observation"].__setitem__("measurement_coverage", 0.9),
+            "neomundi_rgc_measurement_semantics_invalid",
+        ),
+        (
+            lambda a: a["observation"].pop("measurement_boundary"),
+            "neomundi_rgc_measurement_boundary_missing",
+        ),
+        (
+            lambda a: a["observation"].pop("limitations"),
+            "neomundi_rgc_limitations_missing",
+        ),
+    ],
+)
+def test_security_relevant_structure_and_semantics_fail_closed(
+    signing_material: tuple[Ed25519PrivateKey, dict[str, Any]],
+    mutation,
+    reason: str,
+) -> None:
+    artifact, verifier = _valid(signing_material)
+    mutation(artifact)
+    result = verifier.verify(artifact)
+    assert result.verified is False
+    assert result.reason == reason
+
+
+@pytest.mark.parametrize(
+    ("signal", "status", "value", "reason"),
+    [
+        (
+            "stability_score",
+            "measured",
+            None,
+            "neomundi_rgc_measured_signal_invalid",
+        ),
+        (
+            "factual_hallucination_score",
+            "not_measured",
+            0.0,
+            "neomundi_rgc_unmeasured_signal_must_be_null",
+        ),
+        (
+            "factual_hallucination_score",
+            "insufficient_coverage",
+            0.1,
+            "neomundi_rgc_unmeasured_signal_must_be_null",
+        ),
+        (
+            "stability_score",
+            "unknown",
+            0.9,
+            "neomundi_rgc_signal_status_invalid",
+        ),
+    ],
+)
+def test_signal_state_never_promotes_unknown_to_numeric_meaning(
+    signing_material: tuple[Ed25519PrivateKey, dict[str, Any]],
+    signal: str,
+    status: str,
+    value: Any,
+    reason: str,
+) -> None:
+    artifact, verifier = _valid(signing_material)
+    artifact["observation"]["observed_signals"]["signal_status"][signal] = status
+    artifact["observation"]["observed_signals"][signal] = value
+
+    result = verifier.verify(artifact)
+    assert result.verified is False
+    assert result.reason == reason
+
+
+def test_valid_partial_not_assessed_preserves_explicit_nulls(
+    signing_material: tuple[Ed25519PrivateKey, dict[str, Any]]
+) -> None:
+    private_key, jwks = signing_material
+    artifact = _artifact()
+    observation = artifact["observation"]
+    observation["measurement_status"] = "partial"
+    observation["measurement_coverage"] = 0.6
+    signals = observation["observed_signals"]
+    signals["observation_class"] = "not_assessed"
+    signals["factual_hallucination_score"] = None
+    signals["signal_status"]["factual_hallucination_score"] = "insufficient_coverage"
+    _sign(artifact, private_key)
+
+    result = _verifier(jwks).verify(artifact)
+
+    assert result.verified is True
+    assert result.evidence is not None
+    assert result.evidence.semantic_facts["observation_class"] == "not_assessed"
+    assert (
+        result.evidence.semantic_facts["observed_signals"][
+            "factual_hallucination_score"
+        ]
+        is None
+    )
+
+
+def test_tamper_after_signing_is_rejected_by_payload_identity(
+    signing_material: tuple[Ed25519PrivateKey, dict[str, Any]]
+) -> None:
+    artifact, verifier = _valid(signing_material)
+    artifact["observation"]["observed_signals"]["coherence_score"] = 0.2
+
+    result = verifier.verify(artifact)
+
+    assert result.verified is False
+    assert result.reason == "neomundi_rgc_payload_hash_mismatch"
+
+
+def test_unknown_key_is_not_bootstrapped_from_artifact(
+    signing_material: tuple[Ed25519PrivateKey, dict[str, Any]]
+) -> None:
+    private_key, _ = signing_material
+    artifact = _sign(_artifact(), private_key)
+    verifier = NeoMundiRgcV02Verifier(
+        trusted_jwks={
+            "keys": [
+                {
+                    "kty": "OKP",
+                    "crv": "Ed25519",
+                    "kid": "other-key",
+                    "alg": "EdDSA",
+                    "x": _b64url(
+                        Ed25519PrivateKey.generate()
+                        .public_key()
+                        .public_bytes(Encoding.Raw, PublicFormat.Raw)
+                    ),
+                }
+            ]
+        },
+        verifier_policy_id="neomundi-rgc-poc-v02",
+        verifier_trust_level="poc",
+    )
+
+    result = verifier.verify(artifact)
+
+    assert result.verified is False
+    assert result.reason == "neomundi_rgc_key_untrusted"
+
+
+def test_jws_algorithm_and_kid_are_strictly_bound(
+    signing_material: tuple[Ed25519PrivateKey, dict[str, Any]]
+) -> None:
+    private_key, jwks = signing_material
+
+    bad_alg = _sign(_artifact(), private_key, alg="HS256")
+    assert _verifier(jwks).verify(bad_alg).reason == "neomundi_rgc_jws_algorithm_invalid"
+
+    bad_kid = _sign(_artifact(), private_key, header_kid="different-key")
+    assert _verifier(jwks).verify(bad_kid).reason == "neomundi_rgc_jws_kid_mismatch"
+
+
+@pytest.mark.parametrize(
+    ("claim", "wrong_value", "reason"),
+    [
+        (
+            "payload_hash",
+            "0" * 64,
+            "neomundi_rgc_signed_claim_payload_hash_mismatch",
+        ),
+        (
+            "schema_version",
+            "0.1.0",
+            "neomundi_rgc_signed_claim_schema_version_mismatch",
+        ),
+        (
+            "request_id",
+            "other-request",
+            "neomundi_rgc_signed_claim_request_id_mismatch",
+        ),
+        (
+            "timestamp",
+            "2026-09-11T02:04:00+00:00",
+            "neomundi_rgc_signed_claim_timestamp_mismatch",
+        ),
+    ],
+)
+def test_signed_claims_must_exactly_match_received_contract(
+    signing_material: tuple[Ed25519PrivateKey, dict[str, Any]],
+    claim: str,
+    wrong_value: str,
+    reason: str,
+) -> None:
+    private_key, jwks = signing_material
+    artifact = _sign(
+        _artifact(),
+        private_key,
+        claims_override={claim: wrong_value},
+    )
+
+    result = _verifier(jwks).verify(artifact)
+
+    assert result.verified is False
+    assert result.reason == reason
+
+
+def test_generic_boundary_accepts_once_then_rejects_replay(
+    signing_material: tuple[Ed25519PrivateKey, dict[str, Any]]
+) -> None:
+    artifact, verifier = _valid(signing_material)
+    policy = ExternalMeasurementTrustPolicy(
+        policy_id="external-measurement-neomundi-poc-v1",
+        approved_providers=[
+            ApprovedExternalMeasurementProvider(
+                provider_id=NEOMUNDI_PROVIDER_ID,
+                verifier_id=NEOMUNDI_RGC_V02_VERIFIER_ID,
+                verifier_trust_level=verifier.verifier_trust_level,
+                verifier_policy_id=verifier.verifier_policy_id,
+                verifier_policy_hash=verifier.verifier_policy_hash,
+            )
+        ],
+        max_age_seconds=300,
+        max_future_skew_seconds=5,
+        require_expiry=False,
+    )
+    replay = _ReplayGuard()
+
+    proof = verify_external_measurement_artifact_to_evidence(
+        artifact,
+        provider_verifier=verifier,
+        trust_policy=policy,
+        replay_guard=replay,
+        now=NOW,
+    )
+
+    assert proof.evidence.provider_id == NEOMUNDI_PROVIDER_ID
+    assert proof.evidence.metadata["evidence_role"] == "measurement_only"
+    assert not hasattr(proof, "governance_decision")
+
+    with pytest.raises(ValueError, match="external_measurement_replay_detected"):
+        verify_external_measurement_artifact_to_evidence(
+            artifact,
+            provider_verifier=verifier,
+            trust_policy=policy,
+            replay_guard=replay,
+            now=NOW,
+        )
+
+
+def test_generic_boundary_rejects_independent_policy_binding_mismatch(
+    signing_material: tuple[Ed25519PrivateKey, dict[str, Any]]
+) -> None:
+    artifact, verifier = _valid(signing_material)
+    policy = ExternalMeasurementTrustPolicy(
+        policy_id="external-measurement-neomundi-poc-v1",
+        approved_providers=[
+            ApprovedExternalMeasurementProvider(
+                provider_id=NEOMUNDI_PROVIDER_ID,
+                verifier_id=NEOMUNDI_RGC_V02_VERIFIER_ID,
+                verifier_trust_level=verifier.verifier_trust_level,
+                verifier_policy_id=verifier.verifier_policy_id,
+                verifier_policy_hash="f" * 64,
+            )
+        ],
+        max_age_seconds=300,
+        max_future_skew_seconds=5,
+        require_expiry=False,
+    )
+
+    with pytest.raises(
+        ValueError, match="external_measurement_verifier_binding_mismatch"
+    ):
+        verify_external_measurement_artifact_to_evidence(
+            artifact,
+            provider_verifier=verifier,
+            trust_policy=policy,
+            replay_guard=_ReplayGuard(),
+            now=NOW,
+        )
+
+
+def test_trusted_jwks_policy_rejects_private_or_duplicate_key_material() -> None:
+    with pytest.raises(ValueError, match="neomundi_rgc_private_jwk_not_allowed"):
+        NeoMundiRgcV02Verifier(
+            trusted_jwks={
+                "keys": [
+                    {
+                        "kty": "OKP",
+                        "crv": "Ed25519",
+                        "kid": "key-1",
+                        "x": "a" * 43,
+                        "d": "secret",
+                    }
+                ]
+            },
+            verifier_policy_id="policy",
+        )
+
+    with pytest.raises(ValueError, match="neomundi_rgc_trusted_jwks_invalid"):
+        NeoMundiRgcV02Verifier(
+            trusted_jwks={
+                "keys": [
+                    {"kid": "key-1", "kty": "OKP", "crv": "Ed25519", "x": "a"},
+                    {"kid": "key-1", "kty": "OKP", "crv": "Ed25519", "x": "b"},
+                ]
+            },
+            verifier_policy_id="policy",
+        )


### PR DESCRIPTION
## What
- Adds a NeoMundi RGC v0.2 provider-specific verifier/adapter.
- Maps independently verified RGC v0.2 artifacts into the provider-neutral `ExternalMeasurementEvidence` boundary introduced in #2225.
- Adds deterministic positive/negative tests and architecture documentation.

## Security boundary
- NeoMundi measurement remains evidence only.
- No `AuthorityEvidence`, `HumanApproval`, `BindAuthorization`, ALLOW/DENY decision, or execution permission is imported.
- Provider trust remains consumer-controlled by VERITAS.
- Invalid version, payload identity, signature, trusted-key binding, signed claims, measurement semantics, or governance-boundary semantics fail closed.

## Cryptographic verification
- Reconstructs the canonical RGC payload from `identity`, `provenance`, `observation`, and `governance`, excluding `integrity`.
- Recomputes sorted compact UTF-8 JSON SHA-256 identity.
- Requires explicit `integrity.hash_algorithm = sha256` and `integrity.canonicalization = sorted-json-utf8`.
- Verifies compact Ed25519 JWS with `alg=EdDSA` using VERITAS-injected trusted JWKS material.
- Requires exact signed-claim binding for payload hash, hash algorithm, schema version, request id, and timestamp.
- Performs no network JWKS lookup.

## Semantic boundary
- Targets only `identity.schema_version = 0.2.0`; v0.1 is not silently reinterpreted.
- Preserves `measured` / `not_measured` / `insufficient_coverage` without null-to-zero promotion.
- Enforces complete/partial coverage consistency.
- Requires explicit measurement limitations and boundary.
- Requires `authorization_status = not_applicable` and physically present `execution_permission_changed = false`.
- Preserves review recommendation as advisory evidence only.

## Generic boundary composition
- Uses the existing `ExternalMeasurementProviderVerificationResult` seam.
- Binds verifier policy to the configured trusted JWKS.
- Integration tests exercise `verify_external_measurement_artifact_to_evidence(...)` with independent trust-policy binding and replay rejection.

## Non-goals
- No live NeoMundi observation yet.
- No external network calls or effects.
- No RCC/REVAS changes.
- No changes to native v2 authorization, credential resolution, external-effect semantics, BindReceipt/Outcome, reconciliation, or the frozen Decision-to-Effect architecture.

## Next milestone
After this PR is green and reviewed: share the implementation with Sébastien, obtain a real NeoMundi-generated signed RGC v0.2 observation, and run External PoC #1.