### PR TITLE
ci: slim bind effect PostgreSQL contention dependencies

### DIFF
--- a/.github/workflows/bind-effect-state-postgresql.yml
+++ b/.github/workflows/bind-effect-state-postgresql.yml
@@ -50,14 +50,16 @@ jobs:
         with:
           python-version: "3.12"
           cache: pip
+          cache-dependency-path: pyproject.toml
 
-      - name: Install dependencies
+      - name: Install contention-test dependencies
         run: |
           set -euxo pipefail
           python -m pip install --upgrade pip --retries 5 --timeout 60
-          python -m pip install --retries 5 --timeout 60 -r veritas_os/requirements.txt
-          python -m pip install --retries 5 --timeout 60 \
-            "psycopg[binary]" psycopg-pool alembic pytest pytest-asyncio
+          # This job proves PostgreSQL effect-state contention semantics only.
+          # Install the repository's core + PostgreSQL + test profiles rather
+          # than the full profile, which pulls unrelated ML/CUDA dependencies.
+          python -m pip install --retries 5 --timeout 60 ".[postgresql,dev]"
 
       - name: Run Alembic migrations
         run: |

--- a/.github/workflows/bind-effect-state-postgresql.yml
+++ b/.github/workflows/bind-effect-state-postgresql.yml
@@ -57,9 +57,9 @@ jobs:
           set -euxo pipefail
           python -m pip install --upgrade pip --retries 5 --timeout 60
           # This job proves PostgreSQL effect-state contention semantics only.
-          # Install the repository's core + PostgreSQL + test profiles rather
-          # than the full profile, which pulls unrelated ML/CUDA dependencies.
-          python -m pip install --retries 5 --timeout 60 ".[postgresql,dev]"
+          # Install core + PostgreSQL + signing + test profiles rather than the
+          # full profile, which pulls unrelated ML/CUDA dependencies.
+          python -m pip install --retries 5 --timeout 60 ".[postgresql,signing,dev]"
 
       - name: Run Alembic migrations
         run: |


### PR DESCRIPTION
## Summary

Slim the `bind-effect-state-postgresql-contention` job so it installs only the dependency profiles required for this PostgreSQL contention proof.

### Change
- replace full `veritas_os/requirements.txt` installation with `.[postgresql,signing,dev]`
- use `pyproject.toml` as the pip cache dependency path
- keep the existing 15-minute timeout and the test/migration semantics unchanged

### Why
The post-merge run for #2227 was cancelled during dependency installation before the contention test executed. The full requirements profile pulled unrelated ML/CUDA packages through `sentence-transformers`/`torch`, exhausting the job timeout.

The first slimmed run reached the real contention tests successfully, which exposed that the storage import path also requires the existing `signing` profile (`cryptography`). The follow-up commit therefore adds `signing` while still excluding unrelated ML/CUDA dependencies.

This PR does **not** change VERITAS runtime/governance semantics, database migrations, or the contention test itself. It only narrows CI dependencies to the repository's existing core + PostgreSQL + signing + test profiles.

## Validation target
The `Bind Effect State PostgreSQL / bind-effect-state-postgresql-contention` check should complete within the existing timeout and execute the actual PostgreSQL contention tests successfully.