### PR TITLE
feat(poc): add external measurement governance closure harness

### DIFF
--- a/docs/en/architecture/external-measurement-governance-closure-poc.md
+++ b/docs/en/architecture/external-measurement-governance-closure-poc.md
@@ -1,0 +1,154 @@
+# External Measurement Governance Closure PoC
+
+## Purpose
+
+This PoC closes the governance path immediately after a runtime-sealed
+`VerifiedExternalMeasurementEvidence` object exists, while preserving the
+fundamental boundary that external measurement evidence is not execution
+authority.
+
+The harness is intentionally non-executing. It revalidates the sealed external
+measurement, then evaluates independently supplied Policy, AuthorityEvidence,
+and Human Approval through the existing VERITAS commit-boundary machinery. It
+emits a deterministic reviewer-facing closure packet.
+
+## Flow
+
+```text
+VerifiedExternalMeasurementEvidence
+        |
+        | revalidate trust / freshness / proof integrity
+        v
+External measurement evidence reference
+        |
+        +------------------------------+
+        |                              |
+        |  independent Policy          |
+        |  independent Authority       |
+        |  independent Human Approval  |
+        |                              |
+        +--------------+---------------+
+                       |
+                       v
+              CommitBoundaryEvaluator
+                       |
+                       v
+        non-executing governance result
+                       |
+                       v
+        deterministic closure packet
+```
+
+## Core invariant
+
+```text
+ExternalMeasurementEvidence
+!= AuthorityEvidence
+!= HumanApproval
+!= BindAuthorization
+!= execution permission
+```
+
+A valid external signature, a `within_bounds` measurement, or an advisory
+recommendation cannot satisfy missing AuthorityEvidence, missing Human Approval,
+or an independently refusing policy evaluation.
+
+## What the harness evaluates
+
+The harness accepts:
+
+- one runtime-sealed `VerifiedExternalMeasurementEvidence`;
+- the exact `ExternalMeasurementTrustPolicy` used to revalidate it;
+- one `ActionClassContract`;
+- independently produced `AuthorityEvidence` or no authority;
+- independently produced Human Approval state;
+- an independent policy evaluation with an explicit `policy_snapshot_id` and
+  boolean `admissible` result;
+- requested scope and required-evidence presence/freshness metadata.
+
+It then reuses the existing `CommitBoundaryEvaluator` and its
+`RuntimeAuthorityValidator` predicates.
+
+A resulting `commit` means only that the supplied governance inputs were
+admissible at this non-executing PoC review boundary. It does **not** mean that
+VERITAS issued a `BindAuthorization`, resolved credentials, dispatched a
+request, or produced an external effect.
+
+## Closure packet
+
+The packet records:
+
+- external measurement evidence ID, provider ID, artifact ID;
+- measurement evidence hash and verification proof hash;
+- trust policy ID/hash and replay key;
+- independent policy evaluation ID, snapshot, result, and reasons;
+- AuthorityEvidence ID/hash when supplied;
+- Human Approval receipt ID/hash and approval state;
+- commit-boundary governance outcome and failure/refusal/escalation basis;
+- deterministic packet hash;
+- explicit non-execution claim-boundary flags.
+
+The claim-boundary section fixes the following values:
+
+```text
+external_measurement_converted_to_authority = false
+external_measurement_converted_to_human_approval = false
+external_measurement_converted_to_bind_authorization = false
+external_measurement_directly_controls_governance_outcome = false
+bind_authorization_created = false
+credentials_accessed = false
+network_dispatch_performed = false
+external_effect_performed = false
+```
+
+## Runtime-sealed proof boundary
+
+`VerifiedExternalMeasurementEvidence` is intentionally revalidated as a
+runtime-sealed object. A JSON serialization of that proof is useful for review
+and reproducibility, but this PoC does not reinterpret serialized JSON as
+portable trust.
+
+For the first real NeoMundi run, the correct composition is therefore:
+
+```text
+real signed RGC v0.2
+-> NeoMundi provider verification
+-> generic ExternalMeasurementEvidence trust boundary
+-> runtime-sealed VerifiedExternalMeasurementEvidence
+-> this governance closure harness in the same trusted process
+-> reviewer-facing closure packet
+```
+
+The checked-in #2227 verification outputs remain reviewer artifacts; they are
+not silently promoted back into runtime trust.
+
+## Tests
+
+The deterministic synthetic tests cover:
+
+1. valid independent Policy + Authority + Human Approval -> non-executing
+   `commit`;
+2. verified external measurement with missing Authority -> `block`;
+3. verified external measurement with missing Human Approval -> `block`;
+4. independently refusing policy evaluation -> `refuse` even when the external
+   measurement is verified;
+5. tampered runtime-sealed external measurement proof -> fail closed before
+   governance evaluation.
+
+## Non-goals
+
+This PoC does not:
+
+- establish live NeoMundi interoperability;
+- issue `BindAuthorization`;
+- resolve or use credentials;
+- perform Bind execution;
+- dispatch network traffic;
+- create an external effect;
+- change BindReceipt / Outcome / Reconciliation semantics;
+- modify the frozen Decision-to-Effect architecture;
+- claim production readiness, certification, or third-party validation.
+
+Live interoperability remains unproven until a real partner-produced signed
+observation is independently verified and this closure path is executed with
+that runtime-sealed proof.

