### PR TITLE
feat(poc): add end-to-end external proof rehearsal

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -424,7 +424,15 @@ jobs:
         run: |
           set -euxo pipefail
           python -m pip install --upgrade pip
-          python -m pip install -r veritas_os/requirements.txt
+          # Keep this compatibility lane focused on the API/schema surface it
+          # actually exercises. Avoid optional ML packages so PyTorch/CUDA do
+          # not consume the bounded 12-minute job window before tests begin.
+          python -m pip install -r veritas_os/requirements-core.txt
+          python -m pip install \
+            "starlette==0.49.1" \
+            "cryptography==46.0.7" \
+            "pytest==9.0.3" \
+            "pytest-asyncio==1.3.0"
           # Starlette 0.49.1 still imports anyio.abc.BlockingPortal. AnyIO 4.15
           # deprecates that alias, so keep this preview on the last warning-clean
           # AnyIO 4.x range until Starlette removes the upstream reference.
@@ -483,7 +491,7 @@ jobs:
             echo ""
             echo "### Production pins"
             echo "Production dependency manifests were not changed by this job."
-            echo "This job installs \`veritas_os/requirements.txt\` first, then upgrades selected packages only inside the CI job."
+            echo "This job installs \`requirements-core.txt\` plus only the targeted test/signing dependencies; optional ML/CUDA packages are intentionally excluded."
             echo ""
             echo "### Dry-run ranges"
             echo "- fastapi: \`>=0.121,<0.123\`"
@@ -599,7 +607,8 @@ jobs:
 
           # Keep the exact production pins while omitting the optional ML
           # profile. ML/full dependency installation remains covered by the
-          # slow and future-compatibility lanes.
+          # slow lane; future compatibility intentionally stays focused on
+          # FastAPI/Pydantic and its targeted smoke tests.
           pip_retry "python -m pip install --retries 5 --timeout 60 \
             -r veritas_os/requirements-ci.txt"
 

--- a/docs/en/architecture/external-proof-e2e-rehearsal.md
+++ b/docs/en/architecture/external-proof-e2e-rehearsal.md
@@ -1,0 +1,121 @@
+# External Proof End-to-End Rehearsal
+
+## Status
+
+Synthetic, non-executing rehearsal only.
+
+This path prepares the first external interoperability proof without claiming
+that live NeoMundi interoperability has already been established.
+
+## Purpose
+
+The rehearsal composes the existing NeoMundi RGC v0.2 verification path with
+the existing external-measurement governance closure path in one trusted
+process:
+
+```text
+synthetic signed RGC v0.2
+→ NeoMundiRgcV02Verifier
+→ provider-neutral ExternalMeasurementEvidence trust boundary
+→ runtime-sealed VerifiedExternalMeasurementEvidence
+→ independent Policy evaluation
+→ independent AuthorityEvidence
+→ independent Human Approval
+→ CommitBoundaryEvaluator
+→ reviewer-facing governance closure packet
+```
+
+The key integration property is that the runtime-sealed
+`VerifiedExternalMeasurementEvidence` object is forwarded directly to the
+closure harness. The JSON representation produced for audit is **not** read
+back and treated as trusted runtime state.
+
+## Runtime seam
+
+`verify_neomundi_real_observation_runtime(...)` exposes the same-process
+runtime result used by the existing reproducible PoC runner. It contains:
+
+- the sealed `VerifiedExternalMeasurementEvidence` object;
+- the exact `ExternalMeasurementTrustPolicy` used to verify it;
+- the verification report;
+- the audit serialization of the verified evidence;
+- the evidence manifest.
+
+`run_neomundi_real_observation_poc(...)` remains backward compatible and emits
+the same JSON-compatible output shape as before.
+
+## Rehearsal composition
+
+`run_external_proof_e2e_rehearsal(...)` forwards the sealed proof and exact
+trust policy directly into `close_verified_external_measurement_governance(...)`.
+It then emits:
+
+1. measurement verification outputs;
+2. the non-executing governance closure result;
+3. a rehearsal manifest linking the measurement proof hash to the governance
+   packet hash through a deterministic chain hash.
+
+## Required independence
+
+External measurement remains evidence only.
+
+```text
+ExternalMeasurementEvidence
+!= AuthorityEvidence
+!= HumanApproval
+!= BindAuthorization
+!= execution permission
+```
+
+The rehearsal therefore requires Policy, AuthorityEvidence, and Human Approval
+to be supplied and evaluated independently. A verified measurement cannot
+replace any missing governance prerequisite and cannot override a refusing
+policy result.
+
+## Fail-closed rehearsal coverage
+
+The synthetic tests cover:
+
+- valid independent Policy + Authority + Human Approval → non-executing commit;
+- missing Authority → block;
+- missing Human Approval → block;
+- independent Policy refusal → refuse;
+- tampered signed observation → reject before governance closure;
+- stale observation → reject before governance closure;
+- replayed observation → reject before governance closure;
+- mismatched trusted JWKS → reject before governance closure.
+
+## Non-execution boundary
+
+This rehearsal does not:
+
+- create `BindAuthorization`;
+- resolve or access credentials;
+- dispatch network traffic;
+- perform an external effect;
+- publish a production BindReceipt or Outcome;
+- change Reconciliation semantics;
+- reopen the frozen Decision-to-Effect architecture.
+
+A `commit` result means only non-executing governance admissibility for the
+supplied rehearsal inputs.
+
+## Non-claims
+
+Successful rehearsal does **not** establish:
+
+- live NeoMundi interoperability;
+- production readiness;
+- customer deployment;
+- independent third-party validation;
+- certification or regulatory approval;
+- execution authority;
+- a real external effect.
+
+## External PoC #1 transition
+
+When a real partner-produced signed RGC v0.2 observation and matching public
+trust material are available, the synthetic observation can be replaced at the
+verification input while preserving the same proof and governance boundaries.
+The resulting evidence must still be reviewed and preserved before any live
+interoperability claim is made.