--- a/veritas_os/governance/external_measurement_governance_closure.py
+++ b/veritas_os/governance/external_measurement_governance_closure.py
@@ -1,0 +1,258 @@
+"""Non-executing governance closure for verified external measurement evidence.
+
+A verified external measurement remains evidence only.  This PoC harness keeps
+that evidence structurally separate from Policy, AuthorityEvidence, and Human
+Approval, then reuses the existing commit-boundary evaluator to produce an
+inspectable governance result.  It never creates BindAuthorization, accesses
+credentials, dispatches a network action, or performs an external effect.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from veritas_os.governance.action_contracts import ActionClassContract
+from veritas_os.governance.authority_evidence import AuthorityEvidence
+from veritas_os.governance.commit_boundary import CommitBoundaryEvaluator
+from veritas_os.governance.external_measurement_evidence import (
+    ExternalMeasurementTrustPolicy,
+    VerifiedExternalMeasurementEvidence,
+    validate_verified_external_measurement_evidence,
+)
+from veritas_os.security.hash import sha256_of_canonical_json
+
+CLOSURE_PACKET_VERSION = "external-measurement-governance-closure-v1"
+
+
+class ExternalMeasurementGovernanceClosureError(ValueError):
+    """Fail-closed error raised when the closure inputs are not admissible."""
+
+
+@dataclass(frozen=True)
+class ExternalMeasurementGovernanceClosureResult:
+    """Inspectable non-executing governance result and reviewer-facing packet."""
+
+    governance_outcome: str
+    authority_validation_status: str
+    packet: dict[str, Any]
+    packet_hash: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a deterministic JSON-compatible representation."""
+        return {
+            "governance_outcome": self.governance_outcome,
+            "authority_validation_status": self.authority_validation_status,
+            "packet": dict(self.packet),
+            "packet_hash": self.packet_hash,
+        }
+
+
+def _normalize_policy_evaluation(value: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ExternalMeasurementGovernanceClosureError(
+            "external_measurement_closure_policy_evaluation_invalid"
+        )
+
+    policy_snapshot_id = str(value.get("policy_snapshot_id", "")).strip()
+    if not policy_snapshot_id:
+        raise ExternalMeasurementGovernanceClosureError(
+            "external_measurement_closure_policy_snapshot_missing"
+        )
+
+    admissible = value.get("admissible")
+    if not isinstance(admissible, bool):
+        raise ExternalMeasurementGovernanceClosureError(
+            "external_measurement_closure_policy_admissibility_invalid"
+        )
+
+    evaluation_id = str(value.get("evaluation_id", "")).strip()
+    reasons_raw = value.get("reasons", [])
+    if not isinstance(reasons_raw, list) or not all(
+        isinstance(item, str) for item in reasons_raw
+    ):
+        raise ExternalMeasurementGovernanceClosureError(
+            "external_measurement_closure_policy_reasons_invalid"
+        )
+
+    return {
+        "evaluation_id": evaluation_id or "unspecified-policy-evaluation",
+        "policy_snapshot_id": policy_snapshot_id,
+        "admissible": admissible,
+        "reasons": sorted(item.strip() for item in reasons_raw if item.strip()),
+        "source": "independent_policy_evaluation",
+    }
+
+
+def _failure_reasons(boundary_result: Any) -> list[str]:
+    reasons = {
+        str(item.reason)
+        for item in (
+            list(boundary_result.failed_predicates)
+            + list(boundary_result.stale_predicates)
+            + list(boundary_result.missing_predicates)
+        )
+        if str(item.reason).strip()
+    }
+    reasons.update(str(item) for item in boundary_result.refusal_basis if str(item))
+    reasons.update(str(item) for item in boundary_result.escalation_basis if str(item))
+    return sorted(reasons)
+
+
+def _approval_summary(human_approval_state: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "approved": bool(human_approval_state.get("approved", False)),
+        "approval_receipt_id": human_approval_state.get("approval_receipt_id"),
+        "receipt_hash": human_approval_state.get("receipt_hash"),
+        "source": human_approval_state.get("source"),
+        "failure_reasons": sorted(
+            str(item)
+            for item in human_approval_state.get("failure_reasons", [])
+            if str(item)
+        ),
+    }
+
+
+def close_verified_external_measurement_governance(
+    *,
+    verified_measurement: VerifiedExternalMeasurementEvidence,
+    measurement_trust_policy: ExternalMeasurementTrustPolicy,
+    action_contract: ActionClassContract,
+    authority_evidence: AuthorityEvidence | None,
+    human_approval_state: dict[str, Any],
+    policy_evaluation: dict[str, Any],
+    requested_scope: list[str],
+    required_evidence_metadata: dict[str, Any],
+    evidence_freshness_metadata: dict[str, Any],
+    actor_identity: str,
+    now: datetime | None = None,
+) -> ExternalMeasurementGovernanceClosureResult:
+    """Close the post-measurement governance path without executing anything.
+
+    The external measurement is revalidated only as external evidence.  The
+    policy evaluation, AuthorityEvidence, and Human Approval state are supplied
+    independently and are evaluated through the existing commit-boundary
+    machinery.  The returned ``commit`` outcome means only that the supplied
+    governance inputs are admissible at this non-executing review boundary.
+    """
+    current = now or datetime.now(UTC)
+    if current.tzinfo is None or current.utcoffset() is None:
+        raise ExternalMeasurementGovernanceClosureError(
+            "external_measurement_closure_now_timezone_required"
+        )
+
+    measurement_failures = validate_verified_external_measurement_evidence(
+        verified_measurement,
+        trust_policy=measurement_trust_policy,
+        now=current,
+    )
+    if measurement_failures:
+        raise ExternalMeasurementGovernanceClosureError(
+            "external_measurement_closure_measurement_invalid:"
+            + ",".join(sorted(set(measurement_failures)))
+        )
+
+    normalized_policy = _normalize_policy_evaluation(policy_evaluation)
+    policy_snapshot_id = normalized_policy["policy_snapshot_id"]
+
+    boundary_result = CommitBoundaryEvaluator().evaluate(
+        execution_intent={
+            "action_class": action_contract.action_class,
+            "admissible": normalized_policy["admissible"],
+            "non_executing_poc": True,
+        },
+        action_contract=action_contract,
+        authority_evidence=authority_evidence,
+        requested_scope=list(requested_scope),
+        required_evidence_metadata=dict(required_evidence_metadata),
+        evidence_freshness_metadata=dict(evidence_freshness_metadata),
+        policy_snapshot_id=policy_snapshot_id,
+        actor_identity=actor_identity,
+        human_approval_state=dict(human_approval_state),
+        bind_context_metadata={
+            "poc_closure_harness": True,
+            "execution_disabled": True,
+        },
+        now=current,
+    )
+
+    authority_summary = {
+        "authority_evidence_id": (
+            authority_evidence.authority_evidence_id
+            if authority_evidence is not None
+            else None
+        ),
+        "authority_evidence_hash": (
+            authority_evidence.evidence_hash if authority_evidence is not None else None
+        ),
+        "source": "independent_authority_evidence",
+    }
+    decision_record = {
+        "decision_type": "commit_boundary_result",
+        "outcome": boundary_result.commit_boundary_result,
+        "authority_validation_status": boundary_result.authority_validation_status,
+        "reason_summary": boundary_result.reason_summary,
+        "failure_reasons": _failure_reasons(boundary_result),
+        "refusal_basis": sorted(str(item) for item in boundary_result.refusal_basis),
+        "escalation_basis": sorted(
+            str(item) for item in boundary_result.escalation_basis
+        ),
+        "irreversibility_boundary_id": boundary_result.irreversibility_boundary_id,
+        "evaluated_at": boundary_result.evaluated_at,
+        "execution_performed": False,
+        "semantics": "non_executing_governance_admissibility_only",
+    }
+
+    packet_without_hash = {
+        "packet_version": CLOSURE_PACKET_VERSION,
+        "generated_at": current.isoformat(),
+        "external_measurement": {
+            "evidence_id": verified_measurement.evidence.evidence_id,
+            "provider_id": verified_measurement.evidence.provider_id,
+            "artifact_id": verified_measurement.evidence.artifact_id,
+            "evidence_hash": verified_measurement.evidence_hash,
+            "verification_proof_hash": (
+                verified_measurement.verification_proof_hash
+            ),
+            "trust_policy_id": verified_measurement.trust_policy_id,
+            "trust_policy_hash": verified_measurement.trust_policy_hash,
+            "replay_key": verified_measurement.replay_key,
+            "role": "external_measurement_evidence_only",
+        },
+        "policy_evaluation": normalized_policy,
+        "authority": authority_summary,
+        "human_approval": _approval_summary(human_approval_state),
+        "governance_decision": decision_record,
+        "requested_scope": sorted(str(item) for item in requested_scope),
+        "claim_boundary": {
+            "external_measurement_converted_to_authority": False,
+            "external_measurement_converted_to_human_approval": False,
+            "external_measurement_converted_to_bind_authorization": False,
+            "external_measurement_directly_controls_governance_outcome": False,
+            "governance_decision_created": True,
+            "bind_authorization_created": False,
+            "credentials_accessed": False,
+            "network_dispatch_performed": False,
+            "external_effect_performed": False,
+            "outcome_is_non_executing_governance_evaluation": True,
+        },
+        "non_claims": [
+            "not production validation",
+            "not live external interoperability by itself",
+            "not execution authority",
+            "not BindAuthorization issuance",
+            "not credential use",
+            "not network dispatch",
+            "not an external effect",
+        ],
+    }
+    packet_hash = sha256_of_canonical_json(packet_without_hash)
+    packet = {**packet_without_hash, "packet_hash": packet_hash}
+
+    return ExternalMeasurementGovernanceClosureResult(
+        governance_outcome=boundary_result.commit_boundary_result,
+        authority_validation_status=boundary_result.authority_validation_status,
+        packet=packet,
+        packet_hash=packet_hash,
+    )

--- a/veritas_os/tests/test_external_measurement_governance_closure.py
+++ b/veritas_os/tests/test_external_measurement_governance_closure.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from veritas_os.governance.action_contracts import ActionClassContract
+from veritas_os.governance.authority_evidence_ingestion import (
+    ingest_authority_evidence_payload,
+)
+from veritas_os.governance.external_measurement_evidence import (
+    ApprovedExternalMeasurementProvider,
+    ExternalMeasurementEvidence,
+    ExternalMeasurementProviderVerificationResult,
+    ExternalMeasurementTrustPolicy,
+    verify_external_measurement_artifact_to_evidence,
+)
+from veritas_os.governance.external_measurement_governance_closure import (
+    ExternalMeasurementGovernanceClosureError,
+    close_verified_external_measurement_governance,
+)
+from veritas_os.governance.human_approval_receipt import (
+    HumanApprovalReceipt,
+    build_human_approval_state,
+)
+from veritas_os.security.hash import sha256_of_canonical_json
+
+NOW = datetime(2026, 9, 11, 10, 0, tzinfo=UTC)
+POLICY_SNAPSHOT_ID = "policy-closure-001"
+REQUESTED_SCOPE = ["poc:review"]
+
+
+class _ReplayGuard:
+    def __init__(self) -> None:
+        self.used: set[str] = set()
+
+    def consume_once(self, replay_key: str, *, observed_at: datetime) -> bool:
+        del observed_at
+        if replay_key in self.used:
+            return False
+        self.used.add(replay_key)
+        return True
+
+
+class _ProviderVerifier:
+    verifier_id = "fixture-external-measurement-verifier"
+    verifier_trust_level = "test"
+    verifier_policy_id = "fixture-external-measurement-policy"
+    verifier_policy_hash = sha256_of_canonical_json(
+        {"policy_id": verifier_policy_id, "fixture_only": True}
+    )
+
+    def verify(
+        self, artifact: dict[str, Any]
+    ) -> ExternalMeasurementProviderVerificationResult:
+        del artifact
+        evidence = ExternalMeasurementEvidence(
+            evidence_id="eme-closure-001",
+            provider_id="fixture-provider",
+            artifact_id="fixture-observation-001",
+            artifact_type="fixture_measurement",
+            artifact_version="1.0",
+            payload_hash="a" * 64,
+            observed_at="2026-09-11T09:55:00+00:00",
+            issued_at="2026-09-11T09:55:00+00:00",
+            expires_at="2026-09-11T11:00:00+00:00",
+            replay_token="fixture-replay-001",
+            measured_scope={"system": "fixture", "scope": "runtime_state"},
+            measurement_coverage=1.0,
+            semantic_facts={"status": "within_bounds", "advisory_only": True},
+            provenance={"fixture": True},
+            metadata={
+                "measurement_only": True,
+                "execution_permission_changed": False,
+            },
+        )
+        return ExternalMeasurementProviderVerificationResult(
+            verified=True,
+            evidence=evidence,
+            verifier_id=self.verifier_id,
+            verifier_trust_level=self.verifier_trust_level,
+            verifier_policy_id=self.verifier_policy_id,
+            verifier_policy_hash=self.verifier_policy_hash,
+            key_id="fixture-key-001",
+            algorithm="fixture-signature",
+            semantic_consistent=True,
+            reason="fixture_verified",
+        )
+
+
+def _verified_measurement() -> tuple[Any, ExternalMeasurementTrustPolicy]:
+    verifier = _ProviderVerifier()
+    policy = ExternalMeasurementTrustPolicy(
+        policy_id="external-measurement-closure-trust-policy",
+        approved_providers=[
+            ApprovedExternalMeasurementProvider(
+                provider_id="fixture-provider",
+                verifier_id=verifier.verifier_id,
+                verifier_trust_level=verifier.verifier_trust_level,
+                verifier_policy_id=verifier.verifier_policy_id,
+                verifier_policy_hash=verifier.verifier_policy_hash,
+            )
+        ],
+        max_age_seconds=3600,
+        max_future_skew_seconds=60,
+        require_expiry=True,
+    )
+    proof = verify_external_measurement_artifact_to_evidence(
+        {"fixture": "measurement"},
+        provider_verifier=verifier,
+        trust_policy=policy,
+        replay_guard=_ReplayGuard(),
+        now=NOW,
+    )
+    return proof, policy
+
+
+def _contract() -> ActionClassContract:
+    return ActionClassContract(
+        id="external_measurement_closure",
+        version="1.0.0",
+        domain="poc",
+        action_class="external_measurement_review",
+        description="Review external measurement evidence under VERITAS governance.",
+        declared_intent="Evaluate independent governance inputs without execution.",
+        allowed_scope=["poc:review"],
+        prohibited_scope=["poc:execute"],
+        authority_sources=["policy.fixture_governance"],
+        required_evidence=["governance_case_record"],
+        evidence_freshness={"governance_case_record": "PT1H"},
+        irreversibility={"boundary": "poc_non_executing_review", "level": "high"},
+        human_approval_rules={"minimum_approvals": 1},
+        refusal_conditions=["authority_indeterminate"],
+        escalation_conditions=["evidence_stale"],
+        default_failure_mode="fail_closed",
+        metadata={"regulated": True, "fixture_only": True},
+    )
+
+
+def _authority() -> Any:
+    return ingest_authority_evidence_payload(
+        {
+            "authority_evidence_id": "aev-closure-001",
+            "action_contract_id": "external_measurement_closure",
+            "action_contract_version": "1.0.0",
+            "actor_identity": "agent:poc-reviewer",
+            "actor_role": "governance_operator",
+            "authority_source_refs": ["policy.fixture_governance"],
+            "role_or_policy_basis": ["role:governance_operator"],
+            "scope_grants": ["poc:review"],
+            "scope_limitations": ["poc:execute"],
+            "issued_at": "2026-09-11T09:00:00+00:00",
+            "valid_from": "2026-09-11T09:00:00+00:00",
+            "valid_until": "2026-09-11T12:00:00+00:00",
+            "policy_snapshot_id": POLICY_SNAPSHOT_ID,
+            "verification_result": "valid",
+            "metadata": {"source_type": "fixture_policy_registry"},
+        }
+    )
+
+
+def _approval_state(authority_id: str = "aev-closure-001") -> dict[str, Any]:
+    receipt = HumanApprovalReceipt(
+        approval_receipt_id="har-closure-001",
+        decision_id="decision-closure-001",
+        execution_intent_id="intent-closure-001",
+        approver_identity="human:fixture-approver",
+        approver_role="governance_reviewer",
+        approved_action_class="external_measurement_review",
+        approved_scope=list(REQUESTED_SCOPE),
+        approval_basis_refs=["review:closure-001"],
+        approved_at="2026-09-11T09:50:00+00:00",
+        expires_at="2026-09-11T11:00:00+00:00",
+        policy_snapshot_id=POLICY_SNAPSHOT_ID,
+        authority_evidence_id=authority_id,
+        approval_result="approved",
+        signature_verified=True,
+        receipt_hash="",
+        metadata={"fixture_only": True},
+    )
+    return build_human_approval_state(
+        receipt,
+        requested_scope=list(REQUESTED_SCOPE),
+        action_class="external_measurement_review",
+        policy_snapshot_id=POLICY_SNAPSHOT_ID,
+        now=NOW,
+    )
+
+
+def _policy_evaluation(*, admissible: bool = True) -> dict[str, Any]:
+    return {
+        "evaluation_id": "policy-eval-closure-001",
+        "policy_snapshot_id": POLICY_SNAPSHOT_ID,
+        "admissible": admissible,
+        "reasons": ["fixture_policy_evaluated_independently"],
+    }
+
+
+def _close(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    authority: Any | None = None,
+    approval_state: dict[str, Any] | None = None,
+    admissible: bool = True,
+) -> Any:
+    monkeypatch.setenv("VERITAS_POSTURE", "dev")
+    proof, trust_policy = _verified_measurement()
+    return close_verified_external_measurement_governance(
+        verified_measurement=proof,
+        measurement_trust_policy=trust_policy,
+        action_contract=_contract(),
+        authority_evidence=_authority() if authority is None else authority,
+        human_approval_state=(
+            _approval_state() if approval_state is None else approval_state
+        ),
+        policy_evaluation=_policy_evaluation(admissible=admissible),
+        requested_scope=list(REQUESTED_SCOPE),
+        required_evidence_metadata={"governance_case_record": {"present": True}},
+        evidence_freshness_metadata={"governance_case_record": {"fresh": True}},
+        actor_identity="agent:poc-reviewer",
+        now=NOW,
+    )
+
+
+def test_valid_independent_governance_inputs_produce_non_executing_commit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result = _close(monkeypatch)
+
+    assert result.governance_outcome == "commit"
+    assert result.authority_validation_status == "pass"
+    assert result.packet["governance_decision"]["execution_performed"] is False
+    assert result.packet["claim_boundary"]["bind_authorization_created"] is False
+    assert result.packet["claim_boundary"]["credentials_accessed"] is False
+    assert result.packet["claim_boundary"]["network_dispatch_performed"] is False
+    assert result.packet["claim_boundary"]["external_effect_performed"] is False
+    assert result.packet["packet_hash"] == result.packet_hash
+
+
+def test_verified_measurement_does_not_replace_missing_authority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VERITAS_POSTURE", "dev")
+    proof, trust_policy = _verified_measurement()
+    result = close_verified_external_measurement_governance(
+        verified_measurement=proof,
+        measurement_trust_policy=trust_policy,
+        action_contract=_contract(),
+        authority_evidence=None,
+        human_approval_state=_approval_state(),
+        policy_evaluation=_policy_evaluation(),
+        requested_scope=list(REQUESTED_SCOPE),
+        required_evidence_metadata={"governance_case_record": {"present": True}},
+        evidence_freshness_metadata={"governance_case_record": {"fresh": True}},
+        actor_identity="agent:poc-reviewer",
+        now=NOW,
+    )
+
+    assert result.governance_outcome == "block"
+    assert result.authority_validation_status == "fail"
+    assert result.packet["authority"]["authority_evidence_id"] is None
+    assert (
+        result.packet["claim_boundary"]["external_measurement_converted_to_authority"]
+        is False
+    )
+
+
+def test_verified_measurement_does_not_replace_missing_human_approval(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    missing_approval = build_human_approval_state(
+        None,
+        requested_scope=list(REQUESTED_SCOPE),
+    )
+    result = _close(monkeypatch, approval_state=missing_approval)
+
+    assert result.governance_outcome == "block"
+    assert result.packet["human_approval"]["approved"] is False
+    assert (
+        result.packet["claim_boundary"][
+            "external_measurement_converted_to_human_approval"
+        ]
+        is False
+    )
+
+
+def test_independent_policy_refusal_is_not_overridden_by_measurement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result = _close(monkeypatch, admissible=False)
+
+    assert result.governance_outcome == "refuse"
+    assert result.packet["policy_evaluation"]["admissible"] is False
+    assert (
+        result.packet["claim_boundary"][
+            "external_measurement_directly_controls_governance_outcome"
+        ]
+        is False
+    )
+
+
+def test_tampered_runtime_sealed_measurement_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VERITAS_POSTURE", "dev")
+    proof, trust_policy = _verified_measurement()
+    tampered = replace(proof, evidence_hash="0" * 64)
+
+    with pytest.raises(
+        ExternalMeasurementGovernanceClosureError,
+        match="external_measurement_closure_measurement_invalid",
+    ):
+        close_verified_external_measurement_governance(
+            verified_measurement=tampered,
+            measurement_trust_policy=trust_policy,
+            action_contract=_contract(),
+            authority_evidence=_authority(),
+            human_approval_state=_approval_state(),
+            policy_evaluation=_policy_evaluation(),
+            requested_scope=list(REQUESTED_SCOPE),
+            required_evidence_metadata={
+                "governance_case_record": {"present": True}
+            },
+            evidence_freshness_metadata={
+                "governance_case_record": {"fresh": True}
+            },
+            actor_identity="agent:poc-reviewer",
+            now=NOW,
+        )


### PR DESCRIPTION
## What
- Adds a non-executing governance closure harness for runtime-sealed `VerifiedExternalMeasurementEvidence`.
- Revalidates the external measurement proof against the exact `ExternalMeasurementTrustPolicy`.
- Evaluates independently supplied Policy, `AuthorityEvidence`, and Human Approval through the existing `CommitBoundaryEvaluator` / `RuntimeAuthorityValidator` path.
- Emits a deterministic reviewer-facing closure packet with explicit hashes, decision basis, and non-execution claim boundaries.
- Adds deterministic synthetic tests and architecture documentation.

## Critical boundary
External measurement remains evidence only:

```text
ExternalMeasurementEvidence
!= AuthorityEvidence
!= HumanApproval
!= BindAuthorization
!= execution permission
```

A verified measurement cannot replace missing AuthorityEvidence, cannot replace missing Human Approval, and cannot override an independently refusing policy evaluation.

## Non-execution guarantees
This harness does not:
- issue `BindAuthorization`
- resolve or access credentials
- dispatch network traffic
- perform an external effect
- change BindReceipt / Outcome / Reconciliation semantics
- modify the frozen Decision-to-Effect architecture

A `commit` result from this harness means only non-executing governance admissibility for the supplied PoC inputs.

## Runtime-sealed proof handling
The harness accepts a runtime-sealed `VerifiedExternalMeasurementEvidence` object and revalidates it before governance evaluation. It intentionally does not reinterpret the JSON serialization produced by #2227 as portable runtime trust.

For the first real NeoMundi proof, the intended composition is:

```text
real signed RGC v0.2
→ provider verification
→ generic ExternalMeasurementEvidence trust boundary
→ runtime-sealed VerifiedExternalMeasurementEvidence
→ this closure harness in the same trusted process
→ reviewer-facing closure packet
```

## Tests
Covers:
- valid independent Policy + Authority + Human Approval → non-executing `commit`
- missing Authority → `block` despite verified measurement
- missing Human Approval → `block` despite verified measurement
- independent policy refusal → `refuse`
- tampered runtime-sealed measurement proof → fail closed

## Non-claims
This PR does not establish live NeoMundi interoperability, production readiness, customer deployment, certification, or third-party validation. The real partner-produced signed observation is still required for External PoC #1.