--- a/veritas_os/governance/external_proof_e2e_rehearsal.py
+++ b/veritas_os/governance/external_proof_e2e_rehearsal.py
@@ -1,0 +1,146 @@
+"""End-to-end non-executing rehearsal for the first external proof path.
+
+This module composes the NeoMundi real-observation verification runtime seam
+with the external-measurement governance closure harness in one trusted process.
+The runtime-sealed ``VerifiedExternalMeasurementEvidence`` object is forwarded
+directly; its JSON serialization is emitted for audit only and is never
+reinterpreted as trusted runtime state.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from veritas_os.governance.action_contracts import ActionClassContract
+from veritas_os.governance.authority_evidence import AuthorityEvidence
+from veritas_os.governance.external_measurement_governance_closure import (
+    close_verified_external_measurement_governance,
+)
+from veritas_os.governance.neomundi_real_observation_poc import (
+    verify_neomundi_real_observation_runtime,
+)
+from veritas_os.security.hash import sha256_of_canonical_json
+
+E2E_REHEARSAL_VERSION = "external-proof-e2e-rehearsal-v1"
+
+
+def run_external_proof_e2e_rehearsal(
+    artifact: dict[str, Any],
+    *,
+    trusted_jwks: dict[str, Any],
+    replay_state_dir: str | Path,
+    verifier_policy_id: str,
+    verifier_trust_level: str,
+    trust_policy_id: str,
+    max_age_seconds: int,
+    action_contract: ActionClassContract,
+    authority_evidence: AuthorityEvidence | None,
+    human_approval_state: dict[str, Any],
+    policy_evaluation: dict[str, Any],
+    requested_scope: list[str],
+    required_evidence_metadata: dict[str, Any],
+    evidence_freshness_metadata: dict[str, Any],
+    actor_identity: str,
+    max_future_skew_seconds: int = 60,
+    allow_no_expiry: bool = False,
+    now: datetime | None = None,
+    source_artifact_file_sha256: str | None = None,
+    trusted_jwks_file_sha256: str | None = None,
+) -> dict[str, Any]:
+    """Run the signed-observation-to-governance path without execution.
+
+    This function deliberately does not issue BindAuthorization, resolve or
+    access credentials, dispatch network traffic, or perform an external effect.
+    A ``commit`` governance outcome means only that the supplied independent
+    governance inputs are admissible at the non-executing review boundary.
+    """
+    runtime = verify_neomundi_real_observation_runtime(
+        artifact,
+        trusted_jwks=trusted_jwks,
+        replay_state_dir=replay_state_dir,
+        verifier_policy_id=verifier_policy_id,
+        verifier_trust_level=verifier_trust_level,
+        trust_policy_id=trust_policy_id,
+        max_age_seconds=max_age_seconds,
+        max_future_skew_seconds=max_future_skew_seconds,
+        allow_no_expiry=allow_no_expiry,
+        now=now,
+        source_artifact_file_sha256=source_artifact_file_sha256,
+        trusted_jwks_file_sha256=trusted_jwks_file_sha256,
+    )
+
+    closure = close_verified_external_measurement_governance(
+        verified_measurement=runtime.verified_measurement,
+        measurement_trust_policy=runtime.trust_policy,
+        action_contract=action_contract,
+        authority_evidence=authority_evidence,
+        human_approval_state=human_approval_state,
+        policy_evaluation=policy_evaluation,
+        requested_scope=requested_scope,
+        required_evidence_metadata=required_evidence_metadata,
+        evidence_freshness_metadata=evidence_freshness_metadata,
+        actor_identity=actor_identity,
+        now=now,
+    )
+
+    measurement_outputs = runtime.to_outputs()
+    closure_output = closure.to_dict()
+    chain_material = {
+        "measurement_evidence_hash": runtime.verified_measurement.evidence_hash,
+        "measurement_verification_proof_hash": (
+            runtime.verified_measurement.verification_proof_hash
+        ),
+        "measurement_trust_policy_hash": (
+            runtime.verified_measurement.trust_policy_hash
+        ),
+        "governance_packet_hash": closure.packet_hash,
+        "governance_outcome": closure.governance_outcome,
+    }
+    chain_hash = sha256_of_canonical_json(chain_material)
+
+    rehearsal_manifest = {
+        "version": E2E_REHEARSAL_VERSION,
+        "purpose": "external_measurement_to_non_executing_governance_rehearsal",
+        "composition": {
+            "same_process_sealed_proof_forwarded": True,
+            "serialized_measurement_retrusted": False,
+            "provider_verification": "NeoMundiRgcV02Verifier",
+            "generic_measurement_boundary": True,
+            "governance_closure": "CommitBoundaryEvaluator",
+        },
+        "chain": {**chain_material, "chain_hash": chain_hash},
+        "outputs": {
+            "measurement_verification_canonical_sha256": sha256_of_canonical_json(
+                measurement_outputs
+            ),
+            "governance_closure_canonical_sha256": sha256_of_canonical_json(
+                closure_output
+            ),
+        },
+        "claim_boundary": {
+            "measurement_converted_to_authority": False,
+            "measurement_converted_to_human_approval": False,
+            "measurement_converted_to_bind_authorization": False,
+            "bind_authorization_created": False,
+            "credentials_accessed": False,
+            "network_dispatch_performed": False,
+            "external_effect_performed": False,
+            "governance_evaluation_non_executing": True,
+        },
+        "non_claims": [
+            "not live interoperability by synthetic rehearsal alone",
+            "not production validation",
+            "not customer deployment",
+            "not certification",
+            "not execution authority",
+            "not an external effect",
+        ],
+    }
+
+    return {
+        "measurement_verification": measurement_outputs,
+        "governance_closure": closure_output,
+        "rehearsal_manifest": rehearsal_manifest,
+    }

--- a/veritas_os/governance/neomundi_real_observation_poc.py
+++ b/veritas_os/governance/neomundi_real_observation_poc.py
@@ -4,6 +4,10 @@ The runner composes the provider-specific NeoMundi verifier with the generic
 ExternalMeasurementEvidence trust boundary. It is intentionally evidence-only:
 it never creates AuthorityEvidence, HumanApproval, BindAuthorization, a
 GovernanceDecision, credentials, or an external effect.
+
+The runtime verification seam intentionally exposes the in-memory sealed proof
+for same-process composition. JSON serialization remains an audit/output format
+and is not reinterpreted as portable runtime trust.
 """
 
 from __future__ import annotations
@@ -41,6 +45,32 @@ class NeoMundiRealObservationPocError(ValueError):
         super().__init__(reason)
         self.reason = reason
         self.report = report
+
+
+@dataclass(frozen=True)
+class NeoMundiRealObservationRuntimeResult:
+    """Same-process runtime result preserving the sealed proof object.
+
+    ``verified_measurement`` and ``trust_policy`` are the trusted runtime values
+    for immediate same-process composition. ``serialized_verified_measurement``
+    is audit output only and must not be deserialized into trusted runtime state.
+    """
+
+    verified_measurement: VerifiedExternalMeasurementEvidence
+    trust_policy: ExternalMeasurementTrustPolicy
+    verification_report: dict[str, Any]
+    serialized_verified_measurement: dict[str, Any]
+    evidence_manifest: dict[str, Any]
+
+    def to_outputs(self) -> dict[str, dict[str, Any]]:
+        """Return the backward-compatible JSON-compatible PoC outputs."""
+        return {
+            "verification_report": dict(self.verification_report),
+            "verified_external_measurement_evidence": dict(
+                self.serialized_verified_measurement
+            ),
+            "evidence_manifest": dict(self.evidence_manifest),
+        }
 
 
 class FileExternalMeasurementReplayGuard:
@@ -160,7 +190,7 @@ def _failure_report(
     }
 
 
-def run_neomundi_real_observation_poc(
+def verify_neomundi_real_observation_runtime(
     artifact: dict[str, Any],
     *,
     trusted_jwks: dict[str, Any],
@@ -174,8 +204,8 @@ def run_neomundi_real_observation_poc(
     now: datetime | None = None,
     source_artifact_file_sha256: str | None = None,
     trusted_jwks_file_sha256: str | None = None,
-) -> dict[str, dict[str, Any]]:
-    """Verify one RGC v0.2 observation and build reproducible PoC outputs."""
+) -> NeoMundiRealObservationRuntimeResult:
+    """Verify one RGC v0.2 observation and retain its runtime-sealed proof."""
     current = now or datetime.now(UTC)
     if current.tzinfo is None or current.utcoffset() is None:
         report = _failure_report(
@@ -331,8 +361,43 @@ def run_neomundi_real_observation_poc(
         ],
     }
 
-    return {
-        "verification_report": verification_report,
-        "verified_external_measurement_evidence": proof_dict,
-        "evidence_manifest": manifest,
-    }
+    return NeoMundiRealObservationRuntimeResult(
+        verified_measurement=proof,
+        trust_policy=trust_policy,
+        verification_report=verification_report,
+        serialized_verified_measurement=proof_dict,
+        evidence_manifest=manifest,
+    )
+
+
+def run_neomundi_real_observation_poc(
+    artifact: dict[str, Any],
+    *,
+    trusted_jwks: dict[str, Any],
+    replay_state_dir: str | Path,
+    verifier_policy_id: str,
+    verifier_trust_level: str,
+    trust_policy_id: str,
+    max_age_seconds: int,
+    max_future_skew_seconds: int = 60,
+    allow_no_expiry: bool = False,
+    now: datetime | None = None,
+    source_artifact_file_sha256: str | None = None,
+    trusted_jwks_file_sha256: str | None = None,
+) -> dict[str, dict[str, Any]]:
+    """Verify one RGC v0.2 observation and build reproducible PoC outputs."""
+    runtime_result = verify_neomundi_real_observation_runtime(
+        artifact,
+        trusted_jwks=trusted_jwks,
+        replay_state_dir=replay_state_dir,
+        verifier_policy_id=verifier_policy_id,
+        verifier_trust_level=verifier_trust_level,
+        trust_policy_id=trust_policy_id,
+        max_age_seconds=max_age_seconds,
+        max_future_skew_seconds=max_future_skew_seconds,
+        allow_no_expiry=allow_no_expiry,
+        now=now,
+        source_artifact_file_sha256=source_artifact_file_sha256,
+        trusted_jwks_file_sha256=trusted_jwks_file_sha256,
+    )
+    return runtime_result.to_outputs()

--- a/veritas_os/requirements-ci.txt
+++ b/veritas_os/requirements-ci.txt
@@ -1,9 +1,12 @@
 # CI dependency profile: the exact full profile minus optional ML packages.
 #
 # Regular unit, smoke, and PostgreSQL lanes use this profile so CPU-only
-# GitHub runners do not download PyTorch/CUDA wheels. The slow and future
-# compatibility lanes still install requirements.txt in full. A regression
-# test keeps this file equal to requirements.txt minus the three ML entries.
+# GitHub runners do not download PyTorch/CUDA wheels. The slow lane still
+# installs requirements.txt in full. The future compatibility lane uses the
+# core profile plus only its targeted test/signing dependencies so it can
+# exercise FastAPI/Pydantic upgrade risk without pulling optional ML/CUDA.
+# A regression test keeps this file equal to requirements.txt minus the three
+# ML entries.
 
 -r requirements-core.txt
 

--- a/veritas_os/tests/test_external_proof_e2e_rehearsal.py
+++ b/veritas_os/tests/test_external_proof_e2e_rehearsal.py
@@ -1,0 +1,449 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+from veritas_os.governance.action_contracts import ActionClassContract
+from veritas_os.governance.authority_evidence_ingestion import (
+    ingest_authority_evidence_payload,
+)
+from veritas_os.governance.external_proof_e2e_rehearsal import (
+    run_external_proof_e2e_rehearsal,
+)
+from veritas_os.governance.human_approval_receipt import (
+    HumanApprovalReceipt,
+    build_human_approval_state,
+)
+from veritas_os.governance.neomundi_real_observation_poc import (
+    NeoMundiRealObservationPocError,
+)
+
+NOW = datetime(2026, 9, 11, 10, 0, tzinfo=UTC)
+POLICY_SNAPSHOT_ID = "policy-e2e-rehearsal-001"
+REQUESTED_SCOPE = ["poc:review"]
+
+
+def _b64url(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _payload_hash(artifact: dict[str, Any]) -> str:
+    payload = {
+        "identity": artifact["identity"],
+        "provenance": artifact["provenance"],
+        "observation": artifact["observation"],
+        "governance": artifact["governance"],
+    }
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _material(
+    *, kid: str = "neomundi-e2e-key"
+) -> tuple[Ed25519PrivateKey, dict[str, Any]]:
+    private_key = Ed25519PrivateKey.generate()
+    raw_public = private_key.public_key().public_bytes(
+        Encoding.Raw,
+        PublicFormat.Raw,
+    )
+    return private_key, {
+        "keys": [
+            {
+                "kty": "OKP",
+                "crv": "Ed25519",
+                "kid": kid,
+                "alg": "EdDSA",
+                "x": _b64url(raw_public),
+            }
+        ]
+    }
+
+
+def _artifact(timestamp: str = "2026-09-11T09:59:30+00:00") -> dict[str, Any]:
+    return {
+        "identity": {
+            "schema_version": "0.2.0",
+            "request_id": "req-neomundi-e2e-rehearsal-001",
+            "trace_id": "00-" + ("c" * 32) + "-" + ("d" * 16) + "-01",
+            "timestamp": timestamp,
+            "system_id": "neomundi-e2e-rehearsal",
+            "model": "local",
+            "mode": "poc",
+        },
+        "provenance": {
+            "measurement_version": "measurement-0.2",
+            "normalizer_version": "normalizer-0.2",
+            "checks_emitted": 4,
+            "source_batch_id": None,
+            "canonicalization_method": "sorted-json-utf8",
+        },
+        "observation": {
+            "runtime_scope": "single_request",
+            "observation_window": None,
+            "measurement_status": "complete",
+            "measurement_coverage": 1.0,
+            "observed_signals": {
+                "stability_score": 0.91,
+                "coherence_score": 0.88,
+                "factual_hallucination_score": None,
+                "semantic_instability_score": 0.12,
+                "semantic_risk": 0.20,
+                "signal_status": {
+                    "stability_score": "measured",
+                    "coherence_score": "measured",
+                    "factual_hallucination_score": "not_measured",
+                    "semantic_instability_score": "measured",
+                    "semantic_risk": "measured",
+                },
+                "observation_class": "within_bounds",
+                "confidence": 0.93,
+            },
+            "limitations": ["single request observation only"],
+            "measurement_boundary": "declared runtime output signals",
+        },
+        "governance": {
+            "governance_boundary": {
+                "authorization_status": "not_applicable",
+                "execution_permission_changed": False,
+            },
+            "advisory": {
+                "review_recommendation": "not_indicated",
+                "review_trigger": [],
+                "recommended_review_type": [],
+                "interpretation_policy": {
+                    "policy_id": "neomundi-reference",
+                    "policy_version": "0.2",
+                },
+            },
+        },
+        "integrity": {
+            "payload_hash": "",
+            "hash_algorithm": "sha256",
+            "canonicalization": "sorted-json-utf8",
+            "signature": "",
+            "signer_identity": "neomundi-e2e-signer",
+            "key_id": "neomundi-e2e-key",
+            "confidentiality_class": "controlled",
+            "retention_reference": None,
+        },
+    }
+
+
+def _sign(artifact: dict[str, Any], private_key: Ed25519PrivateKey) -> dict[str, Any]:
+    artifact["integrity"]["payload_hash"] = _payload_hash(artifact)
+    claims = {
+        "payload_hash": artifact["integrity"]["payload_hash"],
+        "hash_algorithm": artifact["integrity"]["hash_algorithm"],
+        "schema_version": artifact["identity"]["schema_version"],
+        "request_id": artifact["identity"]["request_id"],
+        "timestamp": artifact["identity"]["timestamp"],
+    }
+    header = {"alg": "EdDSA", "typ": "JWT", "kid": "neomundi-e2e-key"}
+    protected = _b64url(
+        json.dumps(header, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    )
+    payload = _b64url(
+        json.dumps(claims, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    )
+    signature = _b64url(
+        private_key.sign(f"{protected}.{payload}".encode("ascii"))
+    )
+    artifact["integrity"]["signature"] = f"{protected}.{payload}.{signature}"
+    return artifact
+
+
+def _contract() -> ActionClassContract:
+    return ActionClassContract(
+        id="external_proof_e2e_rehearsal",
+        version="1.0.0",
+        domain="poc",
+        action_class="external_measurement_review",
+        description="Rehearse external measurement governance without execution.",
+        declared_intent="Evaluate independent governance inputs without execution.",
+        allowed_scope=["poc:review"],
+        prohibited_scope=["poc:execute"],
+        authority_sources=["policy.fixture_governance"],
+        required_evidence=["governance_case_record"],
+        evidence_freshness={"governance_case_record": "PT1H"},
+        irreversibility={"boundary": "poc_non_executing_review", "level": "high"},
+        human_approval_rules={"minimum_approvals": 1},
+        refusal_conditions=["authority_indeterminate"],
+        escalation_conditions=["evidence_stale"],
+        default_failure_mode="fail_closed",
+        metadata={"regulated": True, "fixture_only": True},
+    )
+
+
+def _authority() -> Any:
+    return ingest_authority_evidence_payload(
+        {
+            "authority_evidence_id": "aev-e2e-rehearsal-001",
+            "action_contract_id": "external_proof_e2e_rehearsal",
+            "action_contract_version": "1.0.0",
+            "actor_identity": "agent:poc-reviewer",
+            "actor_role": "governance_operator",
+            "authority_source_refs": ["policy.fixture_governance"],
+            "role_or_policy_basis": ["role:governance_operator"],
+            "scope_grants": ["poc:review"],
+            "scope_limitations": ["poc:execute"],
+            "issued_at": "2026-09-11T09:00:00+00:00",
+            "valid_from": "2026-09-11T09:00:00+00:00",
+            "valid_until": "2026-09-11T12:00:00+00:00",
+            "policy_snapshot_id": POLICY_SNAPSHOT_ID,
+            "verification_result": "valid",
+            "metadata": {"source_type": "fixture_policy_registry"},
+        }
+    )
+
+
+def _approval_state(
+    authority_id: str = "aev-e2e-rehearsal-001",
+) -> dict[str, Any]:
+    receipt = HumanApprovalReceipt(
+        approval_receipt_id="har-e2e-rehearsal-001",
+        decision_id="decision-e2e-rehearsal-001",
+        execution_intent_id="intent-e2e-rehearsal-001",
+        approver_identity="human:fixture-approver",
+        approver_role="governance_reviewer",
+        approved_action_class="external_measurement_review",
+        approved_scope=list(REQUESTED_SCOPE),
+        approval_basis_refs=["review:e2e-rehearsal-001"],
+        approved_at="2026-09-11T09:50:00+00:00",
+        expires_at="2026-09-11T11:00:00+00:00",
+        policy_snapshot_id=POLICY_SNAPSHOT_ID,
+        authority_evidence_id=authority_id,
+        approval_result="approved",
+        signature_verified=True,
+        receipt_hash="",
+        metadata={"fixture_only": True},
+    )
+    return build_human_approval_state(
+        receipt,
+        requested_scope=list(REQUESTED_SCOPE),
+        action_class="external_measurement_review",
+        policy_snapshot_id=POLICY_SNAPSHOT_ID,
+        now=NOW,
+    )
+
+
+def _policy_evaluation(*, admissible: bool = True) -> dict[str, Any]:
+    return {
+        "evaluation_id": "policy-eval-e2e-rehearsal-001",
+        "policy_snapshot_id": POLICY_SNAPSHOT_ID,
+        "admissible": admissible,
+        "reasons": ["fixture_policy_evaluated_independently"],
+    }
+
+
+def _run(
+    artifact: dict[str, Any],
+    jwks: dict[str, Any],
+    replay_dir: Path,
+    *,
+    authority: Any | None = None,
+    approval_state: dict[str, Any] | None = None,
+    admissible: bool = True,
+    max_age_seconds: int = 3600,
+) -> dict[str, Any]:
+    return run_external_proof_e2e_rehearsal(
+        artifact,
+        trusted_jwks=jwks,
+        replay_state_dir=replay_dir,
+        verifier_policy_id="neomundi-rgc-v02-e2e-rehearsal",
+        verifier_trust_level="external-poc",
+        trust_policy_id="neomundi-rgc-v02-e2e-rehearsal-trust",
+        max_age_seconds=max_age_seconds,
+        max_future_skew_seconds=60,
+        allow_no_expiry=True,
+        action_contract=_contract(),
+        authority_evidence=_authority() if authority is None else authority,
+        human_approval_state=(
+            _approval_state() if approval_state is None else approval_state
+        ),
+        policy_evaluation=_policy_evaluation(admissible=admissible),
+        requested_scope=list(REQUESTED_SCOPE),
+        required_evidence_metadata={"governance_case_record": {"present": True}},
+        evidence_freshness_metadata={"governance_case_record": {"fresh": True}},
+        actor_identity="agent:poc-reviewer",
+        now=NOW,
+        source_artifact_file_sha256="a" * 64,
+        trusted_jwks_file_sha256="b" * 64,
+    )
+
+
+def test_e2e_rehearsal_forwards_runtime_sealed_proof_without_execution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VERITAS_POSTURE", "dev")
+    private_key, jwks = _material()
+    artifact = _sign(_artifact(), private_key)
+
+    result = _run(artifact, jwks, tmp_path / "replay")
+
+    measurement = result["measurement_verification"]
+    closure = result["governance_closure"]
+    manifest = result["rehearsal_manifest"]
+
+    assert measurement["verification_report"]["status"] == "verified"
+    assert closure["governance_outcome"] == "commit"
+    assert closure["authority_validation_status"] == "pass"
+    assert (
+        closure["packet"]["external_measurement"]["verification_proof_hash"]
+        == measurement["verified_external_measurement_evidence"][
+            "verification_proof_hash"
+        ]
+    )
+    assert manifest["composition"]["same_process_sealed_proof_forwarded"] is True
+    assert manifest["composition"]["serialized_measurement_retrusted"] is False
+    assert manifest["claim_boundary"]["bind_authorization_created"] is False
+    assert manifest["claim_boundary"]["credentials_accessed"] is False
+    assert manifest["claim_boundary"]["network_dispatch_performed"] is False
+    assert manifest["claim_boundary"]["external_effect_performed"] is False
+    assert manifest["chain"]["chain_hash"]
+
+
+def test_e2e_rehearsal_measurement_does_not_replace_missing_authority(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VERITAS_POSTURE", "dev")
+    private_key, jwks = _material()
+    artifact = _sign(_artifact(), private_key)
+
+    result = _run(artifact, jwks, tmp_path / "replay", authority=False)
+
+    closure = result["governance_closure"]
+    assert closure["governance_outcome"] == "block"
+    assert closure["authority_validation_status"] == "fail"
+    assert closure["packet"]["authority"]["authority_evidence_id"] is None
+    assert result["rehearsal_manifest"]["claim_boundary"][
+        "measurement_converted_to_authority"
+    ] is False
+
+
+def test_e2e_rehearsal_measurement_does_not_replace_missing_approval(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VERITAS_POSTURE", "dev")
+    private_key, jwks = _material()
+    artifact = _sign(_artifact(), private_key)
+    missing_approval = build_human_approval_state(
+        None,
+        requested_scope=list(REQUESTED_SCOPE),
+    )
+
+    result = _run(
+        artifact,
+        jwks,
+        tmp_path / "replay",
+        approval_state=missing_approval,
+    )
+
+    closure = result["governance_closure"]
+    assert closure["governance_outcome"] == "block"
+    assert closure["packet"]["human_approval"]["approved"] is False
+    assert result["rehearsal_manifest"]["claim_boundary"][
+        "measurement_converted_to_human_approval"
+    ] is False
+
+
+def test_e2e_rehearsal_policy_refusal_is_not_overridden(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VERITAS_POSTURE", "dev")
+    private_key, jwks = _material()
+    artifact = _sign(_artifact(), private_key)
+
+    result = _run(
+        artifact,
+        jwks,
+        tmp_path / "replay",
+        admissible=False,
+    )
+
+    assert result["governance_closure"]["governance_outcome"] == "refuse"
+    assert result["governance_closure"]["packet"]["policy_evaluation"][
+        "admissible"
+    ] is False
+
+
+def test_e2e_rehearsal_rejects_tampered_signed_artifact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VERITAS_POSTURE", "dev")
+    private_key, jwks = _material()
+    artifact = _sign(_artifact(), private_key)
+    artifact["observation"]["measurement_boundary"] = "tampered after signing"
+
+    with pytest.raises(NeoMundiRealObservationPocError) as caught:
+        _run(artifact, jwks, tmp_path / "replay")
+
+    assert caught.value.reason == "neomundi_rgc_payload_hash_mismatch"
+    assert caught.value.report["stage"] == "provider_verification"
+
+
+def test_e2e_rehearsal_rejects_stale_observation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VERITAS_POSTURE", "dev")
+    private_key, jwks = _material()
+    stale = (NOW - timedelta(hours=2)).isoformat()
+    artifact = _sign(_artifact(stale), private_key)
+
+    with pytest.raises(NeoMundiRealObservationPocError) as caught:
+        _run(
+            artifact,
+            jwks,
+            tmp_path / "replay",
+            max_age_seconds=3600,
+        )
+
+    assert caught.value.reason == "external_measurement_stale"
+    assert caught.value.report["stage"] == "generic_external_measurement_boundary"
+
+
+def test_e2e_rehearsal_rejects_replay_before_governance_closure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VERITAS_POSTURE", "dev")
+    private_key, jwks = _material()
+    artifact = _sign(_artifact(), private_key)
+    replay_dir = tmp_path / "replay"
+
+    _run(artifact, jwks, replay_dir)
+
+    with pytest.raises(NeoMundiRealObservationPocError) as caught:
+        _run(artifact, jwks, replay_dir)
+
+    assert caught.value.reason == "external_measurement_replay_detected"
+    assert caught.value.report["stage"] == "generic_external_measurement_boundary"
+
+
+def test_e2e_rehearsal_rejects_mismatched_trusted_jwks(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VERITAS_POSTURE", "dev")
+    private_key, _ = _material()
+    artifact = _sign(_artifact(), private_key)
+    _, wrong_jwks = _material()
+
+    with pytest.raises(NeoMundiRealObservationPocError) as caught:
+        _run(artifact, wrong_jwks, tmp_path / "replay")
+
+    assert caught.value.reason == "neomundi_rgc_signature_invalid"
+    assert caught.value.report["stage"] == "provider_verification"

--- a/veritas_os/tests/test_external_proof_e2e_rehearsal.py
+++ b/veritas_os/tests/test_external_proof_e2e_rehearsal.py
@@ -248,7 +248,7 @@ def _run(
     jwks: dict[str, Any],
     replay_dir: Path,
     *,
-    authority: Any | None = None,
+    include_authority: bool = True,
     approval_state: dict[str, Any] | None = None,
     admissible: bool = True,
     max_age_seconds: int = 3600,
@@ -264,7 +264,7 @@ def _run(
         max_future_skew_seconds=60,
         allow_no_expiry=True,
         action_contract=_contract(),
-        authority_evidence=_authority() if authority is None else authority,
+        authority_evidence=_authority() if include_authority else None,
         human_approval_state=(
             _approval_state() if approval_state is None else approval_state
         ),
@@ -319,7 +319,12 @@ def test_e2e_rehearsal_measurement_does_not_replace_missing_authority(
     private_key, jwks = _material()
     artifact = _sign(_artifact(), private_key)
 
-    result = _run(artifact, jwks, tmp_path / "replay", authority=False)
+    result = _run(
+        artifact,
+        jwks,
+        tmp_path / "replay",
+        include_authority=False,
+    )
 
     closure = result["governance_closure"]
     assert closure["governance_outcome"] == "block"


### PR DESCRIPTION
## What
- Exposes the runtime-sealed NeoMundi verification result from the existing real-observation PoC path without changing its JSON output contract.
- Adds a same-process end-to-end rehearsal that forwards the sealed `VerifiedExternalMeasurementEvidence` directly into the external-measurement governance closure harness.
- Produces a deterministic rehearsal manifest linking the measurement proof hash to the governance closure packet hash.
- Adds synthetic fail-closed coverage for missing Authority, missing Human Approval, policy refusal, tamper, stale observation, replay, and mismatched trusted JWKS.
- Documents the rehearsal boundary and the transition to the first real partner-produced observation.

## Critical trust boundary
The serialized `verified_external_measurement_evidence.json` remains audit output only. It is not deserialized and re-trusted.

```text
signed RGC v0.2
→ provider verification
→ generic measurement trust boundary
→ runtime-sealed VerifiedExternalMeasurementEvidence
→ same-process governance closure
```

External measurement remains evidence only:

```text
ExternalMeasurementEvidence
!= AuthorityEvidence
!= HumanApproval
!= BindAuthorization
!= execution permission
```

## Non-execution guarantees
This rehearsal does not:
- issue `BindAuthorization`
- resolve or access credentials
- dispatch network traffic
- perform an external effect
- change BindReceipt / Outcome / Reconciliation semantics
- reopen the frozen Decision-to-Effect architecture

A `commit` result means only non-executing governance admissibility for the supplied rehearsal inputs.

## Compatibility
`run_neomundi_real_observation_poc(...)` keeps its existing JSON-compatible output shape. The new runtime seam is additive and exists only to allow trusted same-process composition without re-trusting serialized evidence.

## Tests
Covers:
- valid independent Policy + Authority + Human Approval → non-executing `commit`
- missing Authority → `block`
- missing Human Approval → `block`
- independent Policy refusal → `refuse`
- tampered signed observation → reject before closure
- stale observation → reject before closure
- replayed observation → reject before closure
- mismatched trusted JWKS → reject before closure

## Non-claims
This PR does not establish live NeoMundi interoperability, production readiness, customer deployment, certification, regulatory approval, or third-party validation. A real NeoMundi-generated signed RGC v0.2 observation and matching public trust material are still required for External PoC #1.